### PR TITLE
Use portable path instead of string for subdirectory

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -392,6 +392,16 @@ impl std::fmt::Display for PortablePathBuf {
     }
 }
 
+impl From<&str> for PortablePathBuf {
+    fn from(path: &str) -> Self {
+        if path == "." {
+            Self(PathBuf::new())
+        } else {
+            Self(PathBuf::from(path))
+        }
+    }
+}
+
 impl From<PortablePathBuf> for PathBuf {
     fn from(portable: PortablePathBuf) -> Self {
         portable.0

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::env;
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::stdout;


### PR DESCRIPTION
## Summary

A few places where there are extra conversions to and from string that seem unnecessary; a few places where we're using `PathBuf` instead of `PortablePathBuf`.