### PR TITLE
Improve build frontend error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
  "url",
  "uv-auth",
  "uv-build-backend",
+ "uv-build-frontend",
  "uv-cache",
  "uv-cache-info",
  "uv-cache-key",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 uv-auth = { workspace = true }
 uv-build-backend = { workspace = true }
+uv-build-frontend = { workspace = true }
 uv-cache = { workspace = true }
 uv-cache-info = { workspace = true }
 uv-cache-key = { workspace = true }


### PR DESCRIPTION
Move the error handling for `build_package` into an enum, to avoid `bail!` and duplicated `.context()` calls.
