### PR TITLE
Rename `requires-python` validation method

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -45,7 +45,7 @@ use crate::commands::pip::operations::Modifications;
 use crate::commands::project::environment::CachedEnvironment;
 use crate::commands::project::lock::LockMode;
 use crate::commands::project::{
-    default_dependency_groups, validate_requires_python, DependencyGroupsTarget,
+    default_dependency_groups, validate_project_requires_python, DependencyGroupsTarget,
     EnvironmentSpecification, ProjectError, ScriptInterpreter, WorkspacePython,
 };
 use crate::commands::reporters::PythonDownloadReporter;
@@ -538,7 +538,7 @@ pub(crate) async fn run(
                 .into_interpreter();
 
                 if let Some(requires_python) = requires_python.as_ref() {
-                    validate_requires_python(
+                    validate_project_requires_python(
                         &interpreter,
                         Some(project.workspace()),
                         requires_python,

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -9,7 +9,7 @@ use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceError};
 
 use crate::commands::{
-    project::{validate_requires_python, WorkspacePython},
+    project::{validate_project_requires_python, WorkspacePython},
     ExitStatus,
 };
 
@@ -65,7 +65,7 @@ pub(crate) async fn find(
 
     // Warn if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {
-        match validate_requires_python(
+        match validate_project_requires_python(
             python.interpreter(),
             project.as_ref().map(VirtualProject::workspace),
             &requires_python,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -32,7 +32,7 @@ use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceError};
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::{report_interpreter, Changelog};
-use crate::commands::project::{validate_requires_python, WorkspacePython};
+use crate::commands::project::{validate_project_requires_python, WorkspacePython};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -231,7 +231,7 @@ async fn venv_impl(
 
     // Check if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {
-        match validate_requires_python(
+        match validate_project_requires_python(
             &interpreter,
             project.as_ref().map(VirtualProject::workspace),
             &requires_python,


### PR DESCRIPTION
## Summary

I want to differentiate this from `validate_script_requires_python`.

(No behavioral changes.)
