### PR TITLE
Supplement missing separators for UV_INSTALL_DIR in Windows.

### DIFF
--- a/docs/configuration/installer.md
+++ b/docs/configuration/installer.md
@@ -17,7 +17,7 @@ To change the installation path, use `UV_INSTALL_DIR`:
 === "Windows"
 
     ```powershell
-    $env:UV_INSTALL_DIR = "C:\Custom\Path"; powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    powershell -ExecutionPolicy ByPass -c {$env:UV_INSTALL_DIR = "C:\Custom\Path";irm https://astral.sh/uv/install.ps1 | iex}
     ```
 
 ## Disabling shell modifications

--- a/docs/configuration/installer.md
+++ b/docs/configuration/installer.md
@@ -17,7 +17,7 @@ To change the installation path, use `UV_INSTALL_DIR`:
 === "Windows"
 
     ```powershell
-    $env:UV_INSTALL_DIR = "C:\Custom\Path" powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    $env:UV_INSTALL_DIR = "C:\Custom\Path"; powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
 
 ## Disabling shell modifications


### PR DESCRIPTION
## Summary
Ensure proper separation between instructions.
fix #9503 
## Test Plan
Both Windows Powershell (v5) and powershell 7 are available
![image](https://github.com/user-attachments/assets/9a73ea6f-8bee-49a1-b6d4-050317176cd6)



<!-- How was it tested? -->
