### PR TITLE
Avoid filtering Python executables names during install tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -219,7 +219,8 @@ impl TestContext {
     pub fn with_filtered_python_keys(mut self) -> Self {
         // Filter platform keys
         self.filters.push((
-            r"((?:cpython|pypy)-\d+\.\d+(?:\.(?:\[X\]|\d+))?[a-z]?(?:\+[a-z]+)?)-.*".to_string(),
+            r"((?:cpython|pypy)-\d+\.\d+(?:\.(?:\[X\]|\d+))?[a-z]?(?:\+[a-z]+)?)-[a-z0-9]+-[a-z0-9_]+-[a-z]+"
+                .to_string(),
             "$1-[PLATFORM]".to_string(),
         ));
         self


### PR DESCRIPTION
These were erroneously being filtered, interfering with the snapshots in #8650 