### PR TITLE
Add support for optional `--description` in `uv init`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2568,8 +2568,12 @@ pub struct InitArgs {
     ///
     /// By default, adds a requirement on the system Python version; use `--python` to specify an
     /// alternative Python version requirement.
-    #[arg(long, conflicts_with_all=["app", "lib", "package", "build_backend"])]
+    #[arg(long, conflicts_with_all=["app", "lib", "package", "build_backend", "description"])]
     pub r#script: bool,
+
+    /// Set the project description.
+    #[arg(long, conflicts_with = "script")]
+    pub description: Option<String>,
 
     /// Initialize a version control system for the project.
     ///
@@ -2623,15 +2627,6 @@ pub struct InitArgs {
         value_parser = parse_maybe_string,
     )]
     pub python: Option<Maybe<String>>,
-
-    /// Set the description of the project.
-    #[arg(
-        long,
-        value_name = "DESCRIPTION",
-        help_heading = "Project options",
-        help = "Set the project description in the pyproject.toml"
-    )]
-    pub description: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2623,6 +2623,15 @@ pub struct InitArgs {
         value_parser = parse_maybe_string,
     )]
     pub python: Option<Maybe<String>>,
+
+    /// Set the description of the project.
+    #[arg(
+        long,
+        value_name = "DESCRIPTION",
+        help_heading = "Project options",
+        help = "Set the project description in the pyproject.toml"
+    )]
+    pub description: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -41,6 +41,7 @@ pub(crate) async fn init(
     name: Option<PackageName>,
     package: bool,
     init_kind: InitKind,
+    description: Option<String>,
     vcs: Option<VersionControlSystem>,
     build_backend: Option<ProjectBuildBackend>,
     no_readme: bool,
@@ -58,7 +59,6 @@ pub(crate) async fn init(
     cache: &Cache,
     printer: Printer,
     preview: PreviewMode,
-    description: Option<String>,
 ) -> Result<ExitStatus> {
     if build_backend == Some(ProjectBuildBackend::Uv) && preview.is_disabled() {
         warn_user_once!("The uv build backend is experimental and may change without warning");
@@ -130,6 +130,7 @@ pub(crate) async fn init(
                 &name,
                 package,
                 project_kind,
+                description,
                 vcs,
                 build_backend,
                 no_readme,
@@ -146,7 +147,6 @@ pub(crate) async fn init(
                 no_config,
                 cache,
                 printer,
-                description,
             )
             .await?;
 
@@ -272,6 +272,7 @@ async fn init_project(
     name: &PackageName,
     package: bool,
     project_kind: InitProjectKind,
+    description: Option<String>,
     vcs: Option<VersionControlSystem>,
     build_backend: Option<ProjectBuildBackend>,
     no_readme: bool,
@@ -288,7 +289,6 @@ async fn init_project(
     no_config: bool,
     cache: &Cache,
     printer: Printer,
-    description: Option<String>,
 ) -> Result<()> {
     // Discover the current workspace, if it exists.
     let workspace = {
@@ -567,12 +567,12 @@ async fn init_project(
         name,
         path,
         &requires_python,
+        description.as_deref(),
         vcs,
         build_backend,
         author_from,
         no_readme,
         package,
-        description.as_ref(),
     )?;
 
     if let Some(workspace) = workspace {
@@ -691,35 +691,35 @@ impl InitProjectKind {
         name: &PackageName,
         path: &Path,
         requires_python: &RequiresPython,
+        description: Option<&str>,
         vcs: Option<VersionControlSystem>,
         build_backend: Option<ProjectBuildBackend>,
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<&String>,
     ) -> Result<()> {
         match self {
             InitProjectKind::Application => InitProjectKind::init_application(
                 name,
                 path,
                 requires_python,
+                description,
                 vcs,
                 build_backend,
                 author_from,
                 no_readme,
                 package,
-                description,
             ),
             InitProjectKind::Library => InitProjectKind::init_library(
                 name,
                 path,
                 requires_python,
+                description,
                 vcs,
                 build_backend,
                 author_from,
                 no_readme,
                 package,
-                description,
             ),
         }
     }
@@ -729,12 +729,12 @@ impl InitProjectKind {
         name: &PackageName,
         path: &Path,
         requires_python: &RequiresPython,
+        description: Option<&str>,
         vcs: Option<VersionControlSystem>,
         build_backend: Option<ProjectBuildBackend>,
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<&String>,
     ) -> Result<()> {
         fs_err::create_dir_all(path)?;
 
@@ -753,8 +753,8 @@ impl InitProjectKind {
             name,
             requires_python,
             author.as_ref(),
+            description,
             no_readme,
-            description.map(String::as_str),
         );
 
         // Include additional project configuration for packaged applications
@@ -802,12 +802,12 @@ impl InitProjectKind {
         name: &PackageName,
         path: &Path,
         requires_python: &RequiresPython,
+        description: Option<&str>,
         vcs: Option<VersionControlSystem>,
         build_backend: Option<ProjectBuildBackend>,
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<&String>,
     ) -> Result<()> {
         if !package {
             return Err(anyhow!("Library projects must be packaged"));
@@ -822,8 +822,8 @@ impl InitProjectKind {
             name,
             requires_python,
             author.as_ref(),
+            description,
             no_readme,
-            description.map(String::as_str),
         );
 
         // Always include a build system if the project is packaged.
@@ -868,8 +868,8 @@ fn pyproject_project(
     name: &PackageName,
     requires_python: &RequiresPython,
     author: Option<&Author>,
-    no_readme: bool,
     description: Option<&str>,
+    no_readme: bool,
 ) -> String {
     indoc::formatdoc! {r#"
         [project]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -572,7 +572,7 @@ async fn init_project(
         author_from,
         no_readme,
         package,
-        description,
+        description.as_ref(),
     )?;
 
     if let Some(workspace) = workspace {
@@ -696,7 +696,7 @@ impl InitProjectKind {
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<String>,
+        description: Option<&String>,
     ) -> Result<()> {
         match self {
             InitProjectKind::Application => InitProjectKind::init_application(
@@ -734,7 +734,7 @@ impl InitProjectKind {
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<String>,
+        description: Option<&String>,
     ) -> Result<()> {
         fs_err::create_dir_all(path)?;
 
@@ -754,7 +754,7 @@ impl InitProjectKind {
             requires_python,
             author.as_ref(),
             no_readme,
-            description.as_deref(),
+            description.map(String::as_str),
         );
 
         // Include additional project configuration for packaged applications
@@ -807,7 +807,7 @@ impl InitProjectKind {
         author_from: Option<AuthorFrom>,
         no_readme: bool,
         package: bool,
-        description: Option<String>,
+        description: Option<&String>,
     ) -> Result<()> {
         if !package {
             return Err(anyhow!("Library projects must be packaged"));
@@ -823,7 +823,7 @@ impl InitProjectKind {
             requires_python,
             author.as_ref(),
             no_readme,
-            description.as_deref(),
+            description.map(String::as_str),
         );
 
         // Always include a build system if the project is packaged.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1377,6 +1377,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
+                args.description,
             )
             .await
         }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1360,6 +1360,7 @@ async fn run_project(
                 args.name,
                 args.package,
                 args.kind,
+                args.description,
                 args.vcs,
                 args.build_backend,
                 args.no_readme,
@@ -1377,7 +1378,6 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
-                args.description,
             )
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -189,6 +189,7 @@ pub(crate) struct InitSettings {
     pub(crate) name: Option<PackageName>,
     pub(crate) package: bool,
     pub(crate) kind: InitKind,
+    pub(crate) description: Option<String>,
     pub(crate) vcs: Option<VersionControlSystem>,
     pub(crate) build_backend: Option<ProjectBuildBackend>,
     pub(crate) no_readme: bool,
@@ -197,7 +198,6 @@ pub(crate) struct InitSettings {
     pub(crate) no_workspace: bool,
     pub(crate) python: Option<String>,
     pub(crate) install_mirrors: PythonInstallMirrors,
-    pub(crate) description: Option<String>,
 }
 
 impl InitSettings {
@@ -213,6 +213,7 @@ impl InitSettings {
             app,
             lib,
             script,
+            description,
             vcs,
             build_backend,
             no_readme,
@@ -220,7 +221,6 @@ impl InitSettings {
             no_pin_python,
             no_workspace,
             python,
-            description,
         } = args;
 
         let kind = match (app, lib, script) {
@@ -243,6 +243,7 @@ impl InitSettings {
             name,
             package,
             kind,
+            description,
             vcs,
             build_backend,
             no_readme,
@@ -251,7 +252,6 @@ impl InitSettings {
             no_workspace,
             python: python.and_then(Maybe::into_option),
             install_mirrors,
-            description,
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -197,6 +197,7 @@ pub(crate) struct InitSettings {
     pub(crate) no_workspace: bool,
     pub(crate) python: Option<String>,
     pub(crate) install_mirrors: PythonInstallMirrors,
+    pub(crate) description: Option<String>,
 }
 
 impl InitSettings {
@@ -219,6 +220,7 @@ impl InitSettings {
             no_pin_python,
             no_workspace,
             python,
+            description,
         } = args;
 
         let kind = match (app, lib, script) {
@@ -249,6 +251,7 @@ impl InitSettings {
             no_workspace,
             python: python.and_then(Maybe::into_option),
             install_mirrors,
+            description,
         }
     }
 }

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -3271,3 +3271,89 @@ fn init_application_package_uv() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn init_with_description() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let child = context.temp_dir.join("foo");
+    fs_err::create_dir_all(&child)?;
+
+    // Initialize the project with a description
+    context
+        .init()
+        .current_dir(&child)
+        .arg("--description")
+        .arg("A sample project description")
+        .arg("--lib")
+        .assert()
+        .success();
+
+    // Read the generated pyproject.toml
+    let pyproject = fs_err::read_to_string(child.join("pyproject.toml"))?;
+
+    // Verify the description in pyproject.toml
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        description = "A sample project description"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
+fn init_without_description() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let child = context.temp_dir.join("bar");
+    fs_err::create_dir_all(&child)?;
+
+    // Initialize the project without a description
+    context
+        .init()
+        .current_dir(&child)
+        .arg("--lib")
+        .assert()
+        .success();
+
+    // Read the generated pyproject.toml
+    let pyproject = fs_err::read_to_string(child.join("pyproject.toml"))?;
+
+    // Verify the default description in pyproject.toml
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "bar"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#
+        );
+    });
+
+    Ok(())
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -589,7 +589,7 @@ uv init [OPTIONS] [PATH]
 <p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 
 <p>May also be set with the <code>UV_CONFIG_FILE</code> environment variable.</p>
-</dd><dt><code>--description</code> <i>description</i></dt><dd><p>Set the project description in the pyproject.toml</p>
+</dd><dt><code>--description</code> <i>description</i></dt><dd><p>Set the project description</p>
 
 </dd><dt><code>--directory</code> <i>directory</i></dt><dd><p>Change to the given directory prior to running the command.</p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -589,6 +589,8 @@ uv init [OPTIONS] [PATH]
 <p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 
 <p>May also be set with the <code>UV_CONFIG_FILE</code> environment variable.</p>
+</dd><dt><code>--description</code> <i>description</i></dt><dd><p>Set the project description in the pyproject.toml</p>
+
 </dd><dt><code>--directory</code> <i>directory</i></dt><dd><p>Change to the given directory prior to running the command.</p>
 
 <p>Relative paths are resolved with the given directory as the base.</p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Closes #7913 by adding an optional `--description` argument to `uv init` that fills the description field in the pyproject.toml with the supplied arg value.  

Updated `uv init` docs to describe this new optional argument.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Added snapshot tests in `uv/crates/uv/tests/it/init.rs` to test this functionality.
<!-- How was it tested? -->
