### PR TITLE
Improve message when updater receipt is for a different uv executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,8 +277,7 @@ dependencies = [
 [[package]]
 name = "axoupdater"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb8d8889305a413a040f281197bb2f8982a1d25c9696707cab350e3cc780ba5"
+source = "git+https://github.com/axodotdev/axoupdater?rev=9c43536f34df2b1a588ef5249222902d884d5ad2#9c43536f34df2b1a588ef5249222902d884d5ad2"
 dependencies = [
  "axoasset",
  "axoprocess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,8 +276,9 @@ dependencies = [
 
 [[package]]
 name = "axoupdater"
-version = "0.8.1"
-source = "git+https://github.com/axodotdev/axoupdater?rev=9c43536f34df2b1a588ef5249222902d884d5ad2#9c43536f34df2b1a588ef5249222902d884d5ad2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70b7d3a9ea86ef8d17dada23f2c42518ed4b75dd6a8ff761f8988b448db8454"
 dependencies = [
  "axoasset",
  "axoprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zs
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.9.1" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
-axoupdater = { git = "https://github.com/axodotdev/axoupdater", rev = "9c43536f34df2b1a588ef5249222902d884d5ad2", default-features = false }
+axoupdater = { version = "0.8.2", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.1" }
 bitflags = { version = "2.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zs
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.9.1" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
-axoupdater = { version = "0.8.0", default-features = false }
+axoupdater = { git = "https://github.com/axodotdev/axoupdater", rev = "9c43536f34df2b1a588ef5249222902d884d5ad2", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.1" }
 bitflags = { version = "2.6.0" }

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -6,6 +6,7 @@ use owo_colors::OwoColorize;
 use tracing::debug;
 
 use uv_client::WrappedReqwestError;
+use uv_fs::Simplified;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -48,9 +49,9 @@ pub(crate) async fn self_update(
     // uv binaries installed, and the current binary was _not_ installed via the standalone
     // installation scripts.
     if !updater.check_receipt_is_for_this_executable()? {
-        debug!(
-            "receipt is not for this executable; assuming uv was installed via a package manager"
-        );
+        let current_exe = std::env::current_exe()?;
+        let receipt_prefix = updater.install_prefix_root()?;
+
         writeln!(
             printer.stderr(),
             "{}",
@@ -59,10 +60,12 @@ pub(crate) async fn self_update(
                     "{}{} Self-update is only available for uv binaries installed via the standalone installation scripts.",
                     "\n",
                     "\n",
-                    "If you installed uv with pip, brew, or another package manager, update uv with `pip install --upgrade`, `brew upgrade`, or similar."
+                    "The current executable is at `{}` but the standalone installer was used to install uv to `{}`. Are multiple copies of uv installed?"
                 ),
                 "warning".yellow().bold(),
-                ":".bold()
+                ":".bold(),
+                current_exe.simplified_display().bold().cyan(),
+                receipt_prefix.simplified_display().bold().cyan()
             )
         )?;
         return Ok(ExitStatus::Error);


### PR DESCRIPTION
Attempts to improve confusing messaging in cases like https://github.com/astral-sh/uv/issues/6774#issuecomment-2504950681, when the receipt is for a different uv executable. 

```
❯ cargo run --all-features -q -- self update
warning: Self-update is only available for uv binaries installed via the standalone installation scripts.

The current executable is at `/Users/zb/workspace/uv/target/debug/uv` but the standalone installer was used to install uv to `/Users/zb/.cargo`. Are multiple copies of uv installed?
```

Requires https://github.com/axodotdev/axoupdater/pull/221
Closes https://github.com/astral-sh/uv/issues/6774