### PR TITLE
Respect sources in overrides and constraints

### DIFF
--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -1,14 +1,15 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
-use crate::Metadata;
 use uv_configuration::{LowerBound, SourceStrategy};
 use uv_distribution_types::IndexLocations;
 use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_workspace::dependency_groups::FlatDependencyGroups;
 use uv_workspace::pyproject::{Sources, ToolUvSources};
 use uv_workspace::{DiscoveryOptions, ProjectWorkspace};
+
+use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
+use crate::Metadata;
 
 #[derive(Debug, Clone)]
 pub struct RequiresDist {
@@ -164,7 +165,7 @@ impl RequiresDist {
                             let extra = None;
                             LoweredRequirement::from_requirement(
                                 requirement,
-                                &metadata.name,
+                                Some(&metadata.name),
                                 project_workspace.project_root(),
                                 project_sources,
                                 project_indexes,
@@ -209,7 +210,7 @@ impl RequiresDist {
                     let group = None;
                     LoweredRequirement::from_requirement(
                         requirement,
-                        &metadata.name,
+                        Some(&metadata.name),
                         project_workspace.project_root(),
                         project_sources,
                         project_indexes,

--- a/crates/uv-pypi-types/src/metadata/build_requires.rs
+++ b/crates/uv-pypi-types/src/metadata/build_requires.rs
@@ -8,6 +8,6 @@ use crate::VerbatimParsedUrl;
 /// See: <https://peps.python.org/pep-0518/>
 #[derive(Debug, Clone)]
 pub struct BuildRequires {
-    pub name: PackageName,
+    pub name: Option<PackageName>,
     pub requires_dist: Vec<Requirement<VerbatimParsedUrl>>,
 }

--- a/crates/uv-pypi-types/src/requirement.rs
+++ b/crates/uv-pypi-types/src/requirement.rs
@@ -86,6 +86,15 @@ impl Requirement {
         let fragment = url.fragment()?;
         Hashes::parse_fragment(fragment).ok()
     }
+
+    /// Set the source file containing the requirement.
+    #[must_use]
+    pub fn with_origin(self, origin: RequirementOrigin) -> Self {
+        Self {
+            origin: Some(origin),
+            ..self
+        }
+    }
 }
 
 impl From<Requirement> for uv_pep508::Requirement<VerbatimUrl> {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -197,6 +197,9 @@ pub(crate) enum ProjectError {
     Requirements(#[from] uv_requirements::Error),
 
     #[error(transparent)]
+    Metadata(#[from] uv_distribution::MetadataError),
+
+    #[error(transparent)]
     PyprojectMut(#[from] uv_workspace::pyproject_mut::Error),
 
     #[error(transparent)]

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -1999,7 +1999,7 @@ fn sync_group_legacy_non_project_member() -> Result<()> {
             "child",
         ]
         requirements = [
-            { name = "child" },
+            { name = "child", editable = "child" },
             { name = "typing-extensions", specifier = ">=4" },
         ]
 


### PR DESCRIPTION
## Summary

We still only respect overrides and constraints in the workspace root -- which we may want to change -- but overrides and constraints are now correctly lowered.

Closes https://github.com/astral-sh/uv/issues/8148.
