### PR TITLE
Rename Python install scratch directory from `.cache` -> `.temp`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -464,12 +464,12 @@ impl ManagedPythonDownload {
     }
 
     /// Download and extract a Python distribution, retrying on failure.
-    #[instrument(skip(client, installation_dir, cache_dir, reporter), fields(download = % self.key()))]
+    #[instrument(skip(client, installation_dir, scratch_dir, reporter), fields(download = % self.key()))]
     pub async fn fetch_with_retry(
         &self,
         client: &uv_client::BaseClient,
         installation_dir: &Path,
-        cache_dir: &Path,
+        scratch_dir: &Path,
         reinstall: bool,
         python_install_mirror: Option<&str>,
         pypy_install_mirror: Option<&str>,
@@ -483,7 +483,7 @@ impl ManagedPythonDownload {
                 .fetch(
                     client,
                     installation_dir,
-                    cache_dir,
+                    scratch_dir,
                     reinstall,
                     python_install_mirror,
                     pypy_install_mirror,
@@ -514,12 +514,12 @@ impl ManagedPythonDownload {
     }
 
     /// Download and extract a Python distribution.
-    #[instrument(skip(client, installation_dir, cache_dir, reporter), fields(download = % self.key()))]
+    #[instrument(skip(client, installation_dir, scratch_dir, reporter), fields(download = % self.key()))]
     pub async fn fetch(
         &self,
         client: &uv_client::BaseClient,
         installation_dir: &Path,
-        cache_dir: &Path,
+        scratch_dir: &Path,
         reinstall: bool,
         python_install_mirror: Option<&str>,
         pypy_install_mirror: Option<&str>,
@@ -543,7 +543,7 @@ impl ManagedPythonDownload {
             .map(|reporter| (reporter, reporter.on_download_start(&self.key, size)));
 
         // Download and extract into a temporary directory.
-        let temp_dir = tempfile::tempdir_in(cache_dir).map_err(Error::DownloadDirError)?;
+        let temp_dir = tempfile::tempdir_in(scratch_dir).map_err(Error::DownloadDirError)?;
 
         debug!(
             "Downloading {url} to temporary location: {}",

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -137,7 +137,7 @@ impl PythonInstallation {
     ) -> Result<Self, Error> {
         let installations = ManagedPythonInstallations::from_settings()?.init()?;
         let installations_dir = installations.root();
-        let cache_dir = installations.cache();
+        let scratch_dir = installations.scratch();
         let _lock = installations.lock().await?;
 
         let download = ManagedPythonDownload::from_request(&request)?;
@@ -148,7 +148,7 @@ impl PythonInstallation {
             .fetch_with_retry(
                 &client,
                 installations_dir,
-                &cache_dir,
+                &scratch_dir,
                 false,
                 python_install_mirror,
                 pypy_install_mirror,

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -127,9 +127,9 @@ impl ManagedPythonInstallations {
         ))
     }
 
-    /// Return the location of the cache directory for managed Python installations.
-    pub fn cache(&self) -> PathBuf {
-        self.root.join(".cache")
+    /// Return the location of the scratch directory for managed Python installations.
+    pub fn scratch(&self) -> PathBuf {
+        self.root.join(".temp")
     }
 
     /// Initialize the Python installation directory.
@@ -156,9 +156,9 @@ impl ManagedPythonInstallations {
         // Create the directory, if it doesn't exist.
         fs::create_dir_all(root)?;
 
-        // Create the cache directory, if it doesn't exist.
-        let cache = self.cache();
-        fs::create_dir_all(&cache)?;
+        // Create the scratch directory, if it doesn't exist.
+        let scratch = self.scratch();
+        fs::create_dir_all(&scratch)?;
 
         // Add a .gitignore.
         match fs::OpenOptions::new()
@@ -207,7 +207,7 @@ impl ManagedPythonInstallations {
                 })
             }
         };
-        let cache = self.cache();
+        let cache = self.scratch();
         Ok(dirs
             .into_iter()
             .filter(|path| *path != cache)

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -180,7 +180,7 @@ pub(crate) async fn install(
     // Read the existing installations, lock the directory for the duration
     let installations = ManagedPythonInstallations::from_settings()?.init()?;
     let installations_dir = installations.root();
-    let cache_dir = installations.cache();
+    let scratch_dir = installations.scratch();
     let _lock = installations.lock().await?;
     let existing_installations: Vec<_> = installations
         .find_all()?
@@ -259,7 +259,7 @@ pub(crate) async fn install(
                     .fetch_with_retry(
                         &client,
                         installations_dir,
-                        &cache_dir,
+                        &scratch_dir,
                         reinstall,
                         python_install_mirror.as_deref(),
                         pypy_install_mirror.as_deref(),


### PR DESCRIPTION
Addressing the confusion in https://github.com/astral-sh/uv/issues/9749