### PR TITLE
Show a concise error message for missing version field

### DIFF
--- a/crates/uv-pypi-types/src/metadata/mod.rs
+++ b/crates/uv-pypi-types/src/metadata/mod.rs
@@ -34,10 +34,10 @@ pub enum MetadataError {
     MailParse(#[from] MailParseError),
     #[error("Invalid `pyproject.toml`")]
     InvalidPyprojectTomlSyntax(#[source] toml_edit::TomlError),
-    #[error("`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set.")]
-    InvalidPyprojectTomlMissingName(#[source] toml_edit::de::Error),
     #[error(transparent)]
     InvalidPyprojectTomlSchema(toml_edit::de::Error),
+    #[error("`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set")]
+    MissingName,
     #[error("Metadata field {0} not found")]
     FieldNotFound(&'static str),
     #[error("Invalid version: {0}")]

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -35,7 +35,9 @@ pub enum PyprojectTomlError {
     #[error(transparent)]
     TomlSchema(#[from] toml_edit::de::Error),
     #[error("`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set")]
-    MissingName(#[source] toml_edit::de::Error),
+    MissingName,
+    #[error("`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list")]
+    MissingVersion,
 }
 
 /// A `pyproject.toml` as specified in PEP 517.
@@ -63,15 +65,8 @@ impl PyProjectToml {
     pub fn from_string(raw: String) -> Result<Self, PyprojectTomlError> {
         let pyproject: toml_edit::ImDocument<_> =
             toml_edit::ImDocument::from_str(&raw).map_err(PyprojectTomlError::TomlSyntax)?;
-        let pyproject =
-            PyProjectToml::deserialize(pyproject.into_deserializer()).map_err(|err| {
-                // TODO(konsti): A typed error would be nicer, this can break on toml upgrades.
-                if err.message().contains("missing field `name`") {
-                    PyprojectTomlError::MissingName(err)
-                } else {
-                    PyprojectTomlError::TomlSchema(err)
-                }
-            })?;
+        let pyproject = PyProjectToml::deserialize(pyproject.into_deserializer())
+            .map_err(PyprojectTomlError::TomlSchema)?;
         Ok(PyProjectToml { raw, ..pyproject })
     }
 
@@ -207,7 +202,7 @@ impl<'de> Deserialize<'de> for DependencyGroupSpecifier {
 /// See <https://packaging.python.org/en/latest/specifications/pyproject-toml>.
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(test, derive(Serialize))]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", try_from = "ProjectWire")]
 pub struct Project {
     /// The name of the project
     pub name: PackageName,
@@ -226,6 +221,48 @@ pub struct Project {
     /// Used to determine whether a `scripts` section is present.
     #[serde(default, skip_serializing)]
     pub(crate) scripts: Option<serde::de::IgnoredAny>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "kebab-case")]
+struct ProjectWire {
+    name: Option<PackageName>,
+    version: Option<Version>,
+    dynamic: Option<Vec<String>>,
+    requires_python: Option<VersionSpecifiers>,
+    dependencies: Option<Vec<String>>,
+    optional_dependencies: Option<BTreeMap<ExtraName, Vec<String>>>,
+    gui_scripts: Option<serde::de::IgnoredAny>,
+    scripts: Option<serde::de::IgnoredAny>,
+}
+
+impl TryFrom<ProjectWire> for Project {
+    type Error = PyprojectTomlError;
+
+    fn try_from(value: ProjectWire) -> Result<Self, Self::Error> {
+        // If `[project.name]` is not present, show a dedicated error message.
+        let name = value.name.ok_or(PyprojectTomlError::MissingName)?;
+
+        // If `[project.version]` is not present (or listed in `[project.dynamic]`), show a dedicated error message.
+        if value.version.is_none()
+            && !value
+                .dynamic
+                .as_ref()
+                .is_some_and(|dynamic| dynamic.iter().any(|field| field == "version"))
+        {
+            return Err(PyprojectTomlError::MissingVersion);
+        }
+
+        Ok(Project {
+            name,
+            version: value.version,
+            requires_python: value.requires_python,
+            dependencies: value.dependencies,
+            optional_dependencies: value.optional_dependencies,
+            gui_scripts: value.gui_scripts,
+            scripts: value.scripts,
+        })
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -167,8 +167,7 @@ fn invalid_pyproject_toml_project_schema() -> Result<()> {
       |
     1 | [project]
       | ^^^^^^^^^
-    missing field `name`
-
+    `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     "###
     );
 
@@ -285,6 +284,7 @@ fn invalid_pyproject_toml_requirement_indirect() -> Result<()> {
     pyproject_toml.write_str(
         r#"[project]
 name = "project"
+version = "0.1.0"
 dependencies = ["flask==1.0.x"]
 "#,
     )?;

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2774,13 +2774,11 @@ fn run_invalid_project_table() -> Result<()> {
 
     ----- stderr -----
     error: Failed to parse: `pyproject.toml`
-      Caused by: `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
       Caused by: TOML parse error at line 1, column 2
       |
     1 | [project.urls]
       |  ^^^^^^^
-    missing field `name`
-
+    `pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

This now looks like:

```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 1, column 1
  |
1 | [project]
  | ^^^^^^^^^
`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list
```

Closes https://github.com/astral-sh/uv/issues/9910.
