### PR TITLE
Allow download of Python distribution variants with newer CPU instruction sets

### DIFF
--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -1,7 +1,10 @@
 {
   "cpython-3.13.1-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14,7 +17,10 @@
   },
   "cpython-3.13.1-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -27,7 +33,10 @@
   },
   "cpython-3.13.1-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -40,7 +49,10 @@
   },
   "cpython-3.13.1-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -53,7 +65,10 @@
   },
   "cpython-3.13.1-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -66,7 +81,10 @@
   },
   "cpython-3.13.1-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -79,7 +97,10 @@
   },
   "cpython-3.13.1-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -92,7 +113,10 @@
   },
   "cpython-3.13.1-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -105,7 +129,10 @@
   },
   "cpython-3.13.1-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -116,9 +143,108 @@
     "sha256": "46cab519d86c35c129534ebdebc71293711d36ff649c3387aa2a6a9d54488500",
     "variant": null
   },
+  "cpython-3.13.1-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "1ec5a3b90e78243dfc9d655966dd674ada690590baff88de7f3e3842e070e8f8",
+    "variant": null
+  },
+  "cpython-3.13.1-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "4e8530f5185a7cfb68960739e35d66768d8792fc1047de94bcb5056b80b6e0a9",
+    "variant": null
+  },
+  "cpython-3.13.1-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "dac921039c06c9589afe8faa3e56bc816b6886942665516b49721aa64e5c028c",
+    "variant": null
+  },
+  "cpython-3.13.1-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "705a6c68da2ac1d24a4261fa6e45850aa3250b386d58b59f5fb140f9b707b06a",
+    "variant": null
+  },
+  "cpython-3.13.1-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "5abe225419169657c32ea3c72ba71d1b2b050b39808264035329366f735573b5",
+    "variant": null
+  },
+  "cpython-3.13.1-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "8aec74a40027afa2aac9693153aa50d53d861e7fdaad546cff36128cd3d72061",
+    "variant": null
+  },
   "cpython-3.13.1-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -131,7 +257,10 @@
   },
   "cpython-3.13.1-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -144,7 +273,10 @@
   },
   "cpython-3.13.1+freethreaded-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -157,7 +289,10 @@
   },
   "cpython-3.13.1+freethreaded-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -170,7 +305,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -183,7 +321,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -196,7 +337,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -209,7 +353,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -222,7 +369,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -235,7 +385,10 @@
   },
   "cpython-3.13.1+freethreaded-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -246,9 +399,60 @@
     "sha256": "941aee1b089c0fd00a956ea6f39cce98c844b4fbc829f1ffc072a2424ce1dab1",
     "variant": "freethreaded"
   },
+  "cpython-3.13.1+freethreaded-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+    "sha256": "6763ee4c65ba6eac25ad24eb1761bdb565b7c2b13078b324a97e532d51b259fc",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.1+freethreaded-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+    "sha256": "ec942c9eb007ea9c5393eecffa607c14183da45bedce69c6b8aedc043879b747",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.1+freethreaded-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-gnu-freethreaded%2Blto-full.tar.zst",
+    "sha256": "4e2013630d8e14005cceb667b736c5ffd7e61a57a1db3adcebe4c17a50b684e4",
+    "variant": "freethreaded"
+  },
   "cpython-3.13.1+freethreaded-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -261,7 +465,10 @@
   },
   "cpython-3.13.1+freethreaded-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -274,7 +481,10 @@
   },
   "cpython-3.13.1+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -287,7 +497,10 @@
   },
   "cpython-3.13.1+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -300,7 +513,10 @@
   },
   "cpython-3.13.1+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -313,7 +529,10 @@
   },
   "cpython-3.13.1+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -326,7 +545,10 @@
   },
   "cpython-3.13.1+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -339,7 +561,10 @@
   },
   "cpython-3.13.1+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -352,7 +577,10 @@
   },
   "cpython-3.13.1+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -363,9 +591,108 @@
     "sha256": "281af69b8f438921245e96dea39fc1c2b48332c2839293295f105eff27e8c374",
     "variant": "debug"
   },
+  "cpython-3.13.1+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b8e2892fb8ef724b1fe80313e65b131fb779a2755e314de7427e67057a754a60",
+    "variant": "debug"
+  },
+  "cpython-3.13.1+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "f2346c33c760cf37c0483ee18382ac2191edb2d6834b454a9fb31f26a39deb20",
+    "variant": "debug"
+  },
+  "cpython-3.13.1+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5ec8592773a1f70ea6582863fe4ff6dda815a1bc89354967f128902ba9bbe427",
+    "variant": "debug"
+  },
+  "cpython-3.13.1+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ddd9c653c068ce35ba7e08d5be2b5d40e94aee510b765474e48ed8ec9dbf70c1",
+    "variant": "debug"
+  },
+  "cpython-3.13.1+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "854f4cc2343fa0a02af8e54fcd3be3b6b8a7f3aa663bc54952b71c46b13125b1",
+    "variant": "debug"
+  },
+  "cpython-3.13.1+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1ad4b4032e53cec9f48fc48d29612c8dad72cab157fca3040b9b5ee04aae1bd3",
+    "variant": "debug"
+  },
   "cpython-3.13.0-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -378,7 +705,10 @@
   },
   "cpython-3.13.0-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -391,7 +721,10 @@
   },
   "cpython-3.13.0-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -404,7 +737,10 @@
   },
   "cpython-3.13.0-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -417,7 +753,10 @@
   },
   "cpython-3.13.0-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -430,7 +769,10 @@
   },
   "cpython-3.13.0-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -443,7 +785,10 @@
   },
   "cpython-3.13.0-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -456,7 +801,10 @@
   },
   "cpython-3.13.0-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -469,7 +817,10 @@
   },
   "cpython-3.13.0-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -480,9 +831,108 @@
     "sha256": "10978500ab6589760716c644aeadffa0f2c0bf31ea10f0c6160fee933933a567",
     "variant": null
   },
+  "cpython-3.13.0-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "5c10c0b05c66bc6fc9a87f456ac1606057fe1865cc525eb7ecd9a5640f15426a",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "6797067b7da58c29384cd32cb77f62dc18e813e6c72f6b0baf39672d84431bf2",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "a9e705f714ccbe721ba0e29b80e6f2a5f0960c39245959de58c8076fd31515e0",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "0572fbf46e49adaa5a418eeb92daeb624a080466a46d87d48e4a80f1ba9e408a",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "36bd61970dc1d3a7034f2645aa14b47b6aa1669819fb7803650b5a7919afddbf",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "a846556bdd4d61b3f96aa8b096c86db031d7f5b5ef50f9e614c9259527afc9de",
+    "variant": null
+  },
   "cpython-3.13.0-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -495,7 +945,10 @@
   },
   "cpython-3.13.0-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -508,7 +961,10 @@
   },
   "cpython-3.13.0+freethreaded-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -521,7 +977,10 @@
   },
   "cpython-3.13.0+freethreaded-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -534,7 +993,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -547,7 +1009,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -560,7 +1025,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -573,7 +1041,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -586,7 +1057,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -599,7 +1073,10 @@
   },
   "cpython-3.13.0+freethreaded-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -610,9 +1087,60 @@
     "sha256": "a73adeda301ad843cce05f31a2d3e76222b656984535a7b87696a24a098b216c",
     "variant": "freethreaded"
   },
+  "cpython-3.13.0+freethreaded-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+    "sha256": "6dd725b5866e193d201b4d6361bf03b2a954eeb8b67788d875ca4991776f852f",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+    "sha256": "fd16a95790203891163db772b6818522ee887857edae1a1cd6860e58eaf8f305",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-freethreaded%2Blto-full.tar.zst",
+    "sha256": "8ad7fd8dd74cad2c9d5a269ad585885ef2b41468a691804f1dd66e1cec8286cb",
+    "variant": "freethreaded"
+  },
   "cpython-3.13.0+freethreaded-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -625,7 +1153,10 @@
   },
   "cpython-3.13.0+freethreaded-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -638,7 +1169,10 @@
   },
   "cpython-3.13.0+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -651,7 +1185,10 @@
   },
   "cpython-3.13.0+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -664,7 +1201,10 @@
   },
   "cpython-3.13.0+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -677,7 +1217,10 @@
   },
   "cpython-3.13.0+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -690,7 +1233,10 @@
   },
   "cpython-3.13.0+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -703,7 +1249,10 @@
   },
   "cpython-3.13.0+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -716,7 +1265,10 @@
   },
   "cpython-3.13.0+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -727,9 +1279,108 @@
     "sha256": "2647425970b209fc546b0ff94d25567db5575847a8a852a0d79445a3c3806c85",
     "variant": "debug"
   },
+  "cpython-3.13.0+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "af1c336f4827ad86f4bead527145bc99afc5c1100afa7f1a1fa5550bab06d2b1",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8a14b35b54a1d13d2cd3ce4075fa0baa02a51dcaeb277648a9c1c11a7ac83e4e",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b871ef5348b958178f359d7015801ae6e1491d6a4e23e6ec2a1f52318eea8505",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8217b0e8d95ae57de4cabdda0c4c2061ac11af43c43e253e1e56d08532b7ba6f",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1ecf6d840a350ced04b2260f73ba7b49242cf7a083d657476a3b2da7a4d4e1c3",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a00d3d98e56c93afeed35f245345c352e15d6af86cfa2e046ae6eef38ac48fc9",
+    "variant": "debug"
+  },
   "cpython-3.13.0rc3-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -742,7 +1393,10 @@
   },
   "cpython-3.13.0rc3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -755,7 +1409,10 @@
   },
   "cpython-3.13.0rc3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -768,7 +1425,10 @@
   },
   "cpython-3.13.0rc3-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -781,7 +1441,10 @@
   },
   "cpython-3.13.0rc3-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -794,7 +1457,10 @@
   },
   "cpython-3.13.0rc3-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -807,7 +1473,10 @@
   },
   "cpython-3.13.0rc3-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -820,7 +1489,10 @@
   },
   "cpython-3.13.0rc3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -833,7 +1505,10 @@
   },
   "cpython-3.13.0rc3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -844,9 +1519,108 @@
     "sha256": "4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f",
     "variant": null
   },
+  "cpython-3.13.0rc3-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "ae477db35ccec397a19c9d61271455adf4917ab35993dbcacae8d126890f6b12",
+    "variant": null
+  },
+  "cpython-3.13.0rc3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "8c73e28a683b7e826ed5bda4cf119ec8270238fdf936e3a2b3ca0938cfcde8c9",
+    "variant": null
+  },
+  "cpython-3.13.0rc3-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "2a505cda4d7d62dec1829a06fa502eb514a3182c193b2f2aaf9c08bccb143dc0",
+    "variant": null
+  },
+  "cpython-3.13.0rc3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "27a93fc7678782b392e5ee8e654635bc29409939318bbc341df3d29386f2166f",
+    "variant": null
+  },
+  "cpython-3.13.0rc3-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "8c1424f2501419b88560951497df095c82e856af9b8f817f96beedeb4d8bc32d",
+    "variant": null
+  },
+  "cpython-3.13.0rc3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "8c318b2a79d75ca7ce3b76f8799a1db0337ba1278601bf0ec4433d64313d1aca",
+    "variant": null
+  },
   "cpython-3.13.0rc3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -859,7 +1633,10 @@
   },
   "cpython-3.13.0rc3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -872,7 +1649,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -885,7 +1665,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -898,7 +1681,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -911,7 +1697,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -924,7 +1713,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -937,7 +1729,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -950,7 +1745,10 @@
   },
   "cpython-3.13.0rc3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -961,9 +1759,108 @@
     "sha256": "59b19a2ae830bd67bc8190bd839ebdf2423e871ef2e5114f38b84dab652c2e1b",
     "variant": "debug"
   },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "20795d2bae8b26de5554907353fa4bc022e0912b772803298f4b5679dceec71e",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "903df7b90162528c218d5bf2eaa42bea9ff329332670afa98bbeaad1aba0cc40",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "08f365ec1aa442664a9e98988edb6260e40b4739359354694c6f1ee32b58bbb9",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "9323f7b156b8e5220ad7f9cee082d1714d78594f8b4a725b2178e316b10cd19d",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "716c1bf5f329ac969d0b34d33169dc115e4c8b65fc9ba64f1b1d2635e50f36a6",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "609f8b75ecca24f9c4fcd704cdf7f914dfe2cddbebd765a30f319799d50a8b60",
+    "variant": "debug"
+  },
   "cpython-3.13.0rc2-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -976,7 +1873,10 @@
   },
   "cpython-3.13.0rc2-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -989,7 +1889,10 @@
   },
   "cpython-3.13.0rc2-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1002,7 +1905,10 @@
   },
   "cpython-3.13.0rc2-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1015,7 +1921,10 @@
   },
   "cpython-3.13.0rc2-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1028,7 +1937,10 @@
   },
   "cpython-3.13.0rc2-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1041,7 +1953,10 @@
   },
   "cpython-3.13.0rc2-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1054,7 +1969,10 @@
   },
   "cpython-3.13.0rc2-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1067,7 +1985,10 @@
   },
   "cpython-3.13.0rc2-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1078,9 +1999,108 @@
     "sha256": "6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161",
     "variant": null
   },
+  "cpython-3.13.0rc2-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "e60fc176fad636bbd287e92f9e9954b8b10d164984e98f51e4dc3d47314fa8a5",
+    "variant": null
+  },
+  "cpython-3.13.0rc2-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "16f23e539336fb45895b3c4fac981365b53fbbd86115feb9516b50a0716394b1",
+    "variant": null
+  },
+  "cpython-3.13.0rc2-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "bf34803e8c05cdb4eee5df5b051cdded1732975c991116a1af823a2b15e49be3",
+    "variant": null
+  },
+  "cpython-3.13.0rc2-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "df60f51c87da60af67453e5d7c5673f1534c2772d92a4885ae51add3cd32848e",
+    "variant": null
+  },
+  "cpython-3.13.0rc2-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "fb8d87e21bd0cb83bfbb5325f2db170365726a9cac58dd5b552fbd084671b785",
+    "variant": null
+  },
+  "cpython-3.13.0rc2-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "eafb931d1a0e6f7237486d2967d0ccacd49791bef27f233895b5d18581ae939a",
+    "variant": null
+  },
   "cpython-3.13.0rc2-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1093,7 +2113,10 @@
   },
   "cpython-3.13.0rc2-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1106,7 +2129,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1119,7 +2145,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1132,7 +2161,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1145,7 +2177,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1158,7 +2193,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1171,7 +2209,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1184,7 +2225,10 @@
   },
   "cpython-3.13.0rc2+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1195,9 +2239,108 @@
     "sha256": "634e538c9d9e8cec2f27aa278a1e99d6e652d7b013b4f27a0242265e0d8ad0ff",
     "variant": "debug"
   },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dcfd016f90f4cd7a8c09cd62e4ed3e809301ddbfca1d17d97b3dca3d40c4e729",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7646e5e1f544c67d6c6d093c3c6f83a10753337d5304ff994068d20abc00ad04",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "18b9afc024e540b40b656df9d58af9cec9c054a6c883693d15e58e0e4935ed08",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7eac181a7ea5e3cf66bb7209fadbc27e82626a5d1e8307fd355867f881a107c6",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bd021bd31769abec42a07cf77cc4937dc83a0713b5038269e62e268f0e9639d1",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ad9a4c4856a7f05ba59841adfc8f7340a1415989674bf48a0227953ad6f6c6d0",
+    "variant": "debug"
+  },
   "cpython-3.12.8-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1210,7 +2353,10 @@
   },
   "cpython-3.12.8-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1223,7 +2369,10 @@
   },
   "cpython-3.12.8-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1236,7 +2385,10 @@
   },
   "cpython-3.12.8-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1249,7 +2401,10 @@
   },
   "cpython-3.12.8-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1262,7 +2417,10 @@
   },
   "cpython-3.12.8-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1275,7 +2433,10 @@
   },
   "cpython-3.12.8-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1288,7 +2449,10 @@
   },
   "cpython-3.12.8-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1301,7 +2465,10 @@
   },
   "cpython-3.12.8-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1312,9 +2479,108 @@
     "sha256": "3b22bb1a9e6a3c6f0de571c914ac98b47d02e5ec7804ae9741e6fc74eb731cc3",
     "variant": null
   },
+  "cpython-3.12.8-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "bb7ad29fb281b9fd8fc97d8d855ad02ef53ce8daeaade52ffe9927cceb65f7eb",
+    "variant": null
+  },
+  "cpython-3.12.8-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "f4bc6cad0048996eea3d8abcf430696cc9cc21ab851ca1b3438877c3a32acddc",
+    "variant": null
+  },
+  "cpython-3.12.8-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "9915a130643ed82a5e2d44b27669c8b2af9e8fc8f08733986e8aca87ece689b4",
+    "variant": null
+  },
+  "cpython-3.12.8-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "b85f9ba0821895e69cc2a884d08091f1223313bc414907e223eb9797691d8390",
+    "variant": null
+  },
+  "cpython-3.12.8-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "3f102535e3f130afb9a9395f7ef4515227fbbb06965af1c2f02aee76d1af2241",
+    "variant": null
+  },
+  "cpython-3.12.8-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "6c29ed847c629a5b3155f158a5e884603681b81485c71cc4efd5f35d82f391b7",
+    "variant": null
+  },
   "cpython-3.12.8-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1327,7 +2593,10 @@
   },
   "cpython-3.12.8-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1340,7 +2609,10 @@
   },
   "cpython-3.12.8+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1353,7 +2625,10 @@
   },
   "cpython-3.12.8+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1366,7 +2641,10 @@
   },
   "cpython-3.12.8+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1379,7 +2657,10 @@
   },
   "cpython-3.12.8+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1392,7 +2673,10 @@
   },
   "cpython-3.12.8+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1405,7 +2689,10 @@
   },
   "cpython-3.12.8+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1418,7 +2705,10 @@
   },
   "cpython-3.12.8+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1429,9 +2719,108 @@
     "sha256": "366701a9d1a1cf0e6c48b1febde7dc0f152f3fb91005132108950ec2503e7c1a",
     "variant": "debug"
   },
+  "cpython-3.12.8+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cd05b9cad6f23c9a50e6e353414f5ce95aa145dc4a808098afbdbd08743109ee",
+    "variant": "debug"
+  },
+  "cpython-3.12.8+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "66ba97aef6a5321ecae3cac2025000899caebe2d7ec2e9d335239fdbc549af5d",
+    "variant": "debug"
+  },
+  "cpython-3.12.8+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "920bd868c67bbd4e55a19cdcfcc50a99158126d49a8c59d61aeb747ab0241ac2",
+    "variant": "debug"
+  },
+  "cpython-3.12.8+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d77c77103e4f8beddc78aa5d47386ad0a95833bed54d64afac9b65e30108c051",
+    "variant": "debug"
+  },
+  "cpython-3.12.8+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "52e05c75d43d923fcd2af4787c96e3e9954cab66b24a45d14cd31560bdf9ddda",
+    "variant": "debug"
+  },
+  "cpython-3.12.8+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "74279ec7dd0cf6b6e9b1ee9e4a45c2e99b4e0f25f13c7eae9f9830363ad375f1",
+    "variant": "debug"
+  },
   "cpython-3.12.7-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1444,7 +2833,10 @@
   },
   "cpython-3.12.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1457,7 +2849,10 @@
   },
   "cpython-3.12.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1470,7 +2865,10 @@
   },
   "cpython-3.12.7-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1483,7 +2881,10 @@
   },
   "cpython-3.12.7-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1496,7 +2897,10 @@
   },
   "cpython-3.12.7-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1509,7 +2913,10 @@
   },
   "cpython-3.12.7-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1522,7 +2929,10 @@
   },
   "cpython-3.12.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1535,7 +2945,10 @@
   },
   "cpython-3.12.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1546,9 +2959,108 @@
     "sha256": "9314cb4d5aa525f2dc9f8d6ac204bebcfdfa8eb0dd4d3788af68769184355484",
     "variant": null
   },
+  "cpython-3.12.7-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "205395841e6e7cbd33d504b78ac81792364831911866416da7a34d9b4a06d7d1",
+    "variant": null
+  },
+  "cpython-3.12.7-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "bfdd008fb669ddd023a8c36c16987c98b0d2bdfb99c9d45e2c9a792d87710b72",
+    "variant": null
+  },
+  "cpython-3.12.7-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "ad1d2bfccc7006612af93e1dbf6760ede5b07148141d0ca05a7d605ea666a55f",
+    "variant": null
+  },
+  "cpython-3.12.7-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "2c11efdb7df78ed787ac67c094c58a75f6549a78660888d99a861fc08e88ebe2",
+    "variant": null
+  },
+  "cpython-3.12.7-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "172c0ab8ac018a0b44a47f03a7a78cd583bdc1e60cd5cfbf7d05b269c5d73f5c",
+    "variant": null
+  },
+  "cpython-3.12.7-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "4576e092f2eaa6f5685be048b50671f9df0fff2b261ee001f604fb983bc9bb71",
+    "variant": null
+  },
   "cpython-3.12.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1561,7 +3073,10 @@
   },
   "cpython-3.12.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1574,7 +3089,10 @@
   },
   "cpython-3.12.7+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1587,7 +3105,10 @@
   },
   "cpython-3.12.7+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1600,7 +3121,10 @@
   },
   "cpython-3.12.7+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1613,7 +3137,10 @@
   },
   "cpython-3.12.7+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1626,7 +3153,10 @@
   },
   "cpython-3.12.7+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1639,7 +3169,10 @@
   },
   "cpython-3.12.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1652,7 +3185,10 @@
   },
   "cpython-3.12.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1663,9 +3199,108 @@
     "sha256": "5c73361c6bede4dbe8de2bf81fd3006451a7941f547e5474141c3fcb400d648e",
     "variant": "debug"
   },
+  "cpython-3.12.7+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0f089b56633c90757bd7027ea2548f024dd187a08c1702d8bd76ff9c507723b4",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d959ee1efc3c9f4ab99399f1250a60f7bbb636da4a844929075c0f6fe1d66020",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e48c45264c5b2d05188912057be6506afc2f2ab05bbb162941e459c4adba50f7",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2a997737209b78941666c42a8a552c3706da3646deb2d6f465bbacf68f433b3a",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "27b332c2768caef93a69bc955f04e6370fb4d37ebe7db37025f5fddfe3892fd5",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2edcf4b44cdd3488c894798919a0ddb794d2b466536f855b34a30b068ba3adc9",
+    "variant": "debug"
+  },
   "cpython-3.12.6-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1678,7 +3313,10 @@
   },
   "cpython-3.12.6-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1691,7 +3329,10 @@
   },
   "cpython-3.12.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1704,7 +3345,10 @@
   },
   "cpython-3.12.6-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1717,7 +3361,10 @@
   },
   "cpython-3.12.6-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1730,7 +3377,10 @@
   },
   "cpython-3.12.6-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1743,7 +3393,10 @@
   },
   "cpython-3.12.6-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1756,7 +3409,10 @@
   },
   "cpython-3.12.6-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1769,7 +3425,10 @@
   },
   "cpython-3.12.6-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1780,9 +3439,108 @@
     "sha256": "661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef",
     "variant": null
   },
+  "cpython-3.12.6-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "3ce9eb5d974dc2109c3e2c3986f4883ec5403b3479259ea781475a319f9a6787",
+    "variant": null
+  },
+  "cpython-3.12.6-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "6dab95cdd6d3f165aaaa7dcd7cb263add390d97c7b57eb62d2d1ca9a304353da",
+    "variant": null
+  },
+  "cpython-3.12.6-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "8dcc21cd45c09b273cca17c4b144c26c1a9e373eec871d540cc0762ab9c82c12",
+    "variant": null
+  },
+  "cpython-3.12.6-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "f2a295a6e400c16d6b3fe51c63c5b017e6c20a0a9e21a664170ecb6b9a104d8e",
+    "variant": null
+  },
+  "cpython-3.12.6-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "debba8985df38a492e8fc4b7b8d2261567f56eae716aa7630b836523625c6a96",
+    "variant": null
+  },
+  "cpython-3.12.6-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "03c0ac05d6027b603ea0f5f9f2c463bd58f942706ae78dca27922b25dca8f16a",
+    "variant": null
+  },
   "cpython-3.12.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1795,7 +3553,10 @@
   },
   "cpython-3.12.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1808,7 +3569,10 @@
   },
   "cpython-3.12.6+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1821,7 +3585,10 @@
   },
   "cpython-3.12.6+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1834,7 +3601,10 @@
   },
   "cpython-3.12.6+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1847,7 +3617,10 @@
   },
   "cpython-3.12.6+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1860,7 +3633,10 @@
   },
   "cpython-3.12.6+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1873,7 +3649,10 @@
   },
   "cpython-3.12.6+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1886,7 +3665,10 @@
   },
   "cpython-3.12.6+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -1897,9 +3679,108 @@
     "sha256": "1d678f6f70dc0cf32c6f5edd18f81a560ff087c7d1bb4185a810ccd1f145b0c3",
     "variant": "debug"
   },
+  "cpython-3.12.6+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "115a15f1341223ff81a20a65470f41049a7af335a4029e9b83e84679798fb550",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "fac68ab9823b6dab76720f806a5a8bcb2caa7bfd31c025c5b0ce70c57d505100",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "64381ee9fb2349344e0e2e06af114130f9ccb8e585ff2c25501aa0264851bdb6",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "352fa6de409617cd4a1196ced30cac11c21082605a1d2a5c2507f27c640484fc",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4fe2168c7e595f83bb2bf93a84762de84ef3441aaeb9eb8720daecdaab4982c5",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "eb717703d2482dccb40c0f9f85a3349f8651c0e44e9a87e08638bc6875c682ba",
+    "variant": "debug"
+  },
   "cpython-3.12.5-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1912,7 +3793,10 @@
   },
   "cpython-3.12.5-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -1925,7 +3809,10 @@
   },
   "cpython-3.12.5-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1938,7 +3825,10 @@
   },
   "cpython-3.12.5-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -1951,7 +3841,10 @@
   },
   "cpython-3.12.5-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -1964,7 +3857,10 @@
   },
   "cpython-3.12.5-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1977,7 +3873,10 @@
   },
   "cpython-3.12.5-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1990,7 +3889,10 @@
   },
   "cpython-3.12.5-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2003,7 +3905,10 @@
   },
   "cpython-3.12.5-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2014,9 +3919,108 @@
     "sha256": "e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24",
     "variant": null
   },
+  "cpython-3.12.5-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "c0064dcd97e5a09b5ff9529fc65cf6fd7a8a20f71a7050f584ecaa0cc8c33f2d",
+    "variant": null
+  },
+  "cpython-3.12.5-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "35ffd76881bef5ce09a123175f4f3419eb250802e60a6bb78649585325b8409f",
+    "variant": null
+  },
+  "cpython-3.12.5-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "6414f1c4b0efb5c1f2eb30926c70519d01f46b1f0d97d407fe53e360865a4a23",
+    "variant": null
+  },
+  "cpython-3.12.5-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "302a26f5d35e1c9e9d82765aa7dbf5ceb609c402431ec97d7fa0e85d8247c023",
+    "variant": null
+  },
+  "cpython-3.12.5-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "d7e82fcf72ec5faedfbabf1084ca55f850971a559ba54350de312663570f4782",
+    "variant": null
+  },
+  "cpython-3.12.5-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "46771e859224aa128150160d568d5d19a69e0f9a8f27d110ea26c031b588c734",
+    "variant": null
+  },
   "cpython-3.12.5-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2029,7 +4033,10 @@
   },
   "cpython-3.12.5-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2042,7 +4049,10 @@
   },
   "cpython-3.12.5+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2055,7 +4065,10 @@
   },
   "cpython-3.12.5+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -2068,7 +4081,10 @@
   },
   "cpython-3.12.5+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -2081,7 +4097,10 @@
   },
   "cpython-3.12.5+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2094,7 +4113,10 @@
   },
   "cpython-3.12.5+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2107,7 +4129,10 @@
   },
   "cpython-3.12.5+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2120,7 +4145,10 @@
   },
   "cpython-3.12.5+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2131,9 +4159,108 @@
     "sha256": "a2766d5627353e8ce8a8c43b0b5c3007a77f4f095bf773739f5bb936860546cd",
     "variant": "debug"
   },
+  "cpython-3.12.5+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "38d30a3118b51d3502af6c35582a321fad85f49a93437ddf6e72b4d3c5bcbd5b",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e11f010a082c1ce7c55a62169d15f12fa28575bb1183d0d0044e56ac42cc36f7",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "25fa6725aaad5cbbe51ad738bd35857bd886a34a278e9ac0f7f349ef1dadb82c",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "46de80152fa10f409c976493248bf107300e27fddbe33e47a7295705119e2d67",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "810b9fb4978625762fb0f433ad96177af916d8eb8e28cd47bdf5e08ce4d549d7",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "dd593a482ecbe045f870489f40b5becf1c758eb4bd69f02a43a50d998198d6f7",
+    "variant": "debug"
+  },
   "cpython-3.12.4-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2146,7 +4273,10 @@
   },
   "cpython-3.12.4-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2159,7 +4289,10 @@
   },
   "cpython-3.12.4-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2172,7 +4305,10 @@
   },
   "cpython-3.12.4-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -2185,7 +4321,10 @@
   },
   "cpython-3.12.4-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -2198,7 +4337,10 @@
   },
   "cpython-3.12.4-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2211,7 +4353,10 @@
   },
   "cpython-3.12.4-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2224,7 +4369,10 @@
   },
   "cpython-3.12.4-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2237,7 +4385,10 @@
   },
   "cpython-3.12.4-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2248,9 +4399,108 @@
     "sha256": "de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6",
     "variant": null
   },
