### PR TITLE
Fix musl cdylib warning

### DIFF
--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -13,8 +13,6 @@ repository = { workspace = true }
 authors = { workspace = true }
 
 [lib]
-name = "uv_pep508"
-crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [lints]


### PR DESCRIPTION
The `cdylib` was used for the pyo3 bindings to uv-pep508, which don't exist anymore. It was now creating warnings on musl due to musl (statically linked) no supporting shared libraries.