### PR TITLE
Add dedicated error message for musl install attempts

### DIFF
--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -49,6 +49,10 @@ impl Libc {
             _ => Ok(Self::None),
         }
     }
+
+    pub fn is_musl(&self) -> bool {
+        matches!(self, Self::Some(target_lexicon::Environment::Musl))
+    }
 }
 
 impl FromStr for Libc {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -14,10 +14,11 @@ use uv_client::Connectivity;
 use uv_configuration::PreviewMode;
 use uv_configuration::TrustedHost;
 use uv_fs::Simplified;
-use uv_python::downloads::{DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
+use uv_python::downloads::{self, DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
 use uv_python::managed::{
     python_executable_dir, ManagedPythonInstallation, ManagedPythonInstallations,
 };
+use uv_python::platform::Libc;
 use uv_python::{
     PythonDownloads, PythonInstallationKey, PythonRequest, PythonVersionFile,
     VersionFileDiscoveryOptions, VersionFilePreference,
@@ -51,7 +52,17 @@ impl InstallRequest {
             .fill()?;
 
         // Find a matching download
-        let download = ManagedPythonDownload::from_request(&download_request)?;
+        let download = match ManagedPythonDownload::from_request(&download_request) {
+            Ok(download) => download,
+            Err(downloads::Error::NoDownloadFound(request))
+                if request.libc().is_some_and(Libc::is_musl) =>
+            {
+                return Err(anyhow::anyhow!(
+                    "uv does not yet provide musl Python distributions. See https://github.com/astral-sh/uv/issues/6890 to track support."
+                ));
+            }
+            Err(err) => return Err(err.into()),
+        };
 
         Ok(Self {
             request,


### PR DESCRIPTION
Until https://github.com/astral-sh/uv/issues/6890 is fixed, it seems nice to explain that we do not support it
