### PR TITLE
uv build: Catch version mismatch between sdist and wheel 

### DIFF
--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -6,7 +6,7 @@ use uv_pep440::Version;
 pub use build_tag::{BuildTag, BuildTagError};
 pub use egg::{EggInfoFilename, EggInfoFilenameError};
 pub use extension::{DistExtension, ExtensionError, SourceDistExtension};
-pub use source_dist::SourceDistFilename;
+pub use source_dist::{SourceDistFilename, SourceDistFilenameError};
 pub use wheel::{WheelFilename, WheelFilenameError};
 
 mod build_tag;

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -1,5 +1,6 @@
 use crate::common::{uv_snapshot, TestContext};
 use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use fs_err::File;
 use indoc::indoc;
@@ -2325,6 +2326,40 @@ fn list_files_errors() -> Result<()> {
     ----- stderr -----
       × Failed to build `[WORKSPACE]/scripts/packages/anyio_local`
       ╰─▶ Can only use `--list` with the uv backend
+    "###);
+    Ok(())
+}
+
+#[test]
+fn version_mismatch() -> Result<()> {
+    let context = TestContext::new("3.12");
+    let anyio_local = current_dir()?.join("../../scripts/packages/anyio_local");
+    context
+        .build()
+        .arg("--sdist")
+        .arg("--out-dir")
+        .arg(context.temp_dir.path())
+        .arg(anyio_local)
+        .assert()
+        .success();
+    let wrong_source_dist = context.temp_dir.child("anyio-1.2.3.tar.gz");
+    fs_err::rename(
+        context.temp_dir.child("anyio-4.3.0+foo.tar.gz"),
+        &wrong_source_dist,
+    )?;
+    uv_snapshot!(context.filters(), context.build()
+        .arg(wrong_source_dist.path())
+        .arg("--wheel")
+        .arg("--out-dir")
+        .arg(context.temp_dir.path()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel from source distribution...
+      × Failed to build `[TEMP_DIR]/anyio-1.2.3.tar.gz`
+      ╰─▶ The source distribution declares version 1.2.3, but the wheel declares version 4.3.0+foo
     "###);
     Ok(())
 }


### PR DESCRIPTION
When building a wheel from a source distribution or both a source distribution and a wheel, the versions in their filenames must be the same.

By inspecting the filenames, we also assert that the filenames from the build a valid (we don't enforce normalization though, just that uv can parse them).

Note that we're not yet checking that also the `pyproject.toml` version, if declared, and METADATA version matches.