### PR TITLE
Eagerly error when parsing `pyproject.toml` requirements

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -472,8 +472,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Return the [`RequiresDist`] from a `pyproject.toml`, if it can be statically extracted.
-    pub async fn requires_dist(&self, project_root: &Path) -> Result<RequiresDist, Error> {
-        self.builder.requires_dist(project_root).await
+    pub async fn requires_dist(&self, project_root: &Path) -> Result<Option<RequiresDist>, Error> {
+        self.builder.source_tree_requires_dist(project_root).await
     }
 
     /// Stream a wheel from a URL, unzipping it into the cache as it's downloaded.

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -191,8 +191,12 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             )
         })?;
 
-        // If the path is a `pyproject.toml`, attempt to extract the requirements statically.
-        if let Ok(metadata) = self.database.requires_dist(source_tree).await {
+        // If the path is a `pyproject.toml`, attempt to extract the requirements statically. The
+        // distribution database will do this too, but we can be even more aggressive here since we
+        // _only_ need the requirements. So, for example, even if the version is dynamic, we can
+        // still extract the requirements without performing a build, unlike in the database where
+        // we typically construct a "complete" metadata object.
+        if let Some(metadata) = self.database.requires_dist(source_tree).await? {
             return Ok(metadata);
         }
 


### PR DESCRIPTION
## Summary

Small thing I noticed while working on another change: if we error when extracting `requires-dist`, we go through the full metadata build. We need to distinguish between fatal errors and "the data isn't static".
