### PR TITLE
Clarify uninstallation docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -190,24 +190,9 @@ Then restart the shell or source the shell config file.
 
 ## Uninstallation
 
-If you need to remove uv from your system, just remove the `uv` and `uvx` binaries:
+If you need to remove uv from your system, follow these steps:
 
-=== "macOS and Linux"
-
-    ```console
-    $ rm ~/.local/bin/uv ~/.local/bin/uvx
-    ```
-
-=== "Windows"
-
-    ```powershell
-    $ rm $HOME\.local\bin\uv.exe
-    $ rm $HOME\.local\bin\uvx.exe
-    ```
-
-!!! tip
-
-    You may want to remove data that uv has stored before removing the binaries:
+1.  Clean up stored data (optional):
 
     ```console
     $ uv cache clean
@@ -215,11 +200,30 @@ If you need to remove uv from your system, just remove the `uv` and `uvx` binari
     $ rm -r "$(uv tool dir)"
     ```
 
-!!! note
+    !!! tip
 
-    Prior to 0.5.0, uv was installed into `~/.cargo/bin`. The binaries can be removed from there to
-    uninstall. Upgrading from an older version will not automatically remove the binaries from
-    `~/.cargo/bin`.
+        Before removing the binaries, you may want to remove any data that uv has stored.
+
+2.  Remove the uv and uvx binaries:
+
+    === "macOS and Linux"
+
+        ```console
+        $ rm ~/.local/bin/uv ~/.local/bin/uvx
+        ```
+
+    === "Windows"
+
+        ```powershell
+        $ rm $HOME\.local\bin\uv.exe
+        $ rm $HOME\.local\bin\uvx.exe
+        ```
+
+    !!! note
+
+        Prior to 0.5.0, uv was installed into `~/.cargo/bin`. The binaries can be removed from there to
+        uninstall. Upgrading from an older version will not automatically remove the binaries from
+        `~/.cargo/bin`.
 
 ## Next steps
 


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/9871

> The current instructions first mention removing the binaries, and then mention a suggestion for removing stored data. The recommended data removal process involves uv commands that will no longer be available if the binaries are gone 😄.

I've edited the uninstallation docs to first suggest removing stored data before removing the uv and uvx binaries.

<img src="https://github.com/user-attachments/assets/526fcdb3-4fd2-4e04-b895-810cb826aa11" width="600"/>


