### PR TITLE
docs: reference `--no-progress` option in related environment variable

### DIFF
--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -186,7 +186,8 @@ impl EnvVars {
     /// packages.
     pub const UV_CONCURRENT_INSTALLS: &'static str = "UV_CONCURRENT_INSTALLS";
 
-    /// Disables all progress output. For example, spinners and progress bars.
+    /// Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
+    /// example, spinners and progress bars.
     pub const UV_NO_PROGRESS: &'static str = "UV_NO_PROGRESS";
 
     /// Specifies the directory where uv stores managed tools.

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -181,7 +181,7 @@ Ignore `.env` files when executing `uv run` commands.
 
 ### `UV_NO_PROGRESS`
 
-Equivalent to the `--no-progress` command-line argument. Disables all progress output. For example, spinners and progress bars.
+Disables all progress output. For example, spinners and progress bars.
 
 ### `UV_NO_SYNC`
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -181,7 +181,8 @@ Ignore `.env` files when executing `uv run` commands.
 
 ### `UV_NO_PROGRESS`
 
-Equivalent to the `--no-progress` command-line argument. Disables all progress output. For example, spinners and progress bars.
+Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
+example, spinners and progress bars.
 
 ### `UV_NO_SYNC`
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -181,7 +181,7 @@ Ignore `.env` files when executing `uv run` commands.
 
 ### `UV_NO_PROGRESS`
 
-Disables all progress output. For example, spinners and progress bars.
+Equivalent to the `--no-progress` command-line argument. Disables all progress output. For example, spinners and progress bars.
 
 ### `UV_NO_SYNC`
 


### PR DESCRIPTION
## Summary

Aligns the description of `UV_NO_PROGRESS` with other env vars that also have a related flag.

`--no-progress` is a "global option" and exists in every command.