+  "cpython-3.12.4-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "798e562eb68b8d825c25c747b9995046b700c5bafbe8f7e558f41a3d8a57ceb7",
+    "variant": null
+  },
+  "cpython-3.12.4-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "762dc23608111f49729f02c19fa8459219ac886e8694b79f541ef01141bf58c5",
+    "variant": null
+  },
+  "cpython-3.12.4-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "681d65c59f48c4b1bfe29f08ca87a50620c9aef308e27ea11fbe2ef8ce1a3764",
+    "variant": null
+  },
+  "cpython-3.12.4-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "304bdcdf495529a6edcac34646e4f065f0963e4c3061cef9093b76bb0e8cca90",
+    "variant": null
+  },
+  "cpython-3.12.4-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "507fce8676d23af12f97b1f66efa876360d19fbe89675163a0c7c5d631763c84",
+    "variant": null
+  },
+  "cpython-3.12.4-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "8989f75d70f6c874f3031ba1841efd96089f589f04d445fbacd478a1f866c118",
+    "variant": null
+  },
   "cpython-3.12.4-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2263,7 +4513,10 @@
   },
   "cpython-3.12.4-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2276,7 +4529,10 @@
   },
   "cpython-3.12.4+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2289,7 +4545,10 @@
   },
   "cpython-3.12.4+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -2302,7 +4561,10 @@
   },
   "cpython-3.12.4+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -2315,7 +4577,10 @@
   },
   "cpython-3.12.4+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2328,7 +4593,10 @@
   },
   "cpython-3.12.4+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2341,7 +4609,10 @@
   },
   "cpython-3.12.4+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2354,7 +4625,10 @@
   },
   "cpython-3.12.4+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2365,9 +4639,108 @@
     "sha256": "797b3d36a9df38925b7a7c5facb47e56a0d1c4031ae7b121ce41c07433fa1d2e",
     "variant": "debug"
   },
+  "cpython-3.12.4+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5449d31ad213cb19eb4e724f7cf4b8d16e5b7028593aacad0bfda722189ef4a7",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1fffb6494f6540d915b05141ee452e76d6f59b92483bc85161f5dadd1f73b9c5",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f772f9ef369a690a2ca5b2ff7749acbf4e311341bcfd36a651dcf62cf547ccb7",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d0d6d53510ff916b21740c0526ea3b682ba56ea3e6f859f661228a0b9963d10e",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5ad401dba2d3957d3e5d4acf3d4316bec88ad44bec9d72936d04dc27ae3ec177",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "308e7f2e48c32c32090880a8eefc7eb3ea68107ec6ebf904303f4c87c503e26d",
+    "variant": "debug"
+  },
   "cpython-3.12.3-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2380,7 +4753,10 @@
   },
   "cpython-3.12.3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2393,7 +4769,10 @@
   },
   "cpython-3.12.3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2406,7 +4785,10 @@
   },
   "cpython-3.12.3-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -2419,7 +4801,10 @@
   },
   "cpython-3.12.3-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -2432,7 +4817,10 @@
   },
   "cpython-3.12.3-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2445,7 +4833,10 @@
   },
   "cpython-3.12.3-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2458,7 +4849,10 @@
   },
   "cpython-3.12.3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2471,7 +4865,10 @@
   },
   "cpython-3.12.3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2482,9 +4879,108 @@
     "sha256": "eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a",
     "variant": null
   },
+  "cpython-3.12.3-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "b9b91f486e2a52b6cc392101245705d6ab5dd6ad4a4e2b3492baec8e4b96508b",
+    "variant": null
+  },
+  "cpython-3.12.3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e47a8d25c2348bf9b0e818642e4dae90700fc3fbd96ffd7f4ad9518a7206d369",
+    "variant": null
+  },
+  "cpython-3.12.3-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "edb786bf15a92a7c40fc5ace2376736d73ff356458b7c24da0cd408f36b945bf",
+    "variant": null
+  },
+  "cpython-3.12.3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9685fc300be464a9338e94e48fc7315ee0563999833f8c830f2a2dee2d750b7e",
+    "variant": null
+  },
+  "cpython-3.12.3-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "790e70e565b3efc5f1d14294f7cc083d1fb2aa4c15074d547e8e6bb9d2adb70a",
+    "variant": null
+  },
+  "cpython-3.12.3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c4d399923625ff5b5c20eceba0d8580c858768eff73dd9380aa8265030788850",
+    "variant": null
+  },
   "cpython-3.12.3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2497,7 +4993,10 @@
   },
   "cpython-3.12.3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2510,7 +5009,10 @@
   },
   "cpython-3.12.3+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2523,7 +5025,10 @@
   },
   "cpython-3.12.3+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -2536,7 +5041,10 @@
   },
   "cpython-3.12.3+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -2549,7 +5057,10 @@
   },
   "cpython-3.12.3+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2562,7 +5073,10 @@
   },
   "cpython-3.12.3+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2575,7 +5089,10 @@
   },
   "cpython-3.12.3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2588,7 +5105,10 @@
   },
   "cpython-3.12.3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2599,9 +5119,108 @@
     "sha256": "81d9fc9ffd6860229e09b11be5d800db5966080ba6f4b7524ae7917423fd09c6",
     "variant": "debug"
   },
+  "cpython-3.12.3+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4e7c111a3ee36e3adf99b94de0b1ab945a856b33d67ea36e66c985ea93acbda9",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3a1da112630be57fe088cd07568b1ce0743b133fc6aa8fe95b3c6f6cfe526e11",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c75d239ebfcb8b5676184541ecf3a16577b2343e88f529715928a5c6f48601b0",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b3a643688ceb7b38d79c0b39f174d4790e4adb34bc13f731d95675b94fb0ad95",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ddd7363bd343f1f9d38455fe357d6691d805e8f8fb6aa1e287e0f6f9256d1deb",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b6027ddd92733e13ccdc6205daa35a9d8707fb566b0740d87f3e86c9c2a8720f",
+    "variant": "debug"
+  },
   "cpython-3.12.2-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2614,7 +5233,10 @@
   },
   "cpython-3.12.2-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2627,7 +5249,10 @@
   },
   "cpython-3.12.2-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2640,7 +5265,10 @@
   },
   "cpython-3.12.2-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2653,7 +5281,10 @@
   },
   "cpython-3.12.2-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2666,7 +5297,10 @@
   },
   "cpython-3.12.2-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2679,7 +5313,10 @@
   },
   "cpython-3.12.2-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2690,9 +5327,108 @@
     "sha256": "b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81",
     "variant": null
   },
+  "cpython-3.12.2-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "adfe5c1a6039b8806b3dee0aed5fe860540d55231be87df48891a7844279d76a",
+    "variant": null
+  },
+  "cpython-3.12.2-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e5c0adb646defd55791bbdd217f64d08a51855e818ee67e3ea6207521f92abee",
+    "variant": null
+  },
+  "cpython-3.12.2-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "0ab408e31ecc30893020b617dd049af05b76cbe8bb8585b289f75557a24bcfd4",
+    "variant": null
+  },
+  "cpython-3.12.2-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "bcf21a4105fe82cbefbd8bdf76dfc7eb98297b51ad02f0fc0a92929bcc95d6e9",
+    "variant": null
+  },
+  "cpython-3.12.2-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "32ec4268b4d16a428deb642ddd875ae6e738b85558bfbdc4628018ff2e5b9e95",
+    "variant": null
+  },
+  "cpython-3.12.2-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "3b0e8c27c3a1dd339d8e6b53b3fc7faee379a70755093917d6ddca00253621c9",
+    "variant": null
+  },
   "cpython-3.12.2-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2705,7 +5441,10 @@
   },
   "cpython-3.12.2-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2718,7 +5457,10 @@
   },
   "cpython-3.12.2+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2731,7 +5473,10 @@
   },
   "cpython-3.12.2+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2744,7 +5489,10 @@
   },
   "cpython-3.12.2+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2757,7 +5505,10 @@
   },
   "cpython-3.12.2+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2770,7 +5521,10 @@
   },
   "cpython-3.12.2+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2781,9 +5535,108 @@
     "sha256": "2f5f088639e17981b0aeeeeab0fbb6858002d5f10bf57e26eaf32f99b4b6c765",
     "variant": "debug"
   },
+  "cpython-3.12.2+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e8632e829f3e43fd0a9aa16ec8ca14418d78ba4e042673a01dcd20e6c53ad7cc",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "763aa4af52e78e571264d7c809bacc2079ace19192ad6485c7adddb7062e7d99",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9d851a88fb2e83b8e8d9e70102a71e6f8cf53c278e81a45e163b17311d4265b4",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "90845652a0318d00ad056a83fa519528cdca880110e31f716275fbb3e43ffd07",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1b902755013c9c240192a92cafce68d682a54af8953bdb23f5fe88a8c985813",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d640cd4f5a9cc77e6e7d084832f28fea747b9ac07ec4e18cfd05841943ff7196",
+    "variant": "debug"
+  },
   "cpython-3.12.1-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2796,7 +5649,10 @@
   },
   "cpython-3.12.1-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2809,7 +5665,10 @@
   },
   "cpython-3.12.1-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2822,7 +5681,10 @@
   },
   "cpython-3.12.1-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2835,7 +5697,10 @@
   },
   "cpython-3.12.1-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2848,7 +5713,10 @@
   },
   "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2861,7 +5729,10 @@
   },
   "cpython-3.12.1-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2872,9 +5743,108 @@
     "sha256": "876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe",
     "variant": null
   },
+  "cpython-3.12.1-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "9dd6fc5a1326985896493d475e7eae0d07f6de0d932faef3c4b04bdd81b88c0c",
+    "variant": null
+  },
+  "cpython-3.12.1-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "db45fc29b4c0389b23af6ccd2d1427c3200ed7db4a81e5fd3bfbd9a4fd011c41",
+    "variant": null
+  },
+  "cpython-3.12.1-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "a7bcc6c9f66dbd47ea99615f30f101c5d2dd0084ca333d2f7336e64050951338",
+    "variant": null
+  },
+  "cpython-3.12.1-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "2585d13ac6b3e18a24d31f4baea23a810f4c7eb37306c348eeee4dfb87f84866",
+    "variant": null
+  },
+  "cpython-3.12.1-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "510f3f3e1841bb0e236dfac8dbd6680a4990d60a060b6972978cbc89524d4736",
+    "variant": null
+  },
+  "cpython-3.12.1-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "6f34607bafc6104d294ae16be240856af6217555015665c34ff7e94ad33dfe29",
+    "variant": null
+  },
   "cpython-3.12.1-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2887,7 +5857,10 @@
   },
   "cpython-3.12.1-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2900,7 +5873,10 @@
   },
   "cpython-3.12.1+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2913,7 +5889,10 @@
   },
   "cpython-3.12.1+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2926,7 +5905,10 @@
   },
   "cpython-3.12.1+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2939,7 +5921,10 @@
   },
   "cpython-3.12.1+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2952,7 +5937,10 @@
   },
   "cpython-3.12.1+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -2963,9 +5951,108 @@
     "sha256": "0823ed21f7b79129677c51c6a73d3ca53a37179931a5a40a1d53b565d54679ec",
     "variant": "debug"
   },
+  "cpython-3.12.1+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "21a5182c499954bde10344c7cc3ba9f69a39f0b485a9420871bdf65f26587bb7",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d3d402944634b22e2d023ff6356a6e341fecbce67578e1d1ff39f5b76a22aad7",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d2088f53a3e160973ec34376c5a8bc4f430626ea154a57a8ae868f37b43320f3",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "48666cee8413854837c57f769a61e4a99f022cbecb041607fbd2d7802cb446f1",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5c640ffdde33f3d333ed772878694c3be79caf5707de3da23aa8f77cfad4164",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1fb2c5534aa6189ab817ffd4eec7208f5e106d0a09ed2e6ede7e2bead6248941",
+    "variant": "debug"
+  },
   "cpython-3.12.0-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2978,7 +6065,10 @@
   },
   "cpython-3.12.0-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -2991,7 +6081,10 @@
   },
   "cpython-3.12.0-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3004,7 +6097,10 @@
   },
   "cpython-3.12.0-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3017,7 +6113,10 @@
   },
   "cpython-3.12.0-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3030,7 +6129,10 @@
   },
   "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3043,7 +6145,10 @@
   },
   "cpython-3.12.0-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3054,9 +6159,108 @@
     "sha256": "922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5",
     "variant": null
   },
+  "cpython-3.12.0-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "6d7710c9a74f624d1fe60a5a01ed6db874659d906220b1d98a0a79a36bbcb2e6",
+    "variant": null
+  },
+  "cpython-3.12.0-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "927de631f2f37b950c2ea8ca53dc36ce8389026f34c31add31c5f730e7227bae",
+    "variant": null
+  },
+  "cpython-3.12.0-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "dccac6b50581aba8f4ddceb4276589bcc602a672f2461e170076890f0c114444",
+    "variant": null
+  },
+  "cpython-3.12.0-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "28aa3b88cacb908ab57c4202010eebe4a18fad65b5c289d061aec841a0fbbdfb",
+    "variant": null
+  },
+  "cpython-3.12.0-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "13f4c20d3277d0bff7b14125d4904bbf5c498fe14d550d31fd584b5beabe6e0f",
+    "variant": null
+  },
+  "cpython-3.12.0-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "8c20230e3679d5b2d765c6cae2afead81207762c3a9c725249e7ba644f61d4f5",
+    "variant": null
+  },
   "cpython-3.12.0-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3069,7 +6273,10 @@
   },
   "cpython-3.12.0-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3082,7 +6289,10 @@
   },
   "cpython-3.12.0+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3095,7 +6305,10 @@
   },
   "cpython-3.12.0+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3108,7 +6321,10 @@
   },
   "cpython-3.12.0+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3121,7 +6337,10 @@
   },
   "cpython-3.12.0+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3134,7 +6353,10 @@
   },
   "cpython-3.12.0+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3145,9 +6367,108 @@
     "sha256": "0b4380904d53f3322d3e5276de47bfa91a19289b7c734494c127ed0793017dde",
     "variant": "debug"
   },
+  "cpython-3.12.0+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "572f8559f0e8a086c4380ea4417d44f6f3751afd18d01e14e04099ec33e1b199",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e07e32143dd406a2e70ab573b9bc301ea765bfcb3d5092eb06a01a39d67a636f",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1ae35f54bad2b473298858a3cb7bf811291fdd40c8159eff4ff593168ed8765e",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7b86586733acb68e815ac027e8938689d4c6afb468b863361bbe5a9ec70a40e9",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3c900c3495453cfa7e7626026ef0d8be3adf589b2b810969f6a9f44dba3c129d",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "615653eebf06ee913af9254f16836dfcc191a7e54ed0c05f9458d99eb5f4a507",
+    "variant": "debug"
+  },
   "cpython-3.11.11-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3160,7 +6481,10 @@
   },
   "cpython-3.11.11-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3173,7 +6497,10 @@
   },
   "cpython-3.11.11-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3186,7 +6513,10 @@
   },
   "cpython-3.11.11-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3199,7 +6529,10 @@
   },
   "cpython-3.11.11-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3212,7 +6545,10 @@
   },
   "cpython-3.11.11-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3225,7 +6561,10 @@
   },
   "cpython-3.11.11-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3238,7 +6577,10 @@
   },
   "cpython-3.11.11-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3251,7 +6593,10 @@
   },
   "cpython-3.11.11-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3262,9 +6607,108 @@
     "sha256": "87f1a18d62ce76db2fddb86d0389c48023855385c769893a867ecbaaca713234",
     "variant": null
   },
+  "cpython-3.11.11-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "108ddc66731e5bff8e6a9a0a1969e2c2aa2a04e66524d221d97c8b02a3dff3e6",
+    "variant": null
+  },
+  "cpython-3.11.11-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "9d671117d9a139b90f4aa4c28c36c3466af84ca9f1275636f4736c11e2a65388",
+    "variant": null
+  },
+  "cpython-3.11.11-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "55fdef6e77d7abdd352595bea814d3180711f4644038170c6167972e1bc96e94",
+    "variant": null
+  },
+  "cpython-3.11.11-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "a5b836f41f0fff9d53ad79f5dc9c02c9d44a3e343c79b41516374633504cab82",
+    "variant": null
+  },
+  "cpython-3.11.11-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "eb828109f3ba28bc64d45e9c409d4497ab52a33a4e5b0d5b572966f56db7b0f7",
+    "variant": null
+  },
+  "cpython-3.11.11-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "b2889f03b377ea64c9239fcc88cd4ee1ee8705b30a9fa4dc6c7e576373e50605",
+    "variant": null
+  },
   "cpython-3.11.11-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3277,7 +6721,10 @@
   },
   "cpython-3.11.11-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3290,7 +6737,10 @@
   },
   "cpython-3.11.11+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3303,7 +6753,10 @@
   },
   "cpython-3.11.11+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3316,7 +6769,10 @@
   },
   "cpython-3.11.11+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3329,7 +6785,10 @@
   },
   "cpython-3.11.11+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3342,7 +6801,10 @@
   },
   "cpython-3.11.11+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3355,7 +6817,10 @@
   },
   "cpython-3.11.11+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3368,7 +6833,10 @@
   },
   "cpython-3.11.11+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3379,9 +6847,108 @@
     "sha256": "932fbcd64e877a727924829d9918f1e2397563b2809f93c81d952e9aed17ae3c",
     "variant": "debug"
   },
+  "cpython-3.11.11+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9741d956a40e5705242927e0322b864c98ac4f9138f58625662bbbd46f0ac13e",
+    "variant": "debug"
+  },
+  "cpython-3.11.11+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8e1fb834bec5a340f6d8a81b54e2e5ad08bc0229ad98b912b4a176bff9efb9aa",
+    "variant": "debug"
+  },
+  "cpython-3.11.11+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "17c684a3bb28bbd1a5fea1fd936cdbbed452e3c055e352a7e15bcbcf3c46403d",
+    "variant": "debug"
+  },
+  "cpython-3.11.11+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4e5e17fc3824fd14fc8f14d187eb6f3f1d98e4197f03a60c8a4977fbc0b61244",
+    "variant": "debug"
+  },
+  "cpython-3.11.11+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "47892ae10f860bec5e2bfb8bdeac6771a1ee36e9573fa7e803ea5856a2dd9e92",
+    "variant": "debug"
+  },
+  "cpython-3.11.11+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "229cec407fddedbbe5ae32747d5fe9fbbcbfa72efa088ee0042f2f5fd5b00259",
+    "variant": "debug"
+  },
   "cpython-3.11.10-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3394,7 +6961,10 @@
   },
   "cpython-3.11.10-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3407,7 +6977,10 @@
   },
   "cpython-3.11.10-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3420,7 +6993,10 @@
   },
   "cpython-3.11.10-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3433,7 +7009,10 @@
   },
   "cpython-3.11.10-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3446,7 +7025,10 @@
   },
   "cpython-3.11.10-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3459,7 +7041,10 @@
   },
   "cpython-3.11.10-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3472,7 +7057,10 @@
   },
   "cpython-3.11.10-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3485,7 +7073,10 @@
   },
   "cpython-3.11.10-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3496,9 +7087,108 @@
     "sha256": "5b33f0ff29552f15daacf81c426ed585fae24987b47d614142a7906eae6f2b04",
     "variant": null
   },
+  "cpython-3.11.10-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "64aefc042352e6bd10c4f600f1962af7dfec4586385f723c218b6369d3f211a2",
+    "variant": null
+  },
+  "cpython-3.11.10-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "3714fec489d93c1ea458788a348d3380f98de22679a40a063e761753e7a48e71",
+    "variant": null
+  },
+  "cpython-3.11.10-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "ce94270c008e9780a3be5231223a0342e676bae04cb30b7554b0496a8fa7b799",
+    "variant": null
+  },
+  "cpython-3.11.10-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "a2778c2e5c8c48b555f935b4a7ff64f77f6ba0d1bdfb81b12d32905ddf7179cb",
+    "variant": null
+  },
+  "cpython-3.11.10-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "56ed6aeed4795235b4f4349c4c0bf4ee81fdd00ad854eaedcccd5c43388d7545",
+    "variant": null
+  },
+  "cpython-3.11.10-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "c8e8f7a3fa9d797ec0957562f82eaba4dcadf04ef304ac616bdb6332c725a609",
+    "variant": null
+  },
   "cpython-3.11.10-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3511,7 +7201,10 @@
   },
   "cpython-3.11.10-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3524,7 +7217,10 @@
   },
   "cpython-3.11.10+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3537,7 +7233,10 @@
   },
   "cpython-3.11.10+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3550,7 +7249,10 @@
   },
   "cpython-3.11.10+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3563,7 +7265,10 @@
   },
   "cpython-3.11.10+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3576,7 +7281,10 @@
   },
   "cpython-3.11.10+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3589,7 +7297,10 @@
   },
   "cpython-3.11.10+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3602,7 +7313,10 @@
   },
   "cpython-3.11.10+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3613,9 +7327,108 @@
     "sha256": "b18e2b848bbbf75ecda2329dd2aef00bf603dc510c8775cc36bb9cec0318f6e2",
     "variant": "debug"
   },
+  "cpython-3.11.10+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9239d2bdd139c9c461df44de59e111e2ea00c54a34775d0a9df7e7f267dba475",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "03fa1596eb6800ff596219e93cb62c78f5a8cf1ee47a283d57beae50cc37d20c",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9e6f63d6f3978d671f8214febc79e979e296e01ca1be51552c4c8138666c875",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "991dff07922998dca71282287d9df2e6ef2834006d00120a50637b0d84e6c09a",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fc92219ad188e57d67116c15c0b1f2d24bbedabbad0c1db3323635da909e33e9",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "9ba091c7f4c0d6d871a55c9dcdc7aba847f3a5019a136adde07e561f9d3361d0",
+    "variant": "debug"
+  },
   "cpython-3.11.9-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3628,7 +7441,10 @@
   },
   "cpython-3.11.9-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3641,7 +7457,10 @@
   },
   "cpython-3.11.9-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3654,7 +7473,10 @@
   },
   "cpython-3.11.9-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3667,7 +7489,10 @@
   },
   "cpython-3.11.9-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3680,7 +7505,10 @@
   },
   "cpython-3.11.9-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3693,7 +7521,10 @@
   },
   "cpython-3.11.9-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3706,7 +7537,10 @@
   },
   "cpython-3.11.9-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3719,7 +7553,10 @@
   },
   "cpython-3.11.9-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3730,9 +7567,108 @@
     "sha256": "b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9",
     "variant": null
   },
+  "cpython-3.11.9-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "6f579d9b2ec635b7cc4eb983719ae8b4ee34248f2054939cc3b1b23b44c65c60",
+    "variant": null
+  },
+  "cpython-3.11.9-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "d776c6bfd09719f0a18fe23e25b314fed8e32c0c0474c21524020d5481bdcda1",
+    "variant": null
+  },
+  "cpython-3.11.9-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "d6eeb714389614fa954f49e5ec4323f18eccbc700c516521c1297860364226cf",
+    "variant": null
+  },
+  "cpython-3.11.9-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "e8ed1a00acd996590056c8e00351038fd1ecf9910428f592989410f06a765eef",
+    "variant": null
+  },
+  "cpython-3.11.9-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "92247f338ba132e9ff6e4b0dffc2eacfab6958552b0354e623f5016c5e83bafd",
+    "variant": null
+  },
+  "cpython-3.11.9-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "adb10e3c2eb598560c14a375b34776d80bc83656e571f8ddc2b882630db8cd4d",
+    "variant": null
+  },
   "cpython-3.11.9-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3745,7 +7681,10 @@
   },
   "cpython-3.11.9-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3758,7 +7697,10 @@
   },
   "cpython-3.11.9+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3771,7 +7713,10 @@
   },
   "cpython-3.11.9+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -3784,7 +7729,10 @@
   },
   "cpython-3.11.9+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -3797,7 +7745,10 @@
   },
   "cpython-3.11.9+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3810,7 +7761,10 @@
   },
   "cpython-3.11.9+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3823,7 +7777,10 @@
   },
   "cpython-3.11.9+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3836,7 +7793,10 @@
   },
   "cpython-3.11.9+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3847,9 +7807,108 @@
     "sha256": "dc4fd5dd161a0c09375457f29b2c03b1aa026702abbdaedb9db01d2ccc17650b",
     "variant": "debug"
   },
+  "cpython-3.11.9+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a09cd9e3516b3b1a1e654b768f1037b7878d27836a81e484151bb0bb61ca7cc5",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8fdd84f3b942020aee8398cebb0e974d4852e24a855c9e566595990c51fb1709",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e976a7d03df90aef07c2aaafca8577bb46b9f948d580204bc3d1924b4b112ad1",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "fa76d5250edd90b5075b1b69a028b6f8c0862d6c15413027dc542e97d1e417d5",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9d3911236077721c80cd70ac6c3e12bfb1f37403522d82ac797581da2b79edfd",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c55012d0d5f77ad47f77849c5324a3c1852166ada0ea41e872ccb4ab54a8c16e",
+    "variant": "debug"
+  },
   "cpython-3.11.8-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3862,7 +7921,10 @@
   },
   "cpython-3.11.8-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -3875,7 +7937,10 @@
   },
   "cpython-3.11.8-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3888,7 +7953,10 @@
   },
   "cpython-3.11.8-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3901,7 +7969,10 @@
   },
   "cpython-3.11.8-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3914,7 +7985,10 @@
   },
   "cpython-3.11.8-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3927,7 +8001,10 @@
   },
   "cpython-3.11.8-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -3938,9 +8015,108 @@
     "sha256": "08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7",
     "variant": null
   },
+  "cpython-3.11.8-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e4f70dcb40acc2342d63103808a19f728a1c1dc9e0fad5344061daaab03a4ce5",
+    "variant": null
+  },
+  "cpython-3.11.8-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "a3f12605552d5450cfc8fe6c8fc468f99a42b2ae33f1ef42d5f49356d66ad305",
+    "variant": null
+  },
+  "cpython-3.11.8-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "52b3e24b08e53e5098561a13a61e28d241231331fd903dcb2a1e4161f3753dc1",
+    "variant": null
+  },
+  "cpython-3.11.8-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "417890e151d07f9242d0b7ed2e16b7fee59b6606cd133105bba234f14823f8ce",
+    "variant": null
+  },
+  "cpython-3.11.8-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e363cc041a4464bd729771d6d223f3ec13c1e76dacdedc207ad1f6fb777bcb71",
+    "variant": null
+  },
+  "cpython-3.11.8-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9d430c32970e6b0f7cf030ed69dc63ee7b198543ef1e818c5a074c34052fa9e4",
+    "variant": null
+  },
   "cpython-3.11.8-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3953,7 +8129,10 @@
   },
   "cpython-3.11.8-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3966,7 +8145,10 @@
   },
   "cpython-3.11.8+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3979,7 +8161,10 @@
   },
   "cpython-3.11.8+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3992,7 +8177,10 @@
   },
   "cpython-3.11.8+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4005,7 +8193,10 @@
   },
   "cpython-3.11.8+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4018,7 +8209,10 @@
   },
   "cpython-3.11.8+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4029,9 +8223,108 @@
     "sha256": "868adbcbef61c119d10f4da18ecab180423443aa64be0d6c79790df2ed1d12b7",
     "variant": "debug"
   },
+  "cpython-3.11.8+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1bed92aabc3175da3981a2fe5360d8aec3c78f55c557a1f68a5e17b1fce3b303",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3f25e51e767c2ad7b1e76ccd80c1eb19018164eda41f0b969fa2ba63f9db3a80",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "349ee9bf364bee09a3886568a065544e4ecca2a7ea5bf5fe6afe9ebfc2f227b2",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0d8504cee4aa9f387396ef5754723b700334b84ada856b58bed96f8709938a60",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7f9a600733fd202170661249644a1417636f9ec194b0f45273f76774375066d3",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a6f3744ee9cb8bad629c86ab6185e14af35a86fa5bef695dbedd59d73f6c86e3",
+    "variant": "debug"
+  },
   "cpython-3.11.7-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4044,7 +8337,10 @@
   },
   "cpython-3.11.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4057,7 +8353,10 @@
   },
   "cpython-3.11.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4070,7 +8369,10 @@
   },
   "cpython-3.11.7-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4083,7 +8385,10 @@
   },
   "cpython-3.11.7-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4096,7 +8401,10 @@
   },
   "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4109,7 +8417,10 @@
   },
   "cpython-3.11.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4120,9 +8431,108 @@
     "sha256": "1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74",
     "variant": null
   },
+  "cpython-3.11.7-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "2cdd399100e647aa9d381e197e6a8c98e822ecb8fc1b6bda4b1eb554dbfb8177",
+    "variant": null
+  },
+  "cpython-3.11.7-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e9387d628e6f49587206655e61295cdbfea43944c4259c24566fa19e0596ba4e",
+    "variant": null
+  },
+  "cpython-3.11.7-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "08dd57796b8fcc2a7307ed4dbe7a69cf35856cb29a5c79f827fe08a0663c227f",
+    "variant": null
+  },
+  "cpython-3.11.7-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "eec99f0614e8250027e8f72b535776b44e0ad74e24cba9716942cd4c6e08844c",
+    "variant": null
+  },
+  "cpython-3.11.7-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "28590cf568f192dbc5c91814321bca8bfe749cdf5e60a2aad968a0ae74d6bb4a",
+    "variant": null
+  },
+  "cpython-3.11.7-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "3e3b2d4831c6353ae68808a517d59425addd857dbf925958db11b3280f46ed1e",
+    "variant": null
+  },
   "cpython-3.11.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4135,7 +8545,10 @@
   },
   "cpython-3.11.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4148,7 +8561,10 @@
   },
   "cpython-3.11.7+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4161,7 +8577,10 @@
   },
   "cpython-3.11.7+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4174,7 +8593,10 @@
   },
   "cpython-3.11.7+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4187,7 +8609,10 @@
   },
   "cpython-3.11.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4200,7 +8625,10 @@
   },
   "cpython-3.11.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4211,9 +8639,108 @@
     "sha256": "766fd4a583fdfbe65e99b1e3caea843d0eeefde5675d73f3214a53c17a832320",
     "variant": "debug"
   },
