### PR TITLE
Allow the creation of non-activatable envrionments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ See the [Python](#python) section for instructions on installing the Python vers
 ### Windows
 
 You can install CMake from the [installers](https://cmake.org/download/) or with
-`pipx install cmake`.
+`uv tool install cmake`.
 
 ## Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5606,7 +5606,7 @@ version = "0.5.11"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "fs-err 3.0.0",
  "itertools 0.13.0",

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -305,6 +305,7 @@ impl SourceBuild {
                 false,
                 false,
                 false,
+                false,
             )?
         };
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -403,7 +403,8 @@ pub enum Commands {
     ///
     /// When using uv, the virtual environment does not need to be activated. uv
     /// will find a virtual environment (named `.venv`) in the working directory
-    /// or any parent directories.
+    /// or any parent directories. See `--not-activatable` if you wish to disable
+    /// the creation of activation scripts entirely.
     #[command(
         alias = "virtualenv",
         alias = "v",
@@ -2391,6 +2392,20 @@ pub struct VenvArgs {
     /// behavior of uv commands.
     #[arg(long)]
     pub system_site_packages: bool,
+
+    #[arg(long, overrides_with("not_activatable"), hide = true)]
+    pub activatable: bool,
+
+    /// Disable the creation of activation scripts in the environment.
+    ///
+    /// By default, uv will include activation scripts in the environment. When using `uv run`,
+    /// these are often not required and can be skipped with `--not-activatable`.
+    #[arg(
+        long,
+        value_parser = clap::builder::BoolishValueParser::new(),
+        overrides_with("activatable"),
+    )]
+    pub not_activatable: bool,
 
     /// Make the virtual environment relocatable.
     ///

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -272,6 +272,7 @@ impl InstalledTools {
             false,
             false,
             false,
+            false,
         )?;
 
         Ok(venv)

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-virtualenv"
-version = "0.0.4"
+version = "0.0.5"
 publish = false
 description = "virtualenv creation implemented in rust"
 keywords = ["virtualenv", "venv", "python"]

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -53,6 +53,7 @@ pub fn create_venv(
     prompt: Prompt,
     system_site_packages: bool,
     allow_existing: bool,
+    activatable: bool,
     relocatable: bool,
     seed: bool,
 ) -> Result<PythonEnvironment, Error> {
@@ -63,6 +64,7 @@ pub fn create_venv(
         prompt,
         system_site_packages,
         allow_existing,
+        activatable,
         relocatable,
         seed,
     )?;

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -52,6 +52,7 @@ pub(crate) fn create(
     prompt: Prompt,
     system_site_packages: bool,
     allow_existing: bool,
+    activatable: bool,
     relocatable: bool,
     seed: bool,
 ) -> Result<VirtualEnvironment, Error> {
@@ -290,47 +291,51 @@ pub(crate) fn create(
         compile_error!("Only Windows and Unix are supported")
     }
 
-    // Add all the activate scripts for different shells
-    for (name, template) in ACTIVATE_TEMPLATES {
-        let path_sep = if cfg!(windows) { ";" } else { ":" };
+    if activatable {
+        // Add all the activate scripts for different shells
+        for (name, template) in ACTIVATE_TEMPLATES {
+            let path_sep = if cfg!(windows) { ";" } else { ":" };
 
-        let relative_site_packages = [
-            interpreter.virtualenv().purelib.as_path(),
-            interpreter.virtualenv().platlib.as_path(),
-        ]
-        .iter()
-        .dedup()
-        .map(|path| {
-            pathdiff::diff_paths(path, &interpreter.virtualenv().scripts)
-                .expect("Failed to calculate relative path to site-packages")
-        })
-        .map(|path| path.simplified().to_str().unwrap().replace('\\', "\\\\"))
-        .join(path_sep);
+            let relative_site_packages = [
+                interpreter.virtualenv().purelib.as_path(),
+                interpreter.virtualenv().platlib.as_path(),
+            ]
+            .iter()
+            .dedup()
+            .map(|path| {
+                pathdiff::diff_paths(path, &interpreter.virtualenv().scripts)
+                    .expect("Failed to calculate relative path to site-packages")
+            })
+            .map(|path| path.simplified().to_str().unwrap().replace('\\', "\\\\"))
+            .join(path_sep);
 
-        let virtual_env_dir = match (relocatable, name.to_owned()) {
-            (true, "activate") => {
-                r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#.to_string()
-            }
-            (true, "activate.bat") => r"%~dp0..".to_string(),
-            (true, "activate.fish") => {
-                r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#.to_string()
-            }
-            // Note:
-            // * relocatable activate scripts appear not to be possible in csh and nu shell
-            // * `activate.ps1` is already relocatable by default.
-            _ => escape_posix_for_single_quotes(location.simplified().to_str().unwrap()),
-        };
+            let virtual_env_dir = match (relocatable, name.to_owned()) {
+                (true, "activate") => {
+                    r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$SCRIPT_PATH")")")"'"#
+                        .to_string()
+                }
+                (true, "activate.bat") => r"%~dp0..".to_string(),
+                (true, "activate.fish") => {
+                    r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#
+                        .to_string()
+                }
+                // Note:
+                // * relocatable activate scripts appear not to be possible in csh and nu shell
+                // * `activate.ps1` is already relocatable by default.
+                _ => escape_posix_for_single_quotes(location.simplified().to_str().unwrap()),
+            };
 
-        let activator = template
-            .replace("{{ VIRTUAL_ENV_DIR }}", &virtual_env_dir)
-            .replace("{{ BIN_NAME }}", bin_name)
-            .replace(
-                "{{ VIRTUAL_PROMPT }}",
-                prompt.as_deref().unwrap_or_default(),
-            )
-            .replace("{{ PATH_SEP }}", path_sep)
-            .replace("{{ RELATIVE_SITE_PACKAGES }}", &relative_site_packages);
-        fs::write(scripts.join(name), activator)?;
+            let activator = template
+                .replace("{{ VIRTUAL_ENV_DIR }}", &virtual_env_dir)
+                .replace("{{ BIN_NAME }}", bin_name)
+                .replace(
+                    "{{ VIRTUAL_PROMPT }}",
+                    prompt.as_deref().unwrap_or_default(),
+                )
+                .replace("{{ PATH_SEP }}", path_sep)
+                .replace("{{ RELATIVE_SITE_PACKAGES }}", &relative_site_packages);
+            fs::write(scripts.join(name), activator)?;
+        }
     }
 
     let mut pyvenv_cfg_data: Vec<(String, String)> = vec![

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -110,6 +110,7 @@ impl CachedEnvironment {
             uv_virtualenv::Prompt::None,
             false,
             false,
+            false,
             true,
             false,
         )?;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -877,6 +877,7 @@ pub(crate) async fn get_or_init_environment(
                 prompt,
                 false,
                 false,
+                true,
                 false,
                 false,
             )?)

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -368,6 +368,7 @@ pub(crate) async fn run(
                 false,
                 false,
                 false,
+                false,
             )?;
 
             Some(environment.into_interpreter())
@@ -581,6 +582,7 @@ pub(crate) async fn run(
                     temp_dir.path(),
                     interpreter,
                     uv_virtualenv::Prompt::None,
+                    false,
                     false,
                     false,
                     false,
@@ -817,6 +819,7 @@ pub(crate) async fn run(
                     false,
                     false,
                     false,
+                    false,
                 )?;
                 venv.into_interpreter()
             } else {
@@ -863,6 +866,7 @@ pub(crate) async fn run(
                     temp_dir.path(),
                     base_interpreter.clone(),
                     uv_virtualenv::Prompt::None,
+                    false,
                     false,
                     false,
                     false,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -64,6 +64,7 @@ pub(crate) async fn venv(
     no_project: bool,
     cache: &Cache,
     printer: Printer,
+    activatable: bool,
     relocatable: bool,
     preview: PreviewMode,
 ) -> Result<ExitStatus> {
@@ -92,6 +93,7 @@ pub(crate) async fn venv(
         no_project,
         cache,
         printer,
+        activatable,
         relocatable,
         preview,
     )
@@ -151,6 +153,7 @@ async fn venv_impl(
     no_project: bool,
     cache: &Cache,
     printer: Printer,
+    activatable: bool,
     relocatable: bool,
     preview: PreviewMode,
 ) -> miette::Result<ExitStatus> {
@@ -259,6 +262,7 @@ async fn venv_impl(
         prompt,
         system_site_packages,
         allow_existing,
+        activatable,
         relocatable,
         seed,
     )
@@ -372,33 +376,35 @@ async fn venv_impl(
             .into_diagnostic()?;
     }
 
-    // Determine the appropriate activation command.
-    let activation = match Shell::from_env() {
-        None => None,
-        Some(Shell::Bash | Shell::Zsh | Shell::Ksh) => Some(format!(
-            "source {}",
-            shlex_posix(venv.scripts().join("activate"))
-        )),
-        Some(Shell::Fish) => Some(format!(
-            "source {}",
-            shlex_posix(venv.scripts().join("activate.fish"))
-        )),
-        Some(Shell::Nushell) => Some(format!(
-            "overlay use {}",
-            shlex_posix(venv.scripts().join("activate.nu"))
-        )),
-        Some(Shell::Csh) => Some(format!(
-            "source {}",
-            shlex_posix(venv.scripts().join("activate.csh"))
-        )),
-        Some(Shell::Powershell) => Some(shlex_windows(
-            venv.scripts().join("activate"),
-            Shell::Powershell,
-        )),
-        Some(Shell::Cmd) => Some(shlex_windows(venv.scripts().join("activate"), Shell::Cmd)),
-    };
-    if let Some(act) = activation {
-        writeln!(printer.stderr(), "Activate with: {}", act.green()).into_diagnostic()?;
+    if activatable {
+        // Determine the appropriate activation command.
+        let activation = match Shell::from_env() {
+            None => None,
+            Some(Shell::Bash | Shell::Zsh | Shell::Ksh) => Some(format!(
+                "source {}",
+                shlex_posix(venv.scripts().join("activate"))
+            )),
+            Some(Shell::Fish) => Some(format!(
+                "source {}",
+                shlex_posix(venv.scripts().join("activate.fish"))
+            )),
+            Some(Shell::Nushell) => Some(format!(
+                "overlay use {}",
+                shlex_posix(venv.scripts().join("activate.nu"))
+            )),
+            Some(Shell::Csh) => Some(format!(
+                "source {}",
+                shlex_posix(venv.scripts().join("activate.csh"))
+            )),
+            Some(Shell::Powershell) => Some(shlex_windows(
+                venv.scripts().join("activate"),
+                Shell::Powershell,
+            )),
+            Some(Shell::Cmd) => Some(shlex_windows(venv.scripts().join("activate"), Shell::Cmd)),
+        };
+        if let Some(act) = activation {
+            writeln!(printer.stderr(), "Activate with: {}", act.green()).into_diagnostic()?;
+        }
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -813,6 +813,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.no_project,
                 &cache,
                 printer,
+                args.activatable,
                 args.relocatable,
                 globals.preview,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2135,6 +2135,7 @@ pub(crate) struct VenvSettings {
     pub(crate) path: Option<PathBuf>,
     pub(crate) prompt: Option<String>,
     pub(crate) system_site_packages: bool,
+    pub(crate) activatable: bool,
     pub(crate) relocatable: bool,
     pub(crate) no_project: bool,
     pub(crate) settings: PipSettings,
@@ -2152,6 +2153,8 @@ impl VenvSettings {
             path,
             prompt,
             system_site_packages,
+            activatable,
+            not_activatable,
             relocatable,
             index_args,
             index_strategy,
@@ -2169,6 +2172,7 @@ impl VenvSettings {
             prompt,
             system_site_packages,
             no_project,
+            activatable: flag(activatable, not_activatable).unwrap_or(true),
             relocatable,
             settings: PipSettings::combine(
                 PipOptions {


### PR DESCRIPTION
## Summary

To resolve #10070 by allow environments to be created without activation scripts in them.

Saves a bit of time when only uv will be used to interact with the environment meant. This is off by default for user-facing environments (`uv venv` and anything calling `get_or_init_environment`) and on by default for internal environments so no time is wasted in environments that would never be directly interacted with (tool installs, isolated calls to uv run, package builds with build isolation, etc)

## Test Plan

All current tests pass. Will probably need to work with you on how you'd like this tested.

Locally, I have verified that:

- `uv venv` creates an environment with activation scripts
- `uv venv --not-activatable` does not create an environment with activation scripts
- `uv run` when there isn't an existing environment, creates one with activation scripts
- `uv run` when there is an existing environment without activation scripts, leaves the environment without activation scripts
- when the default behavior is to not have activation scripts, `uv venv --activatable` creates a virtual environment with activation scripts

## TODO

Still need to make this configurable as a `uv.toml` / `pyproject.toml` option, but the core behavior is working so I figured I'd throw in draft to make sure I'm on the right path.
