### PR TITLE
Mark `.inc` files as Rust for GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
+*.inc linguist-language=Rust
 
 uv.schema.json linguist-generated=true text=auto eol=lf


### PR DESCRIPTION
## Summary

The `.inc` file is considered C++ right now.

See: https://x.com/_brc_dd/status/1867270194789580870

See: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
