### PR TITLE
Set glibc versions for standalone installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.2-prerelease.3/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.27.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
  "self-replace",
  "serde",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,7 +282,7 @@ inherits = "release"
 # Config for 'dist'
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.2-prerelease.3"
+cargo-dist-version = "0.27.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,3 +334,9 @@ github-custom-job-permissions = { "build-docker" = { packages = "write", content
 install-updater = false
 # Path that installers should place binaries in
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
+
+[workspace.metadata.dist.min-glibc-version]
+# Override glibc version for specific target triplets.
+aarch64-unknown-linux-gnu = "2.28"
+# Override all remaining glibc versions.
+"*" = "2.17"


### PR DESCRIPTION
## Summary

Per Discord, it sounds like `cargo-dist` will assume that 2.31 is our minimum glibc version, since we're building our own binaries. (You can confirm this by looking at [uv-installer.sh](https://github.com/astral-sh/uv/releases/download/0.5.11/uv-installer.sh).)

`cargo-dist` now supports specifying a glibc override for each target: https://opensource.axo.dev/cargo-dist/book/reference/config.html#min-glibc-version. This is great, since we use 2.17 everywhere, but 2.28 for ARM.
