### PR TITLE
Visit source distributions before wheels

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -786,15 +786,13 @@ impl VersionFiles {
     }
 
     pub fn all(self) -> impl Iterator<Item = (DistFilename, File)> {
-        self.wheels
+        self.source_dists
             .into_iter()
-            .map(|VersionWheel { name, file }| (DistFilename::WheelFilename(name), file))
+            .map(|VersionSourceDist { name, file }| (DistFilename::SourceDistFilename(name), file))
             .chain(
-                self.source_dists
+                self.wheels
                     .into_iter()
-                    .map(|VersionSourceDist { name, file }| {
-                        (DistFilename::SourceDistFilename(name), file)
-                    }),
+                    .map(|VersionWheel { name, file }| (DistFilename::WheelFilename(name), file)),
             )
     }
 }

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -638,7 +638,9 @@ pub fn implied_markers(filename: &WheelFilename) -> MarkerTree {
     let mut marker = MarkerTree::FALSE;
     for platform_tag in &filename.platform_tag {
         match platform_tag.as_str() {
-            "any" => marker.or(MarkerTree::TRUE),
+            "any" => {
+                return MarkerTree::TRUE;
+            }
             tag if tag.starts_with("win") => {
                 marker.or(MarkerTree::expression(MarkerExpression::String {
                     key: MarkerValueString::SysPlatform,


### PR DESCRIPTION
## Summary

This should address the comment here: https://github.com/astral-sh/uv/pull/10179#issuecomment-2569189265. We don't compute implied markers if the marker is already `TRUE`, and we set it to `TRUE` as soon as we see a source distribution. So if we visit the source distribution before the wheels, we'll avoid computing these for any irrelevant distributions.
