### PR TITLE
Remove test dependency on `pg_config`

### DIFF
--- a/crates/uv/tests/it/ecosystem.rs
+++ b/crates/uv/tests/it/ecosystem.rs
@@ -56,12 +56,6 @@ fn transformers() -> Result<()> {
 // Source: https://github.com/konstin/warehouse/blob/baae127d90417104c8dee3fdd3855e2ba17aa428/pyproject.toml
 #[test]
 fn warehouse() -> Result<()> {
-    // This build requires running `pg_config`. We could
-    // probably stub it out, but for now, we just skip the
-    // test if we can't run `pg_config`.
-    if std::process::Command::new("pg_config").output().is_err() {
-        return Ok(());
-    }
     // Also, takes too long on non-Linux in CI.
     if !cfg!(target_os = "linux") && std::env::var_os(EnvVars::CI).is_some() {
         return Ok(());

--- a/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
@@ -8,6 +8,12 @@ requires-python = "==3.11.*"
 [options]
 exclude-newer = "2024-08-08T00:00:00Z"
 
+[manifest]
+
+[[manifest.dependency-metadata]]
+name = "psycopg-c"
+version = "3.2.1"
+
 [[package]]
 name = "alabaster"
 version = "1.0.0"

--- a/ecosystem/warehouse/pyproject.toml
+++ b/ecosystem/warehouse/pyproject.toml
@@ -153,6 +153,12 @@ dev-dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# Avoid a dependency on `pg_config`
+[[tool.uv.dependency-metadata]]
+name = "psycopg-c"
+version = "3.2.1"
+requires-dist = []
+
 [tool.coverage.run]
 branch = true
 dynamic_context = "test_function"


### PR DESCRIPTION
By mocking the metadata of `psycopg-c`, we avoid a test dependency on `pg_config` for the warehouse ecosystem test.