### PR TITLE
Align tempfile workspace dependencies with root project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ syn = { version = "2.0.77" }
 sys-info = { version = "0.9.1" }
 tar = { version = "0.4.43" }
 target-lexicon = { version = "0.12.16" }
-tempfile = { version = "3.12.0" }
+tempfile = { version = "3.14.0" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "2.0.0" }
 tl = { git = "https://github.com/astral-sh/tl.git", rev = "6e25b2ee2513d75385101a8ff9f591ef51f314ec" }

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -44,4 +44,4 @@ workspace = true
 [dev-dependencies]
 indoc = { version = "2.0.5" }
 insta = { version = "1.40.0", features = ["filters"] }
-tempfile = { version = "3.12.0" }
+tempfile = { workspace = true }

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -21,7 +21,7 @@ walkdir = { workspace = true }
 [dev-dependencies]
 fs-err = { workspace = true }
 insta = "1.41.1"
-tempfile = "3.14.0"
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -74,5 +74,5 @@ assert_fs = { version = "1.1.2" }
 indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
 temp-env = { version = "0.3.6" }
-tempfile = { version = "3.12.0" }
+tempfile = { workspace = true }
 test-log = { version = "0.2.16", features = ["trace"], default-features = false }

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -42,6 +42,6 @@ assert_fs = { version = "1.1.2" }
 indoc = { version = "2.0.5" }
 insta = { version = "1.40.0", features = ["filters"] }
 itertools = { version = "0.13.0" }
-tempfile = { version = "3.12.0" }
+tempfile = { workspace = true }
 test-case = { version = "3.3.1" }
 tokio = { version = "1.40.0" }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
While working on potential bug fixes with temporary files on Windows (I think I am currently ecountering the same issue as #2810)
I noticed that sub-workspaces were not all having the same `tempfile` version. And they were not relying on the cargo root project dependency. I don't know at all if it was done on purpose or not.
(I also wanted to override the root dependency with a local source but it was not possible due to sub-workspaces not relying on the same).

The root lockfile already pinned to the `3.14.0`. Some sub-workspaces were depending on the `3.12.0`, some others on the `3.14.0`. So I updated the root `Cargo.toml` to the `3.14.0`.

Feel free to decline if it was done on purpose! No worries at all :slightly_smiling_face: 

Thanks!

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
All units tests are still passing on my side. Let's see with the pull-request CI :smile: 
