### PR TITLE
Allow `uv run` arguments when reading from `stdin`

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -175,7 +175,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 Some(RunCommand::PythonRemote(script, _)) => {
                     Pep723Metadata::read(&script).await?.map(Pep723Item::Remote)
                 }
-                Some(RunCommand::PythonStdin(contents)) => {
+                Some(RunCommand::PythonStdin(contents, _)) => {
                     Pep723Metadata::parse(contents)?.map(Pep723Item::Stdin)
                 }
                 _ => None,

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2493,6 +2493,20 @@ fn run_zipapp() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn run_stdin_args() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.run().arg("python").arg("-c").arg("import sys; print(sys.argv)").arg("foo").arg("bar"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ['-c', 'foo', 'bar']
+
+    ----- stderr -----
+    "###);
+}
+
 /// Run a module equivalent to `python -m foo`.
 #[test]
 fn run_module() {


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/10033.
