### PR TITLE
Remove `python_version` from lowered marker representation

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -16,7 +16,6 @@
 
 #![warn(missing_docs)]
 
-use std::collections::HashSet;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::path::Path;
@@ -41,7 +40,7 @@ pub use uv_normalize::{ExtraName, InvalidNameError, PackageName};
 /// Version and version specifiers used in requirements (reexport).
 // https://github.com/konstin/pep508_rs/issues/19
 pub use uv_pep440;
-use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
+use uv_pep440::{VersionSpecifier, VersionSpecifiers};
 pub use verbatim_url::{
     expand_env_vars, split_scheme, strip_host, Scheme, VerbatimUrl, VerbatimUrlError,
 };
@@ -205,21 +204,6 @@ impl<T: Pep508Url> Requirement<T> {
     /// Returns whether the markers apply for the given environment
     pub fn evaluate_markers(&self, env: &MarkerEnvironment, extras: &[ExtraName]) -> bool {
         self.marker.evaluate(env, extras)
-    }
-
-    /// Returns whether the requirement would be satisfied, independent of environment markers, i.e.
-    /// if there is potentially an environment that could activate this requirement.
-    ///
-    /// Note that unlike [`Self::evaluate_markers`] this does not perform any checks for bogus
-    /// expressions but will simply return true. As caller you should separately perform a check
-    /// with an environment and forward all warnings.
-    pub fn evaluate_extras_and_python_version(
-        &self,
-        extras: &HashSet<ExtraName>,
-        python_versions: &[Version],
-    ) -> bool {
-        self.marker
-            .evaluate_extras_and_python_version(extras, python_versions)
     }
 
     /// Return the requirement with an additional marker added, to require the given extra.

--- a/crates/uv-pep508/src/marker/environment.rs
+++ b/crates/uv-pep508/src/marker/environment.rs
@@ -39,7 +39,6 @@ impl MarkerEnvironment {
                 &self.implementation_version().version
             }
             LoweredMarkerValueVersion::PythonFullVersion => &self.python_full_version().version,
-            LoweredMarkerValueVersion::PythonVersion => &self.python_version().version,
         }
     }
 

--- a/crates/uv-pep508/src/marker/lowering.rs
+++ b/crates/uv-pep508/src/marker/lowering.rs
@@ -12,8 +12,6 @@ pub enum LoweredMarkerValueVersion {
     ImplementationVersion,
     /// `python_full_version`
     PythonFullVersion,
-    /// `python_version`
-    PythonVersion,
 }
 
 impl Display for LoweredMarkerValueVersion {
@@ -21,17 +19,6 @@ impl Display for LoweredMarkerValueVersion {
         match self {
             Self::ImplementationVersion => f.write_str("implementation_version"),
             Self::PythonFullVersion => f.write_str("python_full_version"),
-            Self::PythonVersion => f.write_str("python_version"),
-        }
-    }
-}
-
-impl From<MarkerValueVersion> for LoweredMarkerValueVersion {
-    fn from(value: MarkerValueVersion) -> Self {
-        match value {
-            MarkerValueVersion::ImplementationVersion => Self::ImplementationVersion,
-            MarkerValueVersion::PythonFullVersion => Self::PythonFullVersion,
-            MarkerValueVersion::PythonVersion => Self::PythonVersion,
         }
     }
 }
@@ -41,7 +28,6 @@ impl From<LoweredMarkerValueVersion> for MarkerValueVersion {
         match value {
             LoweredMarkerValueVersion::ImplementationVersion => Self::ImplementationVersion,
             LoweredMarkerValueVersion::PythonFullVersion => Self::PythonFullVersion,
-            LoweredMarkerValueVersion::PythonVersion => Self::PythonVersion,
         }
     }
 }

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -10,8 +10,7 @@ pub(crate) fn requires_python(tree: &MarkerTree) -> Option<RequiresPythonRange> 
         match tree.kind() {
             MarkerTreeKind::True | MarkerTreeKind::False => {}
             MarkerTreeKind::Version(marker) => match marker.key() {
-                LoweredMarkerValueVersion::PythonVersion
-                | LoweredMarkerValueVersion::PythonFullVersion => {
+                LoweredMarkerValueVersion::PythonFullVersion => {
                     for (range, tree) in marker.edges() {
                         if !tree.is_false() {
                             markers.push(range.clone());


### PR DESCRIPTION
## Summary

We never construct these -- they should be impossible, since we always translate to `python_full_version`. This PR encodes that impossibility in the types.
