### PR TITLE
Include base installation directory in uv run PATH

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1017,6 +1017,15 @@ pub(crate) async fn run(
             .map(PythonEnvironment::scripts)
             .into_iter()
             .chain(std::iter::once(base_interpreter.scripts()))
+            .chain(
+                // On Windows, non-virtual Python distributions put `python.exe` in the top-level
+                // directory, rather than in the `Scripts` subdirectory.
+                cfg!(windows)
+                    .then(|| base_interpreter.sys_executable().parent())
+                    .flatten()
+                    .into_iter(),
+            )
+            .dedup()
             .map(PathBuf::from)
             .chain(
                 std::env::var_os(EnvVars::PATH)


### PR DESCRIPTION
## Summary

On Windows, non-virtual environments put the `python.exe` in the top-level of the installation directory, rather than in `Scripts`. This PR adds those paths to `PATH` in `uv run` and `uv tool run`.

Closes https://github.com/astral-sh/uv/issues/9574#issuecomment-2512217110.
