### PR TITLE
`metadata_directory` already contains dist-info directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ include = [
     # this one isn't discovered by maturin because it's behind a feature flag
     { path = "crates/uv-performance-memory-allocator/**/*", format = ["sdist", "wheel"] },
     { path = "crates/uv-performance-flate2-backend/**/*", format = ["sdist", "wheel"] },
-    { path = "crates/uv-trampoline/trampolines/*", format = "sdist" }, 
+    { path = "crates/uv-trampoline/trampolines/*", format = "sdist" },
     { path = "LICENSE-APACHE", format = "sdist" },
     { path = "LICENSE-MIT", format = "sdist" },
 ]


### PR DESCRIPTION
From PEP 517:

```python
def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
    ...
```

> Must create a .dist-info directory containing wheel metadata inside the specified metadata_directory (i.e., creates a directory like {metadata_directory}/{package}-{version}.dist-info/).

```python
def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
    ...
```

> If the build frontend has previously called prepare_metadata_for_build_wheel and depends on the wheel resulting from this call to have metadata matching this earlier call, then it should provide the path to the created .dist-info directory as the metadata_directory argument.

Notice that the `metadata_directory` is different for the both hooks: For `prepare_metadata_for_build_wheel` is doesn't contain the `.dist-info` directory as final segment, for `build_wheel` it does.

Previously, the code assumed that both directories didn't contain the `.dist-info` for both cases.

Checked with:

```
maturin build
uv init test-uv-build-backend --build-backend uv
cd test-uv-build-backend
uv build --sdist --preview
cd ..
UV_PREVIEW=1 pip install test-uv-build-backend/dist/test_uv_build_backend-0.1.0.tar.gz --no-index --find-links target/wheels/ -v --no-cache-dir
```

Fixes #9969