### PR TITLE
Docs: Add details of `--seed` to pip environments docs

### DIFF
--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -31,8 +31,8 @@ Note this requires the requested Python version to be available on the system. H
 unavailable, uv will download Python for you. See the
 [Python version](../concepts/python-versions.md) documentation for more details.
 
-uv does not include `pip` in virtual environments by default.
-To include it, use [`--seed`](../reference/cli.md#uv-venv--seed):
+uv does not include `pip` in virtual environments by default. To include it, use
+[`--seed`](../reference/cli.md#uv-venv--seed):
 
 ```console
 $ uv venv --seed

--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -31,14 +31,12 @@ Note this requires the requested Python version to be available on the system. H
 unavailable, uv will download Python for you. See the
 [Python version](../concepts/python-versions.md) documentation for more details.
 
-uv will not include `pip` in virtual environments by default. If you need it, use `--seed`:
+uv does not include `pip` in virtual environments by default.
+To include it, use [`--seed`](../reference/cli.md#uv-venv--seed):
 
 ```console
 $ uv venv --seed
 ```
-
-Note `--seed` may also include other seed packages in addition to `pip`. See the
-[CLI Reference](../reference/cli.md#uv-venv) documentation for more details.
 
 ## Using a virtual environment
 

--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -31,6 +31,15 @@ Note this requires the requested Python version to be available on the system. H
 unavailable, uv will download Python for you. See the
 [Python version](../concepts/python-versions.md) documentation for more details.
 
+uv will not include `pip` in virtual environments by default. If you need it, use `--seed`:
+
+```console
+$ uv venv --seed
+```
+
+Note `--seed` may also include other seed packages in addition to `pip`. See the
+[CLI Reference](../reference/cli.md#uv-venv) documentation for more details.
+
 ## Using a virtual environment
 
 When using the default virtual environment name, uv will automatically find and use the virtual


### PR DESCRIPTION
Add a mention of how to include pip when creating a virtual environment. This will help avoid confusion for those who are expecting and/or require pip in the environment (e.g. #3876).
