### PR TITLE
Add a note to say that dependencies between workspace members are editable

### DIFF
--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -88,6 +88,10 @@ the workspace. The `workspace = true` key-value pair in the `tool.uv.sources` ta
 `bird-feeder` dependency should be provided by the workspace, rather than fetched from PyPI or
 another registry.
 
+!!! note
+
+    Dependencies between workspace members are editable.
+
 Any `tool.uv.sources` definitions in the workspace root apply to all members, unless overridden in
 the `tool.uv.sources` of a specific member. For example, given the following `pyproject.toml`:
 


### PR DESCRIPTION
Just a small note to say that dependencies between workspace members are editable as shown in #9362 

(This might be obvious since if dependencies between workspaces members are not editable then every time a workspace member is update it has to be manually reinstalled but since it's in the concepts documentation and since I see a lot of issues about workspaces, that little note might help newcomers a little bit)