### PR TITLE
Use the build options value to improve hints for no wheel / source distribution errors

### DIFF
--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -177,6 +177,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             OptionsBuilder::new()
                 .exclude_newer(self.exclude_newer)
                 .index_strategy(self.index_strategy)
+                .build_options(self.build_options.clone())
                 .flexibility(Flexibility::Fixed)
                 .build(),
             &python_requirement,

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -28,7 +28,7 @@ pub(crate) struct CandidateSelector {
 impl CandidateSelector {
     /// Return a [`CandidateSelector`] for the given [`Manifest`].
     pub(crate) fn for_resolution(
-        options: Options,
+        options: &Options,
         manifest: &Manifest,
         env: &ResolverEnvironment,
     ) -> Self {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -356,7 +356,7 @@ impl std::fmt::Display for NoSolutionError {
             &self.fork_urls,
             &self.env,
             &self.workspace_members,
-            self.options,
+            &self.options,
             &mut additional_hints,
         );
         for hint in additional_hints {

--- a/crates/uv-resolver/src/options.rs
+++ b/crates/uv-resolver/src/options.rs
@@ -1,10 +1,10 @@
-use uv_configuration::IndexStrategy;
+use uv_configuration::{BuildOptions, IndexStrategy};
 
 use crate::fork_strategy::ForkStrategy;
 use crate::{DependencyMode, ExcludeNewer, PrereleaseMode, ResolutionMode};
 
 /// Options for resolving a manifest.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Options {
     pub resolution_mode: ResolutionMode,
     pub prerelease_mode: PrereleaseMode,
@@ -13,6 +13,7 @@ pub struct Options {
     pub exclude_newer: Option<ExcludeNewer>,
     pub index_strategy: IndexStrategy,
     pub flexibility: Flexibility,
+    pub build_options: BuildOptions,
 }
 
 /// Builder for [`Options`].
@@ -25,6 +26,7 @@ pub struct OptionsBuilder {
     exclude_newer: Option<ExcludeNewer>,
     index_strategy: IndexStrategy,
     flexibility: Flexibility,
+    build_options: BuildOptions,
 }
 
 impl OptionsBuilder {
@@ -82,6 +84,13 @@ impl OptionsBuilder {
         self
     }
 
+    /// Sets the [`BuildOptions`].
+    #[must_use]
+    pub fn build_options(mut self, build_options: BuildOptions) -> Self {
+        self.build_options = build_options;
+        self
+    }
+
     /// Builds the options.
     pub fn build(self) -> Options {
         Options {
@@ -92,6 +101,7 @@ impl OptionsBuilder {
             exclude_newer: self.exclude_newer,
             index_strategy: self.index_strategy,
             flexibility: self.flexibility,
+            build_options: self.build_options,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -216,7 +216,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             index: index.clone(),
             git: git.clone(),
             capabilities: capabilities.clone(),
-            selector: CandidateSelector::for_resolution(options, &manifest, &env),
+            selector: CandidateSelector::for_resolution(&options, &manifest, &env),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),
@@ -675,7 +675,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             &self.python_requirement,
             &self.conflicts,
             self.selector.resolution_strategy(),
-            self.options,
+            self.options.clone(),
         )
     }
 
@@ -2185,7 +2185,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             fork_urls,
             env,
             self.workspace_members.clone(),
-            self.options,
+            self.options.clone(),
         ))
     }
 

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -366,6 +366,7 @@ pub(crate) async fn pip_compile(
         .dependency_mode(dependency_mode)
         .exclude_newer(exclude_newer)
         .index_strategy(index_strategy)
+        .build_options(build_options.clone())
         .build();
 
     // Resolve the requirements.

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -393,6 +393,7 @@ pub(crate) async fn pip_install(
         .dependency_mode(dependency_mode)
         .exclude_newer(exclude_newer)
         .index_strategy(index_strategy)
+        .build_options(build_options.clone())
         .build();
 
     // Resolve the requirements.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -339,6 +339,7 @@ pub(crate) async fn pip_sync(
         .dependency_mode(dependency_mode)
         .exclude_newer(exclude_newer)
         .index_strategy(index_strategy)
+        .build_options(build_options.clone())
         .build();
 
     let resolution = match operations::resolve(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -472,6 +472,7 @@ async fn do_lock(
         .fork_strategy(fork_strategy)
         .exclude_newer(exclude_newer)
         .index_strategy(index_strategy)
+        .build_options(build_options.clone())
         .build();
     let hasher = HashStrategy::Generate;
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1122,6 +1122,7 @@ pub(crate) async fn resolve_environment<'a>(
         .fork_strategy(fork_strategy)
         .exclude_newer(exclude_newer)
         .index_strategy(index_strategy)
+        .build_options(build_options.clone())
         .build();
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
@@ -1478,6 +1479,7 @@ pub(crate) async fn update_environment(
         .fork_strategy(*fork_strategy)
         .exclude_newer(*exclude_newer)
         .index_strategy(*index_strategy)
+        .build_options(build_options.clone())
         .build();
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -12810,7 +12810,7 @@ fn no_binary_only_binary() -> Result<()> {
       ╰─▶ Because only source-distribution>=0.0.1 is available and source-distribution==0.0.1 has no usable wheels, we can conclude that source-distribution<=0.0.1 cannot be used.
           And because you require source-distribution<=0.0.1, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are required for `source-distribution` because building from source is disabled
+          hint: Wheels are required for `source-distribution` because building from source is disabled for all packages (i.e., with `--no-build`)
     "###
     );
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2192,7 +2192,7 @@ fn install_only_binary_all_and_no_binary_all() {
 
           hint: Pre-releases are available for `anyio` in the requested range (e.g., 4.0.0rc1), but pre-releases weren't enabled (try: `--prerelease=allow`)
 
-          hint: Wheels are required for `anyio` because building from source is disabled
+          hint: Wheels are required for `anyio` because building from source is disabled for all packages (i.e., with `--no-build`)
     "###
     );
 
@@ -2285,7 +2285,7 @@ fn only_binary_requirements_txt() {
       × No solution found when resolving dependencies:
       ╰─▶ Because django-allauth==0.51.0 has no usable wheels and you require django-allauth==0.51.0, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are required for `django-allauth` because building from source is disabled
+          hint: Wheels are required for `django-allauth` because building from source is disabled for `django-allauth` (i.e., with `--no-build-package django-allauth`)
     "###
     );
 }

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4205,7 +4205,7 @@ fn no_wheels_no_build() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no usable wheels, we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are required for `package-a` because building from source is disabled
+          hint: Wheels are required for `package-a` because building from source is disabled for `package-a` (i.e., with `--no-build-package package-a`)
     "###);
 
     assert_not_installed(&context.venv, "no_wheels_no_build_a", &context.temp_dir);
@@ -4315,7 +4315,7 @@ fn only_wheels_no_binary() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no source distribution, we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: A source distributions is required for `package-a` because using pre-built wheels is disabled
+          hint: A source distribution is required for `package-a` because using pre-built wheels is disabled for `package-a` (i.e., with `--no-binary-package package-a`)
     "###);
 
     assert_not_installed(&context.venv, "only_wheels_no_binary_a", &context.temp_dir);


### PR DESCRIPTION
Extends the hints from https://github.com/astral-sh/uv/pull/9948 with `BuildOptions` context so we can explain a bit more.