### PR TITLE
Actually use jemalloc

### DIFF
--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -13,8 +13,6 @@ repository = { workspace = true }
 authors = { workspace = true }
 
 [lib]
-name = "uv_pep508"
-crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [lints]

--- a/crates/uv/src/bin/uv.rs
+++ b/crates/uv/src/bin/uv.rs
@@ -1,3 +1,7 @@
+// Don't optimize the alloc crate away due to it being otherwise unused.
+// https://github.com/rust-lang/rust/issues/64402
+extern crate uv_performance_memory_allocator;
+
 use std::process::ExitCode;
 
 use uv::main as uv_main;


### PR DESCRIPTION
The uv-performance-memory-allocator is currently optimized out at least on musl due to the crate being otherwise unused (https://github.com/rust-lang/rust/issues/64402), causing musl to not use jemalloc and being slow.

Command:
```
cargo build --target x86_64-unknown-linux-musl --profile profiling
hyperfine --warmup 1 --runs 10 --prepare "uv venv -p 3.12" "target/x86_64-unknown-linux-musl/profiling/uv pip compile scripts/requirements/airflow.in"
```

Before:
```
Time (mean ± σ):      1.149 s ±  0.013 s    [User: 1.498 s, System: 0.433 s]
Range (min … max):    1.131 s …  1.173 s    10 runs
```

After:
```
Time (mean ± σ):     552.6 ms ±   4.7 ms    [User: 771.7 ms, System: 197.5 ms]
Range (min … max):   546.4 ms … 561.6 ms    10 runs