### PR TITLE
 Fix local packse workflow 

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -37,11 +37,15 @@ pub const PACKSE_VERSION: &str = "0.3.39";
 /// Using a find links url allows using `--index-url` instead of `--extra-index-url` in tests
 /// to prevent dependency confusion attacks against our test suite.
 pub fn build_vendor_links_url() -> String {
-    format!("https://raw.githubusercontent.com/astral-sh/packse/{PACKSE_VERSION}/vendor/links.html")
+    env::var("UV_TEST_VENDOR_LINKS_URL").ok().unwrap_or(format!(
+        "https://raw.githubusercontent.com/astral-sh/packse/{PACKSE_VERSION}/vendor/links.html"
+    ))
 }
 
 pub fn packse_index_url() -> String {
-    format!("https://astral-sh.github.io/packse/{PACKSE_VERSION}/simple-html/")
+    env::var("UV_TEST_INDEX_URL").ok().unwrap_or(format!(
+        "https://astral-sh.github.io/packse/{PACKSE_VERSION}/simple-html/"
+    ))
 }
 
 #[doc(hidden)] // Macro and test context only, don't use directly.

--- a/scripts/scenarios/generate.py
+++ b/scripts/scenarios/generate.py
@@ -83,7 +83,10 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
 
     debug = logging.getLogger().getEffectiveLevel() <= logging.DEBUG
 
-    update_common_mod_rs(packse_version)
+    # Don't update the version to `0.0.0` to preserve the `UV_TEST_VENDOR_LINKS_URL`
+    # in local tests.
+    if packse_version != "0.0.0":
+        update_common_mod_rs(packse_version)
 
     if not scenarios:
         if packse_version == "0.0.0":
@@ -93,7 +96,7 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
                     "Detected development version of packse, using scenarios from %s",
                     path,
                 )
-                scenarios = path.glob("*.json")
+                scenarios = [path]
             else:
                 logging.error(
                     "No scenarios provided. Found development version of packse but is missing scenarios. Is it installed as an editable?"
@@ -108,6 +111,7 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
         if target.is_dir():
             targets.extend(target.glob("**/*.json"))
             targets.extend(target.glob("**/*.toml"))
+            targets.extend(target.glob("**/*.yaml"))
         else:
             targets.append(target)
 
@@ -226,16 +230,20 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
                 "--test-runner",
                 "nextest",
                 "--test",
+                "it",
+                "--",
                 tests.with_suffix("").name,
             ]
-            logging.debug(f"Running {" ".join(command)}")
-            subprocess.call(
+            logging.debug(f"Running {' '.join(command)}")
+            exit_code = subprocess.call(
                 command,
                 cwd=PROJECT_ROOT,
                 stderr=subprocess.STDOUT,
                 stdout=sys.stderr if debug else subprocess.DEVNULL,
                 env=env,
             )
+            if exit_code != 0:
+                logging.warning(f"Snapshot update failed (Exit code: {exit_code})")
         else:
             logging.info("Skipping snapshot update")
 


### PR DESCRIPTION
Make the local packse workflow work again:

```
# In packse:
uv run --extra index --extra serve packse serve --no-hash scenarios &
# In uv:
UV_TEST_INDEX_URL="http://localhost:3141/simple/" ./scripts/scenarios/generate.py
```

Bugs fixed:
* The default scenario pattern didn't match anything.
* The snapshot update test command was wrong since the test centralization
* Snapshot update failures would not be reported