### PR TITLE
Add additional explanation of --mount=type=cache

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -303,7 +303,7 @@ ENV UV_COMPILE_BYTECODE=1
 
 ### Caching
 
-A [cache mount](https://docs.docker.com/build/guide/mounts/#add-a-cache-mount) can be used to
+A [cache mount](https://docs.docker.com/build/cache/optimize/#use-cache-mounts) can be used to
 improve performance across builds:
 
 ```dockerfile title="Dockerfile"

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -313,6 +313,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync
 ```
 
+This will reuse downloaded packages across builds on the same machine, reducing the time taken to
+install dependencies.
+The cache is only mounted for the duration of the `uv sync` command and is not included in the final
+image, minimising the image size.
+
 Changing the default [`UV_LINK_MODE`](../../reference/settings.md#link-mode) silences warnings about
 not being able to use hard links since the cache and sync target are on separate file systems.
 


### PR DESCRIPTION
## Summary

I had not seen this feature of docker before and it took a few minutes of reading the docker docs to clarify what it was doing. Hopefully this update makes it clear why a user would want to do this without duplicating the docker docs too much.

I also fixed the link to the docker docs, which was directing to the top of the page since the name of the anchor had changed.