### PR TITLE
Add resolver error hint for no-binary and no-build failures

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -142,9 +142,7 @@ impl Display for IncompatibleDist {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Wheel(incompatibility) => match incompatibility {
-                IncompatibleWheel::NoBinary => {
-                    f.write_str("no source distribution and using wheels is disabled")
-                }
+                IncompatibleWheel::NoBinary => f.write_str("no source distribution"),
                 IncompatibleWheel::Tag(tag) => match tag {
                     IncompatibleTag::Invalid => f.write_str("no wheels with valid tags"),
                     IncompatibleTag::Python => {
@@ -175,9 +173,7 @@ impl Display for IncompatibleDist {
                 }
             },
             Self::Source(incompatibility) => match incompatibility {
-                IncompatibleSource::NoBuild => {
-                    f.write_str("no usable wheels and building from source is disabled")
-                }
+                IncompatibleSource::NoBuild => f.write_str("no usable wheels"),
                 IncompatibleSource::Yanked(yanked) => match yanked {
                     Yanked::Bool(_) => f.write_str("yanked"),
                     Yanked::Reason(reason) => write!(

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -12807,8 +12807,10 @@ fn no_binary_only_binary() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only source-distribution>=0.0.1 is available and source-distribution==0.0.1 has no usable wheels and building from source is disabled, we can conclude that source-distribution<=0.0.1 cannot be used.
+      ╰─▶ Because only source-distribution>=0.0.1 is available and source-distribution==0.0.1 has no usable wheels, we can conclude that source-distribution<=0.0.1 cannot be used.
           And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are required for `source-distribution` because building from source is disabled
     "###
     );
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2181,7 +2181,7 @@ fn install_only_binary_all_and_no_binary_all() {
               anyio>=3.0.0,<=3.6.2
               anyio>=3.7.0,<=3.7.1
               anyio>=4.0.0
-          have no usable wheels and building from source is disabled, we can conclude that all of:
+          have no usable wheels, we can conclude that all of:
               anyio>=1.0.0,<=1.4.0
               anyio>=2.0.0,<=2.2.0
               anyio>=3.0.0,<=3.6.2
@@ -2191,6 +2191,8 @@ fn install_only_binary_all_and_no_binary_all() {
           And because you require anyio, we can conclude that your requirements are unsatisfiable.
 
           hint: Pre-releases are available for `anyio` in the requested range (e.g., 4.0.0rc1), but pre-releases weren't enabled (try: `--prerelease=allow`)
+
+          hint: Wheels are required for `anyio` because building from source is disabled
     "###
     );
 
@@ -2281,7 +2283,9 @@ fn only_binary_requirements_txt() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because django-allauth==0.51.0 has no usable wheels and building from source is disabled and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are required for `django-allauth` because building from source is disabled
     "###
     );
 }

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4202,8 +4202,10 @@ fn no_wheels_no_build() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no usable wheels and building from source is disabled, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no usable wheels, we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are required for `package-a` because building from source is disabled
     "###);
 
     assert_not_installed(&context.venv, "no_wheels_no_build_a", &context.temp_dir);
@@ -4310,8 +4312,10 @@ fn only_wheels_no_binary() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no source distribution and using wheels is disabled, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no source distribution, we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: A source distributions is required for `package-a` because using pre-built wheels is disabled
     "###);
 
     assert_not_installed(&context.venv, "only_wheels_no_binary_a", &context.temp_dir);


### PR DESCRIPTION
Moves some of the context out of the error chain to improve readability.