### PR TITLE
Build backend: Add template to uv init

### DIFF
--- a/crates/uv-configuration/src/project_build_backend.rs
+++ b/crates/uv-configuration/src/project_build_backend.rs
@@ -4,6 +4,10 @@
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProjectBuildBackend {
+    #[cfg_attr(feature = "clap", value(hide = true))]
+    #[cfg_attr(feature = "schemars", value(hide = true))]
+    /// Use uv as the project build backend.
+    Uv,
     #[default]
     #[serde(alias = "hatchling")]
     #[cfg_attr(feature = "clap", value(alias = "hatchling"))]

--- a/crates/uv-dev/src/generate_cli_reference.rs
+++ b/crates/uv-dev/src/generate_cli_reference.rs
@@ -315,6 +315,7 @@ fn emit_possible_options(opt: &clap::Arg, output: &mut String) {
             "\nPossible values:\n{}",
             values
                 .into_iter()
+                .filter(|value| !value.is_hide_set())
                 .map(|value| {
                     let name = value.get_name();
                     value.get_help().map_or_else(

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1320,6 +1320,7 @@ async fn run_project(
                 no_config,
                 &cache,
                 printer,
+                globals.preview,
             )
             .await
         }


### PR DESCRIPTION
Add a preview option `uv init --build-backend uv --preview` that uses the uv build backend when generating the project. The uv build backend is in preview, so the option is also guarded by preview and hidden from the help message and docs.

For https://github.com/astral-sh/uv/issues/3957#issuecomment-2518757563