+  "cpython-3.11.7+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "24dba70107ca3999c0a2742b3bf898f740a063736f3cd208e80e056adf19cd7f",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8490ae566f8f573031a7bfe1af403c98f42afd47bcddac09fed66573ebc11b9d",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6f5246b7cb8cc36a98025c70f829d2e5d197a7d20d51f21ca44b1e4242b13f0d",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a5f3e309270e82c40441b4b3238cf4878e20ad5d2079887138989ccc6f8f5378",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "74e5053f3f40d4ea018d79139d8a739c0ab0d457b8a9f1597a160bd88fbd58ab",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "f14b33548f64b74f17e0d870c5adc5bc8d3e3135e18f729ea94bd0c1fe70778a",
+    "variant": "debug"
+  },
   "cpython-3.11.6-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4226,7 +8753,10 @@
   },
   "cpython-3.11.6-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4239,7 +8769,10 @@
   },
   "cpython-3.11.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4252,7 +8785,10 @@
   },
   "cpython-3.11.6-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4265,7 +8801,10 @@
   },
   "cpython-3.11.6-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4278,7 +8817,10 @@
   },
   "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4291,7 +8833,10 @@
   },
   "cpython-3.11.6-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4302,9 +8847,108 @@
     "sha256": "c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46",
     "variant": null
   },
+  "cpython-3.11.6-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "d93961f7d6df53f5e888ce070b92d19a7fce588bb03abfac2b6f3c5bf2923c80",
+    "variant": null
+  },
+  "cpython-3.11.6-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "3bb96293951e613fc3f36e7132dcfc34190e5ed634448b12dd1e496723bedbd0",
+    "variant": null
+  },
+  "cpython-3.11.6-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "9a2f2bb9fca7f31502e102306fbeed8ceb7f634f4376a08f9f630c1982f62fcb",
+    "variant": null
+  },
+  "cpython-3.11.6-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "99afdac2a24966c828faf6f13c8c100c6c432d1c888450cfadb39dbc7a7562f1",
+    "variant": null
+  },
+  "cpython-3.11.6-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "ea850efb2de01c9389580ea0a6f55c7271dd3028b31fe0cca3ff9716fb580879",
+    "variant": null
+  },
+  "cpython-3.11.6-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "ebd862470d4f66da160f9a65fc058d4feff3822a97318ccc5c3765a99e0ba439",
+    "variant": null
+  },
   "cpython-3.11.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4317,7 +8961,10 @@
   },
   "cpython-3.11.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4330,7 +8977,10 @@
   },
   "cpython-3.11.6+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4343,7 +8993,10 @@
   },
   "cpython-3.11.6+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4356,7 +9009,10 @@
   },
   "cpython-3.11.6+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4369,7 +9025,10 @@
   },
   "cpython-3.11.6+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4382,7 +9041,10 @@
   },
   "cpython-3.11.6+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4393,9 +9055,108 @@
     "sha256": "c2178b505ac315ede0a2659511841acd022bc7290ef65648e052bb1acebff59f",
     "variant": "debug"
   },
+  "cpython-3.11.6+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2ef8df0de9c400b5d57971fe5bcff36b4dca2410504a9edbd407572ea61044e0",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "baf76c20f6f9dd1384ac7c8985d55922400f220a268ee9a2644a16526235add4",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d96c26d88966873184fc0ee99ca7b941d274b669b1b11e185749fc065d12908f",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "66266853ca23b6dea6f977d69652052d26d61727934a33cc2c31b90c2549cac3",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "865506f3eb1ff9a25f458c1b46d4fe6ceffac869ca01c203c258e3563c87630e",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0ff0cd42a6f73b659f9306751cb3057451db6c323211c24dabbf4a1475bc3038",
+    "variant": "debug"
+  },
   "cpython-3.11.5-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4408,7 +9169,10 @@
   },
   "cpython-3.11.5-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4421,7 +9185,10 @@
   },
   "cpython-3.11.5-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4434,7 +9201,10 @@
   },
   "cpython-3.11.5-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4447,7 +9217,10 @@
   },
   "cpython-3.11.5-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4460,7 +9233,10 @@
   },
   "cpython-3.11.5-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4473,7 +9249,10 @@
   },
   "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4486,7 +9265,10 @@
   },
   "cpython-3.11.5-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4497,9 +9279,108 @@
     "sha256": "fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121",
     "variant": null
   },
+  "cpython-3.11.5-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "6f25769f73827cfc9f80114dbbc04fa959e96f82bf1b1297bc56ae08afaa6a90",
+    "variant": null
+  },
+  "cpython-3.11.5-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "f442249bea0a61dfec2911d86aa49f4c047eabfa2322914d040f2377c1228b48",
+    "variant": null
+  },
+  "cpython-3.11.5-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "5b975dd6a4648d16f278e9d82027f29feb01eda6009b239d7a7c69f421ebd519",
+    "variant": null
+  },
+  "cpython-3.11.5-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "41e2068884c86fc6a51670b12de140e12d6eb849bb450a970c77798f568aef72",
+    "variant": null
+  },
+  "cpython-3.11.5-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "9759ce08bb96716f26aedd4e4d5879f810d9ca1e6f185d9881910837ae66cd29",
+    "variant": null
+  },
+  "cpython-3.11.5-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "568e7a24d390fcd91b7524869c76c4e03dac9940692b381c29ae005651c5f1d7",
+    "variant": null
+  },
   "cpython-3.11.5-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4512,7 +9393,10 @@
   },
   "cpython-3.11.5-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4525,7 +9409,10 @@
   },
   "cpython-3.11.5+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4538,7 +9425,10 @@
   },
   "cpython-3.11.5+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4551,7 +9441,10 @@
   },
   "cpython-3.11.5+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4564,7 +9457,10 @@
   },
   "cpython-3.11.5+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4577,7 +9473,10 @@
   },
   "cpython-3.11.5+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4590,7 +9489,10 @@
   },
   "cpython-3.11.5+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4601,9 +9503,108 @@
     "sha256": "96c77d4b1cbb47ac5eca384d21d689995c46e6a86d487acb73c9210eed3c5614",
     "variant": "debug"
   },
+  "cpython-3.11.5+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d7f5abc89c66a8a1d086394c80a94a17b5b26887983dbf5a80998302f3626ab2",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0471941b959dc707dfaadaeb730792302ddc203198d18b8a9ec64b8f0e73bb65",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "292c37355054d6f4f864b4e772d8bd23541b744d73b3293523f461dcfcad2750",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "df71fed6b655a9ae7927c988b540f5e2cb3a97f5e163552c4aeaa8669ef9c478",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dfa7e0d8fbcde146c5a952f8fa8a1a1121d4b64e7e9e0153d81a06d149a101d3",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "17bc9d5ac04d448ecdba79125aa07a98f9eb27fb5682942b06c9eae08e8e4bc0",
+    "variant": "debug"
+  },
   "cpython-3.11.4-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4616,7 +9617,10 @@
   },
   "cpython-3.11.4-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4629,7 +9633,10 @@
   },
   "cpython-3.11.4-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4642,7 +9649,10 @@
   },
   "cpython-3.11.4-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4655,7 +9665,10 @@
   },
   "cpython-3.11.4-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4668,7 +9681,10 @@
   },
   "cpython-3.11.4-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4681,7 +9697,10 @@
   },
   "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4694,7 +9713,10 @@
   },
   "cpython-3.11.4-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4705,9 +9727,108 @@
     "sha256": "1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806",
     "variant": null
   },
+  "cpython-3.11.4-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "dd1530d8a2e002f68e3d7ed1aa568a0e9278a5c87ba1f2ec4b9bae75777a6bc2",
+    "variant": null
+  },
+  "cpython-3.11.4-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9bea574e0f01eda7154ab1972a3d413c462a731568b5923ed2ae30174167a408",
+    "variant": null
+  },
+  "cpython-3.11.4-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "f6882a821a02c8f727fce12044f8ed03c0814c68c483e9c074b7d62e8aaf3adf",
+    "variant": null
+  },
+  "cpython-3.11.4-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "d8a4a5d572e163eca53f83c91fca78955a92ec5cd2c9713e0e51ad7901add798",
+    "variant": null
+  },
+  "cpython-3.11.4-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "3802bf8c6f305b7b841dbbf1b091d9820d9bd65e9f5b246d2d071c42baa80fec",
+    "variant": null
+  },
+  "cpython-3.11.4-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c50912dce8107bd06c93cd73f96c4bfec0714fc63ba9246c8726b253443e21a7",
+    "variant": null
+  },
   "cpython-3.11.4-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4720,7 +9841,10 @@
   },
   "cpython-3.11.4-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4733,7 +9857,10 @@
   },
   "cpython-3.11.4+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4746,7 +9873,10 @@
   },
   "cpython-3.11.4+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4759,7 +9889,10 @@
   },
   "cpython-3.11.4+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4772,7 +9905,10 @@
   },
   "cpython-3.11.4+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4785,7 +9921,10 @@
   },
   "cpython-3.11.4+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4798,7 +9937,10 @@
   },
   "cpython-3.11.4+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4809,9 +9951,108 @@
     "sha256": "d5467468ddee2b779096c5c4c0dcc74065d35fb38fea6c1c6630e7c2c904b1b9",
     "variant": "debug"
   },
+  "cpython-3.11.4+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "95ac78a3d834ce1feaa45bfe4997563df0bc65c3d2711a5d6d4f39d3c240ffd4",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0e81ab103e2bccbf61de2b968ae705ca52c5fbd650911a89f9c412b45407a31e",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "85859b2993d3c52506625e1dc62b0cb4d9e38816e290d7630fe258aae6b8bca4",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "528c85c2cb9d63784cc84e8196c5290d1c5744e177b5b3d886c0d89c755fb8ba",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a3100464c5f1bc3beb1e15c2bf01ad1aff3888d20a25a1ded1a5baff7be54ff1",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "dc2f89c9c825049c8e00a65b6f5442828a82aec4391ec3fe32b23beb107d92c5",
+    "variant": "debug"
+  },
   "cpython-3.11.3-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4824,7 +10065,10 @@
   },
   "cpython-3.11.3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -4837,7 +10081,10 @@
   },
   "cpython-3.11.3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4850,7 +10097,10 @@
   },
   "cpython-3.11.3-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4863,7 +10113,10 @@
   },
   "cpython-3.11.3-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4876,7 +10129,10 @@
   },
   "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4889,7 +10145,10 @@
   },
   "cpython-3.11.3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4900,9 +10159,108 @@
     "sha256": "82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0",
     "variant": null
   },
+  "cpython-3.11.3-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "d0191c35051ade259d3324f437c6f2422743ccb79197af6dc64c161b06eddca9",
+    "variant": null
+  },
+  "cpython-3.11.3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9715fc26b9a6de09ebc29c978ce1bea81c0a64f730125f1230743c18f536de27",
+    "variant": null
+  },
+  "cpython-3.11.3-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "6452fe315b5240040acffc5688e97fc264d9eb8fbfdd90c6ede0bc46b20640e0",
+    "variant": null
+  },
+  "cpython-3.11.3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9ea67df4e6cafabb6cee6adcc5f863708b1e717caad47be105eb4eb7170eca11",
+    "variant": null
+  },
+  "cpython-3.11.3-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "5bc5eb3892957c0a9eae87fc3ce97f2b0b31406fd6ef1d20bfa8074a44121cb4",
+    "variant": null
+  },
+  "cpython-3.11.3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "7b7645a773cb0660b0f0c807af580b9b4a49d49de39b89d10ccfb01372e5a573",
+    "variant": null
+  },
   "cpython-3.11.3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4915,7 +10273,10 @@
   },
   "cpython-3.11.3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4928,7 +10289,10 @@
   },
   "cpython-3.11.3+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4941,7 +10305,10 @@
   },
   "cpython-3.11.3+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4954,7 +10321,10 @@
   },
   "cpython-3.11.3+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4967,7 +10337,10 @@
   },
   "cpython-3.11.3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4980,7 +10353,10 @@
   },
   "cpython-3.11.3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -4991,9 +10367,108 @@
     "sha256": "b753e060ccfb783b369f1e375ff6cc7a38d864a00506ec2e01ca01ba1956abc6",
     "variant": "debug"
   },
+  "cpython-3.11.3+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f42165d39624cd664ad2c77401b03f2b86c1eaa346a8d97595dc3da9477f7ba7",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ed1ce259ea39c292606097efeee52909b013303d9b6d6d0a0e7001137e75f334",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9b049c8397cb33d8ee8ce810f971569dbeddc058325120dbc9463efd05fd97f4",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "36defe0869e1e8ae6a2cdb819db908c05aa57dbd795556d798958e320f9788a6",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8977784dad18e495cfaaaffa4d3196cba76ddcb6ba665375a3c8d707267478b5",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "004d126ffbe09bb969247d15d98020d413b28908ed35a354033def26bda298fc",
+    "variant": "debug"
+  },
   "cpython-3.11.1-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5006,7 +10481,10 @@
   },
   "cpython-3.11.1-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5019,7 +10497,10 @@
   },
   "cpython-3.11.1-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5032,7 +10513,10 @@
   },
   "cpython-3.11.1-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5045,7 +10529,10 @@
   },
   "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5058,7 +10545,10 @@
   },
   "cpython-3.11.1-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5069,9 +10559,108 @@
     "sha256": "7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82",
     "variant": null
   },
+  "cpython-3.11.1-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "cc322d17b9ead6aeee4ac116fa2f802d525b4d97343fac8b8ada458810b47b40",
+    "variant": null
+  },
+  "cpython-3.11.1-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "0e7dae505cdb31bee4095f7c004a9f89d78263d6f24fe32eb225bfbc34d7f6ab",
+    "variant": null
+  },
+  "cpython-3.11.1-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "a7b538f35630a17ea8b5e1703b38906da189b2d6054297b571c7f5e81fc953a0",
+    "variant": null
+  },
+  "cpython-3.11.1-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "ae7add6ad69f9a1852fed17ca04ebe3412bf5f190e008d8cfbe94bfe21445c48",
+    "variant": null
+  },
+  "cpython-3.11.1-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "dcee403d2f3416c0a7beae2fe58d9ca5646bb73ae47c0431d43911a0a8581a62",
+    "variant": null
+  },
+  "cpython-3.11.1-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "257d4ca1a7167f0b1d65900ca27d0d0f747e1e10bd27fbadeaa4a8bf0bf5b5e3",
+    "variant": null
+  },
   "cpython-3.11.1-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5084,7 +10673,10 @@
   },
   "cpython-3.11.1-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5097,7 +10689,10 @@
   },
   "cpython-3.11.1+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5110,7 +10705,10 @@
   },
   "cpython-3.11.1+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5123,7 +10721,10 @@
   },
   "cpython-3.11.1+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5136,7 +10737,10 @@
   },
   "cpython-3.11.1+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5147,9 +10751,108 @@
     "sha256": "7773aab3d1cbddbd0c6095c931fe841a2c511369e21744097276d22f4bc05621",
     "variant": "debug"
   },
+  "cpython-3.11.1+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea2d1de07fbd276723d61cb9f3c8fe4415f1207b3351593a6985e8e4338e89e0",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bfb7b5328faf30048be5d1d102d6c37ff36c13c5f56137b05bb62f2d2e224f62",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "be1259db03ae12ca8c8cdc1a75a3f4aa47579725f2e62f71022f6049690b6498",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6b7e518c8c65aba363ab1e1db15e4ad2a6c007fb1fb271ab760f32c5af931483",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "abf6c9a813e3c600b095ccfe0fb8c21e2b4156df342e9cf4ea34cb5759a0ff1c",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4bfc948d6fab7a8b788aef0e73211b7bf70def67e34f1fcf9b8622db11ccd419",
+    "variant": "debug"
+  },
   "cpython-3.10.16-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5162,7 +10865,10 @@
   },
   "cpython-3.10.16-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5175,7 +10881,10 @@
   },
   "cpython-3.10.16-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5188,7 +10897,10 @@
   },
   "cpython-3.10.16-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5201,7 +10913,10 @@
   },
   "cpython-3.10.16-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5214,7 +10929,10 @@
   },
   "cpython-3.10.16-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5227,7 +10945,10 @@
   },
   "cpython-3.10.16-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5240,7 +10961,10 @@
   },
   "cpython-3.10.16-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5253,7 +10977,10 @@
   },
   "cpython-3.10.16-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5264,9 +10991,108 @@
     "sha256": "752bda1e074fb5829fd141764d4854fc293911d8d6322a3a36bf22991766dd35",
     "variant": null
   },
+  "cpython-3.10.16-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "ce08564258e2ba4256bbf52898c7e5e456428e01864eb0c8b81f4c5b64138e48",
+    "variant": null
+  },
+  "cpython-3.10.16-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "007c466553d6faa1f3a449ff1813618de649255d8a312e597fcb7ca042b9c79a",
+    "variant": null
+  },
+  "cpython-3.10.16-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "9984ee25ee743d10c9e5359c45357eb3d2448947e39e0a65dc251c0f5e64ccc0",
+    "variant": null
+  },
+  "cpython-3.10.16-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "bc43f14c1f8ef2d7c58166a2e8de5473bef4fd3ff263b59bdc89fa03c2c1e0c8",
+    "variant": null
+  },
+  "cpython-3.10.16-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "d21c8c7a916267f3511357f53cd8101390ee9ba3cb574b9de95206a3f78262bb",
+    "variant": null
+  },
+  "cpython-3.10.16-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "83c04a7d311c9cc12013c430fa24f368f99baaee44458ab35dcdc2c7173cdf05",
+    "variant": null
+  },
   "cpython-3.10.16-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5279,7 +11105,10 @@
   },
   "cpython-3.10.16-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5292,7 +11121,10 @@
   },
   "cpython-3.10.16+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5305,7 +11137,10 @@
   },
   "cpython-3.10.16+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5318,7 +11153,10 @@
   },
   "cpython-3.10.16+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5331,7 +11169,10 @@
   },
   "cpython-3.10.16+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5344,7 +11185,10 @@
   },
   "cpython-3.10.16+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5357,7 +11201,10 @@
   },
   "cpython-3.10.16+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5370,7 +11217,10 @@
   },
   "cpython-3.10.16+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5381,9 +11231,108 @@
     "sha256": "1db866f4f16a7e8afa9f550435f30085db3a87897f2385aca3009ff06978219d",
     "variant": "debug"
   },
+  "cpython-3.10.16+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "26e75bb630c797e618f282cb70f22f7ae5ffd185036e41f67fad8a9ee2111cab",
+    "variant": "debug"
+  },
+  "cpython-3.10.16+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5d15776cd95f33e91b761499a62589366ba1b12388a91f0e1cb1482394f00b84",
+    "variant": "debug"
+  },
+  "cpython-3.10.16+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d02475177517f66af49f0d2c6fcd6498832fbf40e9983ed82e29c2a9941bc917",
+    "variant": "debug"
+  },
+  "cpython-3.10.16+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bebd05404597c39f7a51e997965d9b4958d0177259a2299d87196e56aeb6c27b",
+    "variant": "debug"
+  },
+  "cpython-3.10.16+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b669befacc41be200c92e94dd6bbe43f9c021964f1b15aacd81f8da14e832ba1",
+    "variant": "debug"
+  },
+  "cpython-3.10.16+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "cc366188246668cd383a3c8b2859c657e98860315baa820dce966f85c5bba707",
+    "variant": "debug"
+  },
   "cpython-3.10.15-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5396,7 +11345,10 @@
   },
   "cpython-3.10.15-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5409,7 +11361,10 @@
   },
   "cpython-3.10.15-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5422,7 +11377,10 @@
   },
   "cpython-3.10.15-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5435,7 +11393,10 @@
   },
   "cpython-3.10.15-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5448,7 +11409,10 @@
   },
   "cpython-3.10.15-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5461,7 +11425,10 @@
   },
   "cpython-3.10.15-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5474,7 +11441,10 @@
   },
   "cpython-3.10.15-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5487,7 +11457,10 @@
   },
   "cpython-3.10.15-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5498,9 +11471,108 @@
     "sha256": "a169bdcd98f62421062fb9066763495913f4a86ee88c7d36e51df86d5d3cbe62",
     "variant": null
   },
+  "cpython-3.10.15-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "a85f3481c8117a11b5aa4fda0a6eb174b54e97b122cc8f83cf773a876751785b",
+    "variant": null
+  },
+  "cpython-3.10.15-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "3f78660fd377d6073fa0ab642c20729c16fbc74fd67f8f35688e648fee014f4a",
+    "variant": null
+  },
+  "cpython-3.10.15-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "f36b7ad24ead564455937ff8841a3ec16a194d9eb8411ed0470a0fbd627c683e",
+    "variant": null
+  },
+  "cpython-3.10.15-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "75df2a6b3845ce3e4aa556276d65288e509b17bc35ebb462a60230a8eff5039c",
+    "variant": null
+  },
+  "cpython-3.10.15-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "7d616298bffd2e4ffd0e72ab3786f2e4b9759dcd59a8cf7ac00f74a8642d5537",
+    "variant": null
+  },
+  "cpython-3.10.15-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "b343dff67fc9a6a03943b2bb2d6eb7d15f693533c706cc31f887d7db2625a70d",
+    "variant": null
+  },
   "cpython-3.10.15-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5513,7 +11585,10 @@
   },
   "cpython-3.10.15-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5526,7 +11601,10 @@
   },
   "cpython-3.10.15+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5539,7 +11617,10 @@
   },
   "cpython-3.10.15+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5552,7 +11633,10 @@
   },
   "cpython-3.10.15+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5565,7 +11649,10 @@
   },
   "cpython-3.10.15+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5578,7 +11665,10 @@
   },
   "cpython-3.10.15+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5591,7 +11681,10 @@
   },
   "cpython-3.10.15+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5604,7 +11697,10 @@
   },
   "cpython-3.10.15+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5615,9 +11711,108 @@
     "sha256": "13db15f74f19efc646544ddf7c46df543d2d6a1c3d7fba493d8b64dd3a379d5c",
     "variant": "debug"
   },
+  "cpython-3.10.15+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5f931215e13368ce05ed20837e3ad99cd425564d95b33b12b4fd1e5216c428e4",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "edbe61dbdd6c765e1036d12ba9ea681139bbad73c1c96d83ac0a052ae3735110",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "616d60c112149b4d3ee317ffc072ceb04b163edfa35024d435ccccbd7c9b7f47",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "493250cb67299ce100e5b25e4fec20773ee3e3895285bba02e4e3eaa3ee0354b",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "80240b3c4e493d78a3546f2f5275adbeca20f7b2da93d9b811e861b4e9922b9b",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "f8faa78520e5c4324d153ebf4368701870597037cf53c25b0031028c31d36c55",
+    "variant": "debug"
+  },
   "cpython-3.10.14-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5630,7 +11825,10 @@
   },
   "cpython-3.10.14-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5643,7 +11841,10 @@
   },
   "cpython-3.10.14-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5656,7 +11857,10 @@
   },
   "cpython-3.10.14-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5669,7 +11873,10 @@
   },
   "cpython-3.10.14-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5682,7 +11889,10 @@
   },
   "cpython-3.10.14-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5695,7 +11905,10 @@
   },
   "cpython-3.10.14-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5708,7 +11921,10 @@
   },
   "cpython-3.10.14-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5721,7 +11937,10 @@
   },
   "cpython-3.10.14-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5732,9 +11951,108 @@
     "sha256": "8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c",
     "variant": null
   },
+  "cpython-3.10.14-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "327049baeb8319f0a31a14d28fce5608af546c27fb09994f56e3c0e17efb48c3",
+    "variant": null
+  },
+  "cpython-3.10.14-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "cc2ed06f898466616c6534de1fd3b00d02fae415274ecb7210f5199b2550c38c",
+    "variant": null
+  },
+  "cpython-3.10.14-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "94d7bf472551494c75a122595b30f798b3785b3fcce319e1a66f7b7358399c15",
+    "variant": null
+  },
+  "cpython-3.10.14-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "c3177e9c8a9b339f33fa18ca896d59dbe22853cb88be3d844ac7859c543b5913",
+    "variant": null
+  },
+  "cpython-3.10.14-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "5f0b093b83d5dad323463269d2cd53516e51ef0f5e965001ac8947450c3fc917",
+    "variant": null
+  },
+  "cpython-3.10.14-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "845008e1afab23633b1f8f49323d8de15f24cdda523974df2bab2d080af5bfbf",
+    "variant": null
+  },
   "cpython-3.10.14-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5747,7 +12065,10 @@
   },
   "cpython-3.10.14-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5760,7 +12081,10 @@
   },
   "cpython-3.10.14+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5773,7 +12097,10 @@
   },
   "cpython-3.10.14+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -5786,7 +12113,10 @@
   },
   "cpython-3.10.14+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -5799,7 +12129,10 @@
   },
   "cpython-3.10.14+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5812,7 +12145,10 @@
   },
   "cpython-3.10.14+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5825,7 +12161,10 @@
   },
   "cpython-3.10.14+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5838,7 +12177,10 @@
   },
   "cpython-3.10.14+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5849,9 +12191,108 @@
     "sha256": "cd33d23d8fb79ca99db1398a555daad44af4122d01fb4065fd79e121929c5cb3",
     "variant": "debug"
   },
+  "cpython-3.10.14+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5480ed19c17a087deb3e63b51217ec5fb6a299d53152721cc152f1175dd1b63e",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "09d771b9f11e7492cc775c7853bf34d6e8b3dcb424db0be0df762f408a814118",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c09a17a3441c4c82856f72faad2b76e36264580bf4104305b62fada903c1a9b5",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a7df771ab670843bb66bdd96736c41bceaf6d74dbc759c2d6ad56a5176dc7dbb",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f1b0d3905c719213989e96c06e77092db86c9e120811ffe310472573024c37e3",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "05288ab3fab5d49e8d9c95687dbdf8f8ba9e5c9926aa3c3e0d75e42add811109",
+    "variant": "debug"
+  },
   "cpython-3.10.13-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5864,7 +12305,10 @@
   },
   "cpython-3.10.13-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -5877,7 +12321,10 @@
   },
   "cpython-3.10.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5890,7 +12337,10 @@
   },
   "cpython-3.10.13-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5903,7 +12353,10 @@
   },
   "cpython-3.10.13-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5916,7 +12369,10 @@
   },
   "cpython-3.10.13-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5929,7 +12385,10 @@
   },
   "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5942,7 +12401,10 @@
   },
   "cpython-3.10.13-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -5953,9 +12415,108 @@
     "sha256": "48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180",
     "variant": null
   },
+  "cpython-3.10.13-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "ee43e708b6c4c1ffb5b17b41c51305672e3af2fd686960e4e024a86f969c1a1e",
+    "variant": null
+  },
+  "cpython-3.10.13-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "779be1530f099b4ce0b87fe03f4621e6edca926393c7c857d581f50ffc4df66b",
+    "variant": null
+  },
+  "cpython-3.10.13-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "325b708dccba08446658137517630c1a9fe38519780d516a760597e79a9d8d69",
+    "variant": null
+  },
+  "cpython-3.10.13-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "13d11d53372a058a9df956057d75e14ac229cce8daae6c42d97e742fed63f978",
+    "variant": null
+  },
+  "cpython-3.10.13-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "c1cdc034c483794a4792571b44318f7608769b5b2d116635723e4bd702b5ea69",
+    "variant": null
+  },
+  "cpython-3.10.13-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c1e61caff30433105aad15ea47ddc20b5ced4ccafd8e3666fa85667777354584",
+    "variant": null
+  },
   "cpython-3.10.13-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5968,7 +12529,10 @@
   },
   "cpython-3.10.13-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -5981,7 +12545,10 @@
   },
   "cpython-3.10.13+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -5994,7 +12561,10 @@
   },
   "cpython-3.10.13+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6007,7 +12577,10 @@
   },
   "cpython-3.10.13+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6020,7 +12593,10 @@
   },
   "cpython-3.10.13+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6033,7 +12609,10 @@
   },
   "cpython-3.10.13+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6046,7 +12625,10 @@
   },
   "cpython-3.10.13+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6057,9 +12639,108 @@
     "sha256": "3eec53aef154273c0bc30bb9905734762171f474f73ba256c8883022915b7439",
     "variant": "debug"
   },
+  "cpython-3.10.13+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "375fa4880952a1e78c095704cb50bb001d38c93c3172d0c554c1751ab4138329",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8fda4d7bc57ab9a83644b5ba867bf45b229264c9ccdfdcc7260b41d445ae651f",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "513d9bcdccbee4951c2d494535578220061543a7c1ae202980766641529100ab",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "f96f6d5655e01c15ba8ab4844378fc39e630abc0aafd63b437c96f32dd1425fc",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7baf90a643421989ee592b2c4848f1c4e515c2302067304c1b2d4e54d4282697",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8c4068c68e0a5ecc02325ab83d6977a25bfc479e65ccb1f3886771c86af843df",
+    "variant": "debug"
+  },
   "cpython-3.10.12-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6072,7 +12753,10 @@
   },
   "cpython-3.10.12-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6085,7 +12769,10 @@
   },
   "cpython-3.10.12-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6098,7 +12785,10 @@
   },
   "cpython-3.10.12-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6111,7 +12801,10 @@
   },
   "cpython-3.10.12-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6124,7 +12817,10 @@
   },
   "cpython-3.10.12-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6137,7 +12833,10 @@
   },
   "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6150,7 +12849,10 @@
   },
   "cpython-3.10.12-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6161,9 +12863,108 @@
     "sha256": "9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7",
     "variant": null
   },
+  "cpython-3.10.12-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "843504ad0f655f19614f2edb689808ed5fd2712bbf5a0eb0331ff1ebf871d457",
+    "variant": null
+  },
+  "cpython-3.10.12-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "d5d33effa6d64c83392f12b63fdf122843d943c7cfaa05ab734677699241cf93",
+    "variant": null
+  },
+  "cpython-3.10.12-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "602e8eb7cac2921a9aa12938e9d69ef139797f6952f285ac8522a0502616a137",
+    "variant": null
+  },
+  "cpython-3.10.12-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "bc17cb3b279a031cbcb2427238254758e89ac44541a95a5ddec968bc13ff0181",
+    "variant": null
+  },
+  "cpython-3.10.12-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "7cc21bad92259bf08d60cbe0650133d55f461f102a8ac9908dbd23400d9b35fa",
+    "variant": null
+  },
+  "cpython-3.10.12-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "1eef14ac488ab43ccf54144697d6892645414fc4926cd1456136cd427a8ae454",
+    "variant": null
+  },
   "cpython-3.10.12-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6176,7 +12977,10 @@
   },
   "cpython-3.10.12-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6189,7 +12993,10 @@
   },
   "cpython-3.10.12+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6202,7 +13009,10 @@
   },
   "cpython-3.10.12+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6215,7 +13025,10 @@
   },
   "cpython-3.10.12+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6228,7 +13041,10 @@
   },
   "cpython-3.10.12+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6241,7 +13057,10 @@
   },
   "cpython-3.10.12+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6254,7 +13073,10 @@
   },
   "cpython-3.10.12+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6265,9 +13087,108 @@
     "sha256": "ebff76754ae37694581afe80749efb1260a6da95a9d88f8e60aa2cab75fd5497",
     "variant": "debug"
   },
