### PR TITLE
change example so it works as is on powershell and cmd

### DIFF
--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -89,7 +89,7 @@ automatically download Python versions when they are required. For example, the 
 download Python 3.12 if it was not installed:
 
 ```console
-$ uv run --python 3.12 python -c 'print("hello world")'
+$ uv run --python 3.12 python -c "print('hello world')"
 ```
 
 Even if a specific Python version is not requested, uv will download the latest version on demand.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When going through the docs at https://docs.astral.sh/uv/guides/install-python/#automatic-python-downloads, when you try to copy and paste the example on Windows, in either PowerShell or cmd.exe the example won't work.

Inverting the quotes fixes it, and still works on other shells (I only tried bash under wsl)

## Test Plan

On any windows system, from powershell, running the example yields the following error:

```
> uv run --python 3.12 python -c 'print("hello world")'
  File "<string>", line 1
    print(hello world)
          ^^^^^^^^^^^
SyntaxError: invalid syntax. Perhaps you forgot a comma?
```

on cmd.exe

```
> uv run --python 3.12 python -c 'print("hello world")'

``` 
(there is no output)

Inverting the quotes on powershell
```
> uv run --python 3.12 python -c "print('hello world')"
hello world
```

on cmd.exe
```
> uv run --python 3.12 python -c "print('hello world')"
hello world


```

<!-- How was it tested? -->
