### PR TITLE
Normalize paths when lowering Git dependencies

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -315,11 +315,12 @@ impl LoweredRequirement {
                             })?;
 
                             let source = if let Some(git_member) = &git_member {
-                                // If the workspace comes from a git dependency, all workspace
-                                // members need to be git deps, too.
-                                let subdirectory =
-                                    uv_fs::relative_to(member.root(), git_member.fetch_root)
-                                        .expect("Workspace member must be relative");
+                                // If the workspace comes from a Git dependency, all workspace
+                                // members need to be Git dependencies, too.
+                                let subdirectory = uv_fs::normalize_path(
+                                    &uv_fs::relative_to(member.root(), git_member.fetch_root)
+                                        .expect("Workspace member must be relative"),
+                                );
                                 RequirementSource::Git {
                                     repository: git_member.git_source.git.repository().clone(),
                                     reference: git_member.git_source.git.reference().clone(),

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -191,11 +191,14 @@ impl Urls {
 fn same_resource(a: &ParsedUrl, b: &ParsedUrl, git: &GitResolver) -> bool {
     match (a, b) {
         (ParsedUrl::Archive(a), ParsedUrl::Archive(b)) => {
-            a.subdirectory == b.subdirectory
+            a.subdirectory.as_deref().map(uv_fs::normalize_path)
+                == b.subdirectory.as_deref().map(uv_fs::normalize_path)
                 && CanonicalUrl::new(&a.url) == CanonicalUrl::new(&b.url)
         }
         (ParsedUrl::Git(a), ParsedUrl::Git(b)) => {
-            a.subdirectory == b.subdirectory && git.same_ref(&a.url, &b.url)
+            a.subdirectory.as_deref().map(uv_fs::normalize_path)
+                == b.subdirectory.as_deref().map(uv_fs::normalize_path)
+                && git.same_ref(&a.url, &b.url)
         }
         (ParsedUrl::Path(a), ParsedUrl::Path(b)) => {
             a.install_path == b.install_path


### PR DESCRIPTION
## Summary

Discovered while working on https://github.com/astral-sh/uv/issues/9516. In the linked repo, the root uses a `../dependency` path for the workspace member, which we weren't normalizing.
