### PR TITLE
Remove remaining references to deprecated `first-match`

### DIFF
--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -112,7 +112,7 @@ index.
 ## Searching across multiple indexes
 
 By default, uv will stop at the first index on which a given package is available, and limit
-resolutions to those present on that first index (`first-match`).
+resolutions to those present on that first index (`first-index`).
 
 For example, if an internal index is specified via `[[tool.uv.index]]`, uv's behavior is such that
 if a package exists on that internal index, it will _always_ be installed from that internal index,
@@ -125,7 +125,7 @@ December 2022.
 Users can opt in to alternate index behaviors via the`--index-strategy` command-line option, or the
 `UV_INDEX_STRATEGY` environment variable, which supports the following values:
 
-- `first-match` (default): Search for each package across all indexes, limiting the candidate
+- `first-index` (default): Search for each package across all indexes, limiting the candidate
   versions to those present in the first index that contains the package.
 - `unsafe-first-match`: Search for each package across all indexes, but prefer the first index with
   a compatible version, even if newer versions are available on other indexes.

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -108,7 +108,7 @@ As of v0.1.39, users can opt in to `pip`-style behavior for multiple indexes via
 `--index-strategy` command-line option, or the `UV_INDEX_STRATEGY` environment variable, which
 supports the following values:
 
-- `first-match` (default): Search for each package across all indexes, limiting the candidate
+- `first-index` (default): Search for each package across all indexes, limiting the candidate
   versions to those present in the first index that contains the package, prioritizing the
   `--extra-index-url` indexes over the default index URL.
 - `unsafe-first-match`: Search for each package across all indexes, but prefer the first index with


### PR DESCRIPTION
## Summary

Missed these in https://github.com/astral-sh/uv/pull/10036.
