### PR TITLE
Build backend: Add integration test for scripts

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -319,6 +319,7 @@ mod tests {
         built_by_uv-0.1.0/src/built_by_uv/arithmetic/circle.py
         built_by_uv-0.1.0/src/built_by_uv/arithmetic/pi.txt
         built_by_uv-0.1.0/src/built_by_uv/build-only.h
+        built_by_uv-0.1.0/src/built_by_uv/cli.py
         built_by_uv-0.1.0/third-party-licenses
         built_by_uv-0.1.0/third-party-licenses/PEP-401.txt
         "###);
@@ -336,6 +337,7 @@ mod tests {
         built_by_uv-0.1.0/src/built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
         built_by_uv-0.1.0/src/built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
         built_by_uv-0.1.0/src/built_by_uv/build-only.h (src/built_by_uv/build-only.h)
+        built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
         built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
         "###);
 
@@ -350,6 +352,7 @@ mod tests {
         built_by_uv-0.1.0.dist-info/METADATA
         built_by_uv-0.1.0.dist-info/RECORD
         built_by_uv-0.1.0.dist-info/WHEEL
+        built_by_uv-0.1.0.dist-info/entry_points.txt
         built_by_uv-0.1.0.dist-info/licenses/
         built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE
         built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT
@@ -361,6 +364,7 @@ mod tests {
         built_by_uv/arithmetic/__init__.py
         built_by_uv/arithmetic/circle.py
         built_by_uv/arithmetic/pi.txt
+        built_by_uv/cli.py
         "###);
 
         assert_snapshot!(format_file_list(wheel_list_files), @r###"
@@ -369,6 +373,7 @@ mod tests {
         built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
         built_by_uv-0.1.0.dist-info/METADATA (generated)
         built_by_uv-0.1.0.dist-info/WHEEL (generated)
+        built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
         built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
         built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
         built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
@@ -376,6 +381,7 @@ mod tests {
         built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
         built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
         built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
+        built_by_uv/cli.py (src/built_by_uv/cli.py)
         "###);
 
         // Check that we write deterministic wheels.

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -784,12 +784,13 @@ mod test {
             .filter(|path| !path.is_empty())
             .collect();
         files.sort();
-        assert_snapshot!(files.join("\n"), @r"
+        assert_snapshot!(files.join("\n"), @r###"
         built_by_uv-0.1.0.dist-info
         built_by_uv-0.1.0.dist-info/METADATA
         built_by_uv-0.1.0.dist-info/RECORD
         built_by_uv-0.1.0.dist-info/WHEEL
-        ");
+        built_by_uv-0.1.0.dist-info/entry_points.txt
+        "###);
 
         let metadata_file = metadata_dir
             .path()
@@ -816,6 +817,7 @@ mod test {
             .join("built_by_uv-0.1.0.dist-info/RECORD");
         assert_snapshot!(fs_err::read_to_string(record_file).unwrap(), @r###"
         built_by_uv-0.1.0.dist-info/WHEEL,sha256=3da1bfa0e8fd1b6cc246aa0b2b44a35815596c600cb485c39a6f8c106c3d5a8d,83
+        built_by_uv-0.1.0.dist-info/entry_points.txt,sha256=f883bac9aabac7a1d297ecd61fdeab666818bdfc87947d342f9590a02a73f982,50
         built_by_uv-0.1.0.dist-info/METADATA,sha256=9ba12456f2ab1a6ab1e376ff551e392c70f7ec86713d80b4348e90c7dfd45cb1,474
         built_by_uv-0.1.0.dist-info/RECORD,,
         "###);

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2192,6 +2192,7 @@ fn list_files() -> Result<()> {
     built_by_uv-0.1.0/src/built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv-0.1.0/src/built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
     built_by_uv-0.1.0/src/built_by_uv/build-only.h (src/built_by_uv/build-only.h)
+    built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
     built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     Building built_by_uv-0.1.0-py3-none-any.whl will include the following files:
     built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
@@ -2199,6 +2200,7 @@ fn list_files() -> Result<()> {
     built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
     built_by_uv-0.1.0.dist-info/METADATA (generated)
     built_by_uv-0.1.0.dist-info/WHEEL (generated)
+    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
     built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
     built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
     built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
@@ -2206,6 +2208,7 @@ fn list_files() -> Result<()> {
     built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
     built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
+    built_by_uv/cli.py (src/built_by_uv/cli.py)
 
     ----- stderr -----
     Building source distribution (uv build backend)...
@@ -2247,6 +2250,7 @@ fn list_files() -> Result<()> {
     built_by_uv-0.1.0/src/built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv-0.1.0/src/built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
     built_by_uv-0.1.0/src/built_by_uv/build-only.h (src/built_by_uv/build-only.h)
+    built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
     built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     Building built_by_uv-0.1.0-py3-none-any.whl will include the following files:
     built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
@@ -2254,6 +2258,7 @@ fn list_files() -> Result<()> {
     built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
     built_by_uv-0.1.0.dist-info/METADATA (generated)
     built_by_uv-0.1.0.dist-info/WHEEL (generated)
+    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
     built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
     built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
     built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
@@ -2261,6 +2266,7 @@ fn list_files() -> Result<()> {
     built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
     built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
+    built_by_uv/cli.py (src/built_by_uv/cli.py)
 
     ----- stderr -----
     "###);

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1,4 +1,4 @@
-use crate::common::{uv_snapshot, TestContext};
+use crate::common::{uv_snapshot, venv_bin_path, TestContext};
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use flate2::bufread::GzDecoder;
@@ -60,6 +60,16 @@ fn built_by_uv_direct_wheel() -> Result<()> {
     ----- stdout -----
     Hello 👋
     Area of a circle with r=2: 12.56636
+
+    ----- stderr -----
+    "###);
+
+    uv_snapshot!(Command::new("say-hi")
+        .env(EnvVars::PATH, venv_bin_path(&context.venv)), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hi from a script!
 
     ----- stderr -----
     "###);

--- a/scripts/packages/built-by-uv/pyproject.toml
+++ b/scripts/packages/built-by-uv/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.12"
 dependencies = ["anyio>=4,<5"]
 license-files = ["LICENSE*", "third-party-licenses/*"]
 
+[project.scripts]
+say-hi = "built_by_uv.cli:hello"
+
 [tool.uv.build-backend]
 # A file we need for the source dist -> wheel step, but not in the wheel itself (currently unused)
 source-include = ["data/build-script.py"]

--- a/scripts/packages/built-by-uv/src/built_by_uv/cli.py
+++ b/scripts/packages/built-by-uv/src/built_by_uv/cli.py
@@ -1,0 +1,2 @@
+def hello():
+    print("Hi from a script!")


### PR DESCRIPTION
Scripts (`project.scripts` and `project.gui-scripts`) are already supported, but did not have an integration test.