### PR TITLE
Test with custom install dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Testing uv requires multiple specific Python versions; they can be installed wit
 cargo run python install
 ```
 
-The storage directory can be configured with `UV_PYTHON_INSTALL_DIR`.
+The storage directory can be configured with `UV_PYTHON_INSTALL_DIR`. (It must be an absolute path.)
 
 ### Snapshot testing
 

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -1,4 +1,4 @@
-use std::env;
+use uv_static::EnvVars;
 
 use crate::common::{uv_snapshot, TestContext};
 
@@ -452,13 +452,9 @@ fn help_subcommand() {
 
 #[test]
 fn help_subsubcommand() {
-    if env::var("UV_PYTHON_INSTALL_DIR").is_ok() {
-        // skip this test
-        return;
-    }
     let context = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"
+    uv_snapshot!(context.filters(), context.help().env_remove(EnvVars::UV_PYTHON_INSTALL_DIR).arg("python").arg("install"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use crate::common::{uv_snapshot, TestContext};
 
 #[test]
@@ -450,6 +452,10 @@ fn help_subcommand() {
 
 #[test]
 fn help_subsubcommand() {
+    if env::var("UV_PYTHON_INSTALL_DIR").is_ok() {
+        // skip this test
+        return;
+    }
     let context = TestContext::new_with_versions(&[]);
 
     uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Testing with `UV_PYTHON_INSTALL_DIR` environment variable has some problems. This PR fix them.

- `UV_PYTHON_INSTALL_DIR` must be an absolute path.
  - Cargo tries to find Python executables from each crates in test. If it is relative path, cargo searches in different directories for each tests.
- Skip the test asserting help messages.
  - Clap shows the current value of the environment variables. If `UV_PYTHON_INSTALL_DIR` is set, the test fails.

## Test Plan

<!-- How was it tested? -->

All tests pass with `UV_PYTHON_INSTALL_DIR=/path/to/my/home/uv/target/testpython`.
