### PR TITLE
Patch additional `sysconfig` values such as AR at install time

### DIFF
--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -40,7 +40,6 @@ mod parser;
 /// Replacement mode for sysconfig values.
 #[derive(Debug)]
 enum ReplacementMode {
-    Partial { from: String },
     Full,
 }
 
@@ -53,13 +52,8 @@ struct ReplacementEntry {
 
 impl ReplacementEntry {
     /// Patches a sysconfig value either partially (replacing a specific word) or fully.
-    fn patch(&self, entry: &str) -> String {
+    fn patch(&self, _entry: &str) -> String {
         match &self.mode {
-            ReplacementMode::Partial { from } => entry
-                .split_whitespace()
-                .map(|word| if word == from { &self.to } else { word })
-                .collect::<Vec<_>>()
-                .join(" "),
             ReplacementMode::Full => self.to.clone(),
         }
     }
@@ -68,69 +62,13 @@ impl ReplacementEntry {
 /// Mapping for sysconfig keys to lookup and replace with the appropriate entry.
 static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, ReplacementEntry>> =
     LazyLock::new(|| {
-        BTreeMap::from_iter([
-            (
-                "CC".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang".to_string(),
-                    },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "CXX".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang++".to_string(),
-                    },
-                    to: "c++".to_string(),
-                },
-            ),
-            (
-                "BLDSHARED".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang".to_string(),
-                    },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "LDSHARED".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang".to_string(),
-                    },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "LDCXXSHARED".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang++".to_string(),
-                    },
-                    to: "c++".to_string(),
-                },
-            ),
-            (
-                "LINKCC".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang".to_string(),
-                    },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "AR".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Full,
-                    to: "ar".to_string(),
-                },
-            ),
-        ])
+        BTreeMap::from_iter([(
+            "AR".to_string(),
+            ReplacementEntry {
+                mode: ReplacementMode::Full,
+                to: "ar".to_string(),
+            },
+        )])
     });
 
 /// Update the `sysconfig` data in a Python installation.
@@ -354,8 +292,8 @@ mod tests {
         # system configuration generated and used by the sysconfig module
         build_time_vars = {
             "AR": "ar",
-            "CC": "cc -pthread",
-            "CXX": "c++ -pthread",
+            "CC": "clang -pthread",
+            "CXX": "clang++ -pthread",
             "PYTHON_BUILD_STANDALONE": 1
         }
         "###);
@@ -378,7 +316,7 @@ mod tests {
         insta::assert_snapshot!(data.to_string_pretty()?, @r###"
         # system configuration generated and used by the sysconfig module
         build_time_vars = {
-            "BLDSHARED": "cc -bundle -undefined dynamic_lookup -arch arm64",
+            "BLDSHARED": "clang -bundle -undefined dynamic_lookup -arch arm64",
             "PYTHON_BUILD_STANDALONE": 1
         }
         "###);


### PR DESCRIPTION
## Summary

Minor follow up to https://github.com/astral-sh/uv/pull/9857 to patch AR.

Implements the AR replacement used in [sysconfigpatcher](https://github.com/bluss/sysconfigpatcher/blob/main/src/sysconfigpatcher.py#L54), namely

```python
DEFAULT_VARIABLE_UPDATES = {
    ...
    "AR": "ar",
}
```

## Test Plan

Added an additional test. Tested local python installs.

Related traces
```
TRACE Updated `AR` from `/tools/clang-linux64/bin/llvm-ar` to `ar`
```