### PR TITLE
Fix `--refresh-package` flag mentioned as `--refresh-dependency`

### DIFF
--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -21,7 +21,7 @@ If you're running into caching issues, uv includes a few escape hatches:
 
 - To force uv to revalidate cached data for all dependencies, pass `--refresh` to any command (e.g.,
   `uv sync --refresh` or `uv pip install --refresh ...`).
-- To force uv to revalidate cached data for a specific dependency pass `--refresh-dependency` to any
+- To force uv to revalidate cached data for a specific dependency pass `--refresh-package` to any
   command (e.g., `uv sync --refresh-package flask` or `uv pip install --refresh-package flask ...`).
 - To force uv to ignore existing installed versions, pass `--reinstall` to any installation command
   (e.g., `uv sync --reinstall` or `uv pip install --reinstall ...`).


### PR DESCRIPTION
## Summary

This PR fixes name of `--refresh-package` flag in cache docs. It's misspelled as `--refresh-dependency`.

## Test Plan

Deployed docs locally.