### PR TITLE
Allow syncing to empty virtual environment directories

### DIFF
--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -43,6 +43,7 @@ pub struct InvalidEnvironment {
 #[derive(Debug, Clone)]
 pub enum InvalidEnvironmentKind {
     NotDirectory,
+    Empty,
     MissingExecutable(PathBuf),
 }
 
@@ -128,6 +129,7 @@ impl std::fmt::Display for InvalidEnvironmentKind {
             Self::MissingExecutable(path) => {
                 write!(f, "missing Python executable at `{}`", path.user_display())
             }
+            Self::Empty => write!(f, "directory is empty"),
         }
     }
 }
@@ -174,6 +176,14 @@ impl PythonEnvironment {
             return Err(InvalidEnvironment {
                 path: venv,
                 kind: InvalidEnvironmentKind::NotDirectory,
+            }
+            .into());
+        }
+
+        if venv.read_dir().is_ok_and(|mut dir| dir.next().is_none()) {
+            return Err(InvalidEnvironment {
+                path: venv,
+                kind: InvalidEnvironmentKind::Empty,
             }
             .into());
         }

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -2795,13 +2795,17 @@ fn sync_empty_virtual_environment() -> Result<()> {
 
     // Running `uv sync` should work
     uv_snapshot!(context.filters(), context.sync(), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a compatible environment but cannot be recreated because it is not a virtual environment
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
     "###);
 
     Ok(())


### PR DESCRIPTION
As discussed in https://github.com/astral-sh/uv/issues/9423, it's confusing that we do not allow `uv sync` just because the `.venv` directory _exists_. This change matches `uv venv`.