### PR TITLE
Build backend: Add functions to collect file list

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -77,6 +77,8 @@ pub enum Error {
 /// error case).
 trait DirectoryWriter {
     /// Add a file with the given content.
+    ///
+    /// Files added through the method are considered generated when listing included files.
     fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error>;
 
     /// Add a local file.


### PR DESCRIPTION
Using the directory writer trait, we can collect the files instead of writing them to a real sink. This builds up to a `uv build --list` similar to `cargo package --list`. It is not connected to the cli yet.