### PR TITLE
docs: Clarify build system specific features usage.

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -119,6 +119,10 @@ with the default build system.
     installable. Similarly, if you add a dependency on a local package or install it with `uv pip`,
     uv will always attempt to build and install it.
 
+!!! tip
+
+    To utilize build-system-specific features (e.g., including or excluding files in the distribution), refer to the documentation of your chosen build system (build backend).
+
 ## Project packaging
 
 As discussed in [build systems](#build-systems), a Python project must be built to be installed.

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -125,6 +125,9 @@ Build systems are used to power the following features:
 
 - Including or excluding files from distributions
 - Editable install behavior
+- Dynamic project metadata
+- Compilation of native code
+- Vendoring shared libraries
 
 To configure these features, refer to the documentation of your chosen build system.
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -119,9 +119,14 @@ with the default build system.
     installable. Similarly, if you add a dependency on a local package or install it with `uv pip`,
     uv will always attempt to build and install it.
 
-!!! tip
+### Build system options
 
-    To utilize build-system-specific features (e.g., including or excluding files in the distribution), refer to the documentation of your chosen build system (build backend).
+Build systems are used to power the following features:
+
+- Including or excluding files from distributions
+- Editable install behavior
+
+To configure these features, refer to the documentation of your chosen build system.
 
 ## Project packaging
 


### PR DESCRIPTION
## Summary
Since there are occasional inquiries about how to configure UV for build-system specific features, I want to raise awareness that users should refer to the documentation of the build system they are using for relevant settings.
## Test Plan
Run docs service in local.
https://github.com/astral-sh/uv/pull/10261/commits/9821d58d35dce6bbafe4bdadd9031afba0f787a5
![image](https://github.com/user-attachments/assets/3c07ac15-a562-40e2-9289-204c0975261f)

