### PR TITLE
Build backend: Add function to list source dist files only

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -77,6 +77,8 @@ pub enum Error {
 /// error case).
 trait DirectoryWriter {
     /// Add a file with the given content.
+    ///
+    /// Files added through the method are considered generated when listing included files.
     fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error>;
 
     /// Add a local file.


### PR DESCRIPTION
Add the backend implementation for `uv build --list` without wiring it up to the CLI. We're using the directory writer to capture which file would be added to the archive, without actually adding them. This does not yet add the CLI part.