### PR TITLE
README.md: revise powershell install cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ```bash
 # On Windows.
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -NoP -EP Bypass "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Or, from [PyPI](https://pypi.org/project/uv/):


### PR DESCRIPTION
## Summary

* Primarily:
  * `-NoProfile` (appreviated to `-NoP`) is used as the profile can interfere with the intended operation
* Secondarily:
  * Changed `-ExecutionPolicy` to use its `-EP` abbreviation
  * Removed `-c` as that's already implicit on PowerShell 5.1
  * Changed `ByPass` to `Bypass` (nitpicky I know)