### PR TITLE
Improve uvx error message when uv is missing

### DIFF
--- a/crates/uv/src/bin/uvx.rs
+++ b/crates/uv/src/bin/uvx.rs
@@ -38,6 +38,14 @@ fn run() -> std::io::Result<ExitStatus> {
         .chain(std::env::args_os().skip(1))
         .collect::<Vec<_>>();
 
+    // If we are sure the uv binary does not exist, display a clearer error message
+    if matches!(uv.try_exists(), Ok(false)) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Could not find the `uv` binary at: {}", uv.display()),
+        ));
+    }
+
     let mut cmd = Command::new(uv);
     cmd.args(&args);
     match exec_spawn(&mut cmd)? {}

--- a/crates/uv/src/bin/uvx.rs
+++ b/crates/uv/src/bin/uvx.rs
@@ -30,7 +30,7 @@ fn run() -> std::io::Result<ExitStatus> {
             "Could not determine the location of the `uvx` binary",
         ));
     };
-    let uv = bin.join("uv");
+    let uv = bin.join(format!("uv{}", std::env::consts::EXE_SUFFIX));
     let args = ["tool", "uvx"]
         .iter()
         .map(OsString::from)


### PR DESCRIPTION
from https://github.com/astral-sh/uv/issues/9742

```
❯ cargo run -q --bin uvx
Provide a command to run with `uvx <command>`.

The following tools are installed:

- ansible-core v2.17.5
- black v24.10.0
- rooster-blue v0.0.0

See `uvx --help` for more information.
❯ rm target/debug/uv
❯ cargo run -q --bin uvx
error: Could not find the `uv` binary at /Users/zb/workspace/uv/target/debug/uv
```