### PR TITLE
Use `sys.path` for package discovery

### DIFF
--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -26,7 +26,7 @@ use uv_distribution_types::{
     SourceDist, VersionOrUrlRef,
 };
 use uv_git::GitResolver;
-use uv_installer::{Installer, Plan, Planner, Preparer, SitePackages};
+use uv_installer::{Installer, Plan, Planner, Preparer, InstalledPackages};
 use uv_pypi_types::{Conflicts, Requirement};
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_resolver::{
@@ -229,7 +229,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
         let tags = self.interpreter.tags()?;
 
         // Determine the set of installed packages.
-        let site_packages = SitePackages::from_environment(venv)?;
+        let installed_packages = InstalledPackages::from_environment(venv)?;
 
         let Plan {
             cached,
@@ -237,7 +237,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             reinstalls,
             extraneous: _,
         } = Planner::new(resolution).build(
-            site_packages,
+            installed_packages,
             &Reinstall::default(),
             self.build_options,
             self.hasher,

--- a/crates/uv-installer/src/installed_packages.rs
+++ b/crates/uv-installer/src/installed_packages.rs
@@ -25,7 +25,7 @@ use crate::satisfies::RequirementSatisfaction;
 ///
 /// Packages are indexed by both name and (for editable installs) URL.
 #[derive(Debug, Clone)]
-pub struct SitePackages {
+pub struct InstalledPackages {
     interpreter: Interpreter,
     /// The vector of all installed distributions. The `by_name` and `by_url` indices index into
     /// this vector. The vector may contain `None` values, which represent distributions that were
@@ -39,7 +39,7 @@ pub struct SitePackages {
     by_url: FxHashMap<Url, Vec<usize>>,
 }
 
-impl SitePackages {
+impl InstalledPackages {
     /// Build an index of installed packages from the given Python environment.
     pub fn from_environment(environment: &PythonEnvironment) -> Result<Self> {
         Self::from_interpreter(environment.interpreter())
@@ -185,7 +185,7 @@ impl SitePackages {
     pub fn diagnostics(
         &self,
         markers: &ResolverMarkerEnvironment,
-    ) -> Result<Vec<SitePackagesDiagnostic>> {
+    ) -> Result<Vec<InstalledPackagesDiagnostic>> {
         let mut diagnostics = Vec::new();
 
         for (package, indexes) in &self.by_name {
@@ -198,7 +198,7 @@ impl SitePackages {
 
             if let Some(conflict) = distributions.next() {
                 // There are multiple installed distributions for the same package.
-                diagnostics.push(SitePackagesDiagnostic::DuplicatePackage {
+                diagnostics.push(InstalledPackagesDiagnostic::DuplicatePackage {
                     package: package.clone(),
                     paths: std::iter::once(distribution.path().to_owned())
                         .chain(std::iter::once(conflict.path().to_owned()))
@@ -215,7 +215,7 @@ impl SitePackages {
 
                 // Determine the dependencies for the given package.
                 let Ok(metadata) = distribution.metadata() else {
-                    diagnostics.push(SitePackagesDiagnostic::MetadataUnavailable {
+                    diagnostics.push(InstalledPackagesDiagnostic::MetadataUnavailable {
                         package: package.clone(),
                         path: distribution.path().to_owned(),
                     });
@@ -225,7 +225,7 @@ impl SitePackages {
                 // Verify that the package is compatible with the current Python version.
                 if let Some(requires_python) = metadata.requires_python.as_ref() {
                     if !requires_python.contains(markers.python_full_version()) {
-                        diagnostics.push(SitePackagesDiagnostic::IncompatiblePythonVersion {
+                        diagnostics.push(InstalledPackagesDiagnostic::IncompatiblePythonVersion {
                             package: package.clone(),
                             version: self.interpreter.python_version().clone(),
                             requires_python: requires_python.clone(),
@@ -243,7 +243,7 @@ impl SitePackages {
                     match installed.as_slice() {
                         [] => {
                             // No version installed.
-                            diagnostics.push(SitePackagesDiagnostic::MissingDependency {
+                            diagnostics.push(InstalledPackagesDiagnostic::MissingDependency {
                                 package: package.clone(),
                                 requirement: dependency.clone(),
                             });
@@ -259,7 +259,7 @@ impl SitePackages {
                                     // The installed version doesn't satisfy the requirement.
                                     if !version_specifier.contains(installed.version()) {
                                         diagnostics.push(
-                                            SitePackagesDiagnostic::IncompatibleDependency {
+                                            InstalledPackagesDiagnostic::IncompatibleDependency {
                                                 package: package.clone(),
                                                 version: installed.version().clone(),
                                                 requirement: dependency.clone(),
@@ -394,7 +394,7 @@ pub enum SatisfiesResult {
     Unsatisfied(String),
 }
 
-impl IntoIterator for SitePackages {
+impl IntoIterator for InstalledPackages {
     type Item = InstalledDist;
     type IntoIter = Flatten<std::vec::IntoIter<Option<InstalledDist>>>;
 
@@ -404,7 +404,7 @@ impl IntoIterator for SitePackages {
 }
 
 #[derive(Debug)]
-pub enum SitePackagesDiagnostic {
+pub enum InstalledPackagesDiagnostic {
     MetadataUnavailable {
         /// The package that is missing metadata.
         package: PackageName,
@@ -441,7 +441,7 @@ pub enum SitePackagesDiagnostic {
     },
 }
 
-impl Diagnostic for SitePackagesDiagnostic {
+impl Diagnostic for InstalledPackagesDiagnostic {
     /// Convert the diagnostic into a user-facing message.
     fn message(&self) -> String {
         match self {
@@ -495,7 +495,7 @@ impl Diagnostic for SitePackagesDiagnostic {
     }
 }
 
-impl InstalledPackagesProvider for SitePackages {
+impl InstalledPackagesProvider for InstalledPackages {
     fn iter(&self) -> impl Iterator<Item = &InstalledDist> {
         self.iter()
     }

--- a/crates/uv-installer/src/installed_packages.rs
+++ b/crates/uv-installer/src/installed_packages.rs
@@ -48,15 +48,15 @@ impl InstalledPackages {
     /// Build an index of installed packages from the given Python executable.
     pub fn from_interpreter(interpreter: &Interpreter) -> Result<Self> {
         let mut distributions: Vec<Option<InstalledDist>> = Vec::new();
-        let mut by_name = FxHashMap::default();
-        let mut by_url = FxHashMap::default();
+        let mut by_name: FxHashMap<PackageName, Vec<usize>> = FxHashMap::default();
+        let mut by_url: FxHashMap<Url, Vec<usize>> = FxHashMap::default();
 
-        for site_packages in interpreter.site_packages() {
+        for import_path_entry in interpreter.sys_path() {
             // Read the site-packages directory.
-            let site_packages = match fs::read_dir(site_packages) {
-                Ok(site_packages) => {
+            let ordered_directory_paths = match fs::read_dir(import_path_entry) {
+                Ok(import_path_entry) => {
                     // Collect sorted directory paths; `read_dir` is not stable across platforms
-                    let dist_likes: BTreeSet<_> = site_packages
+                    let dist_likes: BTreeSet<_> = import_path_entry
                         .filter_map(|read_dir| match read_dir {
                             Ok(entry) => match entry.file_type() {
                                 Ok(file_type) => (file_type.is_dir()
@@ -73,18 +73,14 @@ impl InstalledPackages {
                     dist_likes
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    return Ok(Self {
-                        interpreter: interpreter.clone(),
-                        distributions,
-                        by_name,
-                        by_url,
-                    });
+                    // The site-packages directory doesn't exist, skip it.
+                    continue;
                 }
                 Err(err) => return Err(err).context("Failed to read site-packages directory"),
             };
 
             // Index all installed packages by name.
-            for path in site_packages {
+            for path in ordered_directory_paths {
                 let dist_info = match InstalledDist::try_from_path(&path) {
                     Ok(Some(dist_info)) => dist_info,
                     Ok(None) => continue,
@@ -110,10 +106,11 @@ impl InstalledPackages {
                 let idx = distributions.len();
 
                 // Index the distribution by name.
-                by_name
-                    .entry(dist_info.name().clone())
-                    .or_default()
-                    .push(idx);
+                let name = dist_info.name().clone();
+                if by_name.contains_key(&name) {
+                    continue;
+                }
+                by_name.entry(name).or_default().push(idx);
 
                 // Index the distribution by URL.
                 if let InstalledDist::Url(dist) = &dist_info {

--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -2,7 +2,7 @@ pub use compile::{compile_tree, CompileError};
 pub use installer::{Installer, Reporter as InstallReporter};
 pub use plan::{Plan, Planner};
 pub use preparer::{Error as PrepareError, Preparer, Reporter as PrepareReporter};
-pub use site_packages::{SatisfiesResult, SitePackages, SitePackagesDiagnostic};
+pub use installed_packages::{SatisfiesResult, InstalledPackages, InstalledPackagesDiagnostic};
 pub use uninstall::{uninstall, UninstallError};
 
 mod compile;
@@ -11,5 +11,5 @@ mod preparer;
 mod installer;
 mod plan;
 mod satisfies;
-mod site_packages;
+mod installed_packages;
 mod uninstall;

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -18,7 +18,7 @@ use uv_python::PythonEnvironment;
 use uv_types::HashStrategy;
 
 use crate::satisfies::RequirementSatisfaction;
-use crate::SitePackages;
+use crate::InstalledPackages;
 
 /// A planner to generate an [`Plan`] based on a set of requirements.
 #[derive(Debug)]
@@ -45,7 +45,7 @@ impl<'a> Planner<'a> {
     /// return an _installed_ distribution that does not match the required hash.
     pub fn build(
         self,
-        mut site_packages: SitePackages,
+        mut installed_packages: InstalledPackages,
         reinstall: &Reinstall,
         build_options: &BuildOptions,
         hasher: &HashStrategy,
@@ -77,7 +77,7 @@ impl<'a> Planner<'a> {
             let no_build = build_options.no_build_package(dist.name());
 
             // Determine whether the distribution is already installed.
-            let installed_dists = site_packages.remove_packages(dist.name());
+            let installed_dists = installed_packages.remove_packages(dist.name());
             if reinstall {
                 reinstalls.extend(installed_dists);
             } else {
@@ -350,11 +350,11 @@ impl<'a> Planner<'a> {
         }
 
         // Remove any unnecessary packages.
-        if site_packages.any() {
+        if installed_packages.any() {
             // Retain seed packages unless: (1) the virtual environment was created by uv and
             // (2) the `--seed` argument was not passed to `uv venv`.
             let seed_packages = !venv.cfg().is_ok_and(|cfg| cfg.is_uv() && !cfg.is_seed());
-            for dist_info in site_packages {
+            for dist_info in installed_packages {
                 if seed_packages
                     && matches!(
                         dist_info.name().as_ref(),

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -19,7 +19,7 @@ pub use receipt::ToolReceipt;
 pub use tool::{Tool, ToolEntrypoint};
 use uv_cache::Cache;
 use uv_fs::{LockedFile, Simplified};
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_state::{StateBucket, StateStore};
 use uv_static::EnvVars;
@@ -288,9 +288,9 @@ impl InstalledTools {
     pub fn version(&self, name: &PackageName, cache: &Cache) -> Result<Version, Error> {
         let environment_path = self.tool_dir(name);
         let environment = PythonEnvironment::from_root(&environment_path, cache)?;
-        let site_packages = SitePackages::from_environment(&environment)
+        let installed_packages = InstalledPackages::from_environment(&environment)
             .map_err(|err| Error::EnvironmentRead(environment_path.clone(), err.to_string()))?;
-        let packages = site_packages.get_packages(name);
+        let packages = installed_packages.get_packages(name);
         let package = packages
             .first()
             .ok_or_else(|| Error::MissingToolPackage(name.clone()))?;
@@ -363,11 +363,11 @@ pub fn tool_executable_dir() -> Result<PathBuf, Error> {
 
 /// Find the `.dist-info` directory for a package in an environment.
 fn find_dist_info<'a>(
-    site_packages: &'a SitePackages,
+    installed_packages: &'a InstalledPackages,
     package_name: &PackageName,
     package_version: &Version,
 ) -> Result<&'a Path, Error> {
-    site_packages
+    installed_packages
         .get_packages(package_name)
         .iter()
         .find(|package| package.version() == package_version)
@@ -382,12 +382,12 @@ fn find_dist_info<'a>(
 ///
 /// Returns a list of `(name, path)` tuples.
 pub fn entrypoint_paths(
-    site_packages: &SitePackages,
+    installed_packages: &InstalledPackages,
     package_name: &PackageName,
     package_version: &Version,
 ) -> Result<Vec<(String, PathBuf)>, Error> {
     // Find the `.dist-info` directory in the installed environment.
-    let dist_info_path = find_dist_info(site_packages, package_name, package_version)?;
+    let dist_info_path = find_dist_info(installed_packages, package_name, package_version)?;
     debug!(
         "Looking at `.dist-info` at: {}",
         dist_info_path.user_display()
@@ -397,7 +397,7 @@ pub fn entrypoint_paths(
     let record = read_record_file(&mut File::open(dist_info_path.join("RECORD"))?)?;
 
     // The RECORD file uses relative paths, so we're looking for the relative path to be a prefix.
-    let layout = site_packages.interpreter().layout();
+    let layout = installed_packages.interpreter().layout();
     let script_relative = pathdiff::diff_paths(&layout.scheme.scripts, &layout.scheme.purelib)
         .ok_or_else(|| {
             io::Error::new(

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, InstalledDist};
-use uv_installer::{SitePackages, SitePackagesDiagnostic};
+use uv_installer::{InstalledPackages, InstalledPackagesDiagnostic};
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
 use crate::commands::pip::operations::report_target_environment;
@@ -32,8 +32,8 @@ pub(crate) fn pip_check(
     report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
-    let site_packages = SitePackages::from_environment(&environment)?;
-    let packages: Vec<&InstalledDist> = site_packages.iter().collect();
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
+    let packages: Vec<&InstalledDist> = installed_packages.iter().collect();
 
     let s = if packages.len() == 1 { "" } else { "s" };
     writeln!(
@@ -51,8 +51,8 @@ pub(crate) fn pip_check(
     let markers = environment.interpreter().resolver_marker_environment();
 
     // Run the diagnostics.
-    let diagnostics: Vec<SitePackagesDiagnostic> =
-        site_packages.diagnostics(&markers)?.into_iter().collect();
+    let diagnostics: Vec<InstalledPackagesDiagnostic> =
+        installed_packages.diagnostics(&markers)?.into_iter().collect();
 
     if diagnostics.is_empty() {
         writeln!(

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, InstalledDist, Name};
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
 use crate::commands::pip::operations::report_target_environment;
@@ -32,8 +32,8 @@ pub(crate) fn pip_freeze(
     report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
-    let site_packages = SitePackages::from_environment(&environment)?;
-    for dist in site_packages
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
+    for dist in installed_packages
         .iter()
         .filter(|dist| !(exclude_editable && dist.is_editable()))
         .sorted_unstable_by(|a, b| a.name().cmp(b.name()).then(a.version().cmp(b.version())))
@@ -66,7 +66,7 @@ pub(crate) fn pip_freeze(
         // Determine the markers to use for resolution.
         let markers = environment.interpreter().resolver_marker_environment();
 
-        for diagnostic in site_packages.diagnostics(&markers)? {
+        for diagnostic in installed_packages.diagnostics(&markers)? {
             writeln!(
                 printer.stderr(),
                 "{}{} {}",

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -18,7 +18,7 @@ use uv_distribution_types::{
 };
 use uv_fs::Simplified;
 use uv_install_wheel::linker::LinkMode;
-use uv_installer::{SatisfiesResult, SitePackages};
+use uv_installer::{SatisfiesResult, InstalledPackages};
 use uv_pep508::PackageName;
 use uv_pypi_types::{Conflicts, Requirement};
 use uv_python::{
@@ -216,7 +216,7 @@ pub(crate) async fn pip_install(
     );
 
     // Determine the set of installed packages.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     // Check if the current environment satisfies the requirements.
     // Ideally, the resolver would be fast enough to let us remove this check. But right now, for large environments,
@@ -227,7 +227,7 @@ pub(crate) async fn pip_install(
         && overrides.is_empty()
         && matches!(modifications, Modifications::Sufficient)
     {
-        match site_packages.satisfies(&requirements, &constraints, &marker_env)? {
+        match installed_packages.satisfies(&requirements, &constraints, &marker_env)? {
             // If the requirements are already satisfied, we're done.
             SatisfiesResult::Fresh {
                 recursive_requirements,
@@ -405,7 +405,7 @@ pub(crate) async fn pip_install(
         None,
         extras,
         preferences,
-        site_packages.clone(),
+        installed_packages.clone(),
         &hasher,
         &reinstall,
         &upgrade,
@@ -435,7 +435,7 @@ pub(crate) async fn pip_install(
     // Sync the environment.
     match operations::install(
         &resolution,
-        site_packages,
+        installed_packages,
         modifications,
         &reinstall,
         &build_options,

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -18,7 +18,7 @@ use uv_configuration::{Concurrency, IndexStrategy, KeyringProviderType, TrustedH
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{Diagnostic, IndexCapabilities, IndexLocations, InstalledDist, Name};
 use uv_fs::Simplified;
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_python::PythonRequest;
@@ -68,10 +68,10 @@ pub(crate) async fn pip_list(
     report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     // Filter if `--editable` is specified; always sort by name.
-    let results = site_packages
+    let results = installed_packages
         .iter()
         .filter(|dist| editable.is_none() || editable == Some(dist.is_editable()))
         .filter(|dist| !exclude.contains(dist.name()))
@@ -263,7 +263,7 @@ pub(crate) async fn pip_list(
         // Determine the markers to use for resolution.
         let markers = environment.interpreter().resolver_marker_environment();
 
-        for diagnostic in site_packages.diagnostics(&markers)? {
+        for diagnostic in installed_packages.diagnostics(&markers)? {
             writeln!(
                 printer.stderr(),
                 "{}{} {}",

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -26,7 +26,7 @@ use uv_distribution_types::{
 };
 use uv_fs::Simplified;
 use uv_install_wheel::linker::LinkMode;
-use uv_installer::{Plan, Planner, Preparer, SitePackages};
+use uv_installer::{Plan, Planner, Preparer, InstalledPackages};
 use uv_normalize::PackageName;
 use uv_platform_tags::Tags;
 use uv_pypi_types::{Conflicts, ResolverMarkerEnvironment};
@@ -379,7 +379,7 @@ impl Changelog {
 /// Returns a [`Changelog`] summarizing the changes made to the environment.
 pub(crate) async fn install(
     resolution: &Resolution,
-    site_packages: SitePackages,
+    installed_packages: InstalledPackages,
     modifications: Modifications,
     reinstall: &Reinstall,
     build_options: &BuildOptions,
@@ -406,7 +406,7 @@ pub(crate) async fn install(
     // downloaded (`remote`), and those that should be removed (`extraneous`).
     let plan = Planner::new(resolution)
         .build(
-            site_packages,
+            installed_packages,
             reinstall,
             build_options,
             hasher,
@@ -792,8 +792,8 @@ pub(crate) fn diagnose_environment(
     markers: &ResolverMarkerEnvironment,
     printer: Printer,
 ) -> Result<(), Error> {
-    let site_packages = SitePackages::from_environment(venv)?;
-    for diagnostic in site_packages.diagnostics(markers)? {
+    let installed_packages = InstalledPackages::from_environment(venv)?;
+    for diagnostic in installed_packages.diagnostics(markers)? {
         // Only surface diagnostics that are "relevant" to the current resolution.
         if resolution
             .distributions()

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -10,7 +10,7 @@ use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, Name};
 use uv_fs::Simplified;
 use uv_install_wheel::read_record_file;
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_normalize::PackageName;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
@@ -51,7 +51,7 @@ pub(crate) fn pip_show(
     report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     // Determine the markers to use for resolution.
     let markers = environment.interpreter().resolver_marker_environment();
@@ -62,7 +62,7 @@ pub(crate) fn pip_show(
 
     // Map to the local distributions and collect missing packages.
     let (missing, distributions): (Vec<_>, Vec<_>) = packages.iter().partition_map(|name| {
-        let installed = site_packages.get_packages(name);
+        let installed = installed_packages.get_packages(name);
         if installed.is_empty() {
             Either::Left(name)
         } else {
@@ -110,7 +110,7 @@ pub(crate) fn pip_show(
     }
     // For Required-by field
     if !requires_map.is_empty() {
-        for installed in site_packages.iter() {
+        for installed in installed_packages.iter() {
             if requires_map.contains_key(installed.name()) {
                 continue;
             }
@@ -201,7 +201,7 @@ pub(crate) fn pip_show(
 
     // Validate that the environment is consistent.
     if strict {
-        for diagnostic in site_packages.diagnostics(&markers)? {
+        for diagnostic in installed_packages.diagnostics(&markers)? {
             writeln!(
                 printer.stderr(),
                 "{}{} {}",

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -15,7 +15,7 @@ use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{DependencyMetadata, Index, IndexLocations, Origin, Resolution};
 use uv_fs::Simplified;
 use uv_install_wheel::linker::LinkMode;
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_pep508::PackageName;
 use uv_pypi_types::Conflicts;
 use uv_python::{
@@ -331,7 +331,7 @@ pub(crate) async fn pip_sync(
     );
 
     // Determine the set of installed packages.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     let options = OptionsBuilder::new()
         .resolution_mode(resolution_mode)
@@ -350,7 +350,7 @@ pub(crate) async fn pip_sync(
         None,
         &extras,
         preferences,
-        site_packages.clone(),
+        installed_packages.clone(),
         &hasher,
         &reinstall,
         &upgrade,
@@ -380,7 +380,7 @@ pub(crate) async fn pip_sync(
     // Sync the environment.
     match operations::install(
         &resolution,
-        site_packages,
+        installed_packages,
         Modifications::Exact,
         &reinstall,
         &build_options,

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, Name};
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_normalize::PackageName;
 use uv_pep508::{Requirement, VersionOrUrl};
 use uv_pypi_types::{ResolutionMetadata, ResolverMarkerEnvironment, VerbatimParsedUrl};
@@ -45,11 +45,11 @@ pub(crate) fn pip_tree(
     report_target_environment(&environment, cache, printer)?;
 
     // Read packages from the virtual environment.
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     let packages = {
         let mut packages: FxHashMap<_, Vec<_>> = FxHashMap::default();
-        for package in site_packages.iter() {
+        for package in installed_packages.iter() {
             packages
                 .entry(package.name())
                 .or_default()
@@ -88,7 +88,7 @@ pub(crate) fn pip_tree(
 
     // Validate that the environment is consistent.
     if strict {
-        for diagnostic in site_packages.diagnostics(&markers)? {
+        for diagnostic in installed_packages.diagnostics(&markers)? {
             writeln!(
                 printer.stderr(),
                 "{}{} {}",

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -102,7 +102,7 @@ pub(crate) async fn pip_uninstall(
     let _lock = environment.lock().await?;
 
     // Index the current `site-packages` directory.
-    let site_packages = uv_installer::SitePackages::from_environment(&environment)?;
+    let installed_packages = uv_installer::InstalledPackages::from_environment(&environment)?;
 
     // Partition the requirements into named and unnamed requirements.
     let (named, unnamed): (Vec<Requirement>, Vec<UnnamedRequirement<VerbatimParsedUrl>>) = spec
@@ -142,7 +142,7 @@ pub(crate) async fn pip_uninstall(
 
         // Identify all packages that are installed.
         for package in &names {
-            let installed = site_packages.get_packages(package);
+            let installed = installed_packages.get_packages(package);
             if installed.is_empty() {
                 if !dry_run {
                     writeln!(
@@ -160,7 +160,7 @@ pub(crate) async fn pip_uninstall(
 
         // Identify all unnamed distributions that are installed.
         for url in &urls {
-            let installed = site_packages.get_urls(url);
+            let installed = installed_packages.get_urls(url);
             if installed.is_empty() {
                 if !dry_run {
                     writeln!(

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -18,7 +18,7 @@ use uv_distribution_types::{
 };
 use uv_fs::{Simplified, CWD};
 use uv_git::ResolvedRepositoryReference;
-use uv_installer::{SatisfiesResult, SitePackages};
+use uv_installer::{SatisfiesResult, InstalledPackages};
 use uv_normalize::{GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::MarkerTreeContents;
@@ -1240,7 +1240,7 @@ pub(crate) async fn sync_environment(
         sources,
     } = settings;
 
-    let site_packages = SitePackages::from_environment(&venv)?;
+    let installed_packages = InstalledPackages::from_environment(&venv)?;
 
     // Determine the markers tags to use for resolution.
     let interpreter = venv.interpreter();
@@ -1316,7 +1316,7 @@ pub(crate) async fn sync_environment(
     // Sync the environment.
     pip::operations::install(
         resolution,
-        site_packages,
+        installed_packages,
         Modifications::Exact,
         reinstall,
         build_options,
@@ -1414,9 +1414,9 @@ pub(crate) async fn update_environment(
     let marker_env = venv.interpreter().resolver_marker_environment();
 
     // Check if the current environment satisfies the requirements
-    let site_packages = SitePackages::from_environment(&venv)?;
+    let installed_packages = InstalledPackages::from_environment(&venv)?;
     if source_trees.is_empty() && reinstall.is_none() && upgrade.is_none() && overrides.is_empty() {
-        match site_packages.satisfies(&requirements, &constraints, &marker_env)? {
+        match installed_packages.satisfies(&requirements, &constraints, &marker_env)? {
             // If the requirements are already satisfied, we're done.
             SatisfiesResult::Fresh {
                 recursive_requirements,
@@ -1530,7 +1530,7 @@ pub(crate) async fn update_environment(
         None,
         &extras,
         preferences,
-        site_packages.clone(),
+        installed_packages.clone(),
         &hasher,
         reinstall,
         upgrade,
@@ -1556,7 +1556,7 @@ pub(crate) async fn update_environment(
     // Sync the environment.
     let changelog = pip::operations::install(
         &resolution,
-        site_packages,
+        installed_packages,
         Modifications::Exact,
         reinstall,
         build_options,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -24,7 +24,7 @@ use uv_dispatch::SharedState;
 use uv_distribution::LoweredRequirement;
 use uv_fs::which::is_executable;
 use uv_fs::{PythonExt, Simplified};
-use uv_installer::{SatisfiesResult, SitePackages};
+use uv_installer::{SatisfiesResult, InstalledPackages};
 use uv_normalize::PackageName;
 use uv_python::{
     EnvironmentPreference, Interpreter, PythonDownloads, PythonEnvironment, PythonInstallation,
@@ -1124,7 +1124,7 @@ fn can_skip_ephemeral(
         return true;
     };
 
-    let Ok(site_packages) = SitePackages::from_interpreter(base_interpreter) else {
+    let Ok(installed_packages) = InstalledPackages::from_interpreter(base_interpreter) else {
         return false;
     };
 
@@ -1132,7 +1132,7 @@ fn can_skip_ephemeral(
         return false;
     }
 
-    match site_packages.satisfies(
+    match installed_packages.satisfies(
         &spec.requirements,
         &spec.constraints,
         &base_interpreter.resolver_marker_environment(),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -16,7 +16,7 @@ use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{
     DirectorySourceDist, Dist, Index, Resolution, ResolvedDist, SourceDist,
 };
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_normalize::PackageName;
 use uv_pep508::{MarkerTree, Requirement, VersionOrUrl};
 use uv_pypi_types::{
@@ -432,12 +432,12 @@ pub(super) async fn do_sync(
         preview,
     );
 
-    let site_packages = SitePackages::from_environment(venv)?;
+    let installed_packages = InstalledPackages::from_environment(venv)?;
 
     // Sync the environment.
     operations::install(
         &resolution,
-        site_packages,
+        installed_packages,
         modifications,
         reinstall,
         build_options,

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -10,7 +10,7 @@ use uv_distribution_types::{InstalledDist, Name};
 #[cfg(unix)]
 use uv_fs::replace_symlink;
 use uv_fs::Simplified;
-use uv_installer::SitePackages;
+use uv_installer::InstalledPackages;
 use uv_pep508::PackageName;
 use uv_pypi_types::Requirement;
 use uv_python::PythonEnvironment;
@@ -23,11 +23,11 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Return all packages which contain an executable with the given name.
-pub(super) fn matching_packages(name: &str, site_packages: &SitePackages) -> Vec<InstalledDist> {
-    site_packages
+pub(super) fn matching_packages(name: &str, installed_packages: &InstalledPackages) -> Vec<InstalledDist> {
+    installed_packages
         .iter()
         .filter_map(|package| {
-            entrypoint_paths(site_packages, package.name(), package.version())
+            entrypoint_paths(installed_packages, package.name(), package.version())
                 .ok()
                 .and_then(|entrypoints| {
                     entrypoints
@@ -74,8 +74,8 @@ pub(crate) fn install_executables(
     overrides: Vec<Requirement>,
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
-    let site_packages = SitePackages::from_environment(environment)?;
-    let installed = site_packages.get_packages(name);
+    let installed_packages = InstalledPackages::from_environment(environment)?;
+    let installed = installed_packages.get_packages(name);
     let Some(installed_dist) = installed.first().copied() else {
         bail!("Expected at least one requirement")
     };
@@ -91,7 +91,7 @@ pub(crate) fn install_executables(
     );
 
     let entry_points = entrypoint_paths(
-        &site_packages,
+        &installed_packages,
         installed_dist.name(),
         installed_dist.version(),
     )?;
@@ -117,7 +117,7 @@ pub(crate) fn install_executables(
             from = name.cyan()
         )?;
 
-        hint_executable_from_dependency(name, &site_packages, printer)?;
+        hint_executable_from_dependency(name, &installed_packages, printer)?;
 
         // Clean up the environment we just created.
         installed_tools.remove_environment(name)?;
@@ -238,10 +238,10 @@ pub(crate) fn install_executables(
 /// Displays a hint if an executable matching the package name can be found in a dependency of the package.
 fn hint_executable_from_dependency(
     name: &PackageName,
-    site_packages: &SitePackages,
+    installed_packages: &InstalledPackages,
     printer: Printer,
 ) -> anyhow::Result<()> {
-    let packages = matching_packages(name.as_ref(), site_packages);
+    let packages = matching_packages(name.as_ref(), installed_packages);
     match packages.as_slice() {
         [] => {}
         [package] => {

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -17,7 +17,7 @@ use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{Concurrency, PreviewMode, TrustedHost};
 use uv_dispatch::SharedState;
 use uv_distribution_types::{Name, UnresolvedRequirementSpecification};
-use uv_installer::{SatisfiesResult, SitePackages};
+use uv_installer::{SatisfiesResult, InstalledPackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
 use uv_pep508::MarkerTree;
@@ -177,21 +177,21 @@ pub(crate) async fn run(
         args.iter().map(|arg| arg.to_string_lossy()).join(" ")
     );
 
-    let site_packages = SitePackages::from_environment(&environment)?;
+    let installed_packages = InstalledPackages::from_environment(&environment)?;
 
     // We check if the provided command is not part of the executables for the `from` package.
     // If the command is found in other packages, we warn the user about the correct package to use.
     warn_executable_not_provided_by_package(
         executable,
         &from.name,
-        &site_packages,
+        &installed_packages,
         invocation_source,
     );
 
     let mut handle = match process.spawn() {
         Ok(handle) => Ok(handle),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            match get_entrypoints(&from.name, &site_packages) {
+            match get_entrypoints(&from.name, &installed_packages) {
                 Ok(entrypoints) => {
                     writeln!(
                         printer.stdout(),
@@ -298,15 +298,15 @@ fn terminate_process(child: &mut tokio::process::Child) -> anyhow::Result<()> {
 /// Return the entry points for the specified package.
 fn get_entrypoints(
     from: &PackageName,
-    site_packages: &SitePackages,
+    installed_packages: &InstalledPackages,
 ) -> anyhow::Result<Vec<(String, PathBuf)>> {
-    let installed = site_packages.get_packages(from);
+    let installed = installed_packages.get_packages(from);
     let Some(installed_dist) = installed.first().copied() else {
         bail!("Expected at least one requirement")
     };
 
     Ok(entrypoint_paths(
-        site_packages,
+        installed_packages,
         installed_dist.name(),
         installed_dist.version(),
     )?)
@@ -383,10 +383,10 @@ async fn show_help(
 fn warn_executable_not_provided_by_package(
     executable: &str,
     from_package: &PackageName,
-    site_packages: &SitePackages,
+    installed_packages: &InstalledPackages,
     invocation_source: ToolRunCommand,
 ) {
-    let packages = matching_packages(executable, site_packages);
+    let packages = matching_packages(executable, installed_packages);
     if !packages
         .iter()
         .any(|package| package.name() == from_package)
@@ -586,7 +586,7 @@ async fn get_or_create_environment(
                 });
         if let Some(environment) = existing_environment {
             // Check if the installed packages meet the requirements.
-            let site_packages = SitePackages::from_environment(&environment)?;
+            let installed_packages = InstalledPackages::from_environment(&environment)?;
 
             let requirements = requirements
                 .iter()
@@ -596,7 +596,7 @@ async fn get_or_create_environment(
             let constraints = [];
 
             if matches!(
-                site_packages.satisfies(
+                installed_packages.satisfies(
                     &requirements,
                     &constraints,
                     &interpreter.resolver_marker_environment()


### PR DESCRIPTION
Resolves #2500
Intend to resolve #4466 before coming out of draft mode here.

x-ref <https://github.com/astral-sh/uv/pull/2413>, since this PR removes an assumption introduced in that PR that a missing site-packages directory means that there are _no_ packages to be found.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
- Change installed package discovery logic to use `sys.path` rather than inferred paths based on `sysconfig`'s `purelib` and `platlib` directories.
- [TODO] Change uninstallation logic to skip over packages that are installed outside the working environment.
- [TODO] Remove any dead code, if the `site_packages` we were computing for this is not used anywhere else.

## Test Plan

<!-- How was it tested? -->
Only manually tested as of now.

The plan for automated tests is: Use a `.pth` file as an extra path to be injected to the virtual environment being modified, with the extra path pointing to site-packages from another virtual environment.

This should be less complicated than the proposed approaches of using `sitecustomize.py` as well as relying on system-site-packages with a mock system interpreter -- all these approaches modify the `sys.path` in a manner visible to the interpreter introspection script and using a `.pth` file is likely to be the easiest to reason about.
