### PR TITLE
Fix find_uv_bin to find uv with system site packages

### DIFF
--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -29,8 +29,11 @@ def find_uv_bin() -> str:
 
     # Search in `bin` adjacent to package root (as created by `pip install --target`).
     pkg_root = os.path.dirname(os.path.dirname(__file__))
-    target_path = os.path.join(pkg_root, "bin", uv_exe)
-    if os.path.isfile(target_path):
-        return target_path
+    # Search for `bin` when inside a venv created with use system-site-packages and uv is installed in the system.
+    pkg_root2 = os.path.dirname(os.path.dirname(os.path.dirname(pkg_root)))
+    for path in (pkg_root, pkg_root2):
+        target_path = os.path.join(path, "bin", uv_exe)
+        if os.path.isfile(target_path):
+            return target_path
 
     raise FileNotFoundError(path)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This allows `uv` to find its binary when it was installed as a system package. Current implementation fails if someone creates a venv with --system-packages because the relative uv path would be different.

Fixes: #10194

## Test Plan

<!-- How was it tested? -->
