### PR TITLE
fix: always write slash paths to RECORD file

### DIFF
--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -418,12 +418,11 @@ pub fn entrypoint_paths(
         };
 
         let absolute_path = layout.scheme.scripts.join(path_in_scripts);
-        let script_name = entry
-            .path
-            .rsplit('/')
-            .next()
-            .unwrap_or(&entry.path)
-            .to_string();
+        let script_name = relative_path
+            .file_name()
+            .and_then(|filename| filename.to_str())
+            .map(ToString::to_string)
+            .unwrap_or(entry.path);
         entrypoints.push((script_name, absolute_path));
     }
 

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -420,7 +420,7 @@ pub fn entrypoint_paths(
         let absolute_path = layout.scheme.scripts.join(path_in_scripts);
         let script_name = entry
             .path
-            .rsplit(std::path::MAIN_SEPARATOR)
+            .rsplit('/')
             .next()
             .unwrap_or(&entry.path)
             .to_string();


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR solves an issue on Windows that platform-specific paths are written to the `RECORD` file when installing, which is inconsistent with PEP 376, quoting:

> Each record is composed of three elements:
>
>the file’s path
> * a ‘/’-separated path, relative to the base location, if the file is under the base location.
> * a ‘/’-separated path, relative to the base location, if the file is under the installation prefix AND if the base location is a subpath of the installation prefix.
> * an absolute path, using the local platform separator

## Test Plan

<!-- How was it tested? -->
Test case included