### PR TITLE
Fix redundant enumeration of all package versions in some resolver errors

### DIFF
--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13126,16 +13126,7 @@ fn compile_enumerate_no_versions() -> Result<()> {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because the current Python version (3.10.[X]) does not satisfy Python>=3.11,<4.0 and all versions of rooster-blue depend on Python>=3.11,<4.0, we can conclude that all versions of rooster-blue cannot be used.
-          And because only the following versions of rooster-blue are available:
-              rooster-blue==0.0.1
-              rooster-blue==0.0.2
-              rooster-blue==0.0.3
-              rooster-blue==0.0.4
-              rooster-blue==0.0.5
-              rooster-blue==0.0.6
-              rooster-blue==0.0.7
-              rooster-blue==0.0.8
-          and you require rooster-blue, we can conclude that your requirements are unsatisfiable.
+          And because you require rooster-blue, we can conclude that your requirements are unsatisfiable.
     "###);
 
     Ok(())


### PR DESCRIPTION
Closes #4075

There are many more redundant enumerations I want to look into as well.