### PR TITLE
Add `uv python list --all-arches`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4222,6 +4222,12 @@ pub struct PythonListArgs {
     #[arg(long)]
     pub all_platforms: bool,
 
+    /// List Python downloads for all architectures.
+    ///
+    /// By default, only downloads for the current architecture are shown.
+    #[arg(long, alias = "all_architectures")]
+    pub all_arches: bool,
+
     /// Only show installed Python versions, exclude available downloads.
     ///
     /// By default, available downloads for the current platform are shown.

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -145,6 +145,12 @@ impl PythonDownloadRequest {
     }
 
     #[must_use]
+    pub fn with_any_arch(mut self) -> Self {
+        self.arch = None;
+        self
+    }
+
+    #[must_use]
     pub fn with_os(mut self, os: Os) -> Self {
         self.os = Some(os);
         self

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -25,11 +25,12 @@ enum Kind {
 }
 
 /// List available Python installations.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn list(
     kinds: PythonListKinds,
     all_versions: bool,
     all_platforms: bool,
+    all_arches: bool,
     show_urls: bool,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
@@ -49,6 +50,8 @@ pub(crate) async fn list(
                 if python_downloads.is_automatic() {
                     Some(if all_platforms {
                         PythonDownloadRequest::default()
+                    } else if all_arches {
+                        PythonDownloadRequest::from_env()?.with_any_arch()
                     } else {
                         PythonDownloadRequest::from_env()?
                     })

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1088,6 +1088,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.kinds,
                 args.all_versions,
                 args.all_platforms,
+                args.all_arches,
                 args.show_urls,
                 globals.python_preference,
                 globals.python_downloads,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -715,6 +715,7 @@ pub(crate) enum PythonListKinds {
 pub(crate) struct PythonListSettings {
     pub(crate) kinds: PythonListKinds,
     pub(crate) all_platforms: bool,
+    pub(crate) all_arches: bool,
     pub(crate) all_versions: bool,
     pub(crate) show_urls: bool,
 }
@@ -726,6 +727,7 @@ impl PythonListSettings {
         let PythonListArgs {
             all_versions,
             all_platforms,
+            all_arches,
             only_installed,
             only_downloads,
             show_urls,
@@ -742,6 +744,7 @@ impl PythonListSettings {
         Self {
             kinds,
             all_platforms,
+            all_arches,
             all_versions,
             show_urls,
         }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4351,7 +4351,11 @@ uv python list [OPTIONS]
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt><code>--all-platforms</code></dt><dd><p>List Python downloads for all platforms.</p>
+<dl class="cli-reference"><dt><code>--all-arches</code></dt><dd><p>List Python downloads for all architectures.</p>
+
+<p>By default, only downloads for the current architecture are shown.</p>
+
+</dd><dt><code>--all-platforms</code></dt><dd><p>List Python downloads for all platforms.</p>
 
 <p>By default, only downloads for the current platform are shown.</p>
 


### PR DESCRIPTION
With #9781 this becomes even more compelling. This is generally useful as well.

e.g.,

```
❯ cargo run -- python list --all-arches
cpython-3.13.1+freethreaded-macos-x86_64-none     <download available>
cpython-3.13.1-macos-x86_64-none                  <download available>
cpython-3.13.1+freethreaded-macos-aarch64-none    <download available>
cpython-3.13.1-macos-aarch64-none                 <download available>
cpython-3.13.0-macos-aarch64-none                 /Users/zb/.local/bin/python3.13 -> /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
cpython-3.13.0-macos-aarch64-none                 /Users/zb/.local/bin/python3 -> /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
cpython-3.13.0-macos-aarch64-none                 /Users/zb/.local/bin/python -> /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
cpython-3.13.0-macos-aarch64-none                 /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
cpython-3.12.8-macos-x86_64-none                  <download available>
cpython-3.12.8-macos-aarch64-none                 <download available>
...
```