### PR TITLE
Avoid repeatedly patching `sysconfig` data

### DIFF
--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -151,6 +151,14 @@ pub(crate) fn update_sysconfig(
     // Update the `_sysconfigdata_` file in-memory.
     let contents = fs_err::read_to_string(&sysconfigdata)?;
     let data = SysconfigData::from_str(&contents)?;
+
+    // If `_sysconfigdata_` is already patched, skip the update.
+    if data.get("PYTHON_BUILD_STANDALONE").is_some() {
+        trace!("`sysconfig` data is already patched");
+        return Ok(());
+    }
+
+    // Otherwise, patch the `_sysconfigdata_` file.
     let data = patch_sysconfigdata(data, &real_prefix);
     let contents = data.to_string_pretty()?;
 

--- a/crates/uv-python/src/sysconfig/parser.rs
+++ b/crates/uv-python/src/sysconfig/parser.rs
@@ -26,6 +26,11 @@ impl SysconfigData {
         self.0.iter_mut()
     }
 
+    /// Returns the value corresponding to the key.
+    pub(super) fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
+    }
+
     /// Inserts a key-value pair into the map.
     pub(super) fn insert(&mut self, key: String, value: Value) -> Option<Value> {
         self.0.insert(key, value)


### PR DESCRIPTION
## Summary

If we've already patched `_sysconfigdata_`, we can skip patching it again. (This is debatable; we could also just leave this.)

Closes https://github.com/astral-sh/uv/pull/10063.
