### PR TITLE
fix: move comment out of code block to make copy/paste easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,25 +48,29 @@ uv is backed by [Astral](https://astral.sh), the creators of
 
 Install uv with our standalone installers:
 
+**On macOS and Linux.**
+
 ```bash
-# On macOS and Linux.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
+**On Windows.**
+
 ```bash
-# On Windows.
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Or, from [PyPI](https://pypi.org/project/uv/):
 
+**With pip.**
+
 ```bash
-# With pip.
 pip install uv
 ```
 
+**Or pipx.**
+
 ```bash
-# Or pipx.
 pipx install uv
 ```
 


### PR DESCRIPTION
## Summary

Improve the docs and make getting started easier. Move the comments on which environment/tool to use out of the code blocks so you can copy and paste directly into the terminal
