### PR TITLE
Support 32-bit OS on 64-bit ARM host

### DIFF
--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -461,6 +461,14 @@ def get_operating_system_and_architecture():
         # noinspection PyProtectedMember
         from .packaging._musllinux import _get_musl_version
 
+        # https://github.com/pypa/packaging/blob/4dc334c86d43f83371b194ca91618ed99e0e49ca/src/packaging/tags.py#L539-L543
+        # https://github.com/astral-sh/uv/issues/9842
+        if struct.calcsize("P") == 4:
+            if architecture == "x86_64":
+                architecture = "i686"
+            elif architecture == "aarch64":
+                architecture = "armv8l"
+
         musl_version = _get_musl_version(sys.executable)
         glibc_version = _get_glibc_version()
 


### PR DESCRIPTION
When using a 32-bit OS on 64-bit ARM host, almost all Python std methods will report a 64-bit aarch64, but we most not install 64-bit executables since Python is actually 32-bit, identifiable through `struct.calcsize("P") == 4`.

Porting https://github.com/pypa/packaging/blob/4dc334c86d43f83371b194ca91618ed99e0e49ca/src/packaging/tags.py#L539-L543 to uv.

Tested on a raspberry pi 4 with a 64-bit host raspbian and `docker run -it --rm -v arm32v7/ubuntu` as 32-bit "host".

Fixes #9842