+  "cpython-3.10.12+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b4d606147bcb75735dd55928330e111dec35fb2c825d2e3fd71eca23eaa11e5f",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e177cbab8330071fe7c7362c266ec6de6b11f8262c43d0c4a9d38f00b7c2fcba",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3f85d12509db9cfe11785c0947d1e5baca0167e3eaa7065f9424a65fa159fb2f",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1d82da2a5c0ff2c150719cfa0108ab20fbb5afba7b7627e9a1345fe5200c57db",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "259e0c20061ed25a72e72912eb212a8571d0607659edba580272db809af7206e",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2256289741d0779f5c32a82d0b6ba9f51d8d6d3332138b4e1919583b59f5e013",
+    "variant": "debug"
+  },
   "cpython-3.10.11-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6280,7 +13201,10 @@
   },
   "cpython-3.10.11-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6293,7 +13217,10 @@
   },
   "cpython-3.10.11-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6306,7 +13233,10 @@
   },
   "cpython-3.10.11-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6319,7 +13249,10 @@
   },
   "cpython-3.10.11-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6332,7 +13265,10 @@
   },
   "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6345,7 +13281,10 @@
   },
   "cpython-3.10.11-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6356,9 +13295,108 @@
     "sha256": "c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1",
     "variant": null
   },
+  "cpython-3.10.11-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "7e6281f9ff93ac54c38abfffe874907591ae6db431df7633b73fa5e62066582c",
+    "variant": null
+  },
+  "cpython-3.10.11-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "bc168048359070be77bf7cf03af1e4cf8c9144d348e59bd5849ebf046694462c",
+    "variant": null
+  },
+  "cpython-3.10.11-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "d94e9958580586c9ff95a35b2e1c5afde7087b9bb0f32d3d141a5a7ec2b8a50b",
+    "variant": null
+  },
+  "cpython-3.10.11-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "862119d9b37def3cba4ceaf10b7415594bc171b4aa6c057e70433349ecb33474",
+    "variant": null
+  },
+  "cpython-3.10.11-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "488df9d6af3baca3fd2b26005e5b1a0e29b53c602bc6ecfa4f21d20715107fba",
+    "variant": null
+  },
+  "cpython-3.10.11-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "35db9299916982e0b9fbf483ae15b7a4b90a418c857ded61be241d81acbc9779",
+    "variant": null
+  },
   "cpython-3.10.11-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6371,7 +13409,10 @@
   },
   "cpython-3.10.11-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6384,7 +13425,10 @@
   },
   "cpython-3.10.11+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6397,7 +13441,10 @@
   },
   "cpython-3.10.11+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6410,7 +13457,10 @@
   },
   "cpython-3.10.11+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6423,7 +13473,10 @@
   },
   "cpython-3.10.11+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6436,7 +13489,10 @@
   },
   "cpython-3.10.11+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6447,9 +13503,108 @@
     "sha256": "0d5bd092b85ada04f6f27a5ef30e026ec2df8ddc73f89d7d1d397623405011c1",
     "variant": "debug"
   },
+  "cpython-3.10.11+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cd6316c2731d2282587475e781e240677c89a678694cf3e58f12e4c2e57add43",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "30563500ff2d568a376fbeea09ad1ab8b377574d75806d555970b233f03034f0",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea5006c1545afed6f16e833a0d4bac14ec289cc0f5911e12a4ef8704a742cf8e",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4fecdf43aeae1b08bd7d195af1c223074b3a9fcebd41097225194303a106ed47",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6ebe8edb6bb89109b351e6f4361be7f1563860e1ae1cb8926c17ca19588e5fa3",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "38f9924b7222ad58c8cf5d26852406052aa3e140e04116b44edab9a2faddf024",
+    "variant": "debug"
+  },
   "cpython-3.10.9-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6462,7 +13617,10 @@
   },
   "cpython-3.10.9-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6475,7 +13633,10 @@
   },
   "cpython-3.10.9-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6488,7 +13649,10 @@
   },
   "cpython-3.10.9-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6501,7 +13665,10 @@
   },
   "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6514,7 +13681,10 @@
   },
   "cpython-3.10.9-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6525,9 +13695,108 @@
     "sha256": "cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516",
     "variant": null
   },
+  "cpython-3.10.9-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e69b2e48696f1e19231bed30616aa4ac6ef0fb4b3760e9e525e2c9c4c30ddb61",
+    "variant": null
+  },
+  "cpython-3.10.9-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "89d13b06e73bd347e46b1424f8c56823e13920cc3cdb32a75c247852cbc84f76",
+    "variant": null
+  },
+  "cpython-3.10.9-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "062b42b9939908f3587f112769373be3d773f0d965ea1a08c65572e2551a2af4",
+    "variant": null
+  },
+  "cpython-3.10.9-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e7c53f1fe15ecba006276b41c3e1947c19ae3af4d53b6fae35f86b210db4e4df",
+    "variant": null
+  },
+  "cpython-3.10.9-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "2c40f64d283d05755b531247eaeb6172cde6d31ba6c46cfa106b97b4669cea88",
+    "variant": null
+  },
+  "cpython-3.10.9-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "8dae0e8c598003e84351a2559d87b44335d02317eb82c75ea13c51aac5891a3f",
+    "variant": null
+  },
   "cpython-3.10.9-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6540,7 +13809,10 @@
   },
   "cpython-3.10.9-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6553,7 +13825,10 @@
   },
   "cpython-3.10.9+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6566,7 +13841,10 @@
   },
   "cpython-3.10.9+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6579,7 +13857,10 @@
   },
   "cpython-3.10.9+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6592,7 +13873,10 @@
   },
   "cpython-3.10.9+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6603,9 +13887,108 @@
     "sha256": "7e0a0094b580d285163ede7797945e86bd4905d6af3340e6554e6abba7bcb832",
     "variant": "debug"
   },
+  "cpython-3.10.9+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fbd196fc7680e499f374a6946b3618b42980e2890a6d533993337b563bd8abb0",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ab0cd574172c836fa74fa15423a4bf6571854c26f40f65f4b4d63363facec6d8",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ece59c02c9fdc77500bc1b60636077bc0a9536d6e63052c727db11488ae2de8c",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ad98c72428b24e18ed587a93fab176b280ea13e28d2fd688d1814a57466b31a8",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f4aab4df5c104f5d438a1a3b4601e45963a13c4100cbafee832336e47f6479cb",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "9baae621ed4304fef603c8067b86972ca1d53ac4f44b4241fa7ecf4f6785fa13",
+    "variant": "debug"
+  },
   "cpython-3.10.8-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6618,7 +14001,10 @@
   },
   "cpython-3.10.8-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6631,7 +14017,10 @@
   },
   "cpython-3.10.8-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6644,7 +14033,10 @@
   },
   "cpython-3.10.8-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6657,7 +14049,10 @@
   },
   "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6670,7 +14065,10 @@
   },
   "cpython-3.10.8-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6681,9 +14079,108 @@
     "sha256": "9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d",
     "variant": null
   },
+  "cpython-3.10.8-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "81eaeef0c63349f296d6c9fed6bb6ff3f2f29db649f0725351e6af147413cc90",
+    "variant": null
+  },
+  "cpython-3.10.8-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "efe550859e00a15325b6c4fff0d5df23ae08017ba8f74616bc0e9e73f899871d",
+    "variant": null
+  },
+  "cpython-3.10.8-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "06a2fc7fa664301bf2657144650d2a655f1f2557861bc5684315df0d2b54d671",
+    "variant": null
+  },
+  "cpython-3.10.8-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "51ebd0a996a750d9101791d5b7789237f7262e4381c21ee5b87e3a2dd88b7628",
+    "variant": null
+  },
+  "cpython-3.10.8-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "b2617ece01070eeaa37fd5feaf1b5835435bd5151386218e6383cf9ee57bb4d2",
+    "variant": null
+  },
+  "cpython-3.10.8-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c641d68243082094f4afbda99eee7da5226906aa7bfca5859044c217e7133db6",
+    "variant": null
+  },
   "cpython-3.10.8-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6696,7 +14193,10 @@
   },
   "cpython-3.10.8-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6709,7 +14209,10 @@
   },
   "cpython-3.10.8+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6722,7 +14225,10 @@
   },
   "cpython-3.10.8+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6735,7 +14241,10 @@
   },
   "cpython-3.10.8+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6748,7 +14257,10 @@
   },
   "cpython-3.10.8+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6759,9 +14271,108 @@
     "sha256": "935eb97e0c3ef358a2f25e78b0b56aebad68d371e3b63979a157c7588a03585b",
     "variant": "debug"
   },
+  "cpython-3.10.8+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "96c8f51e23a1bd8b9a2d9adc0e2457fa74062f16d25d2d0d659b8a6c94631824",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "9e4ca2b0141e336ee1cc137e907809e13836883df661c33c8e564921b99a58f5",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1053c4ca16bda71ae9f2a973cc82118b9e41aa6e426302d9709d9c74c60af50d",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "cbaa62454b9ed27805c2437f5bce92332d698d275e24e6652518354358985fa5",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f23f744868d70cf2e9588aa961e9682060b6c3d6f55c65a61505e23c4895b7e4",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "177dd2840176bc39c3147dd271f8b7344067c0c1d6b29654a2a06cc586e5dc3e",
+    "variant": "debug"
+  },
   "cpython-3.10.7-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6774,7 +14385,10 @@
   },
   "cpython-3.10.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6787,7 +14401,10 @@
   },
   "cpython-3.10.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6800,7 +14417,10 @@
   },
   "cpython-3.10.7-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6813,7 +14433,10 @@
   },
   "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6826,7 +14449,10 @@
   },
   "cpython-3.10.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6837,9 +14463,108 @@
     "sha256": "3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0",
     "variant": null
   },
+  "cpython-3.10.7-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "ae5ad8fe84d8b1fd2e6fe2f47a632c9a1244686c12ce98cdd4a553be1fda2f9e",
+    "variant": null
+  },
+  "cpython-3.10.7-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "4af5e7eb30ae33db0729c019cbca4d76c973dac27167ad4131902078531eb05b",
+    "variant": null
+  },
+  "cpython-3.10.7-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "a85919da343455cd22f8c5cf2e748498222ae92f4dcd8f37a366fec668622cbe",
+    "variant": null
+  },
+  "cpython-3.10.7-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "1cd4072435039557c0b6f528f18865b4d4d36c807d51abd69a6a43c73c26e9af",
+    "variant": null
+  },
+  "cpython-3.10.7-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "f7c803a2ecd63dfc89210e1b6dffb0c509f2680ec9484e824c2d3a14f91a7803",
+    "variant": null
+  },
+  "cpython-3.10.7-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "2bef222e2469cbb4e8cac98a7b31f92b7dcd9672ec4db714fe6fe0090806ad53",
+    "variant": null
+  },
   "cpython-3.10.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6852,7 +14577,10 @@
   },
   "cpython-3.10.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -6865,7 +14593,10 @@
   },
   "cpython-3.10.7+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6878,7 +14609,10 @@
   },
   "cpython-3.10.7+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6891,7 +14625,10 @@
   },
   "cpython-3.10.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6904,7 +14641,10 @@
   },
   "cpython-3.10.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6915,9 +14655,108 @@
     "sha256": "08f725cdb4d4f6bd76c582b798f7d7685c8f5c5afa03e1553e28e55a3859014e",
     "variant": "debug"
   },
+  "cpython-3.10.7+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fb44d19c8e4da5d5c467b6bbfc1b0350fa7faee71462fbd6ac3d69633c2b334a",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8aadba22a811555789a2d8c94a3deba594a82278d77ea51a4c684290915cb825",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c028a4c945329731be66285168a074ac2fc7f25d28c5bbb9bbbb532d45a82ab4",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "9b3e916c03d8ec7986cd5a1b7f4f6ff7f3741134092ae4a694e25e787d4eb90e",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9ddf213ba0f69ac200dd50e5d2c6a52468307a584a64efe422ef537f446c0da",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2bc89eb770995a5b3ad4149b75de1a23fe8cb495b982386bd2b1dd47c9e4980f",
+    "variant": "debug"
+  },
   "cpython-3.10.6-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6930,7 +14769,10 @@
   },
   "cpython-3.10.6-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -6943,7 +14785,10 @@
   },
   "cpython-3.10.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6956,7 +14801,10 @@
   },
   "cpython-3.10.6-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6969,7 +14817,10 @@
   },
   "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -6982,7 +14833,10 @@
   },
   "cpython-3.10.6-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -6993,9 +14847,108 @@
     "sha256": "8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7",
     "variant": null
   },
+  "cpython-3.10.6-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e5478adc739ecd6f7b770e613fa0e5757f13fe9cbeb34f7990e5522b0593d6db",
+    "variant": null
+  },
+  "cpython-3.10.6-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "6097200a90aa57ad5fe8d4446f4f09d6653b3db6dd1fec80f96cbeafcf76de12",
+    "variant": null
+  },
+  "cpython-3.10.6-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "2601630fef417aaeb1d8d07949e81f6390e439cdd2a347ec90218731bbd24b25",
+    "variant": null
+  },
+  "cpython-3.10.6-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9d36dcbd9b47b3205dc5b1371a3839a5ad5317e7ba5fa353bac326635717a3a0",
+    "variant": null
+  },
+  "cpython-3.10.6-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "327533dae8332ee61ed87dd5b7cfee3188a25a9fde65c3e27865185cb3e79b2b",
+    "variant": null
+  },
+  "cpython-3.10.6-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c09bd9d306cd1eae99ed1de66313b0b2617b63a9cafec5e9fa3c5dd82e2d43ca",
+    "variant": null
+  },
   "cpython-3.10.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7008,7 +14961,10 @@
   },
   "cpython-3.10.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7021,7 +14977,10 @@
   },
   "cpython-3.10.6+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7034,7 +14993,10 @@
   },
   "cpython-3.10.6+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7047,7 +15009,10 @@
   },
   "cpython-3.10.6+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7060,7 +15025,10 @@
   },
   "cpython-3.10.6+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7071,9 +15039,108 @@
     "sha256": "6cd58957e286c132dc7cdbd937144aa180b557772be8a2b70bd1c3f2644ebe65",
     "variant": "debug"
   },
+  "cpython-3.10.6+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4a0cc9f5b57ca1eff38d0c9ee71f38f9bf28fbc34d150edd4914b32b69a84f17",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7440ade465fb52a8da42ab9360b998465100ef50fbce9fe0aee87839a6e2e2e3",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "38bc029b11deed33097aae7e1b2e56b6d85f06df24355ff6105bf85fbb2fcb9b",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d3291ce31b13a94f2b1e5e7b27233faec0586a49625ec7ce1d9458fc3f33fca5",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dc779272bd2363abda4a8a784f6dea2dd7d8b2d86cdcfae5e8970df6e5dfbd76",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1833f880ec83d13b40c0c1ccd5406fef7cb408a05e4ddc787e44ffb6d539f49e",
+    "variant": "debug"
+  },
   "cpython-3.10.5-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7086,7 +15153,10 @@
   },
   "cpython-3.10.5-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7099,7 +15169,10 @@
   },
   "cpython-3.10.5-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7112,7 +15185,10 @@
   },
   "cpython-3.10.5-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7125,7 +15201,10 @@
   },
   "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7138,7 +15217,10 @@
   },
   "cpython-3.10.5-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7149,9 +15231,108 @@
     "sha256": "6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0",
     "variant": null
   },
+  "cpython-3.10.5-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "81e0c857175472f62641c49186f637cd1a391e4741b43afff5f55688512de1f1",
+    "variant": null
+  },
+  "cpython-3.10.5-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "febb7ebb1df876145be4f25a1caabbb8ec05758950e7efdebc33587f7ad3ca3c",
+    "variant": null
+  },
+  "cpython-3.10.5-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "462f88de88b450bf80e8e660610adfd7d0ee2e409270ec406e3584093d2262ce",
+    "variant": null
+  },
+  "cpython-3.10.5-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "f28cfb4da443626267792c81b1ac4919765782d38757b0e90daf2db525502615",
+    "variant": null
+  },
+  "cpython-3.10.5-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "cab2739ef27fcb7920dfbc99e57f2aec1256146a4646cf01488c60a267ed9ea3",
+    "variant": null
+  },
+  "cpython-3.10.5-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "5864ccaefdb3f6372f0b59f9c823e5925526c4064a94afad2bcdc9cf919e9365",
+    "variant": null
+  },
   "cpython-3.10.5-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7164,7 +15345,10 @@
   },
   "cpython-3.10.5-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7177,7 +15361,10 @@
   },
   "cpython-3.10.5+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7190,7 +15377,10 @@
   },
   "cpython-3.10.5+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7203,7 +15393,10 @@
   },
   "cpython-3.10.5+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7216,7 +15409,10 @@
   },
   "cpython-3.10.5+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7227,9 +15423,108 @@
     "sha256": "5217476a38b5273fd98ce45b7f0efcd579b8740c4d2911c6900fa16d59368fcc",
     "variant": "debug"
   },
+  "cpython-3.10.5+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fdf3ade3f03f4a755f378d9abea1e9eb6a6a3fb18ce4620d5b7a6cb223a59741",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8301d837c1e7799d0a4b80b62dc8058cfff9f52e8c75c3ebb49079c511161cdc",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "137823acc0d98178c31ce0f75cef5fb0d3850edaf692ced2fab84ef9777d2c01",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b0dd2039186ce8edd5693b7ced49f48dedbff8ee2e34472c6eea67b3c40897f7",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75fddbd0fa525d9455dab972c56ec8b6d39ddd62c12ab38dca81b558b1e70338",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "23eac33183c0c16a5cd91aa28b8dc9ccbdc5b63ac1686b49fc3e5d8fce5e5dc2",
+    "variant": "debug"
+  },
   "cpython-3.10.4-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7242,7 +15537,10 @@
   },
   "cpython-3.10.4-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7255,7 +15553,10 @@
   },
   "cpython-3.10.4-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7268,7 +15569,10 @@
   },
   "cpython-3.10.4-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7281,7 +15585,10 @@
   },
   "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7294,7 +15601,10 @@
   },
   "cpython-3.10.4-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7305,9 +15615,108 @@
     "sha256": "74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8",
     "variant": null
   },
+  "cpython-3.10.4-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "a94db687c197ac8fd9ade2695fe93ce9da392818ed52980459c25c7d39bcd73f",
+    "variant": null
+  },
+  "cpython-3.10.4-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "c2bfbee97c9a4c4f5f5722ea68ea1a4d9f0e2510d02919af0f989d3061c66b3f",
+    "variant": null
+  },
+  "cpython-3.10.4-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "96fc13a16df730afead8c17812e65e2aad53d64d57e3180ef5169cda035f33e4",
+    "variant": null
+  },
+  "cpython-3.10.4-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "a750ac0ba4c23de6ab3ce494fd23e9b0e47dbf961e1fd29cb543ca60e200ba44",
+    "variant": null
+  },
+  "cpython-3.10.4-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "12b5c2f325e99499fa6d79fb9cef3562f8a7635917353f2a79d4c30ac529e7a0",
+    "variant": null
+  },
+  "cpython-3.10.4-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "70bcf588b9f9b7a6aca236ff8214f17b123caa5da039ecc00ddee4828e9cc1bb",
+    "variant": null
+  },
   "cpython-3.10.4-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7320,7 +15729,10 @@
   },
   "cpython-3.10.4-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7333,7 +15745,10 @@
   },
   "cpython-3.10.4+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7346,7 +15761,10 @@
   },
   "cpython-3.10.4+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7359,7 +15777,10 @@
   },
   "cpython-3.10.4+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7372,7 +15793,10 @@
   },
   "cpython-3.10.4+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7383,9 +15807,108 @@
     "sha256": "8fb78fbf9266b23ee0eaf569f7a36d1696f7102c396106c1d71b3a991b27ad27",
     "variant": "debug"
   },
+  "cpython-3.10.4+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e0849600bee6c588f1aa5f4b0b9342292cfb6eb40de0c705f60bd71f22b713d0",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "91e5e1021266da3917e64240bd209a9caff35e29d1a3223766f02b445050a92e",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2875d103a83ff9f9f7ec2ec3ebc43d0e89f20416cd715b83b541b33f91d59832",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4ecbb16e47d8c6de2ed976588336ca2cba6947e8552aba323715dd07fb70851d",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "839f9cb8f1b0e0eb347164a04323f832b945091ba3482724325d3eed1a75daab",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "646deea0c39465497b0b432f7236778b37f6e46636abcf78a240dbacecb18551",
+    "variant": "debug"
+  },
   "cpython-3.10.3-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7398,7 +15921,10 @@
   },
   "cpython-3.10.3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7411,7 +15937,10 @@
   },
   "cpython-3.10.3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7424,7 +15953,10 @@
   },
   "cpython-3.10.3-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7437,7 +15969,10 @@
   },
   "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7450,7 +15985,10 @@
   },
   "cpython-3.10.3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7461,9 +15999,108 @@
     "sha256": "a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1",
     "variant": null
   },
+  "cpython-3.10.3-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "56b36066cda53fb371d92e769b7dc4b18df2d857930871946052d6be724febce",
+    "variant": null
+  },
+  "cpython-3.10.3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "f2cd3e6824d768603d6adc911aeb31de87f12bff9d3dc93624e944c6312acbdf",
+    "variant": null
+  },
+  "cpython-3.10.3-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "c14205c1de8febc05190c879dd4e3eac67ce9afdae962ec00bd768279b262b18",
+    "variant": null
+  },
+  "cpython-3.10.3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e8ff9e1db06889cc65324a878b3d1e49de1213766a0401345b486761721ea125",
+    "variant": null
+  },
+  "cpython-3.10.3-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "04df195d33f88ce2e1160416951eb772e9c61528aad1d15c508d9fd11041fc59",
+    "variant": null
+  },
+  "cpython-3.10.3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "7ad8fdc6f0d26156bc350533a9af7bf582230be8ad6935934911fd8afd184085",
+    "variant": null
+  },
   "cpython-3.10.3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7476,7 +16113,10 @@
   },
   "cpython-3.10.3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7489,7 +16129,10 @@
   },
   "cpython-3.10.3+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7502,7 +16145,10 @@
   },
   "cpython-3.10.3+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7515,7 +16161,10 @@
   },
   "cpython-3.10.3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7528,7 +16177,10 @@
   },
   "cpython-3.10.3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7539,9 +16191,108 @@
     "sha256": "47637777bc44c6476e499bfcb214959c7abc386879dd66683a0d8e1b714c07cf",
     "variant": "debug"
   },
+  "cpython-3.10.3+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "65215230eacebebb87aa1e56d539fc1770870024dcfdadb5d0e18365c1b3b0a9",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "855b17a3210d08f06ab136816bafc9c25bd816cef37a6f381cdef30109c2fd06",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e15dcd98efdde249e7c2857f80b93092245f8495d822cb6c7af3308a59729c21",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c5eb754738a5fb8e44406d452006ced58fab45f7ac8d51587ea73d53cc8d6cd4",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "412570cf01df665c848dacc213c645a3c17aa5045b1805a86c6d9fa2d82eb9ce",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "719eccf39f552e4dceb39122936d2a5e184f922814d63416b5e183e2824c07b9",
+    "variant": "debug"
+  },
   "cpython-3.10.2-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7554,7 +16305,10 @@
   },
   "cpython-3.10.2-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7567,7 +16321,10 @@
   },
   "cpython-3.10.2-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7580,7 +16337,10 @@
   },
   "cpython-3.10.2-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7593,7 +16353,10 @@
   },
   "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7606,7 +16369,10 @@
   },
   "cpython-3.10.2-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7617,9 +16383,108 @@
     "sha256": "c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae",
     "variant": null
   },
+  "cpython-3.10.2-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "1cbd17424d858fbb37e6184bf355f72830a47d2e33a4b8de872fa87aaa49a15e",
+    "variant": null
+  },
+  "cpython-3.10.2-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "1067c4c6fc40bbd2d8b747177296bbeb4abfcb54e700226f2f211c3a2b90be46",
+    "variant": null
+  },
+  "cpython-3.10.2-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "a110dcb9cdca8ce655b215427b0c5fa2b1a374badfe38fbb57cfb0ce28db434e",
+    "variant": null
+  },
+  "cpython-3.10.2-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "dddc62de5f796dbb33cbc81ebdb496758ea653c918a840d12574373aa4835165",
+    "variant": null
+  },
+  "cpython-3.10.2-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "0493e89aae5b95b17f3092402cd7b6516494cad817aff68cc2988a4c065ae1ab",
+    "variant": null
+  },
+  "cpython-3.10.2-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "7dd9634e06daf56e58dfab4f71bea2d4d9b5c808fc30a40eb6208e76dfe24b14",
+    "variant": null
+  },
   "cpython-3.10.2-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7632,7 +16497,10 @@
   },
   "cpython-3.10.2-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7645,7 +16513,10 @@
   },
   "cpython-3.10.2+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7658,7 +16529,10 @@
   },
   "cpython-3.10.2+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7671,7 +16545,10 @@
   },
   "cpython-3.10.2+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7684,7 +16561,10 @@
   },
   "cpython-3.10.2+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7697,7 +16577,10 @@
   },
   "cpython-3.10.2+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7710,7 +16593,10 @@
   },
   "cpython-3.10.2+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7721,9 +16607,108 @@
     "sha256": "a696f058a0cf69fa49c7e65c0b0b630c3fdc23474d45795e5c742c474abb8f24",
     "variant": "debug"
   },
+  "cpython-3.10.2+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8c772010a27d7fd5a3e271c835c37b73bd41bc04a737523f12a3920bf721598b",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6541c4c356146280e57b327dfc8f3f6b4985534d06a64cc20cd1cbdf6fb743b8",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "03a6116ea6dbd5d4e667d4bec2b5032deefd604bc068908cd105327c417d0906",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "765ba7371d5a5b6ca1899ff2811e1b0960a0eeacda448cab0a677caef47e540f",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2262abca39027b52d96b397c5d3285b07a93fafd7dde52295876a331e9fb48c4",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0129870b2c76b1b78762dc38ef4772b96b643151ce757faa9a72a1e099913243",
+    "variant": "debug"
+  },
   "cpython-3.10.0-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7736,7 +16721,10 @@
   },
   "cpython-3.10.0-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7749,7 +16737,10 @@
   },
   "cpython-3.10.0-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7762,7 +16753,10 @@
   },
   "cpython-3.10.0-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7775,7 +16769,10 @@
   },
   "cpython-3.10.0-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7788,7 +16785,10 @@
   },
   "cpython-3.10.0-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7801,7 +16801,10 @@
   },
   "cpython-3.10.0-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7814,7 +16817,10 @@
   },
   "cpython-3.10.0-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -7827,7 +16833,10 @@
   },
   "cpython-3.10.0+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7840,7 +16849,10 @@
   },
   "cpython-3.10.0+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7853,7 +16865,10 @@
   },
   "cpython-3.10.0+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7866,7 +16881,10 @@
   },
   "cpython-3.10.0+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7879,7 +16897,10 @@
   },
   "cpython-3.10.0+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7892,7 +16913,10 @@
   },
   "cpython-3.10.0+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -7905,7 +16929,10 @@
   },
   "cpython-3.9.21-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7918,7 +16945,10 @@
   },
   "cpython-3.9.21-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -7931,7 +16961,10 @@
   },
   "cpython-3.9.21-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7944,7 +16977,10 @@
   },
   "cpython-3.9.21-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -7957,7 +16993,10 @@
   },
   "cpython-3.9.21-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -7970,7 +17009,10 @@
   },
   "cpython-3.9.21-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7983,7 +17025,10 @@
   },
   "cpython-3.9.21-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -7996,7 +17041,10 @@
   },
   "cpython-3.9.21-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8009,7 +17057,10 @@
   },
   "cpython-3.9.21-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8020,9 +17071,108 @@
     "sha256": "4b4696dc8929b08045c8e1cce2eef1ab6d0fefa776e8f424d5426abf6de52c43",
     "variant": null
   },
+  "cpython-3.9.21-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "a941b1c2d598d96a48f97e945164cdc37a872fd85239ea697146dff872ea5cdb",
+    "variant": null
+  },
+  "cpython-3.9.21-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "ac55f1ffe9727dd8fd98872a0d10538069e7034ff48f359b0dfc55b6b98d5b8b",
+    "variant": null
+  },
+  "cpython-3.9.21-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "bd1736347fc811bae037ab42db7438b205ba685e2379cc972e8ac3485ff7cb7c",
+    "variant": null
+  },
+  "cpython-3.9.21-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "b329fb3c247998ce879869ff730681344c43feaf1d0fb3c88837a46cd580ebb8",
+    "variant": null
+  },
+  "cpython-3.9.21-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "87e41b56899c10d01af055e06de9a69cdf3361e71b8eda008b63d37b3ec1b073",
+    "variant": null
+  },
+  "cpython-3.9.21-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "f0413a469a655406bb5912665af344df34a63cc743839fcd0edc8e74012f2327",
+    "variant": null
+  },
   "cpython-3.9.21-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8035,7 +17185,10 @@
   },
   "cpython-3.9.21-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8048,7 +17201,10 @@
   },
   "cpython-3.9.21+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8061,7 +17217,10 @@
   },
   "cpython-3.9.21+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -8074,7 +17233,10 @@
   },
   "cpython-3.9.21+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -8087,7 +17249,10 @@
   },
   "cpython-3.9.21+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8100,7 +17265,10 @@
   },
   "cpython-3.9.21+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8113,7 +17281,10 @@
   },
   "cpython-3.9.21+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8126,7 +17297,10 @@
   },
   "cpython-3.9.21+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8137,9 +17311,108 @@
     "sha256": "deaaf263e16ff33ffcf4642950a34391c5e3b8a21af8d0fa0b88716807d3f440",
     "variant": "debug"
   },
