### PR TITLE
Pass extra when evaluating lockfile markers

### DIFF
--- a/crates/uv-resolver/src/lock/target.rs
+++ b/crates/uv-resolver/src/lock/target.rs
@@ -3,7 +3,7 @@ use petgraph::Graph;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, VecDeque};
-
+use std::slice;
 use uv_configuration::{BuildOptions, DevGroupsManifest, ExtrasSpecification, InstallOptions};
 use uv_distribution_types::{Edge, Node, Resolution, ResolvedDist};
 use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
@@ -359,7 +359,10 @@ impl<'env> InstallTarget<'env> {
                 Either::Right(package.dependencies.iter())
             };
             for dep in deps {
-                if !dep.complexified_marker.evaluate(marker_env, &[]) {
+                if !dep
+                    .complexified_marker
+                    .evaluate(marker_env, extra.map(slice::from_ref).unwrap_or_default())
+                {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

When we serialize and deserialize the lockfile, we remove the conflict markers. So in the linked case, the edges for the `tqdm` entries are like:

```
complexified_marker: UniversalMarker {
    pep508_marker: python_full_version >= '3.9.0',
    conflict_marker: true,
},
```

However... when we evaluate in-memory, the conflict markers are still there...

```
complexified_marker: UniversalMarker {
    pep508_marker: true,
    conflict_marker: extra == 't1' and extra != 't2',
},
```

So if `uv run` creates the lockfile, we evaluate this as `false`.

We should make this consistent, and I expect @BurntSushi is aware. But for now, it's reasonable / correct to pass the extra when evaluating at this specific point, since we know the dependency was enabled by the marker.

Closes https://github.com/astral-sh/uv/issues/9533#issuecomment-2508908591.
