### PR TITLE
Skip `--native-tls` in `pip compile` header

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -637,6 +637,18 @@ fn cmd(
                 return Some(None);
             }
 
+            // Always skip the `--no-progress` flag.
+            if arg == "--no-progress" {
+                *skip_next = None;
+                return Some(None);
+            }
+
+            // Always skip the `--native-tls` flag.
+            if arg == "--native-tls" {
+                *skip_next = None;
+                return Some(None);
+            }
+
             // Return the argument.
             Some(Some(arg))
         })


### PR DESCRIPTION
## Summary

I also omitted `--no-progress` (we omit `--verbose` and `--quiet` -- this seems similar).

Part of: https://github.com/astral-sh/uv/issues/9873.