+  "cpython-3.9.21+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5cbd71a8ca91ce7ec70615c6f3cf909ecc760fa70f4865edcfad68f6fa890b14",
+    "variant": "debug"
+  },
+  "cpython-3.9.21+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5f6f2d5e07d8665eabab5a6fb3a768972d97a82e75bfdcb89c11d67a930124b2",
+    "variant": "debug"
+  },
+  "cpython-3.9.21+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "81d9486e388e7524ff81b3b8a32a6688209058e850490ba8384ba85dfe407520",
+    "variant": "debug"
+  },
+  "cpython-3.9.21+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6b49f1f6ec5a7884c444d3e012e6c8a0b6ec2872d7b349efd65623d441ae949f",
+    "variant": "debug"
+  },
+  "cpython-3.9.21+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2caf8865749cc62149c624ae74a8c7b799e97b48ce32902cb96da68b869abc56",
+    "variant": "debug"
+  },
+  "cpython-3.9.21+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 21,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c166775a6007e300c963cc97160d2b474bf0035e672c82560c8495f375d89a90",
+    "variant": "debug"
+  },
   "cpython-3.9.20-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8152,7 +17425,10 @@
   },
   "cpython-3.9.20-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8165,7 +17441,10 @@
   },
   "cpython-3.9.20-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8178,7 +17457,10 @@
   },
   "cpython-3.9.20-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -8191,7 +17473,10 @@
   },
   "cpython-3.9.20-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -8204,7 +17489,10 @@
   },
   "cpython-3.9.20-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8217,7 +17505,10 @@
   },
   "cpython-3.9.20-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8230,7 +17521,10 @@
   },
   "cpython-3.9.20-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8243,7 +17537,10 @@
   },
   "cpython-3.9.20-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8254,9 +17551,108 @@
     "sha256": "332ce515daa15173f73d0ecebc988fadfac5583af8355d8895b3eb8086dac813",
     "variant": null
   },
+  "cpython-3.9.20-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "1461b5364d07a56f1879390eaec72542fe0dd48fa369ce4507c555677bfe07ea",
+    "variant": null
+  },
+  "cpython-3.9.20-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "237ec3d144e488130476c1d2c70d8ca7f2b36f423eb0ead348a78c6fc1fb7abb",
+    "variant": null
+  },
+  "cpython-3.9.20-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "0e2c93f61971e0bda6e679a211c1e1ae074f43d2113328b8304b2e38c77c5a32",
+    "variant": null
+  },
+  "cpython-3.9.20-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "0f99bd0d5b0d1afb207f3e6d4fb36be303bf277ac7c327dd07b7d1e6ba90f9ea",
+    "variant": null
+  },
+  "cpython-3.9.20-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "693a3f129a86c48c176b35db81eae0bf54faec893fe8386ec5116070638c4712",
+    "variant": null
+  },
+  "cpython-3.9.20-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "0d8f9e08f4eb14575574728b174591736ceaada37a03c1bdec17184475ffabe8",
+    "variant": null
+  },
   "cpython-3.9.20-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8269,7 +17665,10 @@
   },
   "cpython-3.9.20-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8282,7 +17681,10 @@
   },
   "cpython-3.9.20+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8295,7 +17697,10 @@
   },
   "cpython-3.9.20+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -8308,7 +17713,10 @@
   },
   "cpython-3.9.20+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -8321,7 +17729,10 @@
   },
   "cpython-3.9.20+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8334,7 +17745,10 @@
   },
   "cpython-3.9.20+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8347,7 +17761,10 @@
   },
   "cpython-3.9.20+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8360,7 +17777,10 @@
   },
   "cpython-3.9.20+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8371,9 +17791,108 @@
     "sha256": "acbe099ea4851fd477b8dbac410ba213331d2129f6e2e4d0967dfb1675799f6c",
     "variant": "debug"
   },
+  "cpython-3.9.20+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "76bee8dde45cd59987d0919898d7dcd0cfee17d876c00e8f35934452b63604ff",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e1410d1c912faf10bc51294665c16fd790fc0764b39cd8645d3f79c617d6628a",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5ed265aa97d30c49f871013fffccb4919b5ccf8834f99ba5c944775cc829f672",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "68ee615f0f4f362190561bdcc6a951ebf391487bcb03716a5cfedbe3e8705fe4",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e084b89c3fc2385bcc3098212135b93f5841a690c1500c77afc86d37e3899e6d",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2551286bc3713a73a2da0b81cceaf075e9e6a853c34b6ffdd12d1cc1f2a1d584",
+    "variant": "debug"
+  },
   "cpython-3.9.19-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8386,7 +17905,10 @@
   },
   "cpython-3.9.19-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8399,7 +17921,10 @@
   },
   "cpython-3.9.19-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8412,7 +17937,10 @@
   },
   "cpython-3.9.19-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -8425,7 +17953,10 @@
   },
   "cpython-3.9.19-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -8438,7 +17969,10 @@
   },
   "cpython-3.9.19-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8451,7 +17985,10 @@
   },
   "cpython-3.9.19-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8464,7 +18001,10 @@
   },
   "cpython-3.9.19-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8477,7 +18017,10 @@
   },
   "cpython-3.9.19-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8488,9 +18031,108 @@
     "sha256": "5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b",
     "variant": null
   },
+  "cpython-3.9.19-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "1d8179bde4db3e6cffac45f5c6a105e342a50a854b316b26760c17ba32bb164a",
+    "variant": null
+  },
+  "cpython-3.9.19-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "2f9eac6ff7bc42a06b0f04cc28f5f24e851dcbb5d4a025a170e036ac1511a226",
+    "variant": null
+  },
+  "cpython-3.9.19-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "66c1df96394e43826ff5ed7f980ad93241af1e3ec212ce92b48efea183e8b9db",
+    "variant": null
+  },
+  "cpython-3.9.19-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "3c79c2c628d9412658e2fe21864439f53d22fa2dd8bc4f355564e73115715e37",
+    "variant": null
+  },
+  "cpython-3.9.19-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "7098fa8e0dac6a689d5289e761b85f713b607c476bfb1c1da13b3f86edce8461",
+    "variant": null
+  },
+  "cpython-3.9.19-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "1c6c6d2113fd3965d29b2fc70621ff81a1f7165a9dd660de980b805ba61a5c39",
+    "variant": null
+  },
   "cpython-3.9.19-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8503,7 +18145,10 @@
   },
   "cpython-3.9.19-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8516,7 +18161,10 @@
   },
   "cpython-3.9.19+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8529,7 +18177,10 @@
   },
   "cpython-3.9.19+debug-linux-armv7-gnueabi": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabi",
     "major": 3,
@@ -8542,7 +18193,10 @@
   },
   "cpython-3.9.19+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
-    "arch": "armv7",
+    "arch": {
+      "family": "armv7",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnueabihf",
     "major": 3,
@@ -8555,7 +18209,10 @@
   },
   "cpython-3.9.19+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8568,7 +18225,10 @@
   },
   "cpython-3.9.19+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8581,7 +18241,10 @@
   },
   "cpython-3.9.19+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8594,7 +18257,10 @@
   },
   "cpython-3.9.19+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8605,9 +18271,108 @@
     "sha256": "bb16ecadf1bbd907da5f0e9c65e2b2bd66770e73c1f3a38ac0ca5fa9ac6fc7a2",
     "variant": "debug"
   },
+  "cpython-3.9.19+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "30aec1d450111fc618973d35a17831e77e9003cdd77395e5891e304ade874cd1",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "59598e9108b795695c1b2f3c592236a0f81bad8a750026be52c519647aee859e",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "59507c5036aaca19d53f0e370d97e8cc775a3e7894db821aba64c5090f098a0d",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a45baeac91eefe2ed59811f6d197a0e0e4ee9d9a6300f53b7b590b7133050716",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8d4a91ba4af009e0c3f14ac5dbab29002674715cbe431e319b410d56ed2b23d8",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a7e8528a496b5eb5116a10335ec96700811aa4d7386b3632977207d52a04649d",
+    "variant": "debug"
+  },
   "cpython-3.9.18-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8620,7 +18385,10 @@
   },
   "cpython-3.9.18-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8633,7 +18401,10 @@
   },
   "cpython-3.9.18-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8646,7 +18417,10 @@
   },
   "cpython-3.9.18-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8659,7 +18433,10 @@
   },
   "cpython-3.9.18-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8672,7 +18449,10 @@
   },
   "cpython-3.9.18-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8685,7 +18465,10 @@
   },
   "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8698,7 +18481,10 @@
   },
   "cpython-3.9.18-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8709,9 +18495,108 @@
     "sha256": "cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba",
     "variant": null
   },
+  "cpython-3.9.18-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "ff8e33905d114a590cd13f5e17590efd6ad56c4eb841c9820863da2f55b13860",
+    "variant": null
+  },
+  "cpython-3.9.18-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "2ab7781e0d14d92272d7bcfb1383328ded38213fa9ad9ca00d1d08dae1ada26e",
+    "variant": null
+  },
+  "cpython-3.9.18-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e85a752197d7c7529a19b83c17efa194c8743cbc4608d5cbca77da506ab30956",
+    "variant": null
+  },
+  "cpython-3.9.18-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "20c45210b2ef110ce6f01038e2861435cc6b9ccf94e7f015dcb111c3f5d0b629",
+    "variant": null
+  },
+  "cpython-3.9.18-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "31b1548bd8e259b6b4a84d69d6ddcd27397af5971e3ffadd162f3a38eb623f6a",
+    "variant": null
+  },
+  "cpython-3.9.18-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "61db6789f2974b6cf85fefc0e06950e43898e4a468d3c643cc35427d8ebf4fc0",
+    "variant": null
+  },
   "cpython-3.9.18-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8724,7 +18609,10 @@
   },
   "cpython-3.9.18-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8737,7 +18625,10 @@
   },
   "cpython-3.9.18+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8750,7 +18641,10 @@
   },
   "cpython-3.9.18+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8763,7 +18657,10 @@
   },
   "cpython-3.9.18+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8776,7 +18673,10 @@
   },
   "cpython-3.9.18+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8789,7 +18689,10 @@
   },
   "cpython-3.9.18+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8802,7 +18705,10 @@
   },
   "cpython-3.9.18+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8813,9 +18719,108 @@
     "sha256": "6f199ddd447d3946381c3ccbb89c0f67643fb8a98205b89caa8e217ad0a20fd7",
     "variant": "debug"
   },
+  "cpython-3.9.18+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1574a99758cae4dbfaa7ff0f06464fe90ab5fe6e7dadcd567aa31d8a25a53f32",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "13c4edbc64b62c7d3fedcde6cae58dbacc05ef2bf03c0f8a50e385066a0f7690",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bc1cd137b083c9eb51d1b226750e3ecc484c6757bd52385bc9587d0f90689dc3",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a70d9ed0166bf32d711e80b68d83c28d7722f64e36a1d56b7472c01bff1864aa",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7fab85ea9595d031ea78a8b2f122d11ed6d19f65e02deddb05a232cf6ef758f7",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "79525f4aea8e369ea18f256c1005068a15120456387f5d2d2183506367f73b61",
+    "variant": "debug"
+  },
   "cpython-3.9.17-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8828,7 +18833,10 @@
   },
   "cpython-3.9.17-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -8841,7 +18849,10 @@
   },
   "cpython-3.9.17-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8854,7 +18865,10 @@
   },
   "cpython-3.9.17-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8867,7 +18881,10 @@
   },
   "cpython-3.9.17-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8880,7 +18897,10 @@
   },
   "cpython-3.9.17-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8893,7 +18913,10 @@
   },
   "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8906,7 +18929,10 @@
   },
   "cpython-3.9.17-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -8917,9 +18943,108 @@
     "sha256": "194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d",
     "variant": null
   },
+  "cpython-3.9.17-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "3d9275e70d39030030f7e9db5f05fc07e2be6fb4964af0053f4a461bac9ba1bd",
+    "variant": null
+  },
+  "cpython-3.9.17-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "cdfe58799d017947c414bc8513ddb51bc7f4c25b2e603faa8dfcfd931a47392f",
+    "variant": null
+  },
+  "cpython-3.9.17-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "be15573d9213c20ead1de62f500817f5e069510d41a4f48a78c3086953c1693e",
+    "variant": null
+  },
+  "cpython-3.9.17-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "4a541fb47184505c165adcb88490fa9df11e7d34fd9bd0117f70b42c50dcc7e1",
+    "variant": null
+  },
+  "cpython-3.9.17-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "114573e1c4919116e5ecf4c6425f44e09b03527fcddffe3d53f73fe1ce9df7d8",
+    "variant": null
+  },
+  "cpython-3.9.17-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "53a1b8cd550e803e258ba04192a18ccfe2ce4cbca2dc776cec47b2eba2507305",
+    "variant": null
+  },
   "cpython-3.9.17-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8932,7 +19057,10 @@
   },
   "cpython-3.9.17-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -8945,7 +19073,10 @@
   },
   "cpython-3.9.17+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8958,7 +19089,10 @@
   },
   "cpython-3.9.17+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8971,7 +19105,10 @@
   },
   "cpython-3.9.17+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8984,7 +19121,10 @@
   },
   "cpython-3.9.17+debug-linux-s390x-gnu": {
     "name": "cpython",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -8997,7 +19137,10 @@
   },
   "cpython-3.9.17+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9010,7 +19153,10 @@
   },
   "cpython-3.9.17+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9021,9 +19167,108 @@
     "sha256": "5a117bc64d6545821083afbfb4a381afee05ddaeb0dd45d2c5adbf3b0a67ec88",
     "variant": "debug"
   },
+  "cpython-3.9.17+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3faab5cb6c0bbb601be92575540036454fb34c0d7e4045760c62d782d8455f88",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e3da342005da3bc938a5869e2f4da7c21056470afb31465aa83f39cd362408c9",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c38db0bd66d15fd2f29bd6299dd74040a93fbe780c811827c3f3eca04f9aa3ca",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "62f7b3c70dcd3bf197239fe814e64a937659cd53a4272193dd0e5b955ab9632a",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c9188a2b7edfb9e24d7cdfde239363ff8c79904901201041c0400d3f82923cb5",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0bd787c0b13676a64c01464276ffe02722e2b353bcdb2bffc9fb8d2d0da33b94",
+    "variant": "debug"
+  },
   "cpython-3.9.16-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9036,7 +19281,10 @@
   },
   "cpython-3.9.16-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9049,7 +19297,10 @@
   },
   "cpython-3.9.16-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9062,7 +19313,10 @@
   },
   "cpython-3.9.16-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9075,7 +19329,10 @@
   },
   "cpython-3.9.16-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9088,7 +19345,10 @@
   },
   "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9101,7 +19361,10 @@
   },
   "cpython-3.9.16-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9112,9 +19375,108 @@
     "sha256": "5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3",
     "variant": null
   },
+  "cpython-3.9.16-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "08acda6031601b35291fa54f98888dc17d36c9ff35bdb2adea4631df81e24271",
+    "variant": null
+  },
+  "cpython-3.9.16-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "b78dbd216e23a8f4adda881fbe11f6749371c09b4235dd519a4b4be761dd1504",
+    "variant": null
+  },
+  "cpython-3.9.16-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "337fb379e9c46b6145e4c52f827513989c2feb9c84beac17c38decb50af5b53a",
+    "variant": null
+  },
+  "cpython-3.9.16-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "675b7d77d653f47561536eae8fcd1ffaedd467ffcf43afdd9c96d2d32e8e84c4",
+    "variant": null
+  },
+  "cpython-3.9.16-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "fc289e674fb61ca4e39a4676ee11971e3f87bab607951898336b5df53b6ca328",
+    "variant": null
+  },
+  "cpython-3.9.16-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "9bdb07f9e9dc429553d12b434293f270c9e281ea7c7ffe5be4f6e8b2cc151e03",
+    "variant": null
+  },
   "cpython-3.9.16-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9127,7 +19489,10 @@
   },
   "cpython-3.9.16-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9140,7 +19505,10 @@
   },
   "cpython-3.9.16+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9153,7 +19521,10 @@
   },
   "cpython-3.9.16+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9166,7 +19537,10 @@
   },
   "cpython-3.9.16+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "powerpc64le",
+    "arch": {
+      "family": "powerpc64le",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9179,7 +19553,10 @@
   },
   "cpython-3.9.16+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9192,7 +19569,10 @@
   },
   "cpython-3.9.16+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9203,9 +19583,108 @@
     "sha256": "e698c7a51e7e998e893b0dd25886d477778a14296bd560e6e585352b9d6194f8",
     "variant": "debug"
   },
+  "cpython-3.9.16+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "35dcaff7a658b8c6bf5ffe1c4e2db95df5d647d28b4880a90f09bf3a70f42e8b",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "f5fb5562fd733ac97a703638bd2c0cf24ec15ec9986083a7883282feeb710ddb",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4c00f35b9218e19065ba9e06c123505f056173a4f9b7eeb72ef768d0dfe8f867",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3659a7d30491ffc73721b438775d7f3b195f5754cc27f30e1e637b1755ed8cc0",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b61ccbfd13415891a9120eaaa37ad5e3f6fac3bfad6123c951c955dbaafec6c3",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e69baf81675c03c967e67aba2c77d3218197d6c62d0598270c976d139a8ab938",
+    "variant": "debug"
+  },
   "cpython-3.9.15-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9218,7 +19697,10 @@
   },
   "cpython-3.9.15-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9231,7 +19713,10 @@
   },
   "cpython-3.9.15-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9244,7 +19729,10 @@
   },
   "cpython-3.9.15-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9257,7 +19745,10 @@
   },
   "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9270,7 +19761,10 @@
   },
   "cpython-3.9.15-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9281,9 +19775,108 @@
     "sha256": "81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391",
     "variant": null
   },
+  "cpython-3.9.15-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "436c35bd809abdd028f386cc623ae020c77e6b544eaaca405098387c4daa444c",
+    "variant": null
+  },
+  "cpython-3.9.15-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "52e774f1ccbbc61a30da2a95286348700ee7d7707412ef10035420f43469c39f",
+    "variant": null
+  },
+  "cpython-3.9.15-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "6a3d25cb22b65355dd793bfb4838a16a5cd85edc07e3dac8cc22adad860f2c89",
+    "variant": null
+  },
+  "cpython-3.9.15-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "a7c4dcff34014b01de397ffe6497787935575f604f489d01cdd843b41dd320e6",
+    "variant": null
+  },
+  "cpython-3.9.15-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "65350987640f33876d072a44d03e6e397dcf5d2512819bd8765c892ec5c0f153",
+    "variant": null
+  },
+  "cpython-3.9.15-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "33b227fdde7a236e69635dafc0cfbfcee76594b9892092357ffd35a0dcb303e7",
+    "variant": null
+  },
   "cpython-3.9.15-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9296,7 +19889,10 @@
   },
   "cpython-3.9.15-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9309,7 +19905,10 @@
   },
   "cpython-3.9.15+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9322,7 +19921,10 @@
   },
   "cpython-3.9.15+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9335,7 +19937,10 @@
   },
   "cpython-3.9.15+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9348,7 +19953,10 @@
   },
   "cpython-3.9.15+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9359,9 +19967,108 @@
     "sha256": "c4bf3bd40dc301eb41984b205a204fb85ebe190bfe35fe73c79b749b48ec7a31",
     "variant": "debug"
   },
+  "cpython-3.9.15+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6222695583b32845fbbf17ec4a43981126ce0d6bb08b47a8c8853396e0f5e9f7",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0369aee7ce8a0f208e9146d17f903e3a3acaa594975a1ae5d1799388c2990d7f",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5fbe25175f4338d6f5bb6f13ea6d714a4373a69b4d193c5037e8424ce5f53fb",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "87fcfc6fe35719215faa676ee86f26de00483d528143c74a1c30e27f860ac12a",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5bc44523a504d220e9af9acaa141ba9ac67e2fe998817cbca99b1bcc9a85d3cd",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a668f5aa1e4ff77ea0275205ed82c555e8070ed9d70a2003714aac38445848fa",
+    "variant": "debug"
+  },
   "cpython-3.9.14-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9374,7 +20081,10 @@
   },
   "cpython-3.9.14-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9387,7 +20097,10 @@
   },
   "cpython-3.9.14-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9400,7 +20113,10 @@
   },
   "cpython-3.9.14-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9413,7 +20129,10 @@
   },
   "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9426,7 +20145,10 @@
   },
   "cpython-3.9.14-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9437,9 +20159,108 @@
     "sha256": "ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8",
     "variant": null
   },
+  "cpython-3.9.14-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "3b858cd4a187db8cd1eaedddd5ff80a077783092ca4d84970097127220f55cd4",
+    "variant": null
+  },
+  "cpython-3.9.14-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "d912966b120f5406046bf5a5252a6585cfb7620fe5d570a265cd221dfd8fbeb3",
+    "variant": null
+  },
+  "cpython-3.9.14-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "798cd9d019885fb2f0010a234873ebe7de35e4eb8fc4e2ba1d40ea31b6abb0bf",
+    "variant": null
+  },
+  "cpython-3.9.14-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "46cd2e2b988bb5f6e12b184f2130d678ee781f84520dee1d8c487f2e0d1e3371",
+    "variant": null
+  },
+  "cpython-3.9.14-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "f14391bc3b71dadc8855577325e3a49b17f351d428cc4caad8b1216b90f3ad80",
+    "variant": null
+  },
+  "cpython-3.9.14-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "355b1b5c3098b45f9b3dd1602321787c6731a70e574846efe29d96aef31d1e5b",
+    "variant": null
+  },
   "cpython-3.9.14-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9452,7 +20273,10 @@
   },
   "cpython-3.9.14-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9465,7 +20289,10 @@
   },
   "cpython-3.9.14+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9478,7 +20305,10 @@
   },
   "cpython-3.9.14+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9491,7 +20321,10 @@
   },
   "cpython-3.9.14+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9504,7 +20337,10 @@
   },
   "cpython-3.9.14+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9515,9 +20351,108 @@
     "sha256": "598de16fbb955c2de02ac7765f162bee74601e28b3de9b6efeeecf30d97aecd6",
     "variant": "debug"
   },
+  "cpython-3.9.14+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a78cb80ca372ea98aca28d33a220b3fe91761c6dadaf92f646b82f3b569822c1",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b9a1b56faaade8fdfe646f3893487ee76463277c65df1dfe7b9d0ca7a0df0aaf",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "53d3c637264a57317b304a88ddd418463fe0b37b874495e3ae55940b5c62b363",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "12333172d06f094381245d612404a46836522ab77b3fceb0a2a5dbbf6b2af75a",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "92e5a9fd569c0b1c161958e2e1d3198cb4e27b524d02cf3008b260dba658961f",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6e9ba8f2b5d320c0a9451fe80d69fd6870bcee75cbb0a1206a274883c5a31565",
+    "variant": "debug"
+  },
   "cpython-3.9.13-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9530,7 +20465,10 @@
   },
   "cpython-3.9.13-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9543,7 +20481,10 @@
   },
   "cpython-3.9.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9556,7 +20497,10 @@
   },
   "cpython-3.9.13-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9569,7 +20513,10 @@
   },
   "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9582,7 +20529,10 @@
   },
   "cpython-3.9.13-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9593,9 +20543,108 @@
     "sha256": "766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f",
     "variant": null
   },
+  "cpython-3.9.13-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "1e1b522a91ed805287793427013762bc8f6c02440147e9fa5306316369307e58",
+    "variant": null
+  },
+  "cpython-3.9.13-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "e3142427ed091bfe0986cf49954fa3fcbe7754f42d66e4fd0ce68f41a513c3c1",
+    "variant": null
+  },
+  "cpython-3.9.13-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "315a9fbc75e2a0545254edf8974d88577ec64537ee04322ad1a7ce9752353f33",
+    "variant": null
+  },
+  "cpython-3.9.13-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "40be6728331395abce574e080e5411e781c0a8a3a5d5175ae10534cee8d83ae2",
+    "variant": null
+  },
+  "cpython-3.9.13-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "b4c5a9908a77e4cae37901f8df2655380186d0e10723902672ef5e5296093071",
+    "variant": null
+  },
+  "cpython-3.9.13-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "3b21780f0eba88519f0c00032cfb8ddb959b31a76cf21611a26da5d8296a9200",
+    "variant": null
+  },
   "cpython-3.9.13-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9608,7 +20657,10 @@
   },
   "cpython-3.9.13-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9621,7 +20673,10 @@
   },
   "cpython-3.9.13+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9634,7 +20689,10 @@
   },
   "cpython-3.9.13+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9647,7 +20705,10 @@
   },
   "cpython-3.9.13+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9660,7 +20721,10 @@
   },
   "cpython-3.9.13+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9671,9 +20735,108 @@
     "sha256": "fd18bcb560764e7456431b577ce3b35057c3dd4cda60dfb98a9af8739ec95c43",
     "variant": "debug"
   },
+  "cpython-3.9.13+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "37ace8159aa2f5157abea2c0d854434f21e6676b90eeaf58d313778f64540ca7",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "145f9fec457ac6f3ea642b5d90d275cb9f317cf36f0ef7df4902f871db9725bf",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "59a24171f794139b41d47b3e734c82d02bc11956a4c092a3d28d94a5d0ab7f54",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bb403edaed2809e90d035a74dd3b6cd33b53c13ee37ade2c01876565596c4235",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "920fd94d4352495a804d4ee725764ae7499b29c5f1c15d11cc4380a873498dbf",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b75b92f652498a3073110661062be7a696ace3827c73c63ecd5fbe8ddb3a86a9",
+    "variant": "debug"
+  },
   "cpython-3.9.12-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9686,7 +20849,10 @@
   },
   "cpython-3.9.12-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9699,7 +20865,10 @@
   },
   "cpython-3.9.12-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9712,7 +20881,10 @@
   },
   "cpython-3.9.12-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9725,7 +20897,10 @@
   },
   "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9738,7 +20913,10 @@
   },
   "cpython-3.9.12-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9749,9 +20927,108 @@
     "sha256": "dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6",
     "variant": null
   },
+  "cpython-3.9.12-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "72085205843949f783c9245ad42902a63a00dd35367f1e5ea6f4aa709b2029ce",
+    "variant": null
+  },
+  "cpython-3.9.12-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "140ea77e2924fc312ecd266337f1add09e560084422843673b08ff847259a93f",
+    "variant": null
+  },
+  "cpython-3.9.12-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "bb702440330bf8cd852cf36735a47ee10aa3941271b5d2f96cd6bfa6ac7a46b4",
+    "variant": null
+  },
+  "cpython-3.9.12-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "afceda37726445a1472b023ca7e6fb1b169557c7fc26a2ffa53e2b59247e1c6c",
+    "variant": null
+  },
+  "cpython-3.9.12-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "7a5fcad095ad183049b2f975cd55efd8a2ce3e4d894ee67cb5fa01186f50203e",
+    "variant": null
+  },
+  "cpython-3.9.12-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "81138b9b65bc01ed441bf0ab0fa2225c3d131a3b13838cc698c9e4aaef4cab11",
+    "variant": null
+  },
   "cpython-3.9.12-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9764,7 +21041,10 @@
   },
   "cpython-3.9.12-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9777,7 +21057,10 @@
   },
   "cpython-3.9.12+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9790,7 +21073,10 @@
   },
   "cpython-3.9.12+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9803,7 +21089,10 @@
   },
   "cpython-3.9.12+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9816,7 +21105,10 @@
   },
   "cpython-3.9.12+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9827,9 +21119,108 @@
     "sha256": "410d7e68366f0e4fce4540a73ab3228060aa469949154fc08dc00d9da8ad51c6",
     "variant": "debug"
   },
+  "cpython-3.9.12+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "53dadc107ce8d1ba5f94ca87edbeef485c8a07b2c0e942a99a7c7e163fafb6f4",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "465ef90b1462dc316bd14c5368d88acdeb2074464efdfeb9f35d3d1a47ec8f99",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e7ba8a790a3194a0847ef0b09b8dd8542b9c2ca689b2f4ee4ecb771a44ea41f2",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e3f26b24858786ce3e756d10e6e16edc5bf136ab4df7fd55378312b0c61c42ca",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "afdd26e418ab5a2e5e10b42eb98c79bafd7c198363f70aad8628266b7f3532ab",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a6c3b487b913c514a105d06c55f97e65508bc3d2253f1666b350bc1294643043",
+    "variant": "debug"
+  },
   "cpython-3.9.11-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9842,7 +21233,10 @@
   },
   "cpython-3.9.11-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9855,7 +21249,10 @@
   },
   "cpython-3.9.11-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9868,7 +21265,10 @@
   },
   "cpython-3.9.11-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9881,7 +21281,10 @@
   },
   "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9894,7 +21297,10 @@
   },
   "cpython-3.9.11-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9905,9 +21311,108 @@
     "sha256": "ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d",
     "variant": null
   },
+  "cpython-3.9.11-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "bd9d808283eef69882e8e0c2529fe400c8605b7c08ef64e679d1766c1a87ef95",
+    "variant": null
+  },
+  "cpython-3.9.11-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "69439fb7c2e8f8bda28f2d5f4c71634116800d71a06f7cbeeb8f21ebca829fd2",
+    "variant": null
+  },
+  "cpython-3.9.11-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "9cb5ab650efad6e475026f7782f852094a9403966bcc1f795065b1a4a33e362b",
+    "variant": null
+  },
+  "cpython-3.9.11-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "190cb2cc081d0d6ffca9232e877a959915452f6fd3808cfe128f6ebc392fcfb2",
+    "variant": null
+  },
+  "cpython-3.9.11-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "8d7eee9c085e08f3cc6cdf56be7cc0dc8a3e25e053856c1a933efb3529c087de",
+    "variant": null
+  },
+  "cpython-3.9.11-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "0455c95330532edf5c30d4a30873140e7e6c715fbca921ac127769865382050b",
+    "variant": null
+  },
   "cpython-3.9.11-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9920,7 +21425,10 @@
   },
   "cpython-3.9.11-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -9933,7 +21441,10 @@
   },
   "cpython-3.9.11+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9946,7 +21457,10 @@
   },
   "cpython-3.9.11+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9959,7 +21473,10 @@
   },
   "cpython-3.9.11+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -9972,7 +21489,10 @@
   },
   "cpython-3.9.11+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -9983,9 +21503,108 @@
     "sha256": "046c027a79ab60b70f2853ef978d89a97d2d35d9af3e7d7e9684d20b66afa6bc",
     "variant": "debug"
   },
