### PR TITLE
Fix small typo in editable packages docs

### DIFF
--- a/docs/pip/packages.md
+++ b/docs/pip/packages.md
@@ -62,7 +62,7 @@ for installation from a private repository.
 
 ## Editable packages
 
-Editable packages do not need to be reinstalled for change to their source code to be active.
+Editable packages do not need to be reinstalled for changes to their source code to be active.
 
 To install the current project as an editable package
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Was reading through some of the docs and noticed this small typo in https://docs.astral.sh/uv/pip/packages/#editable-packages

## Test Plan
Not applicable
