### PR TITLE
Make the backoff crate dependency Windows-only

### DIFF
--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 
 [dependencies]
 
-backoff = { workspace = true }
 cachedir = { workspace = true }
 dunce = { workspace = true }
 either = { workspace = true }
@@ -39,6 +38,7 @@ winsafe = { workspace = true }
 rustix = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
+backoff = { workspace = true }
 junction = { workspace = true }
 
 [features]

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -216,6 +216,7 @@ pub fn copy_atomic_sync(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io
     Ok(())
 }
 
+#[cfg(windows)]
 fn backoff_file_move() -> backoff::ExponentialBackoff {
     backoff::ExponentialBackoffBuilder::default()
         .with_initial_interval(std::time::Duration::from_millis(10))
@@ -229,7 +230,8 @@ pub async fn rename_with_retry(
     from: impl AsRef<Path>,
     to: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
         // On Windows, antivirus software can lock files temporarily, making them inaccessible.
         // This is most common for DLLs, and the common suggestion is to retry the operation with
         // some backoff.
@@ -255,7 +257,9 @@ pub async fn rename_with_retry(
             }
         })
         .await
-    } else {
+    }
+    #[cfg(not(windows))]
+    {
         fs_err::tokio::rename(from, to).await
     }
 }
@@ -265,7 +269,8 @@ pub fn rename_with_retry_sync(
     from: impl AsRef<Path>,
     to: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
         // On Windows, antivirus software can lock files temporarily, making them inaccessible.
         // This is most common for DLLs, and the common suggestion is to retry the operation with
         // some backoff.
@@ -299,7 +304,9 @@ pub fn rename_with_retry_sync(
                 ),
             )
         })
-    } else {
+    }
+    #[cfg(not(windows))]
+    {
         fs_err::rename(from, to)
     }
 }
@@ -309,7 +316,8 @@ pub fn persist_with_retry_sync(
     from: NamedTempFile,
     to: impl AsRef<Path>,
 ) -> Result<(), std::io::Error> {
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
         // On Windows, antivirus software can lock files temporarily, making them inaccessible.
         // This is most common for DLLs, and the common suggestion is to retry the operation with
         // some backoff.
@@ -364,7 +372,9 @@ pub fn persist_with_retry_sync(
                 format!("{err:?}"),
             )),
         }
-    } else {
+    }
+    #[cfg(not(windows))]
+    {
         fs_err::rename(from, to)
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Since the `backoff` dependency is only *used* on Windows in practice, this PR would ensure that it is only *compiled* on Windows, too. This is helpful because it appears to be unmaintained upstream, https://github.com/astral-sh/uv/issues/10001, and it would be nice to be able to [drop it from Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=2329729).
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
```
$ cargo run python install
$ cargo test
```