### PR TITLE
Respect user settings for tracing coloring

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -296,6 +296,23 @@ pub enum ColorChoice {
     Never,
 }
 
+impl ColorChoice {
+    /// Combine self (higher priority) with an [`anstream::ColorChoice`] (lower priority).
+    ///
+    /// This method allows prioritizing the user choice, while using the inferred choice for a
+    /// stream as default.
+    pub fn and_colorchoice(self, next: anstream::ColorChoice) -> Self {
+        match self {
+            Self::Auto => match next {
+                anstream::ColorChoice::Auto => Self::Auto,
+                anstream::ColorChoice::Always | anstream::ColorChoice::AlwaysAnsi => Self::Always,
+                anstream::ColorChoice::Never => Self::Never,
+            },
+            Self::Always | Self::Never => self,
+        }
+    }
+}
+
 impl From<ColorChoice> for anstream::ColorChoice {
     fn from(value: ColorChoice) -> Self {
         match value {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -219,6 +219,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             2.. => logging::Level::ExtraVerbose,
         },
         duration_layer,
+        globals.color,
     )?;
 
     // Configure the `Printer`, which controls user-facing output in the CLI.


### PR DESCRIPTION
Previously, `-vvv --color never` would still emit ANSI sequences to stderr.

Ref https://github.com/astral-sh/uv/issues/9668#issuecomment-2522120211