### PR TITLE
Fix mirror script to handle newer metadata format.

### DIFF
--- a/scripts/create-python-mirror.py
+++ b/scripts/create-python-mirror.py
@@ -89,6 +89,16 @@ def collect_metadata_from_git_history() -> List[Dict]:
     return metadata
 
 
+def check_arch(entry, arch):
+    """Checks whether arch entry in metadata matches the provided filter."""
+    match entry:
+        case {"family": family}:
+            return family == arch
+        case str:
+            return entry == arch
+    return False
+
+
 def filter_metadata(
     metadata: List[Dict], name: Optional[str], arch: Optional[str], os: Optional[str]
 ) -> List[Dict]:
@@ -97,7 +107,7 @@ def filter_metadata(
         entry
         for entry in metadata
         if (not name or entry["name"] == name)
-        and (not arch or entry["arch"] == arch)
+        and (not arch or check_arch(entry["arch"], arch))
         and (not os or entry["os"] == os)
     ]
     # Use a set to ensure unique URLs

--- a/scripts/create-python-mirror.py
+++ b/scripts/create-python-mirror.py
@@ -91,11 +91,10 @@ def collect_metadata_from_git_history() -> List[Dict]:
 
 def check_arch(entry, arch):
     """Checks whether arch entry in metadata matches the provided filter."""
-    match entry:
-        case {"family": family}:
-            return family == arch
-        case str:
-            return entry == arch
+    if isinstance(entry, str):
+        return entry == arch
+    elif isinstance(entry, dict) and "family" in entry:
+        return entry["family"] == arch
     return False
 
 


### PR DESCRIPTION
## Summary

The architecture details in `crates/uv-python/download-metadata.json` is now a dictionary with family and variant data, whereas it used to be a string. This patches the architecture filter in `scripts/create-python-mirror.py` to support both scenarios.

## Test Plan

Tested manually using `uv run ./scripts/create-python-mirror.py --name cpython --arch x86_64 --os linux --from-all-history`