### PR TITLE
Use `SharedState` for build dispatch

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -89,10 +89,9 @@ mod resolver {
         BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, LowerBound,
         SourceStrategy,
     };
-    use uv_dispatch::BuildDispatch;
+    use uv_dispatch::{BuildDispatch, SharedState};
     use uv_distribution::DistributionDatabase;
-    use uv_distribution_types::{DependencyMetadata, IndexCapabilities, IndexLocations};
-    use uv_git::GitResolver;
+    use uv_distribution_types::{DependencyMetadata, IndexLocations};
     use uv_install_wheel::linker::LinkMode;
     use uv_pep440::Version;
     use uv_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
@@ -103,7 +102,7 @@ mod resolver {
         FlatIndex, InMemoryIndex, Manifest, OptionsBuilder, PythonRequirement, RequiresPython,
         Resolver, ResolverEnvironment, ResolverOutput,
     };
-    use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
+    use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 
     static MARKERS: LazyLock<MarkerEnvironment> = LazyLock::new(|| {
         MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
@@ -152,11 +151,9 @@ mod resolver {
                 .into(),
         );
         let build_constraints = Constraints::default();
-        let capabilities = IndexCapabilities::default();
         let flat_index = FlatIndex::default();
-        let git = GitResolver::default();
         let hashes = HashStrategy::default();
-        let in_flight = InFlight::default();
+        let state = SharedState::default();
         let index = InMemoryIndex::default();
         let index_locations = IndexLocations::default();
         let installed_packages = EmptyInstalledPackages;
@@ -182,10 +179,7 @@ mod resolver {
             &index_locations,
             &flat_index,
             &dependency_metadata,
-            &index,
-            &git,
-            &capabilities,
-            &in_flight,
+            state,
             IndexStrategy::default(),
             &config_settings,
             build_isolation,

--- a/crates/uv-types/src/downloads.rs
+++ b/crates/uv-types/src/downloads.rs
@@ -1,8 +1,9 @@
+use std::sync::Arc;
 use uv_distribution_types::{CachedDist, DistributionId};
 use uv_once_map::OnceMap;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct InFlight {
     /// The in-flight distribution downloads.
-    pub downloads: OnceMap<DistributionId, Result<CachedDist, String>>,
+    pub downloads: Arc<OnceMap<DistributionId, Result<CachedDist, String>>>,
 }

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -18,7 +18,7 @@ use uv_configuration::{
     BuildKind, BuildOptions, BuildOutput, Concurrency, ConfigSettings, Constraints,
     HashCheckingMode, IndexStrategy, KeyringProviderType, LowerBound, SourceStrategy, TrustedHost,
 };
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_python::{
@@ -35,7 +35,7 @@ use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceError};
 use crate::commands::pip::operations;
 use crate::commands::project::find_requires_python;
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{ExitStatus, SharedState};
+use crate::commands::ExitStatus;
 use crate::printer::Printer;
 use crate::settings::{ResolverSettings, ResolverSettingsRef};
 
@@ -511,10 +511,7 @@ async fn build_package(
         index_locations,
         &flat_index,
         dependency_metadata,
-        &state.index,
-        &state.git,
-        &state.capabilities,
-        &state.in_flight,
+        state.clone(),
         index_strategy,
         config_setting,
         build_isolation,

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -47,14 +47,11 @@ pub(crate) use tool::uninstall::uninstall as tool_uninstall;
 pub(crate) use tool::update_shell::update_shell as tool_update_shell;
 pub(crate) use tool::upgrade::upgrade as tool_upgrade;
 use uv_cache::Cache;
-use uv_distribution_types::{IndexCapabilities, InstalledMetadata};
+use uv_distribution_types::InstalledMetadata;
 use uv_fs::Simplified;
-use uv_git::GitResolver;
 use uv_installer::compile_tree;
 use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
-use uv_resolver::InMemoryIndex;
-use uv_types::InFlight;
 pub(crate) use venv::venv;
 pub(crate) use version::version;
 
@@ -192,19 +189,6 @@ pub(super) fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
     let bytes = bytes as f32;
     let i = ((bytes.log2() / 10.0) as usize).min(UNITS.len() - 1);
     (bytes / 1024_f32.powi(i as i32), UNITS[i])
-}
-
-/// Shared state used during resolution and installation.
-#[derive(Default)]
-pub(crate) struct SharedState {
-    /// The resolved Git references.
-    pub(crate) git: GitResolver,
-    /// The fetched package versions and metadata.
-    pub(crate) index: InMemoryIndex,
-    /// The downloaded distributions.
-    pub(crate) in_flight: InFlight,
-    /// The discovered capabilities for each registry index.
-    pub(crate) capabilities: IndexCapabilities,
 }
 
 /// A multicasting writer that writes to both the standard output and an output file, if present.

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -14,13 +14,12 @@ use uv_configuration::{
     LowerBound, NoBinary, NoBuild, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{
-    DependencyMetadata, Index, IndexCapabilities, IndexLocations, NameRequirementSpecification,
+    DependencyMetadata, Index, IndexLocations, NameRequirementSpecification,
     Origin, UnresolvedRequirementSpecification, Verbatim,
 };
 use uv_fs::Simplified;
-use uv_git::GitResolver;
 use uv_install_wheel::linker::LinkMode;
 use uv_normalize::PackageName;
 use uv_pypi_types::{Conflicts, Requirement, SupportedEnvironments};
@@ -36,7 +35,7 @@ use uv_resolver::{
     InMemoryIndex, OptionsBuilder, PrereleaseMode, PythonRequirement, RequiresPython,
     ResolutionMode, ResolverEnvironment,
 };
-use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
+use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::warn_user;
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
@@ -222,8 +221,8 @@ pub(crate) async fn pip_compile(
         }
     }
 
-    // Create a shared in-memory index.
-    let source_index = InMemoryIndex::default();
+    // Create the shared state.
+    let state = SharedState::default();
 
     // If we're resolving against a different Python version, use a separate index. Source
     // distributions will be built against the installed version, and so the index may contain
@@ -231,7 +230,7 @@ pub(crate) async fn pip_compile(
     let top_level_index = if python_version.is_some() {
         InMemoryIndex::default()
     } else {
-        source_index.clone()
+        state.index().clone()
     };
 
     // Determine the Python requirement, if the user requested a specific version.
@@ -306,8 +305,6 @@ pub(crate) async fn pip_compile(
 
     // Read the lockfile, if present.
     let preferences = read_requirements_txt(output_file, &upgrade).await?;
-    let git = GitResolver::default();
-    let capabilities = IndexCapabilities::default();
 
     // Combine the `--no-binary` and `--no-build` flags from the requirements files.
     let build_options = build_options.combine(no_binary, no_build);
@@ -320,9 +317,6 @@ pub(crate) async fn pip_compile(
             .await?;
         FlatIndex::from_entries(entries, tags.as_deref(), &hasher, &build_options)
     };
-
-    // Track in-flight downloads, builds, etc., across resolutions.
-    let in_flight = InFlight::default();
 
     // Determine whether to enable build isolation.
     let environment;
@@ -352,10 +346,7 @@ pub(crate) async fn pip_compile(
         &index_locations,
         &flat_index,
         &dependency_metadata,
-        &source_index,
-        &git,
-        &capabilities,
-        &in_flight,
+        state,
         index_strategy,
         &config_settings,
         build_isolation,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -11,7 +11,7 @@ use uv_configuration::{
     IndexStrategy, LowerBound, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{
     DependencyMetadata, Index, IndexLocations, NameRequirementSpecification, Origin, Resolution,
     UnresolvedRequirementSpecification,
@@ -36,7 +36,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::operations::{report_interpreter, report_target_environment};
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
-use crate::commands::{diagnostics, ExitStatus, SharedState};
+use crate::commands::{diagnostics, ExitStatus};
 use crate::printer::Printer;
 
 /// Install packages into the current environment.
@@ -374,10 +374,7 @@ pub(crate) async fn pip_install(
         &index_locations,
         &flat_index,
         &dependency_metadata,
-        &state.index,
-        &state.git,
-        &state.capabilities,
-        &state.in_flight,
+        state.clone(),
         index_strategy,
         config_settings,
         build_isolation,
@@ -419,7 +416,7 @@ pub(crate) async fn pip_install(
         Conflicts::empty(),
         &client,
         &flat_index,
-        &state.index,
+        state.index(),
         &build_dispatch,
         concurrency,
         options,
@@ -450,7 +447,7 @@ pub(crate) async fn pip_install(
         &hasher,
         &tags,
         &client,
-        &state.in_flight,
+        state.in_flight(),
         concurrency,
         &build_dispatch,
         &cache,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -11,7 +11,7 @@ use uv_configuration::{
     IndexStrategy, LowerBound, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{DependencyMetadata, Index, IndexLocations, Origin, Resolution};
 use uv_fs::Simplified;
 use uv_install_wheel::linker::LinkMode;
@@ -33,7 +33,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::operations::{report_interpreter, report_target_environment};
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
-use crate::commands::{diagnostics, ExitStatus, SharedState};
+use crate::commands::{diagnostics, ExitStatus};
 use crate::printer::Printer;
 
 /// Install a set of locked requirements into the current Python environment.
@@ -317,10 +317,7 @@ pub(crate) async fn pip_sync(
         &index_locations,
         &flat_index,
         &dependency_metadata,
-        &state.index,
-        &state.git,
-        &state.capabilities,
-        &state.in_flight,
+        state.clone(),
         index_strategy,
         config_settings,
         build_isolation,
@@ -364,7 +361,7 @@ pub(crate) async fn pip_sync(
         Conflicts::empty(),
         &client,
         &flat_index,
-        &state.index,
+        state.index(),
         &build_dispatch,
         concurrency,
         options,
@@ -395,7 +392,7 @@ pub(crate) async fn pip_sync(
         &hasher,
         &tags,
         &client,
-        &state.in_flight,
+        state.in_flight(),
         concurrency,
         &build_dispatch,
         &cache,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -18,7 +18,7 @@ use uv_configuration::{
     ExtrasSpecification, GroupsSpecification, InstallOptions, LowerBound, SourceStrategy,
     TrustedHost,
 };
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{Index, IndexName, UnresolvedRequirement, VersionId};
 use uv_fs::Simplified;
@@ -50,7 +50,7 @@ use crate::commands::project::{
     ProjectInterpreter, ScriptPython,
 };
 use crate::commands::reporters::{PythonDownloadReporter, ResolverReporter};
-use crate::commands::{diagnostics, project, ExitStatus, SharedState};
+use crate::commands::{diagnostics, project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::{ResolverInstallerSettings, ResolverInstallerSettingsRef};
 
@@ -328,10 +328,7 @@ pub(crate) async fn add(
         &settings.index_locations,
         &flat_index,
         &settings.dependency_metadata,
-        &state.index,
-        &state.git,
-        &state.capabilities,
-        &state.in_flight,
+        state.clone(),
         settings.index_strategy,
         &settings.config_setting,
         build_isolation,
@@ -369,7 +366,7 @@ pub(crate) async fn add(
             requirements.extend(
                 NamedRequirementsResolver::new(
                     &hasher,
-                    &state.index,
+                    state.index(),
                     DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads),
                 )
                 .with_reporter(ResolverReporter::from(printer))
@@ -843,7 +840,7 @@ async fn lock_and_sync(
                 let url = Url::from_file_path(project.project_root())
                     .expect("project root is a valid URL");
                 let version_id = VersionId::from_url(&url);
-                let existing = state.index.distributions().remove(&version_id);
+                let existing = state.index().distributions().remove(&version_id);
                 debug_assert!(existing.is_some(), "distribution should exist");
             }
 

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -4,13 +4,13 @@ use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::project::{
     resolve_environment, sync_environment, EnvironmentSpecification, ProjectError,
 };
-use crate::commands::SharedState;
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::{cache_digest, hash_digest};
 use uv_client::Connectivity;
 use uv_configuration::{Concurrency, TrustedHost};
+use uv_dispatch::SharedState;
 use uv_distribution_types::{Name, Resolution};
 use uv_python::{Interpreter, PythonEnvironment};
 

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -12,6 +12,7 @@ use uv_configuration::{
     Concurrency, DevGroupsSpecification, EditableMode, ExportFormat, ExtrasSpecification,
     InstallOptions, LowerBound, TrustedHost,
 };
+use uv_dispatch::SharedState;
 use uv_normalize::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
 use uv_resolver::{InstallTarget, RequirementsTxtExport};
@@ -23,7 +24,7 @@ use crate::commands::project::{
     default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError,
     ProjectInterpreter,
 };
-use crate::commands::{diagnostics, ExitStatus, OutputWriter, SharedState};
+use crate::commands::{diagnostics, ExitStatus, OutputWriter};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -10,6 +10,7 @@ use uv_configuration::{
     Concurrency, DevGroupsManifest, EditableMode, ExtrasSpecification, InstallOptions, LowerBound,
     TrustedHost,
 };
+use uv_dispatch::SharedState;
 use uv_fs::Simplified;
 use uv_normalize::DEV_DEPENDENCIES;
 use uv_pep508::PackageName;
@@ -25,7 +26,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::lock::LockMode;
 use crate::commands::project::{default_dependency_groups, ProjectError};
-use crate::commands::{diagnostics, project, ExitStatus, SharedState};
+use crate::commands::{diagnostics, project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -20,6 +20,7 @@ use uv_configuration::{
     Concurrency, DevGroupsSpecification, EditableMode, ExtrasSpecification, GroupsSpecification,
     InstallOptions, LowerBound, SourceStrategy, TrustedHost,
 };
+use uv_dispatch::SharedState;
 use uv_distribution::LoweredRequirement;
 use uv_fs::which::is_executable;
 use uv_fs::{PythonExt, Simplified};
@@ -48,7 +49,7 @@ use crate::commands::project::{
     DependencyGroupsTarget, EnvironmentSpecification, ProjectError, ScriptPython, WorkspacePython,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{diagnostics, project, ExitStatus, SharedState};
+use crate::commands::{diagnostics, project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -12,7 +12,7 @@ use uv_configuration::{
     Concurrency, Constraints, DevGroupsManifest, DevGroupsSpecification, EditableMode,
     ExtrasSpecification, HashCheckingMode, InstallOptions, LowerBound, TrustedHost,
 };
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{
     DirectorySourceDist, Dist, Index, Resolution, ResolvedDist, SourceDist,
 };
@@ -35,7 +35,7 @@ use crate::commands::pip::operations;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::{
-    default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError, SharedState,
+    default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError,
 };
 use crate::commands::{diagnostics, project, ExitStatus};
 use crate::printer::Printer;
@@ -411,10 +411,7 @@ pub(super) async fn do_sync(
         index_locations,
         &flat_index,
         dependency_metadata,
-        &state.index,
-        &state.git,
-        &state.capabilities,
-        &state.in_flight,
+        state.clone(),
         index_strategy,
         config_setting,
         build_isolation,
@@ -443,7 +440,7 @@ pub(super) async fn do_sync(
         &hasher,
         tags,
         &client,
-        &state.in_flight,
+        state.in_flight(),
         concurrency,
         &build_dispatch,
         cache,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -10,6 +10,7 @@ use uv_client::{Connectivity, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, DevGroupsSpecification, LowerBound, TargetTriple, TrustedHost,
 };
+use uv_dispatch::SharedState;
 use uv_distribution_types::IndexCapabilities;
 use uv_pep508::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
@@ -25,7 +26,7 @@ use crate::commands::project::{
     default_dependency_groups, DependencyGroupsTarget, ProjectError, ProjectInterpreter,
 };
 use crate::commands::reporters::LatestVersionReporter;
-use crate::commands::{diagnostics, ExitStatus, SharedState};
+use crate::commands::{diagnostics, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -8,6 +8,7 @@ use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{Concurrency, Reinstall, TrustedHost, Upgrade};
+use uv_dispatch::SharedState;
 use uv_distribution_types::UnresolvedRequirementSpecification;
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
@@ -29,10 +30,10 @@ use crate::commands::project::{
 };
 use crate::commands::tool::common::remove_entrypoints;
 use crate::commands::tool::Target;
+use crate::commands::ExitStatus;
 use crate::commands::{
     diagnostics, reporters::PythonDownloadReporter, tool::common::install_executables,
 };
-use crate::commands::{ExitStatus, SharedState};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -15,6 +15,7 @@ use uv_cache_info::Timestamp;
 use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{Concurrency, TrustedHost};
+use uv_dispatch::SharedState;
 use uv_distribution_types::{Name, UnresolvedRequirementSpecification};
 use uv_installer::{SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
@@ -37,10 +38,10 @@ use crate::commands::pip::loggers::{
 use crate::commands::project::{resolve_names, EnvironmentSpecification, ProjectError};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::Target;
+use crate::commands::ExitStatus;
 use crate::commands::{
     diagnostics, project::environment::CachedEnvironment, tool::common::matching_packages,
 };
-use crate::commands::{ExitStatus, SharedState};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{Concurrency, TrustedHost};
+use uv_dispatch::SharedState;
 use uv_fs::CWD;
 use uv_normalize::PackageName;
 use uv_pypi_types::Requirement;
@@ -27,7 +28,7 @@ use crate::commands::project::{
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::common::remove_entrypoints;
-use crate::commands::{conjunction, tool::common::install_executables, ExitStatus, SharedState};
+use crate::commands::{conjunction, tool::common::install_executables, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -15,7 +15,7 @@ use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, KeyringProviderType,
     LowerBound, NoBinary, NoBuild, SourceStrategy, TrustedHost,
 };
-use uv_dispatch::BuildDispatch;
+use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{DependencyMetadata, Index, IndexLocations};
 use uv_fs::Simplified;
 use uv_install_wheel::linker::LinkMode;
@@ -34,7 +34,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::{report_interpreter, Changelog};
 use crate::commands::project::{validate_requires_python, WorkspacePython};
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{ExitStatus, SharedState};
+use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Create a virtual environment.
@@ -322,10 +322,7 @@ async fn venv_impl(
             index_locations,
             &flat_index,
             &dependency_metadata,
-            &state.index,
-            &state.git,
-            &state.capabilities,
-            &state.in_flight,
+            state.clone(),
             index_strategy,
             &config_settings,
             BuildIsolation::Isolated,


### PR DESCRIPTION
When looking at the build frontend code, I noticed that we always pass every single field of the shared state to the build dispatch:

```rust
    let build_dispatch = BuildDispatch::new(
        ...
        &state.index,
        &state.git,
        &state.capabilities,
        &state.in_flight,
        ...
    );
```

We can abstract this by moving `SharedState` into the build dispatch. The `BuildDispatch` then has only immutable fields and the `SharedState`. Since the `SharedState` is all `Arc`s, we can clone it freely.
