### PR TITLE
Unify dist error handling

### DIFF
--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -277,26 +277,12 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 .prepare(remote, &self.shared_state.in_flight)
                 .await
                 .map_err(|err| match err {
-                    uv_installer::PrepareError::DownloadAndBuild(dist, chain, err) => {
+                    uv_installer::PrepareError::Dist(kind, dist, chain, err) => {
                         debug_assert!(chain.is_empty());
                         let chain =
                             DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
                                 .unwrap_or_default();
-                        uv_installer::PrepareError::DownloadAndBuild(dist, chain, err)
-                    }
-                    uv_installer::PrepareError::Download(dist, chain, err) => {
-                        debug_assert!(chain.is_empty());
-                        let chain =
-                            DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
-                                .unwrap_or_default();
-                        uv_installer::PrepareError::Download(dist, chain, err)
-                    }
-                    uv_installer::PrepareError::Build(dist, chain, err) => {
-                        debug_assert!(chain.is_empty());
-                        let chain =
-                            DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
-                                .unwrap_or_default();
-                        uv_installer::PrepareError::Build(dist, chain, err)
+                        uv_installer::PrepareError::Dist(kind, dist, chain, err)
                     }
                     _ => err,
                 })?

--- a/crates/uv-distribution-types/src/dist_error.rs
+++ b/crates/uv-distribution-types/src/dist_error.rs
@@ -1,6 +1,29 @@
+use std::fmt::{Display, Formatter};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use version_ranges::Ranges;
+
+/// The operation(s) that failed when reporting an error with a distribution.
+#[derive(Debug)]
+pub enum DistErrorKind {
+    Download,
+    DownloadAndBuild,
+    Build,
+    BuildBackend,
+    Read,
+}
+
+impl Display for DistErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DistErrorKind::Download => f.write_str("Failed to download"),
+            DistErrorKind::DownloadAndBuild => f.write_str("Failed to download and build"),
+            DistErrorKind::Build => f.write_str("Failed to build"),
+            DistErrorKind::BuildBackend => f.write_str("Failed to build"),
+            DistErrorKind::Read => f.write_str("Failed to read"),
+        }
+    }
+}
 
 /// A chain of derivation steps from the root package to the current package, to explain why a
 /// package is included in the resolution.

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -54,8 +54,8 @@ pub use crate::any::*;
 pub use crate::buildable::*;
 pub use crate::cached::*;
 pub use crate::dependency_metadata::*;
-pub use crate::derivation::*;
 pub use crate::diagnostic::*;
+pub use crate::dist_error::*;
 pub use crate::error::*;
 pub use crate::file::*;
 pub use crate::hash::*;
@@ -77,8 +77,8 @@ mod any;
 mod buildable;
 mod cached;
 mod dependency_metadata;
-mod derivation;
 mod diagnostic;
+mod dist_error;
 mod error;
 mod file;
 mod hash;
@@ -549,6 +549,15 @@ impl Dist {
         match self {
             Self::Built(dist) => DistRef::Built(dist),
             Self::Source(dist) => DistRef::Source(dist),
+        }
+    }
+}
+
+impl<'a> From<&'a Dist> for DistRef<'a> {
+    fn from(dist: &'a Dist) -> Self {
+        match dist {
+            Dist::Built(built) => DistRef::Built(built),
+            Dist::Source(source) => DistRef::Source(source),
         }
     }
 }

--- a/crates/uv-requirements/src/lib.rs
+++ b/crates/uv-requirements/src/lib.rs
@@ -4,7 +4,8 @@ pub use crate::source_tree::*;
 pub use crate::sources::*;
 pub use crate::specification::*;
 pub use crate::unnamed::*;
-use uv_distribution_types::{BuiltDist, DerivationChain, Dist, GitSourceDist, SourceDist};
+
+use uv_distribution_types::{DerivationChain, Dist, DistErrorKind, GitSourceDist, SourceDist};
 use uv_git::GitUrl;
 use uv_pypi_types::{Requirement, RequirementSource};
 
