### PR TITLE
Improve fish shell completion instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -160,6 +160,8 @@ To enable shell autocompletion for uv commands, run one of the following:
     echo 'eval "$(uv generate-shell-completion zsh)"' >> ~/.zshrc
     echo 'uv generate-shell-completion fish | source' >> ~/.config/fish/config.fish
     echo 'eval (uv generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
+    # If you are using fish shell you can add the completion to a file in the completions folder, like this:
+    uv generate-shell-completion fish > ~/.config/fish/completions/uv.fish
     ```
 
 === "Windows"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -160,7 +160,10 @@ To enable shell autocompletion for uv commands, run one of the following:
     echo 'eval "$(uv generate-shell-completion zsh)"' >> ~/.zshrc
     echo 'uv generate-shell-completion fish | source' >> ~/.config/fish/config.fish
     echo 'eval (uv generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
-    # If you are using fish shell you can add the completion to a file in the completions folder, like this:
+    # If you are using fish shell you can add the completion to a file in the completions folder.
+    # If you don't have the completions folder, create it like this:
+    mkdir ~/.config/fish/completions/uv.fish
+    # Then add the completion to the completions folder, like this:
     uv generate-shell-completion fish > ~/.config/fish/completions/uv.fish
     ```
 


### PR DESCRIPTION
Suggest adding the completions to a file in the completions folder instead of generating the completions on every shell launch.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Suggest adding the completions to a file in the completions folder instead of generating the completions on every shell launch.

## Test Plan

This was tested by running the specified command on my machine. (this is only a documentation change)