### PR TITLE
re-enable conflicting extra/group tests and fix regression from #9540

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1272,7 +1272,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 requirements
                     .iter()
                     .flat_map(|requirement| {
-                        PubGrubDependency::from_requirement(requirement, None, None)
+                        PubGrubDependency::from_requirement(
+                            &self.conflicts,
+                            requirement,
+                            None,
+                            None,
+                        )
                     })
                     .collect()
             }
@@ -1460,7 +1465,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 let mut dependencies: Vec<_> = requirements
                     .iter()
                     .flat_map(|requirement| {
-                        PubGrubDependency::from_requirement(requirement, dev.as_ref(), Some(name))
+                        PubGrubDependency::from_requirement(
+                            &self.conflicts,
+                            requirement,
+                            dev.as_ref(),
+                            Some(name),
+                        )
                     })
                     .collect();
 

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -1,16 +1,8 @@
 use anyhow::Result;
-use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
-use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
-use std::io::BufReader;
-use url::Url;
 
-use crate::common::{
-    self, build_vendor_links_url, decode_token, download_to_disk, packse_index_url, uv_snapshot,
-    venv_bin_path, TestContext,
-};
-use uv_fs::Simplified;
+use crate::common::{uv_snapshot, TestContext};
 use uv_static::EnvVars;
 
 // All of the tests in this file should use `tool.uv.conflicts` in some way.
@@ -777,7 +769,7 @@ fn extra_multiple_independent() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because project[extra2] depends on sortedcontainers==2.4.0 and project[extra1] depends on sortedcontainers==2.3.0, we can conclude that project[extra1] and project[extra2] are incompatible.
+      ╰─▶ Because project[extra1] depends on sortedcontainers==2.3.0 and project[extra2] depends on sortedcontainers==2.4.0, we can conclude that project[extra1] and project[extra2] are incompatible.
           And because your project requires project[extra1] and project[extra2], we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
@@ -1330,7 +1322,7 @@ fn extra_nested_across_workspace() -> Result<()> {
       ╰─▶ Because dummy[extra2] depends on proxy1[extra2] and only proxy1[extra2]==0.1.0 is available, we can conclude that dummy[extra2] depends on proxy1[extra2]==0.1.0. (1)
 
           Because proxy1[extra1]==0.1.0 depends on anyio==4.1.0 and proxy1[extra2]==0.1.0 depends on anyio==4.2.0, we can conclude that proxy1[extra1]==0.1.0 and proxy1[extra2]==0.1.0 are incompatible.
-          And because we know from (1) that dummy[extra2] depends on proxy1[extra2]==0.1.0, we can conclude that dummy[extra2] and proxy1[extra1]==0.1.0 are incompatible.
+          And because we know from (1) that dummy[extra2] depends on proxy1[extra2]==0.1.0, we can conclude that proxy1[extra1]==0.1.0 and dummy[extra2] are incompatible.
           And because only proxy1[extra1]==0.1.0 is available and dummysub[extra1] depends on proxy1[extra1], we can conclude that dummysub[extra1] and dummy[extra2] are incompatible.
           And because your workspace requires dummy[extra2] and dummysub[extra1], we can conclude that your workspace's requirements are unsatisfiable.
     "###);
@@ -1845,8 +1837,8 @@ fn mixed() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because project:group1 depends on sortedcontainers==2.3.0 and project[extra1] depends on sortedcontainers==2.4.0, we can conclude that project[extra1] and project:group1 are incompatible.
-          And because your project depends on project:group1 and your project requires project[extra1], we can conclude that your projects's requirements are unsatisfiable.
+      ╰─▶ Because project:group1 depends on sortedcontainers==2.3.0 and your project depends on project:group1, we can conclude that your project depends on sortedcontainers==2.3.0.
+          And because project[extra1] depends on sortedcontainers==2.4.0 and your project requires project[extra1], we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
     // And now with the same extra/group configuration, we tell uv

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -34,6 +34,9 @@ mod init;
 #[cfg(all(feature = "python", feature = "pypi"))]
 mod lock;
 
+#[cfg(all(feature = "python", feature = "pypi"))]
+mod lock_conflict;
+
 mod lock_scenarios;
 
 mod pip_check;


### PR DESCRIPTION
It turns out that #9540 _did_ regress some existing tests, but it went
unnoticed because of a gaffe by myself: #9474 moved the conflicting
extra/group tests, but never enabled them!

This PR re-enables them, updates the snapshots and fixes the regression
from #9540. The commit messages give more detail.
