### PR TITLE
Add a lowered representation for markers

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -28,7 +28,8 @@ use url::Url;
 
 use cursor::Cursor;
 pub use marker::{
-    ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerEnvironment,
+    ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, LoweredMarkerValueExtra,
+    LoweredMarkerValueString, LoweredMarkerValueVersion, MarkerEnvironment,
     MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree, MarkerTreeContents,
     MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueString, MarkerValueVersion,
     MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,

--- a/crates/uv-pep508/src/marker/environment.rs
+++ b/crates/uv-pep508/src/marker/environment.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use uv_pep440::{Version, VersionParseError};
 
-use crate::{MarkerValueString, MarkerValueVersion, StringVersion};
+use crate::{LoweredMarkerValueString, LoweredMarkerValueVersion, StringVersion};
 
 /// The marker values for a python interpreter, normally the current one
 ///
@@ -33,35 +33,36 @@ struct MarkerEnvironmentInner {
 
 impl MarkerEnvironment {
     /// Returns of the PEP 440 version typed value of the key in the current environment
-    pub fn get_version(&self, key: MarkerValueVersion) -> &Version {
+    pub fn get_version(&self, key: LoweredMarkerValueVersion) -> &Version {
         match key {
-            MarkerValueVersion::ImplementationVersion => &self.implementation_version().version,
-            MarkerValueVersion::PythonFullVersion => &self.python_full_version().version,
-            MarkerValueVersion::PythonVersion => &self.python_version().version,
+            LoweredMarkerValueVersion::ImplementationVersion => {
+                &self.implementation_version().version
+            }
+            LoweredMarkerValueVersion::PythonFullVersion => &self.python_full_version().version,
+            LoweredMarkerValueVersion::PythonVersion => &self.python_version().version,
         }
     }
 
     /// Returns of the stringly typed value of the key in the current environment
-    pub fn get_string(&self, key: MarkerValueString) -> &str {
+    pub fn get_string(&self, key: LoweredMarkerValueString) -> &str {
         match key {
-            MarkerValueString::ImplementationName => self.implementation_name(),
-            MarkerValueString::OsName | MarkerValueString::OsNameDeprecated => self.os_name(),
-            MarkerValueString::PlatformMachine | MarkerValueString::PlatformMachineDeprecated => {
-                self.platform_machine()
+            LoweredMarkerValueString::ImplementationName => self.implementation_name(),
+            LoweredMarkerValueString::OsName | LoweredMarkerValueString::OsNameDeprecated => {
+                self.os_name()
             }
-            MarkerValueString::PlatformPythonImplementation
-            | MarkerValueString::PlatformPythonImplementationDeprecated
-            | MarkerValueString::PythonImplementationDeprecated => {
+            LoweredMarkerValueString::PlatformMachine
+            | LoweredMarkerValueString::PlatformMachineDeprecated => self.platform_machine(),
+            LoweredMarkerValueString::PlatformPythonImplementation
+            | LoweredMarkerValueString::PlatformPythonImplementationDeprecated
+            | LoweredMarkerValueString::PythonImplementationDeprecated => {
                 self.platform_python_implementation()
             }
-            MarkerValueString::PlatformRelease => self.platform_release(),
-            MarkerValueString::PlatformSystem => self.platform_system(),
-            MarkerValueString::PlatformVersion | MarkerValueString::PlatformVersionDeprecated => {
-                self.platform_version()
-            }
-            MarkerValueString::SysPlatform | MarkerValueString::SysPlatformDeprecated => {
-                self.sys_platform()
-            }
+            LoweredMarkerValueString::PlatformRelease => self.platform_release(),
+            LoweredMarkerValueString::PlatformSystem => self.platform_system(),
+            LoweredMarkerValueString::PlatformVersion
+            | LoweredMarkerValueString::PlatformVersionDeprecated => self.platform_version(),
+            LoweredMarkerValueString::SysPlatform
+            | LoweredMarkerValueString::SysPlatformDeprecated => self.sys_platform(),
         }
     }
 }

--- a/crates/uv-pep508/src/marker/lowering.rs
+++ b/crates/uv-pep508/src/marker/lowering.rs
@@ -1,0 +1,186 @@
+use std::fmt::{Display, Formatter};
+
+use uv_normalize::ExtraName;
+
+use crate::{MarkerValueExtra, MarkerValueString, MarkerValueVersion};
+
+/// Those environment markers with a PEP 440 version as value such as `python_version`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[allow(clippy::enum_variant_names)]
+pub enum LoweredMarkerValueVersion {
+    /// `implementation_version`
+    ImplementationVersion,
+    /// `python_full_version`
+    PythonFullVersion,
+    /// `python_version`
+    PythonVersion,
+}
+
+impl Display for LoweredMarkerValueVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ImplementationVersion => f.write_str("implementation_version"),
+            Self::PythonFullVersion => f.write_str("python_full_version"),
+            Self::PythonVersion => f.write_str("python_version"),
+        }
+    }
+}
+
+impl From<MarkerValueVersion> for LoweredMarkerValueVersion {
+    fn from(value: MarkerValueVersion) -> Self {
+        match value {
+            MarkerValueVersion::ImplementationVersion => Self::ImplementationVersion,
+            MarkerValueVersion::PythonFullVersion => Self::PythonFullVersion,
+            MarkerValueVersion::PythonVersion => Self::PythonVersion,
+        }
+    }
+}
+
+impl From<LoweredMarkerValueVersion> for MarkerValueVersion {
+    fn from(value: LoweredMarkerValueVersion) -> Self {
+        match value {
+            LoweredMarkerValueVersion::ImplementationVersion => Self::ImplementationVersion,
+            LoweredMarkerValueVersion::PythonFullVersion => Self::PythonFullVersion,
+            LoweredMarkerValueVersion::PythonVersion => Self::PythonVersion,
+        }
+    }
+}
+
+/// Those environment markers with an arbitrary string as value such as `sys_platform`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum LoweredMarkerValueString {
+    /// `implementation_name`
+    ImplementationName,
+    /// `os_name`
+    OsName,
+    /// Deprecated `os.name` from <https://peps.python.org/pep-0345/#environment-markers>
+    OsNameDeprecated,
+    /// `platform_machine`
+    PlatformMachine,
+    /// Deprecated `platform.machine` from <https://peps.python.org/pep-0345/#environment-markers>
+    PlatformMachineDeprecated,
+    /// `platform_python_implementation`
+    PlatformPythonImplementation,
+    /// Deprecated `platform.python_implementation` from <https://peps.python.org/pep-0345/#environment-markers>
+    PlatformPythonImplementationDeprecated,
+    /// Deprecated `python_implementation` from <https://github.com/pypa/packaging/issues/72>
+    PythonImplementationDeprecated,
+    /// `platform_release`
+    PlatformRelease,
+    /// `platform_system`
+    PlatformSystem,
+    /// `platform_version`
+    PlatformVersion,
+    /// Deprecated `platform.version` from <https://peps.python.org/pep-0345/#environment-markers>
+    PlatformVersionDeprecated,
+    /// `sys_platform`
+    SysPlatform,
+    /// Deprecated `sys.platform` from <https://peps.python.org/pep-0345/#environment-markers>
+    SysPlatformDeprecated,
+}
+
+impl From<MarkerValueString> for LoweredMarkerValueString {
+    fn from(value: MarkerValueString) -> Self {
+        match value {
+            MarkerValueString::ImplementationName => Self::ImplementationName,
+            MarkerValueString::OsName => Self::OsName,
+            MarkerValueString::OsNameDeprecated => Self::OsNameDeprecated,
+            MarkerValueString::PlatformMachine => Self::PlatformMachine,
+            MarkerValueString::PlatformMachineDeprecated => Self::PlatformMachineDeprecated,
+            MarkerValueString::PlatformPythonImplementation => Self::PlatformPythonImplementation,
+            MarkerValueString::PlatformPythonImplementationDeprecated => {
+                Self::PlatformPythonImplementationDeprecated
+            }
+            MarkerValueString::PythonImplementationDeprecated => {
+                Self::PythonImplementationDeprecated
+            }
+            MarkerValueString::PlatformRelease => Self::PlatformRelease,
+            MarkerValueString::PlatformSystem => Self::PlatformSystem,
+            MarkerValueString::PlatformVersion => Self::PlatformVersion,
+            MarkerValueString::PlatformVersionDeprecated => Self::PlatformVersionDeprecated,
+            MarkerValueString::SysPlatform => Self::SysPlatform,
+            MarkerValueString::SysPlatformDeprecated => Self::SysPlatformDeprecated,
+        }
+    }
+}
+
+impl From<LoweredMarkerValueString> for MarkerValueString {
+    fn from(value: LoweredMarkerValueString) -> Self {
+        match value {
+            LoweredMarkerValueString::ImplementationName => Self::ImplementationName,
+            LoweredMarkerValueString::OsName => Self::OsName,
+            LoweredMarkerValueString::OsNameDeprecated => Self::OsNameDeprecated,
+            LoweredMarkerValueString::PlatformMachine => Self::PlatformMachine,
+            LoweredMarkerValueString::PlatformMachineDeprecated => Self::PlatformMachineDeprecated,
+            LoweredMarkerValueString::PlatformPythonImplementation => {
+                Self::PlatformPythonImplementation
+            }
+            LoweredMarkerValueString::PlatformPythonImplementationDeprecated => {
+                Self::PlatformPythonImplementationDeprecated
+            }
+            LoweredMarkerValueString::PythonImplementationDeprecated => {
+                Self::PythonImplementationDeprecated
+            }
+            LoweredMarkerValueString::PlatformRelease => Self::PlatformRelease,
+            LoweredMarkerValueString::PlatformSystem => Self::PlatformSystem,
+            LoweredMarkerValueString::PlatformVersion => Self::PlatformVersion,
+            LoweredMarkerValueString::PlatformVersionDeprecated => Self::PlatformVersionDeprecated,
+            LoweredMarkerValueString::SysPlatform => Self::SysPlatform,
+            LoweredMarkerValueString::SysPlatformDeprecated => Self::SysPlatformDeprecated,
+        }
+    }
+}
+
+impl Display for LoweredMarkerValueString {
+    /// Normalizes deprecated names to the proper ones
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ImplementationName => f.write_str("implementation_name"),
+            Self::OsName | Self::OsNameDeprecated => f.write_str("os_name"),
+            Self::PlatformMachine | Self::PlatformMachineDeprecated => {
+                f.write_str("platform_machine")
+            }
+            Self::PlatformPythonImplementation
+            | Self::PlatformPythonImplementationDeprecated
+            | Self::PythonImplementationDeprecated => f.write_str("platform_python_implementation"),
+            Self::PlatformRelease => f.write_str("platform_release"),
+            Self::PlatformSystem => f.write_str("platform_system"),
+            Self::PlatformVersion | Self::PlatformVersionDeprecated => {
+                f.write_str("platform_version")
+            }
+            Self::SysPlatform | Self::SysPlatformDeprecated => f.write_str("sys_platform"),
+        }
+    }
+}
+
+/// The [`ExtraName`] value used in `extra` markers.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum LoweredMarkerValueExtra {
+    /// A valid [`ExtraName`].
+    Extra(ExtraName),
+}
+
+impl LoweredMarkerValueExtra {
+    /// Returns the [`ExtraName`] value.
+    pub fn extra(&self) -> &ExtraName {
+        match self {
+            Self::Extra(extra) => extra,
+        }
+    }
+}
+
+impl From<LoweredMarkerValueExtra> for MarkerValueExtra {
+    fn from(value: LoweredMarkerValueExtra) -> Self {
+        match value {
+            LoweredMarkerValueExtra::Extra(extra) => Self::Extra(extra),
+        }
+    }
+}
+
+impl Display for LoweredMarkerValueExtra {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Extra(extra) => extra.fmt(f),
+        }
+    }
+}

