### PR TITLE
Build backend: Default excludes

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -304,7 +304,7 @@ pub fn build_wheel(
 ) -> Result<WheelFilename, Error> {
     let contents = fs_err::read_to_string(source_tree.join("pyproject.toml"))?;
     let pyproject_toml = PyProjectToml::parse(&contents)?;
-    pyproject_toml.check_build_system("1.0.0+test");
+    pyproject_toml.check_build_system(uv_version);
     let settings = pyproject_toml
         .settings()
         .cloned()
@@ -465,7 +465,7 @@ pub fn build_editable(
 ) -> Result<WheelFilename, Error> {
     let contents = fs_err::read_to_string(source_tree.join("pyproject.toml"))?;
     let pyproject_toml = PyProjectToml::parse(&contents)?;
-    pyproject_toml.check_build_system("1.0.0+test");
+    pyproject_toml.check_build_system(uv_version);
     let settings = pyproject_toml
         .settings()
         .cloned()

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -1,6 +1,6 @@
 mod metadata;
 
-use crate::metadata::{BuildBackendSettings, PyProjectToml, ValidationError};
+use crate::metadata::{BuildBackendSettings, PyProjectToml, ValidationError, DEFAULT_EXCLUDES};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use fs_err::File;
@@ -326,7 +326,16 @@ pub fn build_wheel(
     let mut wheel_writer = ZipDirectoryWriter::new_wheel(File::create(&wheel_path)?);
 
     // Wheel excludes
-    let mut excludes: Vec<String> = settings.wheel_exclude;
+    let mut excludes: Vec<String> = Vec::new();
+    if settings.default_excludes {
+        excludes.extend(DEFAULT_EXCLUDES.iter().map(ToString::to_string));
+    }
+    for exclude in settings.wheel_exclude {
+        // Avoid duplicate entries.
+        if !excludes.contains(&exclude) {
+            excludes.push(exclude);
+        }
+    }
     // The wheel must not include any files excluded by the source distribution (at least until we
     // have files generated in the source dist -> wheel build step).
     for exclude in settings.source_exclude {
@@ -693,7 +702,15 @@ pub fn build_source_dist(
         })?;
 
     let mut excludes: Vec<String> = Vec::new();
-    excludes.extend(settings.source_exclude);
+    if settings.default_excludes {
+        excludes.extend(DEFAULT_EXCLUDES.iter().map(ToString::to_string));
+    }
+    for exclude in settings.source_exclude {
+        // Avoid duplicate entries.
+        if !excludes.contains(&exclude) {
+            excludes.push(exclude);
+        }
+    }
     debug!("Source dist excludes: {:?}", excludes);
     let exclude_matcher = build_exclude_matcher(excludes)?;
     if exclude_matcher.is_match("pyproject.toml") {

--- a/scripts/packages/built-by-uv/pyproject.toml
+++ b/scripts/packages/built-by-uv/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE*", "third-party-licenses/*"]
 # A file we need for the source dist -> wheel step, but not in the wheel itself (currently unused)
 source-include = ["data/build-script.py"]
 # A temporary or generated file we want to ignore
-source-exclude = ["/src/built_by_uv/not-packaged.txt", "__pycache__", "*.pyc", "*.pyo"]
+source-exclude = ["/src/built_by_uv/not-packaged.txt"]
 # Headers are build-only
 wheel-exclude = ["build-*.h"]
 
@@ -21,5 +21,5 @@ data = "assets"
 headers = "header"
 
 [build-system]
-requires = ["uv>=0.4.15,<5"]
+requires = ["uv>=0.5,<0.6"]
 build-backend = "uv"


### PR DESCRIPTION
When adding excludes, we usually don't want to include python cache files. On the contrary, I haven't seen any project in my ecosystem research that would want any of `__pycache__`, `*.pyc`, `*.pyo` to be included. By moving them behind a `default-excludes` toggle, they are always active even when defining custom excludes, but can be deactivated if the user so chooses.

With includes and excludes being this small again, we can roll back the include-exclude anchored difference to always using anchored globs (i.e. you would need to use `**/build-*.h` below).

A pyproject.toml with custom settings with the change applied:

```toml
[project]
name = "foo"
version = "0.1.0"
readme = "README.md"
license-files = ["LICENSE*", "third-party-licenses/*"]

[tool.uv.build-backend]
# A file we need for the source dist -> wheel step, but not in the wheel itself (currently unused)
source-include = ["data/build-script.py"]
# A temporary or generated file we want to ignore
source-exclude = ["/src/foo/not-packaged.txt"]
# Headers are build-only
wheel-exclude = ["build-*.h"]

[tool.uv.build-backend.data]
scripts = "scripts"
data = "assets"
headers = "header"

[build-system]
requires = ["uv>=0.5.5,<0.6"]
build-backend = "uv"
```