### PR TITLE
Store dependency groups separate from dependencies in lockfile

### DIFF
--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -107,6 +107,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -114,6 +114,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -106,6 +106,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -178,6 +178,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -178,6 +178,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -178,6 +178,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -87,6 +87,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -83,6 +83,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -73,6 +73,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -73,6 +73,7 @@ Ok(
         manifest: ResolverManifest {
             members: {},
             requirements: {},
+            dependency_groups: {},
             constraints: {},
             overrides: {},
             dependency_metadata: {},

--- a/crates/uv-workspace/src/dependency_groups.rs
+++ b/crates/uv-workspace/src/dependency_groups.rs
@@ -12,7 +12,7 @@ use uv_pypi_types::VerbatimParsedUrl;
 use crate::pyproject::DependencyGroupSpecifier;
 
 /// PEP 735 dependency groups, with any `include-group` entries resolved.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct FlatDependencyGroups(
     BTreeMap<GroupName, Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,
 );
@@ -104,11 +104,29 @@ impl FlatDependencyGroups {
         self.0.get(group)
     }
 
+    /// Return the entry for a given group, if any.
     pub fn entry(
         &mut self,
         group: GroupName,
     ) -> Entry<GroupName, Vec<uv_pep508::Requirement<VerbatimParsedUrl>>> {
         self.0.entry(group)
+    }
+
+    /// Consume the [`FlatDependencyGroups`] and return the inner map.
+    pub fn into_inner(self) -> BTreeMap<GroupName, Vec<uv_pep508::Requirement<VerbatimParsedUrl>>> {
+        self.0
+    }
+}
+
+impl FromIterator<(GroupName, Vec<uv_pep508::Requirement<VerbatimParsedUrl>>)>
+    for FlatDependencyGroups
+{
+    fn from_iter<
+        T: IntoIterator<Item = (GroupName, Vec<uv_pep508::Requirement<VerbatimParsedUrl>>)>,
+    >(
+        iter: T,
+    ) -> Self {
+        Self(iter.into_iter().collect())
     }
 }
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -4432,7 +4432,9 @@ fn add_non_project() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [{ name = "iniconfig", specifier = ">=2.0.0" }]
+
+        [manifest.dependency-groups]
+        dev = [{ name = "iniconfig", specifier = ">=2.0.0" }]
 
         [[package]]
         name = "iniconfig"

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1231,7 +1231,9 @@ fn non_project_fork() -> Result<()> {
             members = [
                 "child",
             ]
-            requirements = [{ name = "anyio" }]
+
+            [manifest.dependency-groups]
+            async = [{ name = "anyio" }]
 
             [[package]]
             name = "anyio"

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -8035,7 +8035,9 @@ fn lock_redact_git_pep508_non_project() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
+
+        [manifest.dependency-groups]
+        dev = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
 
         [[package]]
         name = "uv-private-pypackage"
@@ -13644,7 +13646,9 @@ fn lock_non_project_fork() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [
+
+        [manifest.dependency-groups]
+        dev = [
             { name = "anyio", marker = "python_full_version < '3.11'", specifier = ">3" },
             { name = "anyio", marker = "python_full_version >= '3.11'", specifier = "<3" },
         ]
@@ -13830,7 +13834,9 @@ fn lock_non_project_conditional() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [{ name = "anyio", marker = "sys_platform == 'linux'", specifier = ">3" }]
+
+        [manifest.dependency-groups]
+        dev = [{ name = "anyio", marker = "sys_platform == 'linux'", specifier = ">3" }]
 
         [[package]]
         name = "anyio"
@@ -13936,11 +13942,13 @@ fn lock_non_project_group() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [
+
+        [manifest.dependency-groups]
+        dev = [
             { name = "anyio" },
-            { name = "iniconfig" },
             { name = "typing-extensions" },
         ]
+        lint = [{ name = "iniconfig" }]
 
         [[package]]
         name = "anyio"
@@ -14074,7 +14082,9 @@ fn lock_non_project_sources() -> Result<()> {
         exclude-newer = "2024-03-25T00:00:00Z"
 
         [manifest]
-        requirements = [{ name = "idna", url = "https://files.pythonhosted.org/packages/d7/77/ff688d1504cdc4db2a938e2b7b9adee5dd52e34efbd2431051efc9984de9/idna-3.2-py3-none-any.whl" }]
+
+        [manifest.dependency-groups]
+        dev = [{ name = "idna", url = "https://files.pythonhosted.org/packages/d7/77/ff688d1504cdc4db2a938e2b7b9adee5dd52e34efbd2431051efc9984de9/idna-3.2-py3-none-any.whl" }]
 
         [[package]]
         name = "idna"


### PR DESCRIPTION
## Summary

This is necessary for some future improvements to non-`[project]` workspaces and PEP 723 scripts. It's not "breaking", but it will invalidate lockfiles for non-`[project]` workspaces. I think that's okay, since we consider those legacy right now, and they're really rare.