### PR TITLE
Respect self-constraints on recursive extras

### DIFF
--- a/crates/uv-pypi-types/src/requirement.rs
+++ b/crates/uv-pypi-types/src/requirement.rs
@@ -562,6 +562,16 @@ impl RequirementSource {
         matches!(self, Self::Directory { editable: true, .. })
     }
 
+    /// Returns `true` if the source is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Registry { specifier, .. } => specifier.is_empty(),
+            Self::Url { .. } | Self::Git { .. } | Self::Path { .. } | Self::Directory { .. } => {
+                false
+            }
+        }
+    }
+
     /// If the source is the registry, return the version specifiers
     pub fn version_specifiers(&self) -> Option<&VersionSpecifiers> {
         match self {

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -1328,7 +1328,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::DependsOnItself { package } => {
                 write!(
                     f,
-                    "{}{} The package `{}` depends on itself. This is likely a mistake. Consider removing the dependency.",
+                    "{}{} The package `{}` depends on itself at an incompatible version. This is likely a mistake. Consider removing the dependency.",
                     "hint".bold().cyan(),
                     ":".bold(),
                     package.cyan(),


### PR DESCRIPTION
## Summary

Sort of ridiculous, but today this passes, when it should fail:

```toml
[project]
name = "foo"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.13.0"
dependencies = []

[project.optional-dependencies]
async = [
    "foo[async]==0.2.0",
]
```