+  "cpython-3.9.11+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7d7a745a3d6eade5fd7352b444c4c91ce562a2d188716d6995155c2ed5d1e337",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b0b1389d83b844aed6bfa73270fefd902a9869403e9dae79772506f9a0344578",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea43a4a473ebf99af4f7b9ae1d00e3bd6c5a2a329096e5657590ed5d823903dd",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bd1d91ca3f95e1b7314604d9377013a0b537c6ae32408d0b25ef0e46792d1146",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a1e7c4554d200d4fa50dc43cda6db020df99f75bb105dd7c44139c44d5040fae",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d61f3edf4284c0d1a9acf4e68b684eb518db0cea191be20188ee58a59546b286",
+    "variant": "debug"
+  },
   "cpython-3.9.10-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -9998,7 +21617,10 @@
   },
   "cpython-3.9.10-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10011,7 +21633,10 @@
   },
   "cpython-3.9.10-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10024,7 +21649,10 @@
   },
   "cpython-3.9.10-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10037,7 +21665,10 @@
   },
   "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10050,7 +21681,10 @@
   },
   "cpython-3.9.10-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10061,9 +21695,108 @@
     "sha256": "30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d",
     "variant": null
   },
+  "cpython-3.9.10-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "f9c6b0412c0773e604a1f95d5db97f79f98d960bcf0e85215e533ea573721216",
+    "variant": null
+  },
+  "cpython-3.9.10-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "5e4bde1751608e7f3ae2d9029c8866d0325db24c5a3b8441b62bef14fb8484be",
+    "variant": null
+  },
+  "cpython-3.9.10-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "5c23a5f13356adfcf26d27df7e48885e634489e3a2383e67c013c3f1ec2e082e",
+    "variant": null
+  },
+  "cpython-3.9.10-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "649371a944665efa5b286d530c76808fb4f6ae4694f59c2ced8596fbe65d5164",
+    "variant": null
+  },
+  "cpython-3.9.10-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "e97477ab9d30b52faf7de9e364ff50acf4490a28f7bf6fa11887f5a26e56ec93",
+    "variant": null
+  },
+  "cpython-3.9.10-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+    "sha256": "6bcba95a5d6f1378821ba16c5d5b8a2e02bb365c1314d0492f66545973459ae4",
+    "variant": null
+  },
   "cpython-3.9.10-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10076,7 +21809,10 @@
   },
   "cpython-3.9.10-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10089,7 +21825,10 @@
   },
   "cpython-3.9.10+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10102,7 +21841,10 @@
   },
   "cpython-3.9.10+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10115,7 +21857,10 @@
   },
   "cpython-3.9.10+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10128,7 +21873,10 @@
   },
   "cpython-3.9.10+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10141,7 +21889,10 @@
   },
   "cpython-3.9.10+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10154,7 +21905,10 @@
   },
   "cpython-3.9.10+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10165,9 +21919,108 @@
     "sha256": "3ea1f4b06710a87a4f817b9084f60cc7ea481eb1090adc81306031ac4b382131",
     "variant": "debug"
   },
+  "cpython-3.9.10+debug-linux-x86_64_v2-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8317251d7480b9fc8b4f0b76dbb91b339bc55760cc92715e66f91a3055396497",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v2"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2d99f49e6ae4c56f63653a0a85eccf3d8e39077c1f9585e8d15d77835ecab976",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64_v3-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c2a8ef2fd0f2c033371e931c2588444c5872b3c1fe7c787e0139e9ee03177ea6",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v3"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bca138192f93c76d0b26d48bd7fdbd31e75dae403a5a34cb826284748549dba7",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64_v4-gnu": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "162da56c07f3bec783c3c202b274c89ab115dae82ab7783b04404c7e315b819f",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": {
+      "family": "x86_64",
+      "variant": "v4"
+    },
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ecd1b5c6a1183ab24284dd7a71b4cfe72dc1c9759c67d4266733fb839d7b3a99",
+    "variant": "debug"
+  },
   "cpython-3.9.7-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10180,7 +22033,10 @@
   },
   "cpython-3.9.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10193,7 +22049,10 @@
   },
   "cpython-3.9.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10206,7 +22065,10 @@
   },
   "cpython-3.9.7-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10219,7 +22081,10 @@
   },
   "cpython-3.9.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10232,7 +22097,10 @@
   },
   "cpython-3.9.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10245,7 +22113,10 @@
   },
   "cpython-3.9.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10258,7 +22129,10 @@
   },
   "cpython-3.9.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10271,7 +22145,10 @@
   },
   "cpython-3.9.7+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10284,7 +22161,10 @@
   },
   "cpython-3.9.7+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10297,7 +22177,10 @@
   },
   "cpython-3.9.7+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10310,7 +22193,10 @@
   },
   "cpython-3.9.7+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10323,7 +22209,10 @@
   },
   "cpython-3.9.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10336,7 +22225,10 @@
   },
   "cpython-3.9.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10349,7 +22241,10 @@
   },
   "cpython-3.9.6-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10362,7 +22257,10 @@
   },
   "cpython-3.9.6-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10375,7 +22273,10 @@
   },
   "cpython-3.9.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10388,7 +22289,10 @@
   },
   "cpython-3.9.6-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10401,7 +22305,10 @@
   },
   "cpython-3.9.6-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10414,7 +22321,10 @@
   },
   "cpython-3.9.6-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10427,7 +22337,10 @@
   },
   "cpython-3.9.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10440,7 +22353,10 @@
   },
   "cpython-3.9.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10453,7 +22369,10 @@
   },
   "cpython-3.9.6+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10466,7 +22385,10 @@
   },
   "cpython-3.9.6+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10479,7 +22401,10 @@
   },
   "cpython-3.9.6+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10492,7 +22417,10 @@
   },
   "cpython-3.9.6+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10505,7 +22433,10 @@
   },
   "cpython-3.9.6+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10518,7 +22449,10 @@
   },
   "cpython-3.9.6+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10531,7 +22465,10 @@
   },
   "cpython-3.9.5-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10544,7 +22481,10 @@
   },
   "cpython-3.9.5-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10557,7 +22497,10 @@
   },
   "cpython-3.9.5-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10570,7 +22513,10 @@
   },
   "cpython-3.9.5-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10583,7 +22529,10 @@
   },
   "cpython-3.9.5-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10596,7 +22545,10 @@
   },
   "cpython-3.9.5-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10609,7 +22561,10 @@
   },
   "cpython-3.9.5-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10622,7 +22577,10 @@
   },
   "cpython-3.9.5+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10635,7 +22593,10 @@
   },
   "cpython-3.9.5+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10648,7 +22609,10 @@
   },
   "cpython-3.9.5+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10661,7 +22625,10 @@
   },
   "cpython-3.9.5+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10674,7 +22641,10 @@
   },
   "cpython-3.9.5+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10687,7 +22657,10 @@
   },
   "cpython-3.9.4-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10700,7 +22673,10 @@
   },
   "cpython-3.9.4-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10713,7 +22689,10 @@
   },
   "cpython-3.9.4-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10726,7 +22705,10 @@
   },
   "cpython-3.9.4-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10739,7 +22721,10 @@
   },
   "cpython-3.9.4-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10752,7 +22737,10 @@
   },
   "cpython-3.9.4-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10765,7 +22753,10 @@
   },
   "cpython-3.9.4-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10778,7 +22769,10 @@
   },
   "cpython-3.9.4+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10791,7 +22785,10 @@
   },
   "cpython-3.9.4+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10804,7 +22801,10 @@
   },
   "cpython-3.9.4+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10817,7 +22817,10 @@
   },
   "cpython-3.9.4+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10830,7 +22833,10 @@
   },
   "cpython-3.9.4+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10843,7 +22849,10 @@
   },
   "cpython-3.9.3-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10856,7 +22865,10 @@
   },
   "cpython-3.9.3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10869,7 +22881,10 @@
   },
   "cpython-3.9.3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10882,7 +22897,10 @@
   },
   "cpython-3.9.3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10895,7 +22913,10 @@
   },
   "cpython-3.9.3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10908,7 +22929,10 @@
   },
   "cpython-3.9.3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -10921,7 +22945,10 @@
   },
   "cpython-3.9.3+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10934,7 +22961,10 @@
   },
   "cpython-3.9.3+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10947,7 +22977,10 @@
   },
   "cpython-3.9.3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -10960,7 +22993,10 @@
   },
   "cpython-3.9.3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -10973,7 +23009,10 @@
   },
   "cpython-3.9.2-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10986,7 +23025,10 @@
   },
   "cpython-3.9.2-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -10999,7 +23041,10 @@
   },
   "cpython-3.9.2-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11012,7 +23057,10 @@
   },
   "cpython-3.9.2-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11025,7 +23073,10 @@
   },
   "cpython-3.9.2-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11038,7 +23089,10 @@
   },
   "cpython-3.9.2-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11051,7 +23105,10 @@
   },
   "cpython-3.9.2-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11064,7 +23121,10 @@
   },
   "cpython-3.9.2+debug-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11077,7 +23137,10 @@
   },
   "cpython-3.9.2+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11090,7 +23153,10 @@
   },
   "cpython-3.9.2+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11103,7 +23169,10 @@
   },
   "cpython-3.9.2+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11116,7 +23185,10 @@
   },
   "cpython-3.9.2+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11129,7 +23201,10 @@
   },
   "cpython-3.9.1-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11142,7 +23217,10 @@
   },
   "cpython-3.9.1-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11155,7 +23233,10 @@
   },
   "cpython-3.9.1-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11168,7 +23249,10 @@
   },
   "cpython-3.9.1-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11181,7 +23265,10 @@
   },
   "cpython-3.9.1-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11194,7 +23281,10 @@
   },
   "cpython-3.9.1+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11207,7 +23297,10 @@
   },
   "cpython-3.9.1+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11220,7 +23313,10 @@
   },
   "cpython-3.9.1+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11233,7 +23329,10 @@
   },
   "cpython-3.9.0-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11246,7 +23345,10 @@
   },
   "cpython-3.9.0-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11259,7 +23361,10 @@
   },
   "cpython-3.9.0-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11272,7 +23377,10 @@
   },
   "cpython-3.9.0-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11285,7 +23393,10 @@
   },
   "cpython-3.9.0-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11298,7 +23409,10 @@
   },
   "cpython-3.9.0+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11311,7 +23425,10 @@
   },
   "cpython-3.9.0+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11324,7 +23441,10 @@
   },
   "cpython-3.9.0+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11337,7 +23457,10 @@
   },
   "cpython-3.8.20-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11350,7 +23473,10 @@
   },
   "cpython-3.8.20-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11363,7 +23489,10 @@
   },
   "cpython-3.8.20-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11376,7 +23505,10 @@
   },
   "cpython-3.8.20-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11389,7 +23521,10 @@
   },
   "cpython-3.8.20-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11402,7 +23537,10 @@
   },
   "cpython-3.8.20-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11415,7 +23553,10 @@
   },
   "cpython-3.8.20-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11428,7 +23569,10 @@
   },
   "cpython-3.8.20+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11441,7 +23585,10 @@
   },
   "cpython-3.8.20+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11454,7 +23601,10 @@
   },
   "cpython-3.8.20+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11467,7 +23617,10 @@
   },
   "cpython-3.8.19-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11480,7 +23633,10 @@
   },
   "cpython-3.8.19-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11493,7 +23649,10 @@
   },
   "cpython-3.8.19-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11506,7 +23665,10 @@
   },
   "cpython-3.8.19-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11519,7 +23681,10 @@
   },
   "cpython-3.8.19-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11532,7 +23697,10 @@
   },
   "cpython-3.8.19-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11545,7 +23713,10 @@
   },
   "cpython-3.8.19-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11558,7 +23729,10 @@
   },
   "cpython-3.8.19+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11571,7 +23745,10 @@
   },
   "cpython-3.8.19+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11584,7 +23761,10 @@
   },
   "cpython-3.8.19+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11597,7 +23777,10 @@
   },
   "cpython-3.8.18-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11610,7 +23793,10 @@
   },
   "cpython-3.8.18-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11623,7 +23809,10 @@
   },
   "cpython-3.8.18-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11636,7 +23825,10 @@
   },
   "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11649,7 +23841,10 @@
   },
   "cpython-3.8.18-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11662,7 +23857,10 @@
   },
   "cpython-3.8.18-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11675,7 +23873,10 @@
   },
   "cpython-3.8.18-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11688,7 +23889,10 @@
   },
   "cpython-3.8.18+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11701,7 +23905,10 @@
   },
   "cpython-3.8.18+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11714,7 +23921,10 @@
   },
   "cpython-3.8.18+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11727,7 +23937,10 @@
   },
   "cpython-3.8.17-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11740,7 +23953,10 @@
   },
   "cpython-3.8.17-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11753,7 +23969,10 @@
   },
   "cpython-3.8.17-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11766,7 +23985,10 @@
   },
   "cpython-3.8.17-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11779,7 +24001,10 @@
   },
   "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11792,7 +24017,10 @@
   },
   "cpython-3.8.17-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11805,7 +24033,10 @@
   },
   "cpython-3.8.17-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11818,7 +24049,10 @@
   },
   "cpython-3.8.17-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11831,7 +24065,10 @@
   },
   "cpython-3.8.17+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11844,7 +24081,10 @@
   },
   "cpython-3.8.17+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11857,7 +24097,10 @@
   },
   "cpython-3.8.17+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11870,7 +24113,10 @@
   },
   "cpython-3.8.17+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11883,7 +24129,10 @@
   },
   "cpython-3.8.16-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11896,7 +24145,10 @@
   },
   "cpython-3.8.16-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -11909,7 +24161,10 @@
   },
   "cpython-3.8.16-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11922,7 +24177,10 @@
   },
   "cpython-3.8.16-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11935,7 +24193,10 @@
   },
   "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -11948,7 +24209,10 @@
   },
   "cpython-3.8.16-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -11961,7 +24225,10 @@
   },
   "cpython-3.8.16-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11974,7 +24241,10 @@
   },
   "cpython-3.8.16-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -11987,7 +24257,10 @@
   },
   "cpython-3.8.16+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12000,7 +24273,10 @@
   },
   "cpython-3.8.16+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12013,7 +24289,10 @@
   },
   "cpython-3.8.16+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12026,7 +24305,10 @@
   },
   "cpython-3.8.16+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12039,7 +24321,10 @@
   },
   "cpython-3.8.15-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12052,7 +24337,10 @@
   },
   "cpython-3.8.15-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12065,7 +24353,10 @@
   },
   "cpython-3.8.15-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12078,7 +24369,10 @@
   },
   "cpython-3.8.15-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12091,7 +24385,10 @@
   },
   "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12104,7 +24401,10 @@
   },
   "cpython-3.8.15-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12117,7 +24417,10 @@
   },
   "cpython-3.8.15-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12130,7 +24433,10 @@
   },
   "cpython-3.8.15-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12143,7 +24449,10 @@
   },
   "cpython-3.8.15+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12156,7 +24465,10 @@
   },
   "cpython-3.8.15+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12169,7 +24481,10 @@
   },
   "cpython-3.8.15+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12182,7 +24497,10 @@
   },
   "cpython-3.8.15+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12195,7 +24513,10 @@
   },
   "cpython-3.8.14-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12208,7 +24529,10 @@
   },
   "cpython-3.8.14-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12221,7 +24545,10 @@
   },
   "cpython-3.8.14-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12234,7 +24561,10 @@
   },
   "cpython-3.8.14-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12247,7 +24577,10 @@
   },
   "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12260,7 +24593,10 @@
   },
   "cpython-3.8.14-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12273,7 +24609,10 @@
   },
   "cpython-3.8.14-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12286,7 +24625,10 @@
   },
   "cpython-3.8.14-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12299,7 +24641,10 @@
   },
   "cpython-3.8.14+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12312,7 +24657,10 @@
   },
   "cpython-3.8.14+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12325,7 +24673,10 @@
   },
   "cpython-3.8.14+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12338,7 +24689,10 @@
   },
   "cpython-3.8.14+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12351,7 +24705,10 @@
   },
   "cpython-3.8.13-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12364,7 +24721,10 @@
   },
   "cpython-3.8.13-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12377,7 +24737,10 @@
   },
   "cpython-3.8.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12390,7 +24753,10 @@
   },
   "cpython-3.8.13-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12403,7 +24769,10 @@
   },
   "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12416,7 +24785,10 @@
   },
   "cpython-3.8.13-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12429,7 +24801,10 @@
   },
   "cpython-3.8.13-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12442,7 +24817,10 @@
   },
   "cpython-3.8.13-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12455,7 +24833,10 @@
   },
   "cpython-3.8.13+debug-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12468,7 +24849,10 @@
   },
   "cpython-3.8.13+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12481,7 +24865,10 @@
   },
   "cpython-3.8.13+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12494,7 +24881,10 @@
   },
   "cpython-3.8.13+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12507,7 +24897,10 @@
   },
   "cpython-3.8.12-darwin-aarch64-none": {
     "name": "cpython",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12520,7 +24913,10 @@
   },
   "cpython-3.8.12-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12533,7 +24929,10 @@
   },
   "cpython-3.8.12-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12546,7 +24945,10 @@
   },
   "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12559,7 +24961,10 @@
   },
   "cpython-3.8.12-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12572,7 +24977,10 @@
   },
   "cpython-3.8.12-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12585,7 +24993,10 @@
   },
   "cpython-3.8.12-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12598,7 +25009,10 @@
   },
   "cpython-3.8.12+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12611,7 +25025,10 @@
   },
   "cpython-3.8.12+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12624,7 +25041,10 @@
   },
   "cpython-3.8.12+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12637,7 +25057,10 @@
   },
   "cpython-3.8.12+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12650,7 +25073,10 @@
   },
   "cpython-3.8.11-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12663,7 +25089,10 @@
   },
   "cpython-3.8.11-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12676,7 +25105,10 @@
   },
   "cpython-3.8.11-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12689,7 +25121,10 @@
   },
   "cpython-3.8.11-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12702,7 +25137,10 @@
   },
   "cpython-3.8.11-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12715,7 +25153,10 @@
   },
   "cpython-3.8.11-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12728,7 +25169,10 @@
   },
   "cpython-3.8.11+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12741,7 +25185,10 @@
   },
   "cpython-3.8.11+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12754,7 +25201,10 @@
   },
   "cpython-3.8.11+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12767,7 +25217,10 @@
   },
   "cpython-3.8.11+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12780,7 +25233,10 @@
   },
   "cpython-3.8.10-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12793,7 +25249,10 @@
   },
   "cpython-3.8.10-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12806,7 +25265,10 @@
   },
   "cpython-3.8.10-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12819,7 +25281,10 @@
   },
   "cpython-3.8.10-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12832,7 +25297,10 @@
   },
   "cpython-3.8.10-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12845,7 +25313,10 @@
   },
   "cpython-3.8.10-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12858,7 +25329,10 @@
   },
   "cpython-3.8.10+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12871,7 +25345,10 @@
   },
   "cpython-3.8.10+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12884,7 +25361,10 @@
   },
   "cpython-3.8.10+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12897,7 +25377,10 @@
   },
   "cpython-3.8.10+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12910,7 +25393,10 @@
   },
   "cpython-3.8.9-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -12923,7 +25409,10 @@
   },
   "cpython-3.8.9-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12936,7 +25425,10 @@
   },
   "cpython-3.8.9-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -12949,7 +25441,10 @@
   },
   "cpython-3.8.9-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -12962,7 +25457,10 @@
   },
   "cpython-3.8.9-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12975,7 +25473,10 @@
   },
   "cpython-3.8.9-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -12988,7 +25489,10 @@
   },
   "cpython-3.8.9+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13001,7 +25505,10 @@
   },
   "cpython-3.8.9+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13014,7 +25521,10 @@
   },
   "cpython-3.8.9+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13027,7 +25537,10 @@
   },
   "cpython-3.8.9+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13040,7 +25553,10 @@
   },
   "cpython-3.8.8-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13053,7 +25569,10 @@
   },
   "cpython-3.8.8-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13066,7 +25585,10 @@
   },
   "cpython-3.8.8-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13079,7 +25601,10 @@
   },
   "cpython-3.8.8-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13092,7 +25617,10 @@
   },
   "cpython-3.8.8-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13105,7 +25633,10 @@
   },
   "cpython-3.8.8-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13118,7 +25649,10 @@
   },
   "cpython-3.8.8+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13131,7 +25665,10 @@
   },
   "cpython-3.8.8+debug-linux-i686-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13144,7 +25681,10 @@
   },
   "cpython-3.8.8+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13157,7 +25697,10 @@
   },
   "cpython-3.8.8+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13170,7 +25713,10 @@
   },
   "cpython-3.8.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13183,7 +25729,10 @@
   },
   "cpython-3.8.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13196,7 +25745,10 @@
   },
   "cpython-3.8.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13209,7 +25761,10 @@
   },
   "cpython-3.8.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13222,7 +25777,10 @@
   },
   "cpython-3.8.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13235,7 +25793,10 @@
   },
   "cpython-3.8.7+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13248,7 +25809,10 @@
   },
   "cpython-3.8.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13261,7 +25825,10 @@
   },
   "cpython-3.8.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13274,7 +25841,10 @@
   },
   "cpython-3.8.6-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13287,7 +25857,10 @@
   },
   "cpython-3.8.6-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13300,7 +25873,10 @@
   },
   "cpython-3.8.6-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13313,7 +25889,10 @@
   },
   "cpython-3.8.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13326,7 +25905,10 @@
   },
   "cpython-3.8.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13339,7 +25921,10 @@
   },
   "cpython-3.8.6+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13352,7 +25937,10 @@
   },
   "cpython-3.8.6+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13365,7 +25953,10 @@
   },
   "cpython-3.8.6+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13378,7 +25969,10 @@
   },
   "cpython-3.8.5-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13391,7 +25985,10 @@
   },
   "cpython-3.8.5-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13404,7 +26001,10 @@
   },
   "cpython-3.8.5-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13417,7 +26017,10 @@
   },
   "cpython-3.8.5-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13430,7 +26033,10 @@
   },
   "cpython-3.8.5-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13443,7 +26049,10 @@
   },
   "cpython-3.8.5+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13456,7 +26065,10 @@
   },
   "cpython-3.8.5+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13469,7 +26081,10 @@
   },
   "cpython-3.8.5+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13482,7 +26097,10 @@
   },
   "cpython-3.8.3-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13495,7 +26113,10 @@
   },
   "cpython-3.8.3-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13508,7 +26129,10 @@
   },
   "cpython-3.8.3-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13521,7 +26145,10 @@
   },
   "cpython-3.8.3-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13534,7 +26161,10 @@
   },
   "cpython-3.8.3-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13547,7 +26177,10 @@
   },
   "cpython-3.8.3+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13560,7 +26193,10 @@
   },
   "cpython-3.8.3+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13573,7 +26209,10 @@
   },
   "cpython-3.8.3+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13586,7 +26225,10 @@
   },
   "cpython-3.8.2-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13599,7 +26241,10 @@
   },
   "cpython-3.8.2-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13612,7 +26257,10 @@
   },
   "cpython-3.8.2-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13625,7 +26273,10 @@
   },
   "cpython-3.8.2-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13638,7 +26289,10 @@
   },
   "cpython-3.8.2-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13651,7 +26305,10 @@
   },
   "cpython-3.8.2+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13664,7 +26321,10 @@
   },
   "cpython-3.8.2+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13677,7 +26337,10 @@
   },
   "cpython-3.7.9-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13690,7 +26353,10 @@
   },
   "cpython-3.7.9-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13703,7 +26369,10 @@
   },
   "cpython-3.7.9-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13716,7 +26385,10 @@
   },
   "cpython-3.7.9-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13729,7 +26401,10 @@
   },
   "cpython-3.7.9-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13742,7 +26417,10 @@
   },
   "cpython-3.7.9+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13755,7 +26433,10 @@
   },
   "cpython-3.7.9+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13768,7 +26449,10 @@
   },
   "cpython-3.7.9+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13781,7 +26465,10 @@
   },
   "cpython-3.7.7-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13794,7 +26481,10 @@
   },
   "cpython-3.7.7-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13807,7 +26497,10 @@
   },
   "cpython-3.7.7-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13820,7 +26513,10 @@
   },
   "cpython-3.7.7-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13833,7 +26529,10 @@
   },
   "cpython-3.7.7-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13846,7 +26545,10 @@
   },
   "cpython-3.7.7+debug-darwin-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13859,7 +26561,10 @@
   },
   "cpython-3.7.7+debug-linux-x86_64-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13872,7 +26577,10 @@
   },
   "cpython-3.7.7+debug-linux-x86_64-musl": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "musl",
     "major": 3,
@@ -13885,7 +26593,10 @@
   },
   "cpython-3.7.6-windows-i686-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13898,7 +26609,10 @@
   },
   "cpython-3.7.6-windows-x86_64-none": {
     "name": "cpython",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -13911,7 +26625,10 @@
   },
   "pypy-3.10.14-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13924,7 +26641,10 @@
   },
   "pypy-3.10.14-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -13937,7 +26657,10 @@
   },
   "pypy-3.10.14-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13950,7 +26673,10 @@
   },
   "pypy-3.10.14-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13963,7 +26689,10 @@
   },
   "pypy-3.10.14-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13976,7 +26705,10 @@
   },
   "pypy-3.10.14-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -13989,7 +26721,10 @@
   },
   "pypy-3.10.14-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14002,7 +26737,10 @@
   },
   "pypy-3.10.13-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14015,7 +26753,10 @@
   },
   "pypy-3.10.13-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14028,7 +26769,10 @@
   },
   "pypy-3.10.13-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14041,7 +26785,10 @@
   },
   "pypy-3.10.13-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14054,7 +26801,10 @@
   },
   "pypy-3.10.13-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14067,7 +26817,10 @@
   },
   "pypy-3.10.13-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14080,7 +26833,10 @@
   },
   "pypy-3.10.13-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14093,7 +26849,10 @@
   },
   "pypy-3.10.12-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14106,7 +26865,10 @@
   },
   "pypy-3.10.12-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14119,7 +26881,10 @@
   },
   "pypy-3.10.12-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14132,7 +26897,10 @@
   },
   "pypy-3.10.12-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14145,7 +26913,10 @@
   },
   "pypy-3.10.12-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14158,7 +26929,10 @@
   },
   "pypy-3.10.12-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14171,7 +26945,10 @@
   },
   "pypy-3.10.12-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14184,7 +26961,10 @@
   },
   "pypy-3.9.19-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14197,7 +26977,10 @@
   },
   "pypy-3.9.19-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14210,7 +26993,10 @@
   },
   "pypy-3.9.19-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14223,7 +27009,10 @@
   },
   "pypy-3.9.19-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14236,7 +27025,10 @@
   },
   "pypy-3.9.19-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14249,7 +27041,10 @@
   },
   "pypy-3.9.19-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14262,7 +27057,10 @@
   },
   "pypy-3.9.19-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14275,7 +27073,10 @@
   },
   "pypy-3.9.18-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14288,7 +27089,10 @@
   },
   "pypy-3.9.18-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14301,7 +27105,10 @@
   },
   "pypy-3.9.18-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14314,7 +27121,10 @@
   },
   "pypy-3.9.18-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14327,7 +27137,10 @@
   },
   "pypy-3.9.18-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14340,7 +27153,10 @@
   },
   "pypy-3.9.18-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14353,7 +27169,10 @@
   },
   "pypy-3.9.18-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14366,7 +27185,10 @@
   },
   "pypy-3.9.17-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14379,7 +27201,10 @@
   },
   "pypy-3.9.17-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14392,7 +27217,10 @@
   },
   "pypy-3.9.17-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14405,7 +27233,10 @@
   },
   "pypy-3.9.17-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14418,7 +27249,10 @@
   },
   "pypy-3.9.17-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14431,7 +27265,10 @@
   },
   "pypy-3.9.17-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14444,7 +27281,10 @@
   },
   "pypy-3.9.17-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14457,7 +27297,10 @@
   },
   "pypy-3.9.16-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14470,7 +27313,10 @@
   },
   "pypy-3.9.16-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14483,7 +27329,10 @@
   },
   "pypy-3.9.16-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14496,7 +27345,10 @@
   },
   "pypy-3.9.16-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14509,7 +27361,10 @@
   },
   "pypy-3.9.16-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14522,7 +27377,10 @@
   },
   "pypy-3.9.16-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14535,7 +27393,10 @@
   },
   "pypy-3.9.16-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14548,7 +27409,10 @@
   },
   "pypy-3.9.15-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14561,7 +27425,10 @@
   },
   "pypy-3.9.15-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14574,7 +27441,10 @@
   },
   "pypy-3.9.15-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14587,7 +27457,10 @@
   },
   "pypy-3.9.15-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14600,7 +27473,10 @@
   },
   "pypy-3.9.15-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14613,7 +27489,10 @@
   },
   "pypy-3.9.15-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14626,7 +27505,10 @@
   },
   "pypy-3.9.15-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14639,7 +27521,10 @@
   },
   "pypy-3.9.12-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14652,7 +27537,10 @@
   },
   "pypy-3.9.12-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14665,7 +27553,10 @@
   },
   "pypy-3.9.12-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14678,7 +27569,10 @@
   },
   "pypy-3.9.12-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14691,7 +27585,10 @@
   },
   "pypy-3.9.12-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14704,7 +27601,10 @@
   },
   "pypy-3.9.12-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14717,7 +27617,10 @@
   },
   "pypy-3.9.10-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14730,7 +27633,10 @@
   },
   "pypy-3.9.10-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14743,7 +27649,10 @@
   },
   "pypy-3.9.10-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14756,7 +27665,10 @@
   },
   "pypy-3.9.10-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14769,7 +27681,10 @@
   },
   "pypy-3.9.10-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14782,7 +27697,10 @@
   },
   "pypy-3.9.10-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14795,7 +27713,10 @@
   },
   "pypy-3.8.16-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14808,7 +27729,10 @@
   },
   "pypy-3.8.16-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14821,7 +27745,10 @@
   },
   "pypy-3.8.16-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14834,7 +27761,10 @@
   },
   "pypy-3.8.16-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14847,7 +27777,10 @@
   },
   "pypy-3.8.16-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14860,7 +27793,10 @@
   },
   "pypy-3.8.16-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14873,7 +27809,10 @@
   },
   "pypy-3.8.16-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14886,7 +27825,10 @@
   },
   "pypy-3.8.15-darwin-aarch64-none": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14899,7 +27841,10 @@
   },
   "pypy-3.8.15-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14912,7 +27857,10 @@
   },
   "pypy-3.8.15-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14925,7 +27873,10 @@
   },
   "pypy-3.8.15-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14938,7 +27889,10 @@
   },
   "pypy-3.8.15-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14951,7 +27905,10 @@
   },
   "pypy-3.8.15-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -14964,7 +27921,10 @@
   },
   "pypy-3.8.15-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -14977,7 +27937,10 @@
   },
   "pypy-3.8.13-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -14990,7 +27953,10 @@
   },
   "pypy-3.8.13-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15003,7 +27969,10 @@
   },
   "pypy-3.8.13-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15016,7 +27985,10 @@
   },
   "pypy-3.8.13-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15029,7 +28001,10 @@
   },
   "pypy-3.8.13-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15042,7 +28017,10 @@
   },
   "pypy-3.8.13-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -15055,7 +28033,10 @@
   },
   "pypy-3.8.12-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -15068,7 +28049,10 @@
   },
   "pypy-3.8.12-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15081,7 +28065,10 @@
   },
   "pypy-3.8.12-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15094,7 +28081,10 @@
   },
   "pypy-3.8.12-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15107,7 +28097,10 @@
   },
   "pypy-3.8.12-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15120,7 +28113,10 @@
   },
   "pypy-3.8.12-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -15133,7 +28129,10 @@
   },
   "pypy-3.7.13-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -15146,7 +28145,10 @@
   },
   "pypy-3.7.13-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15159,7 +28161,10 @@
   },
   "pypy-3.7.13-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15172,7 +28177,10 @@
   },
   "pypy-3.7.13-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15185,7 +28193,10 @@
   },
   "pypy-3.7.13-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15198,7 +28209,10 @@
   },
   "pypy-3.7.13-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -15211,7 +28225,10 @@
   },
   "pypy-3.7.12-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -15224,7 +28241,10 @@
   },
   "pypy-3.7.12-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15237,7 +28257,10 @@
   },
   "pypy-3.7.12-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15250,7 +28273,10 @@
   },
   "pypy-3.7.12-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15263,7 +28289,10 @@
   },
   "pypy-3.7.12-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15276,7 +28305,10 @@
   },
   "pypy-3.7.12-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -15289,7 +28321,10 @@
   },
   "pypy-3.7.10-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -15302,7 +28337,10 @@
   },
   "pypy-3.7.10-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15315,7 +28353,10 @@
   },
   "pypy-3.7.10-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15328,7 +28369,10 @@
   },
   "pypy-3.7.10-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15341,7 +28385,10 @@
   },
   "pypy-3.7.10-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15354,7 +28401,10 @@
   },
   "pypy-3.7.10-windows-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -15367,7 +28417,10 @@
   },
   "pypy-3.7.9-darwin-x86_64-none": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "darwin",
     "libc": "none",
     "major": 3,
