### PR TITLE
Escape path in batch script

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -291,6 +291,8 @@ pub(crate) fn create(
                 r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#.to_string()
             }
             (true, "activate.bat") => r"%~dp0..".to_string(),
+            // https://stackoverflow.com/a/562080/3549270
+            (false, "activate.bat") => location.simplified().to_str().unwrap().replace('"', "\"\""),
             (true, "activate.fish") => {
                 r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#.to_string()
             }


### PR DESCRIPTION
## Summary

In the batch activator script, we need to escape double quotes with an additional double quote (https://stackoverflow.com/a/562080/3549270).

See #9424.

## Test Plan

Unclear.