### PR TITLE
Fix commits_since_last_tag in version info

### DIFF
--- a/crates/uv-cli/build.rs
+++ b/crates/uv-cli/build.rs
@@ -55,7 +55,7 @@ fn commit_info(workspace_root: &Path) {
         .arg("-1")
         .arg("--date=short")
         .arg("--abbrev=9")
-        .arg("--format=%H %h %cd %(describe)")
+        .arg("--format=%H %h %cd %(describe:tags)")
         .output()
     {
         Ok(output) if output.status.success() => output,


### PR DESCRIPTION
## Summary

Before:
```console
$ cargo run -- --version
uv 0.5.7 (b17902da0 2024-12-09)
```

After:
```console
$ cargo run -- --version
uv 0.5.7+14 (7cd0ab77a 2024-12-09)
```

Currently `cargo run -- --version` does not includes the number of commits since last tag, because `cargo-dist` create non-annotated tag, and
`git log -1 --date=short --abbrev=9 --format='%H %h %cd %(describe)'` use only annoated tags by default.

```console
$ git log -1 --date=short --abbrev=9 --format='%H %h %cd %(describe)'
7cd0ab77a91b57f5c101aa0bd46396ede947f330 7cd0ab77a 2024-12-09
```

To include these tags, use `git log -1 --date=short --abbrev=9 --format='%H %h %cd %(describe:tags)'`, which will display:

```console
$ git log -1 --date=short --abbrev=9 --format='%H %h %cd %(describe:tags)'
7cd0ab77a91b57f5c101aa0bd46396ede947f330 7cd0ab77a 2024-12-09 0.5.7-14-g7cd0ab77a
```