@@ -15380,7 +28433,10 @@
   },
   "pypy-3.7.9-linux-aarch64-gnu": {
     "name": "pypy",
-    "arch": "aarch64",
+    "arch": {
+      "family": "aarch64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15393,7 +28449,10 @@
   },
   "pypy-3.7.9-linux-i686-gnu": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15406,7 +28465,10 @@
   },
   "pypy-3.7.9-linux-s390x-gnu": {
     "name": "pypy",
-    "arch": "s390x",
+    "arch": {
+      "family": "s390x",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15419,7 +28481,10 @@
   },
   "pypy-3.7.9-linux-x86_64-gnu": {
     "name": "pypy",
-    "arch": "x86_64",
+    "arch": {
+      "family": "x86_64",
+      "variant": null
+    },
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -15432,7 +28497,10 @@
   },
   "pypy-3.7.9-windows-i686-none": {
     "name": "pypy",
-    "arch": "i686",
+    "arch": {
+      "family": "i686",
+      "variant": null
+    },
     "os": "windows",
     "libc": "none",
     "major": 3,

--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -3,6 +3,7 @@
 // Generated with `crates/uv-python/template-download-metadata.py`
 // From template at `crates/uv-python/src/downloads.inc.mustache`
 
+use crate::platform::ArchVariant;
 use crate::PythonVariant;
 use uv_pep440::{Prerelease, PrereleaseKind};
 
@@ -14,7 +15,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -29,7 +33,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -44,7 +51,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -59,7 +69,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -74,7 +87,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -89,7 +105,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -104,7 +123,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -119,7 +141,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -134,7 +159,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -149,7 +177,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("1ec5a3b90e78243dfc9d655966dd674ada690590baff88de7f3e3842e070e8f8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("4e8530f5185a7cfb68960739e35d66768d8792fc1047de94bcb5056b80b6e0a9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("dac921039c06c9589afe8faa3e56bc816b6886942665516b49721aa64e5c028c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("705a6c68da2ac1d24a4261fa6e45850aa3250b386d58b59f5fb140f9b707b06a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("5abe225419169657c32ea3c72ba71d1b2b050b39808264035329366f735573b5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("8aec74a40027afa2aac9693153aa50d53d861e7fdaad546cff36128cd3d72061")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -164,7 +303,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -179,7 +321,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -194,7 +339,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -209,7 +357,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -224,7 +375,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Freethreaded
@@ -239,7 +393,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Freethreaded
@@ -254,7 +411,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -269,7 +429,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -284,7 +447,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -299,7 +465,64 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v2-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+        sha256: Some("6763ee4c65ba6eac25ad24eb1761bdb565b7c2b13078b324a97e532d51b259fc")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v3-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+        sha256: Some("ec942c9eb007ea9c5393eecffa607c14183da45bedce69c6b8aedc043879b747")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.13.1%2B20241206-x86_64_v4-unknown-linux-gnu-freethreaded%2Blto-full.tar.zst",
+        sha256: Some("4e2013630d8e14005cceb667b736c5ffd7e61a57a1db3adcebe4c17a50b684e4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -314,7 +537,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -329,7 +555,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -344,7 +573,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -359,7 +591,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -374,7 +609,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -389,7 +627,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -404,7 +645,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -419,7 +663,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -434,7 +681,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -449,7 +699,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -464,7 +717,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("5c10c0b05c66bc6fc9a87f456ac1606057fe1865cc525eb7ecd9a5640f15426a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("6797067b7da58c29384cd32cb77f62dc18e813e6c72f6b0baf39672d84431bf2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("a9e705f714ccbe721ba0e29b80e6f2a5f0960c39245959de58c8076fd31515e0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("0572fbf46e49adaa5a418eeb92daeb624a080466a46d87d48e4a80f1ba9e408a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("36bd61970dc1d3a7034f2645aa14b47b6aa1669819fb7803650b5a7919afddbf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("a846556bdd4d61b3f96aa8b096c86db031d7f5b5ef50f9e614c9259527afc9de")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -479,7 +843,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -494,7 +861,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -509,7 +879,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -524,7 +897,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -539,7 +915,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Freethreaded
@@ -554,7 +933,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Freethreaded
@@ -569,7 +951,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -584,7 +969,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -599,7 +987,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Freethreaded
@@ -614,7 +1005,64 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+        sha256: Some("6dd725b5866e193d201b4d6361bf03b2a954eeb8b67788d875ca4991776f852f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
+        sha256: Some("fd16a95790203891163db772b6818522ee887857edae1a1cd6860e58eaf8f305")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-freethreaded%2Blto-full.tar.zst",
+        sha256: Some("8ad7fd8dd74cad2c9d5a269ad585885ef2b41468a691804f1dd66e1cec8286cb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -629,7 +1077,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Freethreaded
@@ -644,7 +1095,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -659,7 +1113,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -674,7 +1131,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -689,7 +1149,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -704,7 +1167,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -719,7 +1185,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -734,7 +1203,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -749,7 +1221,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -764,7 +1239,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -779,7 +1257,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("ae477db35ccec397a19c9d61271455adf4917ab35993dbcacae8d126890f6b12")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("8c73e28a683b7e826ed5bda4cf119ec8270238fdf936e3a2b3ca0938cfcde8c9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("2a505cda4d7d62dec1829a06fa502eb514a3182c193b2f2aaf9c08bccb143dc0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("27a93fc7678782b392e5ee8e654635bc29409939318bbc341df3d29386f2166f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("8c1424f2501419b88560951497df095c82e856af9b8f817f96beedeb4d8bc32d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("8c318b2a79d75ca7ce3b76f8799a1db0337ba1278601bf0ec4433d64313d1aca")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -794,7 +1383,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -809,7 +1401,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -824,7 +1419,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -839,7 +1437,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -854,7 +1455,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -869,7 +1473,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -884,7 +1491,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -899,7 +1509,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -914,7 +1527,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -929,7 +1545,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -944,7 +1563,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("e60fc176fad636bbd287e92f9e9954b8b10d164984e98f51e4dc3d47314fa8a5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("16f23e539336fb45895b3c4fac981365b53fbbd86115feb9516b50a0716394b1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("bf34803e8c05cdb4eee5df5b051cdded1732975c991116a1af823a2b15e49be3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("df60f51c87da60af67453e5d7c5673f1534c2772d92a4885ae51add3cd32848e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("fb8d87e21bd0cb83bfbb5325f2db170365726a9cac58dd5b552fbd084671b785")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("eafb931d1a0e6f7237486d2967d0ccacd49791bef27f233895b5d18581ae939a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -959,7 +1689,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -974,7 +1707,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -989,7 +1725,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1004,7 +1743,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1019,7 +1761,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1034,7 +1779,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1049,7 +1797,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1064,7 +1815,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1079,7 +1833,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1094,7 +1851,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1109,7 +1869,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("bb7ad29fb281b9fd8fc97d8d855ad02ef53ce8daeaade52ffe9927cceb65f7eb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("f4bc6cad0048996eea3d8abcf430696cc9cc21ab851ca1b3438877c3a32acddc")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("9915a130643ed82a5e2d44b27669c8b2af9e8fc8f08733986e8aca87ece689b4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("b85f9ba0821895e69cc2a884d08091f1223313bc414907e223eb9797691d8390")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("3f102535e3f130afb9a9395f7ef4515227fbbb06965af1c2f02aee76d1af2241")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.12.8%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("6c29ed847c629a5b3155f158a5e884603681b81485c71cc4efd5f35d82f391b7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1124,7 +1995,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1139,7 +2013,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1154,7 +2031,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1169,7 +2049,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1184,7 +2067,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1199,7 +2085,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1214,7 +2103,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1229,7 +2121,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1244,7 +2139,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1259,7 +2157,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1274,7 +2175,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("205395841e6e7cbd33d504b78ac81792364831911866416da7a34d9b4a06d7d1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("bfdd008fb669ddd023a8c36c16987c98b0d2bdfb99c9d45e2c9a792d87710b72")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("ad1d2bfccc7006612af93e1dbf6760ede5b07148141d0ca05a7d605ea666a55f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("2c11efdb7df78ed787ac67c094c58a75f6549a78660888d99a861fc08e88ebe2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("172c0ab8ac018a0b44a47f03a7a78cd583bdc1e60cd5cfbf7d05b269c5d73f5c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("4576e092f2eaa6f5685be048b50671f9df0fff2b261ee001f604fb983bc9bb71")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1289,7 +2301,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1304,7 +2319,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1319,7 +2337,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1334,7 +2355,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1349,7 +2373,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1364,7 +2391,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1379,7 +2409,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1394,7 +2427,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1409,7 +2445,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1424,7 +2463,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1439,7 +2481,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("3ce9eb5d974dc2109c3e2c3986f4883ec5403b3479259ea781475a319f9a6787")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("6dab95cdd6d3f165aaaa7dcd7cb263add390d97c7b57eb62d2d1ca9a304353da")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("8dcc21cd45c09b273cca17c4b144c26c1a9e373eec871d540cc0762ab9c82c12")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("f2a295a6e400c16d6b3fe51c63c5b017e6c20a0a9e21a664170ecb6b9a104d8e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("debba8985df38a492e8fc4b7b8d2261567f56eae716aa7630b836523625c6a96")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("03c0ac05d6027b603ea0f5f9f2c463bd58f942706ae78dca27922b25dca8f16a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1454,7 +2607,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1469,7 +2625,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1484,7 +2643,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1499,7 +2661,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1514,7 +2679,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1529,7 +2697,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1544,7 +2715,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1559,7 +2733,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1574,7 +2751,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1589,7 +2769,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1604,7 +2787,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("c0064dcd97e5a09b5ff9529fc65cf6fd7a8a20f71a7050f584ecaa0cc8c33f2d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("35ffd76881bef5ce09a123175f4f3419eb250802e60a6bb78649585325b8409f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("6414f1c4b0efb5c1f2eb30926c70519d01f46b1f0d97d407fe53e360865a4a23")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("302a26f5d35e1c9e9d82765aa7dbf5ceb609c402431ec97d7fa0e85d8247c023")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("d7e82fcf72ec5faedfbabf1084ca55f850971a559ba54350de312663570f4782")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("46771e859224aa128150160d568d5d19a69e0f9a8f27d110ea26c031b588c734")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1619,7 +2913,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1634,7 +2931,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1649,7 +2949,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1664,7 +2967,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1679,7 +2985,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1694,7 +3003,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1709,7 +3021,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1724,7 +3039,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1739,7 +3057,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1754,7 +3075,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1769,7 +3093,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("798e562eb68b8d825c25c747b9995046b700c5bafbe8f7e558f41a3d8a57ceb7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("762dc23608111f49729f02c19fa8459219ac886e8694b79f541ef01141bf58c5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("681d65c59f48c4b1bfe29f08ca87a50620c9aef308e27ea11fbe2ef8ce1a3764")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("304bdcdf495529a6edcac34646e4f065f0963e4c3061cef9093b76bb0e8cca90")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("507fce8676d23af12f97b1f66efa876360d19fbe89675163a0c7c5d631763c84")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("8989f75d70f6c874f3031ba1841efd96089f589f04d445fbacd478a1f866c118")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1784,7 +3219,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1799,7 +3237,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1814,7 +3255,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1829,7 +3273,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1844,7 +3291,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -1859,7 +3309,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -1874,7 +3327,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1889,7 +3345,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1904,7 +3363,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -1919,7 +3381,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -1934,7 +3399,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("b9b91f486e2a52b6cc392101245705d6ab5dd6ad4a4e2b3492baec8e4b96508b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e47a8d25c2348bf9b0e818642e4dae90700fc3fbd96ffd7f4ad9518a7206d369")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("edb786bf15a92a7c40fc5ace2376736d73ff356458b7c24da0cd408f36b945bf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9685fc300be464a9338e94e48fc7315ee0563999833f8c830f2a2dee2d750b7e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("790e70e565b3efc5f1d14294f7cc083d1fb2aa4c15074d547e8e6bb9d2adb70a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c4d399923625ff5b5c20eceba0d8580c858768eff73dd9380aa8265030788850")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1949,7 +3525,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1964,7 +3543,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1979,7 +3561,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -1994,7 +3579,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2009,7 +3597,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2024,7 +3615,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2039,7 +3633,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2054,7 +3651,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2069,7 +3669,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("adfe5c1a6039b8806b3dee0aed5fe860540d55231be87df48891a7844279d76a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e5c0adb646defd55791bbdd217f64d08a51855e818ee67e3ea6207521f92abee")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("0ab408e31ecc30893020b617dd049af05b76cbe8bb8585b289f75557a24bcfd4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("bcf21a4105fe82cbefbd8bdf76dfc7eb98297b51ad02f0fc0a92929bcc95d6e9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("32ec4268b4d16a428deb642ddd875ae6e738b85558bfbdc4628018ff2e5b9e95")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("3b0e8c27c3a1dd339d8e6b53b3fc7faee379a70755093917d6ddca00253621c9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2084,7 +3795,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2099,7 +3813,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2114,7 +3831,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2129,7 +3849,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2144,7 +3867,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2159,7 +3885,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2174,7 +3903,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2189,7 +3921,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2204,7 +3939,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("9dd6fc5a1326985896493d475e7eae0d07f6de0d932faef3c4b04bdd81b88c0c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("db45fc29b4c0389b23af6ccd2d1427c3200ed7db4a81e5fd3bfbd9a4fd011c41")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("a7bcc6c9f66dbd47ea99615f30f101c5d2dd0084ca333d2f7336e64050951338")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("2585d13ac6b3e18a24d31f4baea23a810f4c7eb37306c348eeee4dfb87f84866")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("510f3f3e1841bb0e236dfac8dbd6680a4990d60a060b6972978cbc89524d4736")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("6f34607bafc6104d294ae16be240856af6217555015665c34ff7e94ad33dfe29")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2219,7 +4065,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2234,7 +4083,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2249,7 +4101,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2264,7 +4119,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2279,7 +4137,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2294,7 +4155,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2309,7 +4173,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2324,7 +4191,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2339,7 +4209,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("6d7710c9a74f624d1fe60a5a01ed6db874659d906220b1d98a0a79a36bbcb2e6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("927de631f2f37b950c2ea8ca53dc36ce8389026f34c31add31c5f730e7227bae")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("dccac6b50581aba8f4ddceb4276589bcc602a672f2461e170076890f0c114444")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("28aa3b88cacb908ab57c4202010eebe4a18fad65b5c289d061aec841a0fbbdfb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("13f4c20d3277d0bff7b14125d4904bbf5c498fe14d550d31fd584b5beabe6e0f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("8c20230e3679d5b2d765c6cae2afead81207762c3a9c725249e7ba644f61d4f5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2354,7 +4335,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2369,7 +4353,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2384,7 +4371,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2399,7 +4389,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2414,7 +4407,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -2429,7 +4425,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -2444,7 +4443,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2459,7 +4461,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2474,7 +4479,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2489,7 +4497,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2504,7 +4515,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("108ddc66731e5bff8e6a9a0a1969e2c2aa2a04e66524d221d97c8b02a3dff3e6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("9d671117d9a139b90f4aa4c28c36c3466af84ca9f1275636f4736c11e2a65388")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("55fdef6e77d7abdd352595bea814d3180711f4644038170c6167972e1bc96e94")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("a5b836f41f0fff9d53ad79f5dc9c02c9d44a3e343c79b41516374633504cab82")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("eb828109f3ba28bc64d45e9c409d4497ab52a33a4e5b0d5b572966f56db7b0f7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.11.11%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("b2889f03b377ea64c9239fcc88cd4ee1ee8705b30a9fa4dc6c7e576373e50605")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2519,7 +4641,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2534,7 +4659,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2549,7 +4677,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2564,7 +4695,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2579,7 +4713,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -2594,7 +4731,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -2609,7 +4749,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2624,7 +4767,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2639,7 +4785,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2654,7 +4803,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2669,7 +4821,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("64aefc042352e6bd10c4f600f1962af7dfec4586385f723c218b6369d3f211a2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("3714fec489d93c1ea458788a348d3380f98de22679a40a063e761753e7a48e71")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("ce94270c008e9780a3be5231223a0342e676bae04cb30b7554b0496a8fa7b799")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("a2778c2e5c8c48b555f935b4a7ff64f77f6ba0d1bdfb81b12d32905ddf7179cb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("56ed6aeed4795235b4f4349c4c0bf4ee81fdd00ad854eaedcccd5c43388d7545")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("c8e8f7a3fa9d797ec0957562f82eaba4dcadf04ef304ac616bdb6332c725a609")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2684,7 +4947,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2699,7 +4965,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2714,7 +4983,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2729,7 +5001,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2744,7 +5019,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -2759,7 +5037,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -2774,7 +5055,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2789,7 +5073,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2804,7 +5091,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2819,7 +5109,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2834,7 +5127,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("6f579d9b2ec635b7cc4eb983719ae8b4ee34248f2054939cc3b1b23b44c65c60")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("d776c6bfd09719f0a18fe23e25b314fed8e32c0c0474c21524020d5481bdcda1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("d6eeb714389614fa954f49e5ec4323f18eccbc700c516521c1297860364226cf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("e8ed1a00acd996590056c8e00351038fd1ecf9910428f592989410f06a765eef")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("92247f338ba132e9ff6e4b0dffc2eacfab6958552b0354e623f5016c5e83bafd")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("adb10e3c2eb598560c14a375b34776d80bc83656e571f8ddc2b882630db8cd4d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2849,7 +5253,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2864,7 +5271,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2879,7 +5289,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2894,7 +5307,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2909,7 +5325,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2924,7 +5343,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2939,7 +5361,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -2954,7 +5379,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -2969,7 +5397,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e4f70dcb40acc2342d63103808a19f728a1c1dc9e0fad5344061daaab03a4ce5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("a3f12605552d5450cfc8fe6c8fc468f99a42b2ae33f1ef42d5f49356d66ad305")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("52b3e24b08e53e5098561a13a61e28d241231331fd903dcb2a1e4161f3753dc1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("417890e151d07f9242d0b7ed2e16b7fee59b6606cd133105bba234f14823f8ce")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e363cc041a4464bd729771d6d223f3ec13c1e76dacdedc207ad1f6fb777bcb71")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9d430c32970e6b0f7cf030ed69dc63ee7b198543ef1e818c5a074c34052fa9e4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2984,7 +5523,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -2999,7 +5541,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3014,7 +5559,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3029,7 +5577,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3044,7 +5595,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3059,7 +5613,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3074,7 +5631,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3089,7 +5649,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3104,7 +5667,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("2cdd399100e647aa9d381e197e6a8c98e822ecb8fc1b6bda4b1eb554dbfb8177")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e9387d628e6f49587206655e61295cdbfea43944c4259c24566fa19e0596ba4e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("08dd57796b8fcc2a7307ed4dbe7a69cf35856cb29a5c79f827fe08a0663c227f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("eec99f0614e8250027e8f72b535776b44e0ad74e24cba9716942cd4c6e08844c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("28590cf568f192dbc5c91814321bca8bfe749cdf5e60a2aad968a0ae74d6bb4a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("3e3b2d4831c6353ae68808a517d59425addd857dbf925958db11b3280f46ed1e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3119,7 +5793,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3134,7 +5811,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3149,7 +5829,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3164,7 +5847,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3179,7 +5865,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3194,7 +5883,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3209,7 +5901,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3224,7 +5919,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3239,7 +5937,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("d93961f7d6df53f5e888ce070b92d19a7fce588bb03abfac2b6f3c5bf2923c80")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("3bb96293951e613fc3f36e7132dcfc34190e5ed634448b12dd1e496723bedbd0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("9a2f2bb9fca7f31502e102306fbeed8ceb7f634f4376a08f9f630c1982f62fcb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("99afdac2a24966c828faf6f13c8c100c6c432d1c888450cfadb39dbc7a7562f1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("ea850efb2de01c9389580ea0a6f55c7271dd3028b31fe0cca3ff9716fb580879")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("ebd862470d4f66da160f9a65fc058d4feff3822a97318ccc5c3765a99e0ba439")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3254,7 +6063,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3269,7 +6081,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3284,7 +6099,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3299,7 +6117,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3314,7 +6135,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3329,7 +6153,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3344,7 +6171,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3359,7 +6189,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3374,7 +6207,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3389,7 +6225,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("6f25769f73827cfc9f80114dbbc04fa959e96f82bf1b1297bc56ae08afaa6a90")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("f442249bea0a61dfec2911d86aa49f4c047eabfa2322914d040f2377c1228b48")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("5b975dd6a4648d16f278e9d82027f29feb01eda6009b239d7a7c69f421ebd519")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("41e2068884c86fc6a51670b12de140e12d6eb849bb450a970c77798f568aef72")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("9759ce08bb96716f26aedd4e4d5879f810d9ca1e6f185d9881910837ae66cd29")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("568e7a24d390fcd91b7524869c76c4e03dac9940692b381c29ae005651c5f1d7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3404,7 +6351,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3419,7 +6369,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3434,7 +6387,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3449,7 +6405,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3464,7 +6423,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3479,7 +6441,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3494,7 +6459,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3509,7 +6477,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3524,7 +6495,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3539,7 +6513,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("dd1530d8a2e002f68e3d7ed1aa568a0e9278a5c87ba1f2ec4b9bae75777a6bc2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9bea574e0f01eda7154ab1972a3d413c462a731568b5923ed2ae30174167a408")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("f6882a821a02c8f727fce12044f8ed03c0814c68c483e9c074b7d62e8aaf3adf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("d8a4a5d572e163eca53f83c91fca78955a92ec5cd2c9713e0e51ad7901add798")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("3802bf8c6f305b7b841dbbf1b091d9820d9bd65e9f5b246d2d071c42baa80fec")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c50912dce8107bd06c93cd73f96c4bfec0714fc63ba9246c8726b253443e21a7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3554,7 +6639,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3569,7 +6657,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3584,7 +6675,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3599,7 +6693,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3614,7 +6711,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3629,7 +6729,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3644,7 +6747,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3659,7 +6765,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3674,7 +6783,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("d0191c35051ade259d3324f437c6f2422743ccb79197af6dc64c161b06eddca9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9715fc26b9a6de09ebc29c978ce1bea81c0a64f730125f1230743c18f536de27")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("6452fe315b5240040acffc5688e97fc264d9eb8fbfdd90c6ede0bc46b20640e0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9ea67df4e6cafabb6cee6adcc5f863708b1e717caad47be105eb4eb7170eca11")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("5bc5eb3892957c0a9eae87fc3ce97f2b0b31406fd6ef1d20bfa8074a44121cb4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("7b7645a773cb0660b0f0c807af580b9b4a49d49de39b89d10ccfb01372e5a573")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3689,7 +6909,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3704,7 +6927,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3719,7 +6945,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3734,7 +6963,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3749,7 +6981,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3764,7 +6999,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3779,7 +7017,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3794,7 +7035,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("cc322d17b9ead6aeee4ac116fa2f802d525b4d97343fac8b8ada458810b47b40")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("0e7dae505cdb31bee4095f7c004a9f89d78263d6f24fe32eb225bfbc34d7f6ab")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("a7b538f35630a17ea8b5e1703b38906da189b2d6054297b571c7f5e81fc953a0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("ae7add6ad69f9a1852fed17ca04ebe3412bf5f190e008d8cfbe94bfe21445c48")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("dcee403d2f3416c0a7beae2fe58d9ca5646bb73ae47c0431d43911a0a8581a62")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("257d4ca1a7167f0b1d65900ca27d0d0f747e1e10bd27fbadeaa4a8bf0bf5b5e3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3809,7 +7161,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3824,7 +7179,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3839,7 +7197,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3854,7 +7215,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3869,7 +7233,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -3884,7 +7251,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -3899,7 +7269,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3914,7 +7287,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3929,7 +7305,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -3944,7 +7323,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -3959,7 +7341,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("ce08564258e2ba4256bbf52898c7e5e456428e01864eb0c8b81f4c5b64138e48")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("007c466553d6faa1f3a449ff1813618de649255d8a312e597fcb7ca042b9c79a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("9984ee25ee743d10c9e5359c45357eb3d2448947e39e0a65dc251c0f5e64ccc0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("bc43f14c1f8ef2d7c58166a2e8de5473bef4fd3ff263b59bdc89fa03c2c1e0c8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("d21c8c7a916267f3511357f53cd8101390ee9ba3cb574b9de95206a3f78262bb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.10.16%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("83c04a7d311c9cc12013c430fa24f368f99baaee44458ab35dcdc2c7173cdf05")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3974,7 +7467,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -3989,7 +7485,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4004,7 +7503,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4019,7 +7521,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4034,7 +7539,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -4049,7 +7557,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -4064,7 +7575,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4079,7 +7593,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4094,7 +7611,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4109,7 +7629,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4124,7 +7647,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("a85f3481c8117a11b5aa4fda0a6eb174b54e97b122cc8f83cf773a876751785b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("3f78660fd377d6073fa0ab642c20729c16fbc74fd67f8f35688e648fee014f4a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("f36b7ad24ead564455937ff8841a3ec16a194d9eb8411ed0470a0fbd627c683e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("75df2a6b3845ce3e4aa556276d65288e509b17bc35ebb462a60230a8eff5039c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("7d616298bffd2e4ffd0e72ab3786f2e4b9759dcd59a8cf7ac00f74a8642d5537")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("b343dff67fc9a6a03943b2bb2d6eb7d15f693533c706cc31f887d7db2625a70d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4139,7 +7773,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4154,7 +7791,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4169,7 +7809,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4184,7 +7827,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4199,7 +7845,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -4214,7 +7863,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -4229,7 +7881,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4244,7 +7899,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4259,7 +7917,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4274,7 +7935,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4289,7 +7953,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("327049baeb8319f0a31a14d28fce5608af546c27fb09994f56e3c0e17efb48c3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("cc2ed06f898466616c6534de1fd3b00d02fae415274ecb7210f5199b2550c38c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("94d7bf472551494c75a122595b30f798b3785b3fcce319e1a66f7b7358399c15")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("c3177e9c8a9b339f33fa18ca896d59dbe22853cb88be3d844ac7859c543b5913")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("5f0b093b83d5dad323463269d2cd53516e51ef0f5e965001ac8947450c3fc917")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("845008e1afab23633b1f8f49323d8de15f24cdda523974df2bab2d080af5bfbf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4304,7 +8079,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4319,7 +8097,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4334,7 +8115,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4349,7 +8133,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4364,7 +8151,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4379,7 +8169,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4394,7 +8187,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4409,7 +8205,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4424,7 +8223,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4439,7 +8241,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("ee43e708b6c4c1ffb5b17b41c51305672e3af2fd686960e4e024a86f969c1a1e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("779be1530f099b4ce0b87fe03f4621e6edca926393c7c857d581f50ffc4df66b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("325b708dccba08446658137517630c1a9fe38519780d516a760597e79a9d8d69")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("13d11d53372a058a9df956057d75e14ac229cce8daae6c42d97e742fed63f978")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("c1cdc034c483794a4792571b44318f7608769b5b2d116635723e4bd702b5ea69")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c1e61caff30433105aad15ea47ddc20b5ced4ccafd8e3666fa85667777354584")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4454,7 +8367,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4469,7 +8385,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4484,7 +8403,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4499,7 +8421,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4514,7 +8439,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4529,7 +8457,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4544,7 +8475,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4559,7 +8493,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4574,7 +8511,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4589,7 +8529,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("843504ad0f655f19614f2edb689808ed5fd2712bbf5a0eb0331ff1ebf871d457")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("d5d33effa6d64c83392f12b63fdf122843d943c7cfaa05ab734677699241cf93")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("602e8eb7cac2921a9aa12938e9d69ef139797f6952f285ac8522a0502616a137")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("bc17cb3b279a031cbcb2427238254758e89ac44541a95a5ddec968bc13ff0181")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("7cc21bad92259bf08d60cbe0650133d55f461f102a8ac9908dbd23400d9b35fa")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("1eef14ac488ab43ccf54144697d6892645414fc4926cd1456136cd427a8ae454")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4604,7 +8655,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4619,7 +8673,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4634,7 +8691,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4649,7 +8709,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4664,7 +8727,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4679,7 +8745,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4694,7 +8763,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4709,7 +8781,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4724,7 +8799,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("7e6281f9ff93ac54c38abfffe874907591ae6db431df7633b73fa5e62066582c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("bc168048359070be77bf7cf03af1e4cf8c9144d348e59bd5849ebf046694462c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("d94e9958580586c9ff95a35b2e1c5afde7087b9bb0f32d3d141a5a7ec2b8a50b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("862119d9b37def3cba4ceaf10b7415594bc171b4aa6c057e70433349ecb33474")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("488df9d6af3baca3fd2b26005e5b1a0e29b53c602bc6ecfa4f21d20715107fba")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("35db9299916982e0b9fbf483ae15b7a4b90a418c857ded61be241d81acbc9779")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4739,7 +8925,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4754,7 +8943,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4769,7 +8961,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4784,7 +8979,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4799,7 +8997,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4814,7 +9015,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4829,7 +9033,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4844,7 +9051,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e69b2e48696f1e19231bed30616aa4ac6ef0fb4b3760e9e525e2c9c4c30ddb61")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("89d13b06e73bd347e46b1424f8c56823e13920cc3cdb32a75c247852cbc84f76")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("062b42b9939908f3587f112769373be3d773f0d965ea1a08c65572e2551a2af4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e7c53f1fe15ecba006276b41c3e1947c19ae3af4d53b6fae35f86b210db4e4df")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("2c40f64d283d05755b531247eaeb6172cde6d31ba6c46cfa106b97b4669cea88")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("8dae0e8c598003e84351a2559d87b44335d02317eb82c75ea13c51aac5891a3f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4859,7 +9177,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4874,7 +9195,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4889,7 +9213,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4904,7 +9231,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4919,7 +9249,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4934,7 +9267,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -4949,7 +9285,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -4964,7 +9303,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("81eaeef0c63349f296d6c9fed6bb6ff3f2f29db649f0725351e6af147413cc90")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("efe550859e00a15325b6c4fff0d5df23ae08017ba8f74616bc0e9e73f899871d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("06a2fc7fa664301bf2657144650d2a655f1f2557861bc5684315df0d2b54d671")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("51ebd0a996a750d9101791d5b7789237f7262e4381c21ee5b87e3a2dd88b7628")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("b2617ece01070eeaa37fd5feaf1b5835435bd5151386218e6383cf9ee57bb4d2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c641d68243082094f4afbda99eee7da5226906aa7bfca5859044c217e7133db6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4979,7 +9429,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -4994,7 +9447,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5009,7 +9465,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5024,7 +9483,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5039,7 +9501,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5054,7 +9519,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5069,7 +9537,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5084,7 +9555,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("ae5ad8fe84d8b1fd2e6fe2f47a632c9a1244686c12ce98cdd4a553be1fda2f9e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("4af5e7eb30ae33db0729c019cbca4d76c973dac27167ad4131902078531eb05b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("a85919da343455cd22f8c5cf2e748498222ae92f4dcd8f37a366fec668622cbe")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("1cd4072435039557c0b6f528f18865b4d4d36c807d51abd69a6a43c73c26e9af")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("f7c803a2ecd63dfc89210e1b6dffb0c509f2680ec9484e824c2d3a14f91a7803")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("2bef222e2469cbb4e8cac98a7b31f92b7dcd9672ec4db714fe6fe0090806ad53")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5099,7 +9681,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5114,7 +9699,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5129,7 +9717,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5144,7 +9735,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5159,7 +9753,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5174,7 +9771,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5189,7 +9789,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5204,7 +9807,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e5478adc739ecd6f7b770e613fa0e5757f13fe9cbeb34f7990e5522b0593d6db")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("6097200a90aa57ad5fe8d4446f4f09d6653b3db6dd1fec80f96cbeafcf76de12")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("2601630fef417aaeb1d8d07949e81f6390e439cdd2a347ec90218731bbd24b25")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9d36dcbd9b47b3205dc5b1371a3839a5ad5317e7ba5fa353bac326635717a3a0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("327533dae8332ee61ed87dd5b7cfee3188a25a9fde65c3e27865185cb3e79b2b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c09bd9d306cd1eae99ed1de66313b0b2617b63a9cafec5e9fa3c5dd82e2d43ca")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5219,7 +9933,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5234,7 +9951,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5249,7 +9969,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5264,7 +9987,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5279,7 +10005,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5294,7 +10023,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5309,7 +10041,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5324,7 +10059,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("81e0c857175472f62641c49186f637cd1a391e4741b43afff5f55688512de1f1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("febb7ebb1df876145be4f25a1caabbb8ec05758950e7efdebc33587f7ad3ca3c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("462f88de88b450bf80e8e660610adfd7d0ee2e409270ec406e3584093d2262ce")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("f28cfb4da443626267792c81b1ac4919765782d38757b0e90daf2db525502615")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("cab2739ef27fcb7920dfbc99e57f2aec1256146a4646cf01488c60a267ed9ea3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("5864ccaefdb3f6372f0b59f9c823e5925526c4064a94afad2bcdc9cf919e9365")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5339,7 +10185,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5354,7 +10203,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5369,7 +10221,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5384,7 +10239,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5399,7 +10257,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5414,7 +10275,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5429,7 +10293,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5444,7 +10311,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("a94db687c197ac8fd9ade2695fe93ce9da392818ed52980459c25c7d39bcd73f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("c2bfbee97c9a4c4f5f5722ea68ea1a4d9f0e2510d02919af0f989d3061c66b3f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("96fc13a16df730afead8c17812e65e2aad53d64d57e3180ef5169cda035f33e4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("a750ac0ba4c23de6ab3ce494fd23e9b0e47dbf961e1fd29cb543ca60e200ba44")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("12b5c2f325e99499fa6d79fb9cef3562f8a7635917353f2a79d4c30ac529e7a0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("70bcf588b9f9b7a6aca236ff8214f17b123caa5da039ecc00ddee4828e9cc1bb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5459,7 +10437,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5474,7 +10455,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5489,7 +10473,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5504,7 +10491,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5519,7 +10509,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5534,7 +10527,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5549,7 +10545,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5564,7 +10563,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("56b36066cda53fb371d92e769b7dc4b18df2d857930871946052d6be724febce")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("f2cd3e6824d768603d6adc911aeb31de87f12bff9d3dc93624e944c6312acbdf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("c14205c1de8febc05190c879dd4e3eac67ce9afdae962ec00bd768279b262b18")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e8ff9e1db06889cc65324a878b3d1e49de1213766a0401345b486761721ea125")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("04df195d33f88ce2e1160416951eb772e9c61528aad1d15c508d9fd11041fc59")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("7ad8fdc6f0d26156bc350533a9af7bf582230be8ad6935934911fd8afd184085")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5579,7 +10689,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5594,7 +10707,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5609,7 +10725,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5624,7 +10743,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5639,7 +10761,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5654,7 +10779,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5669,7 +10797,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5684,7 +10815,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("1cbd17424d858fbb37e6184bf355f72830a47d2e33a4b8de872fa87aaa49a15e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("1067c4c6fc40bbd2d8b747177296bbeb4abfcb54e700226f2f211c3a2b90be46")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("a110dcb9cdca8ce655b215427b0c5fa2b1a374badfe38fbb57cfb0ce28db434e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("dddc62de5f796dbb33cbc81ebdb496758ea653c918a840d12574373aa4835165")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("0493e89aae5b95b17f3092402cd7b6516494cad817aff68cc2988a4c065ae1ab")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("7dd9634e06daf56e58dfab4f71bea2d4d9b5c808fc30a40eb6208e76dfe24b14")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5699,7 +10941,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5714,7 +10959,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5729,7 +10977,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5744,7 +10995,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5759,7 +11013,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5774,7 +11031,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5789,7 +11049,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5804,7 +11067,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5819,7 +11085,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5834,7 +11103,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5849,7 +11121,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5864,7 +11139,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5879,7 +11157,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -5894,7 +11175,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -5909,7 +11193,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5924,7 +11211,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5939,7 +11229,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -5954,7 +11247,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -5969,7 +11265,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("a941b1c2d598d96a48f97e945164cdc37a872fd85239ea697146dff872ea5cdb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("ac55f1ffe9727dd8fd98872a0d10538069e7034ff48f359b0dfc55b6b98d5b8b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("bd1736347fc811bae037ab42db7438b205ba685e2379cc972e8ac3485ff7cb7c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("b329fb3c247998ce879869ff730681344c43feaf1d0fb3c88837a46cd580ebb8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("87e41b56899c10d01af055e06de9a69cdf3361e71b8eda008b63d37b3ec1b073")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-3.9.21%2B20241206-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("f0413a469a655406bb5912665af344df34a63cc743839fcd0edc8e74012f2327")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 21,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5984,7 +11391,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 21,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -5999,7 +11409,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6014,7 +11427,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6029,7 +11445,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6044,7 +11463,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -6059,7 +11481,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -6074,7 +11499,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6089,7 +11517,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6104,7 +11535,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6119,7 +11553,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6134,7 +11571,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("1461b5364d07a56f1879390eaec72542fe0dd48fa369ce4507c555677bfe07ea")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("237ec3d144e488130476c1d2c70d8ca7f2b36f423eb0ead348a78c6fc1fb7abb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("0e2c93f61971e0bda6e679a211c1e1ae074f43d2113328b8304b2e38c77c5a32")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("0f99bd0d5b0d1afb207f3e6d4fb36be303bf277ac7c327dd07b7d1e6ba90f9ea")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("693a3f129a86c48c176b35db81eae0bf54faec893fe8386ec5116070638c4712")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("0d8f9e08f4eb14575574728b174591736ceaada37a03c1bdec17184475ffabe8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6149,7 +11697,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6164,7 +11715,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6179,7 +11733,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6194,7 +11751,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6209,7 +11769,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
@@ -6224,7 +11787,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
             variant: PythonVariant::Default
@@ -6239,7 +11805,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6254,7 +11823,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6269,7 +11841,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6284,7 +11859,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6299,7 +11877,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("1d8179bde4db3e6cffac45f5c6a105e342a50a854b316b26760c17ba32bb164a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("2f9eac6ff7bc42a06b0f04cc28f5f24e851dcbb5d4a025a170e036ac1511a226")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("66c1df96394e43826ff5ed7f980ad93241af1e3ec212ce92b48efea183e8b9db")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("3c79c2c628d9412658e2fe21864439f53d22fa2dd8bc4f355564e73115715e37")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("7098fa8e0dac6a689d5289e761b85f713b607c476bfb1c1da13b3f86edce8461")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
+        sha256: Some("1c6c6d2113fd3965d29b2fc70621ff81a1f7165a9dd660de980b805ba61a5c39")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6314,7 +12003,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6329,7 +12021,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6344,7 +12039,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6359,7 +12057,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6374,7 +12075,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6389,7 +12093,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6404,7 +12111,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6419,7 +12129,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6434,7 +12147,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6449,7 +12165,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("ff8e33905d114a590cd13f5e17590efd6ad56c4eb841c9820863da2f55b13860")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("2ab7781e0d14d92272d7bcfb1383328ded38213fa9ad9ca00d1d08dae1ada26e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e85a752197d7c7529a19b83c17efa194c8743cbc4608d5cbca77da506ab30956")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("20c45210b2ef110ce6f01038e2861435cc6b9ccf94e7f015dcb111c3f5d0b629")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("31b1548bd8e259b6b4a84d69d6ddcd27397af5971e3ffadd162f3a38eb623f6a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("61db6789f2974b6cf85fefc0e06950e43898e4a468d3c643cc35427d8ebf4fc0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6464,7 +12291,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6479,7 +12309,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6494,7 +12327,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6509,7 +12345,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6524,7 +12363,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6539,7 +12381,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6554,7 +12399,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6569,7 +12417,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6584,7 +12435,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6599,7 +12453,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("3d9275e70d39030030f7e9db5f05fc07e2be6fb4964af0053f4a461bac9ba1bd")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("cdfe58799d017947c414bc8513ddb51bc7f4c25b2e603faa8dfcfd931a47392f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("be15573d9213c20ead1de62f500817f5e069510d41a4f48a78c3086953c1693e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("4a541fb47184505c165adcb88490fa9df11e7d34fd9bd0117f70b42c50dcc7e1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("114573e1c4919116e5ecf4c6425f44e09b03527fcddffe3d53f73fe1ce9df7d8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("53a1b8cd550e803e258ba04192a18ccfe2ce4cbca2dc776cec47b2eba2507305")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6614,7 +12579,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6629,7 +12597,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6644,7 +12615,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6659,7 +12633,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6674,7 +12651,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6689,7 +12669,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            arch: Arch{
+                family: target_lexicon::Architecture::Powerpc64le,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6704,7 +12687,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6719,7 +12705,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6734,7 +12723,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("08acda6031601b35291fa54f98888dc17d36c9ff35bdb2adea4631df81e24271")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("b78dbd216e23a8f4adda881fbe11f6749371c09b4235dd519a4b4be761dd1504")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("337fb379e9c46b6145e4c52f827513989c2feb9c84beac17c38decb50af5b53a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("675b7d77d653f47561536eae8fcd1ffaedd467ffcf43afdd9c96d2d32e8e84c4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("fc289e674fb61ca4e39a4676ee11971e3f87bab607951898336b5df53b6ca328")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("9bdb07f9e9dc429553d12b434293f270c9e281ea7c7ffe5be4f6e8b2cc151e03")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6749,7 +12849,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6764,7 +12867,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6779,7 +12885,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6794,7 +12903,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6809,7 +12921,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6824,7 +12939,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6839,7 +12957,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6854,7 +12975,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("436c35bd809abdd028f386cc623ae020c77e6b544eaaca405098387c4daa444c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("52e774f1ccbbc61a30da2a95286348700ee7d7707412ef10035420f43469c39f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("6a3d25cb22b65355dd793bfb4838a16a5cd85edc07e3dac8cc22adad860f2c89")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("a7c4dcff34014b01de397ffe6497787935575f604f489d01cdd843b41dd320e6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("65350987640f33876d072a44d03e6e397dcf5d2512819bd8765c892ec5c0f153")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("33b227fdde7a236e69635dafc0cfbfcee76594b9892092357ffd35a0dcb303e7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6869,7 +13101,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6884,7 +13119,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6899,7 +13137,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6914,7 +13155,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6929,7 +13173,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6944,7 +13191,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -6959,7 +13209,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -6974,7 +13227,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("3b858cd4a187db8cd1eaedddd5ff80a077783092ca4d84970097127220f55cd4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("d912966b120f5406046bf5a5252a6585cfb7620fe5d570a265cd221dfd8fbeb3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("798cd9d019885fb2f0010a234873ebe7de35e4eb8fc4e2ba1d40ea31b6abb0bf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("46cd2e2b988bb5f6e12b184f2130d678ee781f84520dee1d8c487f2e0d1e3371")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("f14391bc3b71dadc8855577325e3a49b17f351d428cc4caad8b1216b90f3ad80")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("355b1b5c3098b45f9b3dd1602321787c6731a70e574846efe29d96aef31d1e5b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -6989,7 +13353,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7004,7 +13371,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7019,7 +13389,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7034,7 +13407,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7049,7 +13425,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7064,7 +13443,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7079,7 +13461,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7094,7 +13479,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("1e1b522a91ed805287793427013762bc8f6c02440147e9fa5306316369307e58")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("e3142427ed091bfe0986cf49954fa3fcbe7754f42d66e4fd0ce68f41a513c3c1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("315a9fbc75e2a0545254edf8974d88577ec64537ee04322ad1a7ce9752353f33")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("40be6728331395abce574e080e5411e781c0a8a3a5d5175ae10534cee8d83ae2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("b4c5a9908a77e4cae37901f8df2655380186d0e10723902672ef5e5296093071")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("3b21780f0eba88519f0c00032cfb8ddb959b31a76cf21611a26da5d8296a9200")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7109,7 +13605,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7124,7 +13623,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7139,7 +13641,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7154,7 +13659,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7169,7 +13677,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7184,7 +13695,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7199,7 +13713,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7214,7 +13731,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("72085205843949f783c9245ad42902a63a00dd35367f1e5ea6f4aa709b2029ce")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("140ea77e2924fc312ecd266337f1add09e560084422843673b08ff847259a93f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("bb702440330bf8cd852cf36735a47ee10aa3941271b5d2f96cd6bfa6ac7a46b4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("afceda37726445a1472b023ca7e6fb1b169557c7fc26a2ffa53e2b59247e1c6c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("7a5fcad095ad183049b2f975cd55efd8a2ce3e4d894ee67cb5fa01186f50203e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("81138b9b65bc01ed441bf0ab0fa2225c3d131a3b13838cc698c9e4aaef4cab11")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7229,7 +13857,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7244,7 +13875,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7259,7 +13893,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7274,7 +13911,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7289,7 +13929,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7304,7 +13947,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7319,7 +13965,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7334,7 +13983,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("bd9d808283eef69882e8e0c2529fe400c8605b7c08ef64e679d1766c1a87ef95")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("69439fb7c2e8f8bda28f2d5f4c71634116800d71a06f7cbeeb8f21ebca829fd2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("9cb5ab650efad6e475026f7782f852094a9403966bcc1f795065b1a4a33e362b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("190cb2cc081d0d6ffca9232e877a959915452f6fd3808cfe128f6ebc392fcfb2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("8d7eee9c085e08f3cc6cdf56be7cc0dc8a3e25e053856c1a933efb3529c087de")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("0455c95330532edf5c30d4a30873140e7e6c715fbca921ac127769865382050b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7349,7 +14109,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7364,7 +14127,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7379,7 +14145,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7394,7 +14163,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7409,7 +14181,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7424,7 +14199,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7439,7 +14217,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7454,7 +14235,118 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("f9c6b0412c0773e604a1f95d5db97f79f98d960bcf0e85215e533ea573721216")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V2),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("5e4bde1751608e7f3ae2d9029c8866d0325db24c5a3b8441b62bef14fb8484be")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("5c23a5f13356adfcf26d27df7e48885e634489e3a2383e67c013c3f1ec2e082e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V3),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("649371a944665efa5b286d530c76808fb4f6ae4694f59c2ced8596fbe65d5164")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e97477ab9d30b52faf7de9e364ff50acf4490a28f7bf6fa11887f5a26e56ec93")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: Some(ArchVariant::V4),
+            },
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
+        sha256: Some("6bcba95a5d6f1378821ba16c5d5b8a2e02bb365c1314d0492f66545973459ae4")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7469,7 +14361,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7484,7 +14379,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7499,7 +14397,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7514,7 +14415,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7529,7 +14433,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7544,7 +14451,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7559,7 +14469,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7574,7 +14487,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7589,7 +14505,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7604,7 +14523,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7619,7 +14541,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7634,7 +14559,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7649,7 +14577,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7664,7 +14595,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7679,7 +14613,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7694,7 +14631,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7709,7 +14649,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7724,7 +14667,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7739,7 +14685,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7754,7 +14703,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7769,7 +14721,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7784,7 +14739,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7799,7 +14757,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7814,7 +14775,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7829,7 +14793,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7844,7 +14811,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7859,7 +14829,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7874,7 +14847,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7889,7 +14865,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7904,7 +14883,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7919,7 +14901,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7934,7 +14919,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7949,7 +14937,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -7964,7 +14955,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -7979,7 +14973,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -7994,7 +14991,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8009,7 +15009,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8024,7 +15027,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8039,7 +15045,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8054,7 +15063,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8069,7 +15081,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8084,7 +15099,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8099,7 +15117,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8114,7 +15135,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8129,7 +15153,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8144,7 +15171,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8159,7 +15189,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8174,7 +15207,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8189,7 +15225,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8204,7 +15243,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8219,7 +15261,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8234,7 +15279,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8249,7 +15297,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8264,7 +15315,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8279,7 +15333,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8294,7 +15351,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8309,7 +15369,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8324,7 +15387,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8339,7 +15405,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8354,7 +15423,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8369,7 +15441,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8384,7 +15459,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8399,7 +15477,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8414,7 +15495,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8429,7 +15513,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8444,7 +15531,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8459,7 +15549,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8474,7 +15567,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8489,7 +15585,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8504,7 +15603,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8519,7 +15621,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8534,7 +15639,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8549,7 +15657,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8564,7 +15675,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8579,7 +15693,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8594,7 +15711,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8609,7 +15729,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8624,7 +15747,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8639,7 +15765,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8654,7 +15783,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8669,7 +15801,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8684,7 +15819,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8699,7 +15837,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8714,7 +15855,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8729,7 +15873,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8744,7 +15891,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8759,7 +15909,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8774,7 +15927,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8789,7 +15945,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8804,7 +15963,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8819,7 +15981,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8834,7 +15999,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8849,7 +16017,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8864,7 +16035,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8879,7 +16053,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8894,7 +16071,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8909,7 +16089,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -8924,7 +16107,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8939,7 +16125,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8954,7 +16143,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8969,7 +16161,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -8984,7 +16179,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -8999,7 +16197,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9014,7 +16215,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9029,7 +16233,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9044,7 +16251,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9059,7 +16269,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9074,7 +16287,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9089,7 +16305,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9104,7 +16323,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9119,7 +16341,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9134,7 +16359,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9149,7 +16377,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9164,7 +16395,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9179,7 +16413,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9194,7 +16431,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9209,7 +16449,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9224,7 +16467,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9239,7 +16485,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9254,7 +16503,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9269,7 +16521,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9284,7 +16539,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9299,7 +16557,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9314,7 +16575,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9329,7 +16593,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9344,7 +16611,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9359,7 +16629,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9374,7 +16647,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9389,7 +16665,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9404,7 +16683,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9419,7 +16701,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9434,7 +16719,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9449,7 +16737,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9464,7 +16755,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9479,7 +16773,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9494,7 +16791,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9509,7 +16809,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9524,7 +16827,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9539,7 +16845,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9554,7 +16863,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9569,7 +16881,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9584,7 +16899,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9599,7 +16917,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9614,7 +16935,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9629,7 +16953,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9644,7 +16971,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9659,7 +16989,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9674,7 +17007,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9689,7 +17025,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9704,7 +17043,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9719,7 +17061,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9734,7 +17079,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9749,7 +17097,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9764,7 +17115,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9779,7 +17133,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9794,7 +17151,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9809,7 +17169,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9824,7 +17187,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9839,7 +17205,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9854,7 +17223,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9869,7 +17241,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9884,7 +17259,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9899,7 +17277,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9914,7 +17295,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -9929,7 +17313,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9944,7 +17331,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9959,7 +17349,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -9974,7 +17367,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -9989,7 +17385,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -10004,7 +17403,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10019,7 +17421,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10034,7 +17439,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10049,7 +17457,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10064,7 +17475,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -10079,7 +17493,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10094,7 +17511,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10109,7 +17529,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10124,7 +17547,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10139,7 +17565,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
             variant: PythonVariant::Default
@@ -10154,7 +17583,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10169,7 +17601,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10184,7 +17619,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10199,7 +17637,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10214,7 +17655,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10229,7 +17673,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10244,7 +17691,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10259,7 +17709,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10274,7 +17727,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10289,7 +17745,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10304,7 +17763,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10319,7 +17781,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10334,7 +17799,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10349,7 +17817,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10364,7 +17835,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10379,7 +17853,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10394,7 +17871,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10409,7 +17889,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10424,7 +17907,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10439,7 +17925,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10454,7 +17943,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10469,7 +17961,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10484,7 +17979,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10499,7 +17997,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10514,7 +18015,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10529,7 +18033,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10544,7 +18051,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10559,7 +18069,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10574,7 +18087,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10589,7 +18105,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10604,7 +18123,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10619,7 +18141,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10634,7 +18159,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10649,7 +18177,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10664,7 +18195,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10679,7 +18213,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10694,7 +18231,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10709,7 +18249,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10724,7 +18267,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10739,7 +18285,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10754,7 +18303,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10769,7 +18321,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10784,7 +18339,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10799,7 +18357,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10814,7 +18375,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10829,7 +18393,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10844,7 +18411,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10859,7 +18429,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10874,7 +18447,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10889,7 +18465,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10904,7 +18483,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10919,7 +18501,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10934,7 +18519,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10949,7 +18537,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10964,7 +18555,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -10979,7 +18573,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -10994,7 +18591,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11009,7 +18609,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11024,7 +18627,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11039,7 +18645,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11054,7 +18663,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11069,7 +18681,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11084,7 +18699,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11099,7 +18717,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11114,7 +18735,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11129,7 +18753,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11144,7 +18771,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11159,7 +18789,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11174,7 +18807,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11189,7 +18825,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11204,7 +18843,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11219,7 +18861,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11234,7 +18879,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11249,7 +18897,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11264,7 +18915,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11279,7 +18933,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11294,7 +18951,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11309,7 +18969,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11324,7 +18987,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11339,7 +19005,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11354,7 +19023,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11369,7 +19041,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11384,7 +19059,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11399,7 +19077,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11414,7 +19095,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11429,7 +19113,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11444,7 +19131,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11459,7 +19149,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11474,7 +19167,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11489,7 +19185,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11504,7 +19203,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11519,7 +19221,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11534,7 +19239,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11549,7 +19257,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11564,7 +19275,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11579,7 +19293,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11594,7 +19311,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11609,7 +19329,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11624,7 +19347,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11639,7 +19365,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11654,7 +19383,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11669,7 +19401,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11684,7 +19419,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11699,7 +19437,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11714,7 +19455,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11729,7 +19473,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11744,7 +19491,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11759,7 +19509,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11774,7 +19527,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11789,7 +19545,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11804,7 +19563,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11819,7 +19581,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11834,7 +19599,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11849,7 +19617,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11864,7 +19635,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11879,7 +19653,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11894,7 +19671,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
             variant: PythonVariant::Default
@@ -11909,7 +19689,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            arch: Arch{
+                family: target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11924,7 +19707,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11939,7 +19725,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::S390x),
+            arch: Arch{
+                family: target_lexicon::Architecture::S390x,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11954,7 +19743,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_64,
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
@@ -11969,7 +19761,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch{
+                family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
+                variant: None,
+            },
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
             variant: PythonVariant::Default

--- a/crates/uv-python/src/downloads.inc.mustache
+++ b/crates/uv-python/src/downloads.inc.mustache
@@ -3,6 +3,7 @@
 
 use uv_pep440::{Prerelease, PrereleaseKind};
 use crate::PythonVariant;
+use crate::platform::ArchVariant;
 
 pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
     {{#versions}}
@@ -13,7 +14,10 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: {{value.patch}},
             prerelease: {{value.prerelease}},
             implementation: LenientImplementationName::Known(ImplementationName::{{value.name}}),
-            arch: Arch(target_lexicon::Architecture::{{value.arch}}),
+            arch: Arch{
+                family: target_lexicon::Architecture::{{value.arch_family}},
+                variant: {{value.arch_variant}},
+            },
             os: Os(target_lexicon::OperatingSystem::{{value.os}}),
             {{#value.libc}}
             libc: Libc::Some(target_lexicon::Environment::{{.}}),

--- a/crates/uv-python/template-download-metadata.py
+++ b/crates/uv-python/template-download-metadata.py
@@ -62,17 +62,23 @@ def prepare_variant(variant: str | None) -> str | None:
             raise ValueError(f"Unknown variant: {variant}")
 
 
-def prepare_arch(arch: str) -> str:
-    match arch:
+def prepare_arch(arch: dict) -> tuple[str, str]:
+    match arch["family"]:
         # Special constructors
         case "i686":
-            return "X86_32(target_lexicon::X86_32Architecture::I686)"
+            family = "X86_32(target_lexicon::X86_32Architecture::I686)"
         case "aarch64":
-            return "Aarch64(target_lexicon::Aarch64Architecture::Aarch64)"
+            family = "Aarch64(target_lexicon::Aarch64Architecture::Aarch64)"
         case "armv7":
-            return "Arm(target_lexicon::ArmArchitecture::Armv7)"
-        case _:
-            return arch.capitalize()
+            family = "Arm(target_lexicon::ArmArchitecture::Armv7)"
+        case value:
+            family = value.capitalize()
+    variant = (
+        f"Some(ArchVariant::{arch['variant'].capitalize()})"
+        if arch["variant"]
+        else "None"
+    )
+    return family, variant
 
 
 def prepare_prerelease(prerelease: str) -> str:
@@ -86,7 +92,7 @@ def prepare_prerelease(prerelease: str) -> str:
 
 def prepare_value(value: dict) -> dict:
     value["os"] = value["os"].title()
-    value["arch"] = prepare_arch(value["arch"])
+    value["arch_family"], value["arch_variant"] = prepare_arch(value["arch"])
     value["name"] = prepare_name(value["name"])
     value["libc"] = prepare_libc(value["libc"])
     value["prerelease"] = prepare_prerelease(value["prerelease"])


### PR DESCRIPTION
Supersedes https://github.com/astral-sh/uv/pull/8517 with an alternative approach of making all the variants available instead of replacing the x86_64 (v1) variant with x86_64_v2.

Doesn't add automatic inference of the supported instructions, but that should be doable per @charliermarsh's comment there. Going to do it as a follow-up since this has been pretty time consuming.

e.g.,

```
❯ cargo run -q -- python install cpython-3.12.8-linux-x86_64_v3-gnu
Installed Python 3.12.8 in 2.72s
 + cpython-3.12.8-linux-x86_64_v3-gnu
```