--- a/crates/uv-pep508/src/marker/mod.rs
+++ b/crates/uv-pep508/src/marker/mod.rs
@@ -11,11 +11,13 @@
 
 mod algebra;
 mod environment;
+mod lowering;
 pub(crate) mod parse;
 mod simplify;
 mod tree;
 
 pub use environment::{MarkerEnvironment, MarkerEnvironmentBuilder};
+pub use lowering::{LoweredMarkerValueExtra, LoweredMarkerValueString, LoweredMarkerValueVersion};
 pub use tree::{
     ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerExpression,
     MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeDebugGraph, MarkerTreeKind,

--- a/crates/uv-pep508/src/marker/simplify.rs
+++ b/crates/uv-pep508/src/marker/simplify.rs
@@ -51,7 +51,7 @@ fn collect_dnf(
                     let current = path.len();
                     for version in excluded {
                         path.push(MarkerExpression::Version {
-                            key: marker.key(),
+                            key: marker.key().into(),
                             specifier: VersionSpecifier::not_equals_version(version.clone()),
                         });
                     }
@@ -64,7 +64,7 @@ fn collect_dnf(
                 // Detect whether the range for this edge can be simplified as a star inequality.
                 if let Some(specifier) = star_range_inequality(&range) {
                     path.push(MarkerExpression::Version {
-                        key: marker.key(),
+                        key: marker.key().into(),
                         specifier,
                     });
 
@@ -77,7 +77,7 @@ fn collect_dnf(
                     let current = path.len();
                     for specifier in VersionSpecifier::from_release_only_bounds(bounds) {
                         path.push(MarkerExpression::Version {
-                            key: marker.key(),
+                            key: marker.key().into(),
                             specifier,
                         });
                     }
@@ -94,7 +94,7 @@ fn collect_dnf(
                     let current = path.len();
                     for value in excluded {
                         path.push(MarkerExpression::String {
-                            key: marker.key(),
+                            key: marker.key().into(),
                             operator: MarkerOperator::NotEqual,
                             value: value.clone(),
                         });
@@ -109,7 +109,7 @@ fn collect_dnf(
                     let current = path.len();
                     for (operator, value) in MarkerOperator::from_bounds(bounds) {
                         path.push(MarkerExpression::String {
-                            key: marker.key(),
+                            key: marker.key().into(),
                             operator,
                             value: value.clone(),
                         });
@@ -129,7 +129,7 @@ fn collect_dnf(
                 };
 
                 let expr = MarkerExpression::String {
-                    key: marker.key(),
+                    key: marker.key().into(),
                     value: marker.value().to_owned(),
                     operator,
                 };
@@ -148,7 +148,7 @@ fn collect_dnf(
                 };
 
                 let expr = MarkerExpression::String {
-                    key: marker.key(),
+                    key: marker.key().into(),
                     value: marker.value().to_owned(),
                     operator,
                 };
@@ -167,7 +167,7 @@ fn collect_dnf(
                 };
 
                 let expr = MarkerExpression::Extra {
-                    name: marker.name().clone(),
+                    name: marker.name().clone().into(),
                     operator,
                 };
 

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -1,7 +1,8 @@
-use crate::requires_python::{LowerBound, RequiresPythonRange, UpperBound};
 use pubgrub::Range;
 use uv_pep440::Version;
-use uv_pep508::{MarkerTree, MarkerTreeKind, MarkerValueVersion};
+use uv_pep508::{LoweredMarkerValueVersion, MarkerTree, MarkerTreeKind};
+
+use crate::requires_python::{LowerBound, RequiresPythonRange, UpperBound};
 
 /// Returns the bounding Python versions that can satisfy the [`MarkerTree`], if it's constrained.
 pub(crate) fn requires_python(tree: &MarkerTree) -> Option<RequiresPythonRange> {
@@ -9,14 +10,15 @@ pub(crate) fn requires_python(tree: &MarkerTree) -> Option<RequiresPythonRange> 
         match tree.kind() {
             MarkerTreeKind::True | MarkerTreeKind::False => {}
             MarkerTreeKind::Version(marker) => match marker.key() {
-                MarkerValueVersion::PythonVersion | MarkerValueVersion::PythonFullVersion => {
+                LoweredMarkerValueVersion::PythonVersion
+                | LoweredMarkerValueVersion::PythonFullVersion => {
                     for (range, tree) in marker.edges() {
                         if !tree.is_false() {
                             markers.push(range.clone());
                         }
                     }
                 }
-                MarkerValueVersion::ImplementationVersion => {
+                LoweredMarkerValueVersion::ImplementationVersion => {
                     for (_, tree) in marker.edges() {
                         collect_python_markers(&tree, markers);
                     }

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -586,7 +586,8 @@ impl ResolverOutput {
         marker_env: &MarkerEnvironment,
     ) -> Result<MarkerTree, Box<ParsedUrlError>> {
         use uv_pep508::{
-            MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString, MarkerValueVersion,
+            LoweredMarkerValueString, LoweredMarkerValueVersion, MarkerExpression, MarkerOperator,
+            MarkerTree,
         };
 
         /// A subset of the possible marker values.
@@ -596,8 +597,8 @@ impl ResolverOutput {
         /// values based on the current marker environment.
         #[derive(Debug, Eq, Hash, PartialEq)]
         enum MarkerParam {
-            Version(MarkerValueVersion),
-            String(MarkerValueString),
+            Version(LoweredMarkerValueVersion),
+            String(LoweredMarkerValueString),
         }
 
         /// Add all marker parameters from the given tree to the given set.
@@ -687,14 +688,14 @@ impl ResolverOutput {
                 MarkerParam::Version(value_version) => {
                     let from_env = marker_env.get_version(value_version);
                     MarkerExpression::Version {
-                        key: value_version,
+                        key: value_version.into(),
                         specifier: VersionSpecifier::equals_version(from_env.clone()),
                     }
                 }
                 MarkerParam::String(value_string) => {
                     let from_env = marker_env.get_string(value_string);
                     MarkerExpression::String {
-                        key: value_string,
+                        key: value_string.into(),
                         operator: MarkerOperator::Equal,
                         value: from_env.to_string(),
                     }


### PR DESCRIPTION
## Summary

This PR introduces a set of parallel structs to `MarkerValueString`, `MarkerValueExtra`, and `MarkerValueVersion` that remove various pieces of information and representations that shouldn't be available in the marker algebra. To start, I've _just_ removed the invalid extra component from `MarkerValueExtra` -- there are no other changes to the representation. So, throughout the marker algebra, we can't represent and thus don't have to worry about clauses with invalid extras.

The subsequent changes I plan to make are:

1. Removing `python_version`, since we exclusively use `python_version_full` in the algebra.
2. Removing the deprecated aliases, such that we re-map to the correct marker value.
3. Consolidating `sys_platform` and `platform_release` (the original motivation).
