### PR TITLE
Add hint on build backend import with preview disabled

### DIFF
--- a/python/uv/__init__.py
+++ b/python/uv/__init__.py
@@ -28,3 +28,21 @@ if os.environ.get("UV_PREVIEW"):
     ]
 else:
     __all__ = ["find_uv_bin"]
+
+
+def __getattr__(attr_name: str) -> object:
+    if attr_name in {
+        "build_sdist",
+        "build_wheel",
+        "build_editable",
+        "get_requires_for_build_sdist",
+        "get_requires_for_build_wheel",
+        "prepare_metadata_for_build_wheel",
+        "get_requires_for_build_editable",
+        "prepare_metadata_for_build_editable",
+    }:
+        err = f"Using `uv.{attr_name}` is not allowed. The uv build backend requires preview mode to be enabled, e.g., via the `UV_PREVIEW=1` environment variable."
+        raise AttributeError(err)
+
+    err = f"module 'uv' has no attribute '{attr_name}'"
+    raise AttributeError(err)


### PR DESCRIPTION
See #9686

```
❯ uv run python -c "import uv; uv.build_sdist"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/zb/workspace/uv/python/uv/__init__.py", line 45, in __getattr__
    raise AttributeError(err)
AttributeError: Using `uv.build_sdist` is not allowed. The uv build backend requires preview mode to be 
                enabled, e.g., via the `UV_PREVIEW=1` environment variable.

❯ uv run python -c "import uv; uv.foo"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/zb/workspace/uv/python/uv/__init__.py", line 48, in __getattr__
    raise AttributeError(err)
AttributeError: module 'uv' has no attribute 'foo'

❯ uv run python -c "import uv; uv.find_uv_bin"
```