### PR TITLE
Test binary builds on `Cargo.lock` changes

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -17,6 +17,7 @@ on:
       # When we change project metadata, we want to ensure that the maturin builds still work.
       - pyproject.toml
       - Cargo.toml
+      - Cargo.lock
       # And when we change this workflow itself...
       - .github/workflows/build-binaries.yml
 


### PR DESCRIPTION
This would be helpful to know if the regression was caused by a dependency update.