### PR TITLE
Include explicit indexes in publish index choice

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -283,6 +283,22 @@ impl<'a> IndexLocations {
             .filter(|index| !index.explicit)
     }
 
+    /// Return an iterator over all simple [`Index`] entries in order.
+    ///
+    /// If `no_index` was enabled, then this always returns an empty iterator.
+    pub fn simple_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
+        if self.no_index {
+            Either::Left(std::iter::empty())
+        } else {
+            let mut seen = FxHashSet::default();
+            Either::Right(
+                self.indexes.iter().filter(move |index| {
+                    index.name.as_ref().map_or(true, |name| seen.insert(name))
+                }),
+            )
+        }
+    }
+
     /// Return an iterator over the [`FlatIndexLocation`] entries.
     pub fn flat_indexes(&'a self) -> impl Iterator<Item = &'a Index> + 'a {
         self.flat_index.iter()

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1218,7 +1218,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             let (publish_url, check_url) = if let Some(index_name) = index {
                 debug!("Publishing with index {index_name}");
                 let index = index_locations
-                    .indexes()
+                    .simple_indexes()
                     .find(|index| {
                         index
                             .name
@@ -1227,7 +1227,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     })
                     .with_context(|| {
                         let mut index_names: Vec<String> = index_locations
-                            .indexes()
+                            .simple_indexes()
                             .filter_map(|index| index.name.as_ref())
                             .map(ToString::to_string)
                             .collect();

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -337,6 +337,7 @@ fn invalid_index() {
         version = "0.1.0"
 
         [[tool.uv.index]]
+        explicit = true
         name = "foo"
         url = "https://example.com"
 


### PR DESCRIPTION
For publishing, we want to allow all simple `[[tool.uv.index]]` entries, whether they  are explicit or not. We don't allow flat indexes here, assuming that an index you can upload to has a simple index URL (and generally doesn't have a flat index URL, at least I don't know any case that has).

The `no_index` branch isn't used atm, but I left it in case the method gathers more users.

Fixes #9919