### PR TITLE
windows ci: Run `cargo clippy` in the dev drive workspace to reuse the cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         run: rustup component add clippy
 
       - name: "Clippy"
+        working-directory: ${{ env.UV_WORKSPACE }}
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   cargo-dev-generate-all:


### PR DESCRIPTION
## Summary

In the Windows Clippy job, the workspace is transferred to `UV_WORKSPACE`. However, `cargo clippy` continues to execute in the `github.workspace`, and `Swatinem/rust-cache` only caches the `UV_WORKSPACE/target`, resulting in `cargo clippy` having no cache.

 This adjustment will take effect when any changes are made to `Cargo.toml` or `Cargo.lock`, prompting `Swatinem/rust-cache` to updat the cache.

