### PR TITLE
Use `shutil.which` for the build backend

### DIFF
--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -26,14 +26,15 @@ def warn_config_settings(config_settings: "dict | None" = None):
 
 def call(args: "list[str]", config_settings: "dict | None" = None) -> str:
     """Invoke a uv subprocess and return the filename from stdout."""
+    import shutil
     import subprocess
     import sys
 
-    from ._find_uv import find_uv_bin
-
     warn_config_settings(config_settings)
+    # Unlike `find_uv_bin`, this mechanism must work according to PEP 517
+    uv_bin = shutil.which("uv")
     # Forward stderr, capture stdout for the filename
-    result = subprocess.run([find_uv_bin()] + args, stdout=subprocess.PIPE)
+    result = subprocess.run([uv_bin] + args, stdout=subprocess.PIPE)
     if result.returncode != 0:
         sys.exit(result.returncode)
     # If there was extra stdout, forward it (there should not be extra stdout)

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -33,6 +33,8 @@ def call(args: "list[str]", config_settings: "dict | None" = None) -> str:
     warn_config_settings(config_settings)
     # Unlike `find_uv_bin`, this mechanism must work according to PEP 517
     uv_bin = shutil.which("uv")
+    if uv_bin is None:
+        raise RuntimeError("uv was not properly installed")
     # Forward stderr, capture stdout for the filename
     result = subprocess.run([uv_bin] + args, stdout=subprocess.PIPE)
     if result.returncode != 0:


### PR DESCRIPTION
From PEP 517:

> All command-line scripts provided by the build-required packages must be present in the build environment’s PATH. For example, if a project declares a build-requirement on flit, then the following must work as a mechanism for running the flit command-line tool:
>
> ```python
> import subprocess
> import shutil
> subprocess.check_call([shutil.which("flit"), ...])
> ```

Fixes #9991