### PR TITLE
Avoid reusing interpreter metadata when running under Rosetta

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -784,7 +784,7 @@ impl CacheBucket {
             Self::SourceDistributions => "sdists-v6",
             Self::FlatIndex => "flat-index-v2",
             Self::Git => "git-v0",
-            Self::Interpreter => "interpreter-v3",
+            Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in crates/uv/tests/cache_clean.rs.
             Self::Simple => "simple-v14",

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::env::consts::ARCH;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
@@ -746,7 +747,9 @@ impl InterpreterInfo {
 
         let cache_entry = cache.entry(
             CacheBucket::Interpreter,
-            "",
+            // Shard interpreter metadata by host architecture, to avoid cache collisions when
+            // running universal binaries under Rosetta.
+            ARCH,
             // We use the absolute path for the cache entry to avoid cache collisions for relative
             // paths. But we don't to query the executable with symbolic links resolved.
             format!("{}.msgpack", cache_digest(&absolute)),


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/9836.