@@ -18,23 +19,10 @@ pub mod upgrade;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Failed to download `{0}`")]
-    Download(
-        Box<BuiltDist>,
-        DerivationChain,
-        #[source] uv_distribution::Error,
-    ),
-
-    #[error("Failed to download and build `{0}`")]
-    DownloadAndBuild(
-        Box<SourceDist>,
-        DerivationChain,
-        #[source] uv_distribution::Error,
-    ),
-
-    #[error("Failed to build `{0}`")]
-    Build(
-        Box<SourceDist>,
+    #[error("{0} `{1}`")]
+    Dist(
+        DistErrorKind,
+        Box<Dist>,
         DerivationChain,
         #[source] uv_distribution::Error,
     ),
@@ -53,13 +41,24 @@ impl Error {
     /// Create an [`Error`] from a distribution error.
     pub(crate) fn from_dist(dist: Dist, cause: uv_distribution::Error) -> Self {
         match dist {
-            Dist::Built(dist) => Self::Download(Box::new(dist), DerivationChain::default(), cause),
+            Dist::Built(dist) => Self::Dist(
+                DistErrorKind::Download,
+                Box::new(Dist::Built(dist)),
+                DerivationChain::default(),
+                cause,
+            ),
             Dist::Source(dist) => {
-                if dist.is_local() {
-                    Self::Build(Box::new(dist), DerivationChain::default(), cause)
+                let kind = if dist.is_local() {
+                    DistErrorKind::Build
                 } else {
-                    Self::DownloadAndBuild(Box::new(dist), DerivationChain::default(), cause)
-                }
+                    DistErrorKind::DownloadAndBuild
+                };
+                Self::Dist(
+                    kind,
+                    Box::new(Dist::Source(dist)),
+                    DerivationChain::default(),
+                    cause,
+                )
             }
         }
     }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -10,8 +10,8 @@ use rustc_hash::FxHashMap;
 use tracing::trace;
 
 use uv_distribution_types::{
-    BuiltDist, DerivationChain, IndexCapabilities, IndexLocations, IndexUrl, InstalledDist,
-    SourceDist,
+    DerivationChain, Dist, DistErrorKind, IndexCapabilities, IndexLocations, IndexUrl,
+    InstalledDist,
 };
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{LocalVersionSlice, Version};
@@ -97,23 +97,10 @@ pub enum ResolveError {
     #[error(transparent)]
     ParsedUrl(#[from] uv_pypi_types::ParsedUrlError),
 
-    #[error("Failed to download `{0}`")]
-    Download(
-        Box<BuiltDist>,
-        DerivationChain,
-        #[source] Arc<uv_distribution::Error>,
-    ),
-
-    #[error("Failed to download and build `{0}`")]
-    DownloadAndBuild(
-        Box<SourceDist>,
-        DerivationChain,
-        #[source] Arc<uv_distribution::Error>,
-    ),
-
-    #[error("Failed to read `{0}`")]
-    Read(
-        Box<BuiltDist>,
+    #[error("{0} `{1}`")]
+    Dist(
+        DistErrorKind,
+        Box<Dist>,
         DerivationChain,
         #[source] Arc<uv_distribution::Error>,
     ),
@@ -121,13 +108,6 @@ pub enum ResolveError {
     // TODO(zanieb): Use `thiserror` in `InstalledDist` so we can avoid chaining `anyhow`
     #[error("Failed to read metadata from installed package `{0}`")]
     ReadInstalled(Box<InstalledDist>, DerivationChain, #[source] anyhow::Error),
-
-    #[error("Failed to build `{0}`")]
-    Build(
-        Box<SourceDist>,
-        DerivationChain,
-        #[source] Arc<uv_distribution::Error>,
-    ),
 
     #[error(transparent)]
     NoSolution(#[from] NoSolutionError),

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -1,20 +1,17 @@
 use std::str::FromStr;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
 use version_ranges::Ranges;
 
-use uv_distribution_types::{BuiltDist, DerivationChain, DerivationStep, Name, SourceDist};
+use uv_distribution_types::{DerivationChain, DerivationStep, Dist, DistErrorKind, Name};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_resolver::SentinelRange;
 
 use crate::commands::pip;
 
-type Error = Box<dyn std::error::Error + Send + Sync>;
-
-/// Static map of common package name typos or misconfigurations to their correct package names.
 static SUGGESTIONS: LazyLock<FxHashMap<PackageName, PackageName>> = LazyLock::new(|| {
     let suggestions: Vec<(String, String)> =
         serde_json::from_str(include_str!("suggestions.json")).unwrap();
@@ -75,72 +72,31 @@ impl OperationDiagnostic {
                 }
                 None
             }
-            pip::operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(
+            pip::operations::Error::Resolve(uv_resolver::ResolveError::Dist(
+                kind,
                 dist,
                 chain,
                 err,
             )) => {
-                download_and_build(dist, &chain, Box::new(err));
+                dist_error(kind, dist, &chain, err);
                 None
             }
-            pip::operations::Error::Resolve(uv_resolver::ResolveError::Download(
+            pip::operations::Error::Requirements(uv_requirements::Error::Dist(
+                kind,
                 dist,
                 chain,
                 err,
             )) => {
-                download(dist, &chain, Box::new(err));
+                dist_error(kind, dist, &chain, Arc::new(err));
                 None
             }
-            pip::operations::Error::Resolve(uv_resolver::ResolveError::Build(dist, chain, err)) => {
-                build(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Requirements(uv_requirements::Error::DownloadAndBuild(
+            pip::operations::Error::Prepare(uv_installer::PrepareError::Dist(
+                kind,
                 dist,
                 chain,
                 err,
             )) => {
-                download_and_build(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Requirements(uv_requirements::Error::Download(
-                dist,
-                chain,
-                err,
-            )) => {
-                download(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Requirements(uv_requirements::Error::Build(
-                dist,
-                chain,
-                err,
-            )) => {
-                build(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Prepare(uv_installer::PrepareError::DownloadAndBuild(
-                dist,
-                chain,
-                err,
-            )) => {
-                download_and_build(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Prepare(uv_installer::PrepareError::Download(
-                dist,
-                chain,
-                err,
-            )) => {
-                download(dist, &chain, Box::new(err));
-                None
-            }
-            pip::operations::Error::Prepare(uv_installer::PrepareError::Build(
-                dist,
-                chain,
-                err,
-            )) => {
-                build(dist, &chain, Box::new(err));
+                dist_error(kind, dist, &chain, Arc::new(err));
                 None
             }
             pip::operations::Error::Requirements(err) => {
@@ -158,113 +114,47 @@ impl OperationDiagnostic {
     }
 }
 
-/// Render a remote source distribution build failure with a help message.
-pub(crate) fn download_and_build(sdist: Box<SourceDist>, chain: &DerivationChain, cause: Error) {
+/// Render a distribution failure (read, download or build) with a help message.
+pub(crate) fn dist_error(
+    kind: DistErrorKind,
+    dist: Box<Dist>,
+    chain: &DerivationChain,
+    cause: Arc<uv_distribution::Error>,
+) {
     #[derive(Debug, miette::Diagnostic, thiserror::Error)]
-    #[error("Failed to download and build `{sdist}`")]
+    #[error("{kind} `{dist}`")]
     #[diagnostic()]
     struct Diagnostic {
-        sdist: Box<SourceDist>,
+        kind: DistErrorKind,
+        dist: Box<Dist>,
         #[source]
-        cause: Error,
+        cause: Arc<uv_distribution::Error>,
         #[help]
         help: Option<String>,
     }
 
+    let help = SUGGESTIONS
+        .get(dist.name())
+        .map(|suggestion| {
+            format!(
+                "`{}` is often confused for `{}` Did you mean to install `{}` instead?",
+                dist.name().cyan(),
+                suggestion.cyan(),
+                suggestion.cyan(),
+            )
+        })
+        .or_else(|| {
+            if chain.is_empty() {
+                None
+            } else {
+                Some(format_chain(dist.name(), dist.version(), chain))
+            }
+        });
     let report = miette::Report::new(Diagnostic {
-        help: SUGGESTIONS
-            .get(sdist.name())
-            .map(|suggestion| {
-                format!(
-                    "`{}` is often confused for `{}` Did you mean to install `{}` instead?",
-                    sdist.name().cyan(),
-                    suggestion.cyan(),
-                    suggestion.cyan(),
-                )
-            })
-            .or_else(|| {
-                if chain.is_empty() {
-                    None
-                } else {
-                    Some(format_chain(sdist.name(), sdist.version(), chain))
-                }
-            }),
-        sdist,
+        kind,
+        dist,
         cause,
-    });
-    anstream::eprint!("{report:?}");
-}
-
-/// Render a remote binary distribution download failure with a help message.
-pub(crate) fn download(wheel: Box<BuiltDist>, chain: &DerivationChain, cause: Error) {
-    #[derive(Debug, miette::Diagnostic, thiserror::Error)]
-    #[error("Failed to download `{wheel}`")]
-    #[diagnostic()]
-    struct Diagnostic {
-        wheel: Box<BuiltDist>,
-        #[source]
-        cause: Error,
-        #[help]
-        help: Option<String>,
-    }
-
-    let report = miette::Report::new(Diagnostic {
-        help: SUGGESTIONS
-            .get(wheel.name())
-            .map(|suggestion| {
-                format!(
-                    "`{}` is often confused for `{}` Did you mean to install `{}` instead?",
-                    wheel.name().cyan(),
-                    suggestion.cyan(),
-                    suggestion.cyan(),
-                )
-            })
-            .or_else(|| {
-                if chain.is_empty() {
-                    None
-                } else {
-                    Some(format_chain(wheel.name(), Some(wheel.version()), chain))
-                }
-            }),
-        wheel,
-        cause,
-    });
-    anstream::eprint!("{report:?}");
-}
-
-/// Render a local source distribution build failure with a help message.
-pub(crate) fn build(sdist: Box<SourceDist>, chain: &DerivationChain, cause: Error) {
-    #[derive(Debug, miette::Diagnostic, thiserror::Error)]
-    #[error("Failed to build `{sdist}`")]
-    #[diagnostic()]
-    struct Diagnostic {
-        sdist: Box<SourceDist>,
-        #[source]
-        cause: Error,
-        #[help]
-        help: Option<String>,
-    }
-
-    let report = miette::Report::new(Diagnostic {
-        help: SUGGESTIONS
-            .get(sdist.name())
-            .map(|suggestion| {
-                format!(
-                    "`{}` is often confused for `{}` Did you mean to install `{}` instead?",
-                    sdist.name().cyan(),
-                    suggestion.cyan(),
-                    suggestion.cyan(),
-                )
-            })
-            .or_else(|| {
-                if chain.is_empty() {
-                    None
-                } else {
-                    Some(format_chain(sdist.name(), sdist.version(), chain))
-                }
-            }),
-        sdist,
-        cause,
+        help,
     });
     anstream::eprint!("{report:?}");
 }

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -469,28 +469,12 @@ pub(crate) async fn install(
             .map_err(Error::from)
             .map_err(|err| match err {
                 // Attach resolution context to the error.
-                Error::Prepare(uv_installer::PrepareError::Download(dist, chain, err)) => {
+                Error::Prepare(uv_installer::PrepareError::Dist(kind, dist, chain, err)) => {
                     debug_assert!(chain.is_empty());
                     let chain =
                         DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
                             .unwrap_or_default();
-                    Error::Prepare(uv_installer::PrepareError::Download(dist, chain, err))
-                }
-                Error::Prepare(uv_installer::PrepareError::Build(dist, chain, err)) => {
-                    debug_assert!(chain.is_empty());
-                    let chain =
-                        DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
-                            .unwrap_or_default();
-                    Error::Prepare(uv_installer::PrepareError::Build(dist, chain, err))
-                }
-                Error::Prepare(uv_installer::PrepareError::DownloadAndBuild(dist, chain, err)) => {
-                    debug_assert!(chain.is_empty());
-                    let chain =
-                        DerivationChainBuilder::from_resolution(resolution, (&*dist).into())
-                            .unwrap_or_default();
-                    Error::Prepare(uv_installer::PrepareError::DownloadAndBuild(
-                        dist, chain, err,
-                    ))
+                    Error::Prepare(uv_installer::PrepareError::Dist(kind, dist, chain, err))
                 }
                 _ => err,
             })?;


### PR DESCRIPTION
This came up when trying to improve the build error reporting. Introduces `DistErrorKind` to avoid error variants for each case that are only different in one line of the message.