### PR TITLE
Allow execution of pyw files on Unix

### DIFF
--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -542,7 +542,6 @@ fn run_pep723_script_requires_python() -> Result<()> {
 
 /// Run a `.pyw` script. The script should be executed with `pythonw.exe`.
 #[test]
-#[cfg(windows)]
 fn run_pythonw_script() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
I don't see any real reason to forbid executing these in a cross-platform way

```
❯ echo "print('hello world')" > test.pyw
❯ uv run test.pyw
error: Failed to spawn: `test.pyw`
  Caused by: No such file or directory (os error 2)
❯ cargo run -q -- run test.pyw
hello world
```

Closes https://github.com/astral-sh/uv/issues/9757