### PR TITLE
Make pip install snapshot independent of settings fields

### DIFF
--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -178,7 +178,13 @@ fn invalid_pyproject_toml_option_unknown_field() -> Result<()> {
         unknown = "field"
     "#})?;
 
-    uv_snapshot!(context.pip_install()
+    let mut filters = context.filters();
+    filters.push((
+        "expected one of `native-tls`, `offline`, .*",
+        "expected one of `native-tls`, `offline`, [...]",
+    ));
+
+    uv_snapshot!(filters, context.pip_install()
         .arg("-r")
         .arg("pyproject.toml"), @r###"
     success: true
@@ -191,7 +197,7 @@ fn invalid_pyproject_toml_option_unknown_field() -> Result<()> {
         |
       2 | unknown = "field"
         | ^^^^^^^
-      unknown field `unknown`, expected one of `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `allow-insecure-host`, `resolution`, `prerelease`, `dependency-metadata`, `config-settings`, `no-build-isolation`, `no-build-isolation-package`, `exclude-newer`, `link-mode`, `compile-bytecode`, `no-sources`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `python-install-mirror`, `pypy-install-mirror`, `publish-url`, `trusted-publishing`, `pip`, `cache-keys`, `override-dependencies`, `constraint-dependencies`, `environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dev-dependencies`, `source-dist`, `wheel`
+      unknown field `unknown`, expected one of `native-tls`, `offline`, [...]
 
     Resolved in [TIME]
     Audited in [TIME]


### PR DESCRIPTION
When changing something about the settings, `invalid_pyproject_toml_option_unknown_field` would fail unexpectedly because the exact list of possible options had changed. Since we're already testing this list in the settings-related test `resolve_config_file`, i'm stubbing the exact output here.