### PR TITLE
Fix show_settings tests not to be affected by system configs

### DIFF
--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -10,12 +10,16 @@ use crate::common::{uv_snapshot, TestContext};
 /// In particular, remove any user-defined environment variables and set any machine-specific
 /// environment variables to static values.
 fn add_shared_args(mut command: Command) -> Command {
+    // Create an empty directory for XDG_CONFIG_DIRS to avoid loading system configuration.
+    let xdg = assert_fs::TempDir::new().expect("Failed to create temp dir");
+
     command
         .env_clear()
         .env(EnvVars::UV_LINK_MODE, "clone")
         .env(EnvVars::UV_CONCURRENT_DOWNLOADS, "50")
         .env(EnvVars::UV_CONCURRENT_BUILDS, "16")
-        .env(EnvVars::UV_CONCURRENT_INSTALLS, "8");
+        .env(EnvVars::UV_CONCURRENT_INSTALLS, "8")
+        .env(EnvVars::XDG_CONFIG_DIRS, xdg.path());
 
     if cfg!(unix) {
         // Avoid locale issues in tests


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Override XDG_CONFIG_DIRS in show_settings tests, in order to ensure that they don't pick system configuration, and therefore fail due to value mismatches.  This specifically addresses test failures on Gentoo where a default `/etc/xdg/uv/uv.toml` is installed, and users are free to modify it.

Prior to #9914, we used to set `XDG_CONFIG_DIRS` locally before running the test suite.  However, since the test now wipes the environment, the problem can no longer be resolved downstream.

## Test Plan

`cargo test` on a Gentoo system (with `/etc/xdg/uv/uv.toml` present).
