### PR TITLE
`uv run` tries executing script if installed

### DIFF
--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use project::export::export;
 pub(crate) use project::init::{init, InitKind, InitProjectKind};
 pub(crate) use project::lock::lock;
 pub(crate) use project::remove::remove;
-pub(crate) use project::run::{run, RunCommand, ResolvedRunCommand};
+pub(crate) use project::run::{run, ResolvedRunCommand, RunCommand};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
 pub(crate) use publish::publish;

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use project::export::export;
 pub(crate) use project::init::{init, InitKind, InitProjectKind};
 pub(crate) use project::lock::lock;
 pub(crate) use project::remove::remove;
-pub(crate) use project::run::{run, RunCommand};
+pub(crate) use project::run::{run, RunCommand, ResolvedRunCommand};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
 pub(crate) use publish::publish;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1168,9 +1168,9 @@ fn can_skip_ephemeral(
 pub(crate) enum RunCommand {
     Resolved(ResolvedRunCommand),
     /// The execution behavior depends on the virtual environment
-    /// so the resolution is delayed until then. 
+    /// so the resolution is delayed until then.
     Unresolved(UnresolvedRunCommand),
-} 
+}
 
 #[derive(Debug)]
 pub(crate) enum ResolvedRunCommand {
@@ -1201,7 +1201,7 @@ pub(crate) enum ResolvedRunCommand {
 #[derive(Debug)]
 pub(crate) struct UnresolvedRunCommand {
     target: OsString,
-    args: Vec<OsString>
+    args: Vec<OsString>,
 }
 
 impl ResolvedRunCommand {
@@ -1355,7 +1355,7 @@ impl RunCommand {
     fn display_executable(&self) -> Cow<'_, str> {
         match self {
             Self::Resolved(command) => command.display_executable(),
-            Self::Unresolved(_command) => Cow::Borrowed("unknown")
+            Self::Unresolved(_command) => Cow::Borrowed("unknown"),
         }
     }
 
@@ -1364,8 +1364,8 @@ impl RunCommand {
         match self {
             Self::Resolved(command) => command.as_command(interpreter),
             Self::Unresolved(command) => {
-                // Determine whether the command should be executed as a 
-                // script, package, or external command, in that order of preference. 
+                // Determine whether the command should be executed as a
+                // script, package, or external command, in that order of preference.
                 let UnresolvedRunCommand { target, args } = command;
                 let target_path = PathBuf::from(target);
                 let metadata = target_path.metadata();
@@ -1447,14 +1447,23 @@ impl RunCommand {
                     writer.write_all(&chunk?)?;
                 }
 
-                return Ok(Self::Resolved(ResolvedRunCommand::PythonRemote(file, args.to_vec())));
+                return Ok(Self::Resolved(ResolvedRunCommand::PythonRemote(
+                    file,
+                    args.to_vec(),
+                )));
             }
         }
 
         if module {
-            return Ok(Self::Resolved(ResolvedRunCommand::PythonModule(target.clone(), args.to_vec())));
+            return Ok(Self::Resolved(ResolvedRunCommand::PythonModule(
+                target.clone(),
+                args.to_vec(),
+            )));
         } else if script {
-            return Ok(Self::Resolved(ResolvedRunCommand::PythonScript(target.clone().into(), args.to_vec())));
+            return Ok(Self::Resolved(ResolvedRunCommand::PythonScript(
+                target.clone().into(),
+                args.to_vec(),
+            )));
         }
 
         let metadata = target_path.metadata();
@@ -1471,18 +1480,27 @@ impl RunCommand {
             .is_some_and(|ext| ext.eq_ignore_ascii_case("py") || ext.eq_ignore_ascii_case("pyc"))
             && is_file
         {
-            Ok(Self::Resolved(ResolvedRunCommand::PythonScript(target_path, args.to_vec())))
+            Ok(Self::Resolved(ResolvedRunCommand::PythonScript(
+                target_path,
+                args.to_vec(),
+            )))
         } else if cfg!(windows)
             && target_path
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("pyw"))
             && is_file
         {
-            Ok(Self::Resolved(ResolvedRunCommand::PythonGuiScript(target_path, args.to_vec())))
+            Ok(Self::Resolved(ResolvedRunCommand::PythonGuiScript(
+                target_path,
+                args.to_vec(),
+            )))
         } else if is_file && is_python_zipapp(&target_path) {
-            Ok(Self::Resolved(ResolvedRunCommand::PythonZipapp(target_path, args.to_vec())))
+            Ok(Self::Resolved(ResolvedRunCommand::PythonZipapp(
+                target_path,
+                args.to_vec(),
+            )))
         } else {
-            Ok(Self::Unresolved(UnresolvedRunCommand{
+            Ok(Self::Unresolved(UnresolvedRunCommand {
                 target: target.clone(),
                 args: args.to_vec(),
             }))

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -32,7 +32,7 @@ use uv_static::EnvVars;
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::{DiscoveryOptions, Workspace};
 
-use crate::commands::{ExitStatus, RunCommand, ResolvedRunCommand, ToolRunCommand};
+use crate::commands::{ExitStatus, ResolvedRunCommand, RunCommand, ToolRunCommand};
 use crate::printer::Printer;
 use crate::settings::{
     CacheSettings, GlobalSettings, PipCheckSettings, PipCompileSettings, PipFreezeSettings,
@@ -166,20 +166,19 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     let script = if let Commands::Project(command) = &*cli.command {
         if let ProjectCommand::Run(uv_cli::RunArgs { .. }) = &**command {
             match run_command.as_ref() {
-                Some(RunCommand::Resolved(command)) => {
-                    match command {
-                        ResolvedRunCommand::PythonScript(script, _) | ResolvedRunCommand::PythonGuiScript(script, _) => {
-                            Pep723Script::read(&script).await?.map(Pep723Item::Script)
-                        }
-                        ResolvedRunCommand::PythonRemote(script, _) => {
-                            Pep723Metadata::read(&script).await?.map(Pep723Item::Remote)
-                        }
-                        ResolvedRunCommand::PythonStdin(contents) => {
-                            Pep723Metadata::parse(contents)?.map(Pep723Item::Stdin)
-                        }
-                        _ => None,
+                Some(RunCommand::Resolved(command)) => match command {
+                    ResolvedRunCommand::PythonScript(script, _)
+                    | ResolvedRunCommand::PythonGuiScript(script, _) => {
+                        Pep723Script::read(&script).await?.map(Pep723Item::Script)
                     }
-                }
+                    ResolvedRunCommand::PythonRemote(script, _) => {
+                        Pep723Metadata::read(&script).await?.map(Pep723Item::Remote)
+                    }
+                    ResolvedRunCommand::PythonStdin(contents) => {
+                        Pep723Metadata::parse(contents)?.map(Pep723Item::Stdin)
+                    }
+                    _ => None,
+                },
                 _ => None,
             }
         } else if let ProjectCommand::Remove(uv_cli::RemoveArgs {


### PR DESCRIPTION
## Summary

This PR implements a solution to https://github.com/astral-sh/uv/issues/9167. It prioritizes executing the `uv run` command as a python script, if the script is installed, over executing the command as a python package or external command. 

## Test Plan

I tested my solution against the repoduction of the issue created here: https://github.com/raqbit/uv-scripts-repro/, and verified that `uv run foo` now executes the python script.
