### PR TITLE
Avoid `panic!()` when current directory does not exist

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -6,8 +6,13 @@ use either::Either;
 use path_slash::PathExt;
 
 /// The current working directory.
-pub static CWD: LazyLock<PathBuf> =
-    LazyLock::new(|| std::env::current_dir().expect("The current directory must exist"));
+#[allow(clippy::exit, clippy::print_stderr)]
+pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
+    std::env::current_dir().unwrap_or_else(|_e| {
+        eprintln!("Current directory does not exist.");
+        std::process::exit(1);
+    })
+});
 
 pub trait Simplified {
     /// Simplify a [`Path`].

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -9,7 +9,7 @@ use path_slash::PathExt;
 #[allow(clippy::exit, clippy::print_stderr)]
 pub static CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::current_dir().unwrap_or_else(|_e| {
-        eprintln!("Current directory does not exist.");
+        eprintln!("Current directory does not exist");
         std::process::exit(1);
     })
 });


### PR DESCRIPTION
## Summary

If the shell is currently in a directory that no longer exists, uv will panic from any command. Panicking is a confusing behavior to those unfamiliar with Rust and can sometimes make it hard to determine the true issue.

Closes #9875 

## Test Plan

The reproduction steps in the issue report were followed and uv no longer panics. `uv version` can still successfully print the version if the directory does exist.