### PR TITLE
added aarch64 build binary for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,21 +570,32 @@ jobs:
       - name: Download LLVM (aarch64)
         uses: robinraju/release-downloader@v1
         with:
-          repository: 'llvm/llvm-project'
-          tag: 'llvmorg-19.1.5'
-          filename: 'LLVM-19.1.5-woa64.exe'
-          
+          repository: "llvm/llvm-project"
+          tag: "llvmorg-19.1.5"
+          filename: "LLVM-19.1.5-woa64.exe"
+
       - name: Install LLVM (aarch64)
         run: |
           Start-Process -FilePath "LLVM-19.1.5-woa64.exe" -ArgumentList '/S' -NoNewWindow -Wait
-          
+
       - name: Install Build Tools (aarch64)
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM --add Microsoft.VisualStudio.Component.VC.ASAN"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "^
+            --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
+            --add Microsoft.VisualStudio.Component.Windows11SDK.22621 ^
+            --add Microsoft.VisualStudio.Workload.VCTools ^
+            --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
+            --add Microsoft.VisualStudio.Component.VC.Llvm.Clang ^
+            --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ^
+            --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset ^
+            --add Microsoft.VisualStudio.Component.VC.CMake.Project ^
+            --add Microsoft.VisualStudio.Component.VC.ATL ^
+            --add Microsoft.VisualStudio.Component.VC.ATL.ARM ^
+            --add Microsoft.VisualStudio.Component.VC.ASAN"
 
       - name: Install Nightly Rust (aarch64)
         run: |
@@ -595,10 +606,10 @@ jobs:
       - name: Download Git for Windows (aarch64)
         uses: robinraju/release-downloader@v1
         with:
-          repository: 'git-for-windows/git'
-          tag: 'v2.48.0-rc1.windows.1'
-          filename: 'Git-2.48.0-rc1-arm64.exe'
-          
+          repository: "git-for-windows/git"
+          tag: "v2.48.0-rc1.windows.1"
+          filename: "Git-2.48.0-rc1-arm64.exe"
+
       - name: Install Git for Windows (aarch64)
         run: |
           Start-Process -FilePath "Git-2.48.0-rc1-arm64.exe" -ArgumentList "/VERYSILENT" -NoNewWindow -Wait

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,11 +588,13 @@ jobs:
 
       - name: Add clang to PATH and check if clang exists
         run: |
+          $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin" -Encoding utf8
           clang --version
       
       - name: Add cmake to PATH and check if cmake exists
         run: |
+          $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" -Encoding utf8
           cmake --version
 
@@ -620,7 +622,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Build"
-        run: cargo build --target aarch64-pc-windows-msvc
+        run: $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"; $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"; cargo build --target aarch64-pc-windows-msvc
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,11 +584,11 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM --add Microsoft.VisualStudio.Component.VC.ASAN"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang"
 
       - name: Add clang to PATH and check if clang exists
         run: |
-          $env:PATH += ";C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Llvm\ARM64\bin\"
+          $env:PATH += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"
           clang --version
 
       - name: Install Nightly Rust (aarch64)
@@ -615,13 +615,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Build"
-        run: cargo build  -vv --target aarch64-pc-windows-msvc
+        run: cargo build --target aarch64-pc-windows-msvc
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
-          path: target/debug/uv.exe
+          name: uv-windows-aarch64-${{ github.sha }}
+          path: target/aarch64-pc-windows-msvc/debug/uv.exe
           retention-days: 1
 
   cargo-build-msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,11 @@ jobs:
     name: "build binary | windows aarch64"
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,7 @@ jobs:
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
           choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
+          choco cache list -v
 
       - name: Add clang to PATH and check if clang exists
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,7 +591,7 @@ jobs:
           $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin" -Encoding utf8
           clang --version
-      
+
       - name: Add cmake to PATH and check if cmake exists
         run: |
           $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,12 +584,17 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
 
       - name: Add clang to PATH and check if clang exists
         run: |
           $env:PATH += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"
           clang --version
+      
+      - name: Add cmake to PATH and check if cmake exists
+        run: |
+          $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"
+          cmake --version
 
       - name: Install Nightly Rust (aarch64)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,27 +569,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-
-      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
-
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ env.UV_WORKSPACE }}
 
       - name: "Build"
-        working-directory: ${{ env.UV_WORKSPACE }}
         run: cargo build --target aarch64-pc-windows-msvc
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4
         with:
           name: uv-windows-${{ github.sha }}
-          path: ${{ env.UV_WORKSPACE }}/target/debug/uv.exe
+          path: target/debug/uv.exe
           retention-days: 1
 
   cargo-build-msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM --add Microsoft.VisualStudio.Component.VC.ASAN"
 
       - name: Install Nightly Rust (aarch64)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
-build-binary
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,17 +567,48 @@ jobs:
       labels: github-windows-11-aarch64-4
     name: "build binary | windows aarch64"
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Download LLVM (aarch64)
+        uses: robinraju/release-downloader@v1
         with:
-          targets: aarch64-pc-windows-msvc
+          repository: 'llvm/llvm-project'
+          tag: 'llvmorg-19.1.5'
+          filename: 'LLVM-19.1.5-woa64.exe'
+          
+      - name: Install LLVM (aarch64)
+        run: |
+          Start-Process -FilePath "LLVM-19.1.5-woa64.exe" -ArgumentList '/S' -NoNewWindow -Wait
+          
+      - name: Install Build Tools (aarch64)
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+
+      - name: Install Nightly Rust (aarch64)
+        run: |
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.cargo\bin" -Encoding utf8
+          Invoke-WebRequest -Uri "https://win.rustup.rs/aarch64" -OutFile "$env:RUNNER_TEMP\rustup-init.exe"
+          & "$env:RUNNER_TEMP\rustup-init.exe" --default-host aarch64-pc-windows-msvc --default-toolchain nightly -y
+
+      - name: Download Git for Windows (aarch64)
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: 'git-for-windows/git'
+          tag: 'v2.48.0-rc1.windows.1'
+          filename: 'Git-2.48.0-rc1-arm64.exe'
+          
+      - name: Install Git for Windows (aarch64)
+        run: |
+          Start-Process -FilePath "Git-2.48.0-rc1-arm64.exe" -ArgumentList "/VERYSILENT" -NoNewWindow -Wait
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\cmd" -Encoding utf8
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\bin" -Encoding utf8
 
       - uses: Swatinem/rust-cache@v2
 
       - name: "Build"
-        run: cargo build --target aarch64-pc-windows-msvc
+        run: cargo build  -vv --target aarch64-pc-windows-msvc
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,12 +588,12 @@ jobs:
 
       - name: Add clang to PATH and check if clang exists
         run: |
-          $env:PATH += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"
+          "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin" >> $env:GITHUB_PATH
           clang --version
       
       - name: Add cmake to PATH and check if cmake exists
         run: |
-          $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"
+          "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\" >> $env:GITHUB_PATH
           cmake --version
 
       - name: Install Nightly Rust (aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang"
 
       - name: Install Nightly Rust (aarch64)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,12 +588,12 @@ jobs:
 
       - name: Add clang to PATH and check if clang exists
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin" >> $env:GITHUB_PATH
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin" -Encoding utf8
           clang --version
       
       - name: Add cmake to PATH and check if cmake exists
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\" >> $env:GITHUB_PATH
+          Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" -Encoding utf8
           cmake --version
 
       - name: Install Nightly Rust (aarch64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
-
+build-binary
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -526,7 +526,7 @@ jobs:
           path: ./target/debug/uv
           retention-days: 1
 
-  build-binary-windows:
+  build-binary-windows-x86_64:
     needs: determine_changes
     timeout-minutes: 10
     if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
@@ -551,6 +551,39 @@ jobs:
       - name: "Build"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: cargo build
+
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v4
+        with:
+          name: uv-windows-${{ github.sha }}
+          path: ${{ env.UV_WORKSPACE }}/target/debug/uv.exe
+          retention-days: 1
+
+  build-binary-windows-aarch64:
+    needs: determine_changes
+    timeout-minutes: 10
+    if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    runs-on:
+      labels: github-windows-11-aarch64-4
+    name: "build binary | windows aarch64"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Dev Drive using ReFS
+        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+
+      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
+      - name: Copy Git Repo to Dev Drive
+        run: |
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ env.UV_WORKSPACE }}
+
+      - name: "Build"
+        working-directory: ${{ env.UV_WORKSPACE }}
+        run: cargo build --target aarch64-pc-windows-msvc
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
           choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
 
@@ -617,9 +617,9 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\cmd" -Encoding utf8
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Git\bin" -Encoding utf8
 
-      - uses: Swatinem/rust-cache@v2
-
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: "Build"
         run: $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\bin"; $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\"; cargo build --target aarch64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - uses: actions/checkout@v4
+
       - name: "Build"
         run: cargo build  -vv --target aarch64-pc-windows-msvc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.CMake.Project"
 
       - name: Install Nightly Rust (aarch64)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,7 +561,7 @@ jobs:
 
   build-binary-windows-aarch64:
     needs: determine_changes
-    timeout-minutes: 10
+    timeout-minutes: 30
     if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
       labels: github-windows-11-aarch64-4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -586,6 +586,11 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
           choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM --add Microsoft.VisualStudio.Component.VC.ASAN"
 
+      - name: Add clang to PATH and check if clang exists
+        run: |
+          $env:PATH += ";C:\Program Files\Microsoft Visual Studio\2022\BuildTools\Llvm\ARM64\bin\"
+          clang --version
+
       - name: Install Nightly Rust (aarch64)
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.cargo\bin" -Encoding utf8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,18 +584,7 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
           iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) 
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ProgramData\chocolatey\bin" -Encoding utf8
-          choco install visualstudio2022buildtools -y --no-progress --package-parameters "^
-            --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 ^
-            --add Microsoft.VisualStudio.Component.Windows11SDK.22621 ^
-            --add Microsoft.VisualStudio.Workload.VCTools ^
-            --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
-            --add Microsoft.VisualStudio.Component.VC.Llvm.Clang ^
-            --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang ^
-            --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset ^
-            --add Microsoft.VisualStudio.Component.VC.CMake.Project ^
-            --add Microsoft.VisualStudio.Component.VC.ATL ^
-            --add Microsoft.VisualStudio.Component.VC.ATL.ARM ^
-            --add Microsoft.VisualStudio.Component.VC.ASAN"
+          choco install visualstudio2022buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.Windows11SDK.22621 --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.CMake.Project --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATL.ARM --add Microsoft.VisualStudio.Component.VC.ASAN"
 
       - name: Install Nightly Rust (aarch64)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,7 +526,7 @@ jobs:
           path: ./target/debug/uv
           retention-days: 1
 
-  build-binary-windows-x86_64:
+  build-binary-windows:
     needs: determine_changes
     timeout-minutes: 10
     if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,7 +526,7 @@ jobs:
           path: ./target/debug/uv
           retention-days: 1
 
-  build-binary-windows:
+  build-binary-windows-x86_64:
     needs: determine_changes
     timeout-minutes: 10
     if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
@@ -555,7 +555,7 @@ jobs:
       - name: "Upload binary"
         uses: actions/upload-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
           path: ${{ env.UV_WORKSPACE }}/target/debug/uv.exe
           retention-days: 1
 
@@ -822,9 +822,9 @@ jobs:
         run: |
           ./uv pip install -v anyio
 
-  integration-test-free-threaded-windows:
+  integration-test-free-threaded-windows-x86_64:
     timeout-minutes: 10
-    needs: build-binary-windows
+    needs: build-binary-windows-x86_64
     name: "integration test | free-threaded on windows"
     runs-on: windows-latest
     env:
@@ -835,7 +835,7 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
 
       - name: "Install free-threaded Python via uv"
         run: |
@@ -869,6 +869,55 @@ jobs:
         run: |
           ./uv run python -c ""
           ./uv run -p 3.13t python -c ""
+  
+  integration-test-free-threaded-windows-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "integration test | free-threaded on windows"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+
+    steps:
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
+
+      - name: "Install free-threaded Python via uv"
+        run: |
+          ./uv python install -v 3.13t
+
+      - name: "Create a virtual environment (stdlib)"
+        run: |
+          & (./uv python find 3.13t) -m venv .venv
+
+      - name: "Check version (stdlib)"
+        run: |
+          .venv/Scripts/python --version
+
+      - name: "Create a virtual environment (uv)"
+        run: |
+          ./uv venv -p 3.13t --python-preference only-managed
+
+      - name: "Check version (uv)"
+        run: |
+          .venv/Scripts/python --version
+
+      - name: "Check is free-threaded"
+        run: |
+          .venv/Scripts/python -c "import sys; exit(1) if sys._is_gil_enabled() else exit(0)"
+
+      - name: "Check install"
+        run: |
+          ./uv pip install -v anyio
+
+      - name: "Check uv run"
+        run: |
+          ./uv run python -c ""
+          ./uv run -p 3.13t python -c ""
+
 
   integration-test-pypy-linux:
     timeout-minutes: 10
@@ -934,9 +983,9 @@ jobs:
         run: |
           ./uv pip install anyio
 
-  integration-test-pypy-windows:
+  integration-test-pypy-windows-x86_64:
     timeout-minutes: 10
-    needs: build-binary-windows
+    needs: build-binary-windows-x86_64
     name: "integration test | pypy on windows"
     runs-on: windows-latest
 
@@ -944,7 +993,70 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
+
+      - name: "Install PyPy"
+        run: .\uv.exe python install pypy3.9
+
+      - name: "Create a virtual environment"
+        run: |
+          .\uv.exe venv -p pypy3.9 --python-preference only-managed
+
+      - name: "Check for executables"
+        shell: python
+        run: |
+          import sys
+          from pathlib import Path
+
+          def binary_exist(binary):
+            binaries_path = Path(".venv\\Scripts")
+            if (binaries_path / binary).exists():
+              return True
+            print(f"Executable '{binary}' not found in folder '{binaries_path}'.")
+
+          all_found = True
+          expected_binaries = [
+              "pypy3.9.exe",
+              "pypy3.9w.exe",
+              "pypy3.exe",
+              "pypyw.exe",
+              "python.exe",
+              "python3.9.exe",
+              "python3.exe",
+              "pythonw.exe",
+          ]
+          for binary in expected_binaries:
+            if not binary_exist(binary):
+              all_found = False
+
+          if not all_found:
+            print("One or more expected executables were not found.")
+            sys.exit(1)
+
+      - name: "Check version"
+        run: |
+          & .venv\Scripts\pypy3.9.exe --version
+          & .venv\Scripts\pypy3.exe --version
+          & .venv\Scripts\python.exe --version
+
+      - name: "Check install"
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+        run: |
+          .\uv.exe pip install anyio
+  
+  integration-test-pypy-windows-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "integration test | pypy on windows"
+    runs-on: github-windows-11-aarch64-4
+
+    steps:
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
 
       - name: "Install PyPy"
         run: .\uv.exe python install pypy3.9
@@ -1066,9 +1178,9 @@ jobs:
         run: |
           ./uv pip install anyio
 
-  integration-test-graalpy-windows:
+  integration-test-graalpy-windows-x86_64:
     timeout-minutes: 10
-    needs: build-binary-windows
+    needs: build-binary-windows-x86_64
     name: "integration test | graalpy on windows"
     runs-on: windows-latest
 
@@ -1080,7 +1192,70 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
+
+      - name: Graalpy info
+        run: Get-Command graalpy
+
+      - name: "Create a virtual environment"
+        run: |
+          $graalpy = (Get-Command graalpy).source
+          .\uv.exe venv -p $graalpy
+
+      - name: "Check for executables"
+        shell: python
+        run: |
+          import sys
+          from pathlib import Path
+
+          def binary_exist(binary):
+            binaries_path = Path(".venv\\Scripts")
+            if (binaries_path / binary).exists():
+              return True
+            print(f"Executable '{binary}' not found in folder '{binaries_path}'.")
+
+          all_found = True
+          expected_binaries = [
+              "graalpy.exe",
+              "python.exe",
+              "python3.exe",
+          ]
+          for binary in expected_binaries:
+            if not binary_exist(binary):
+              all_found = False
+
+          if not all_found:
+            print("One or more expected executables were not found.")
+            sys.exit(1)
+
+      - name: "Check version"
+        run: |
+          & .venv\Scripts\graalpy.exe --version
+          & .venv\Scripts\python3.exe --version
+          & .venv\Scripts\python.exe --version
+
+      - name: "Check install"
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+        run: |
+          .\uv.exe pip install anyio
+ 
+  integration-test-graalpy-windows-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "integration test | graalpy on windows"
+    runs-on: github-windows-11-aarch64-4
+
+    steps:
+      - uses: timfel/setup-python@fc9bcb4a04f5b1ea7d678c2ca7ea1c479a2468d7
+        with:
+          python-version: "graalpy24.1"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
 
       - name: Graalpy info
         run: Get-Command graalpy
@@ -1614,8 +1789,8 @@ jobs:
 
   system-test-windows-python-310:
     timeout-minutes: 10
-    needs: build-binary-windows
-    name: "check system | python3.10 on windows"
+    needs: build-binary-windows-x86_64
+    name: "check system | python3.10 on windows x86_64"
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
@@ -1630,7 +1805,33 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
+
+      - name: "Print Python path"
+        run: echo $(which python)
+
+      - name: "Validate global Python install"
+        run: py -3.10 ./scripts/check_system_python.py --uv ./uv.exe
+
+  system-test-windows-python-310-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "check system | python3.10 on windows aarch64"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
 
       - name: "Print Python path"
         run: echo $(which python)
@@ -1640,7 +1841,7 @@ jobs:
 
   system-test-windows-x86-python-310:
     timeout-minutes: 10
-    needs: build-binary-windows
+    needs: build-binary-windows-x86_64
     name: "check system | python3.10 on windows x86"
     runs-on: windows-latest
     env:
@@ -1657,7 +1858,34 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
+
+      - name: "Print Python path"
+        run: echo $(which python)
+
+      - name: "Validate global Python install"
+        run: python ./scripts/check_system_python.py --uv ./uv.exe
+  
+  system-test-windows-aarch64-python-310:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "check system | python3.10 on windows aarch64"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: "aarch64"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
 
       - name: "Print Python path"
         run: echo $(which python)
@@ -1665,10 +1893,10 @@ jobs:
       - name: "Validate global Python install"
         run: python ./scripts/check_system_python.py --uv ./uv.exe
 
-  system-test-windows-python-313:
+  system-test-windows-x86_64-python-313:
     timeout-minutes: 10
-    needs: build-binary-windows
-    name: "check system | python3.13 on windows"
+    needs: build-binary-windows-x86_64
+    name: "check system | python3.13 on windows x86_64"
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
@@ -1685,7 +1913,35 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
+
+      - name: "Print Python path"
+        run: echo $(which python)
+
+      - name: "Validate global Python install"
+        run: py -3.13 ./scripts/check_system_python.py --uv ./uv.exe
+  
+  system-test-windows-aarch64-python-313:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "check system | python3.13 on windows aarch64"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          allow-prereleases: true
+          cache: pip
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
 
       - name: "Print Python path"
         run: echo $(which python)
@@ -1695,7 +1951,7 @@ jobs:
 
   system-test-choco:
     timeout-minutes: 10
-    needs: build-binary-windows
+    needs: build-binary-windows-x86_64
     name: "check system | python3.12 via chocolatey"
     runs-on: windows-latest
     env:
@@ -1710,13 +1966,39 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
 
       - name: "Print Python path"
         run: echo $(which python3)
 
       - name: "Validate global Python install"
         run: py -3.9 ./scripts/check_system_python.py --uv ./uv.exe
+
+  system-test-choco-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "check system | python3.12 via chocolatey"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Python"
+        run: choco install python3 --verbose --version=3.9.13
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
+
+      - name: "Print Python path"
+        run: echo $(which python3)
+
+      - name: "Validate global Python install"
+        run: py -3.9 ./scripts/check_system_python.py --uv ./uv.exe
+
 
   system-test-pyenv:
     timeout-minutes: 10
@@ -1789,7 +2071,7 @@ jobs:
   system-test-conda:
     timeout-minutes: 10
     needs:
-      [build-binary-windows, build-binary-macos-aarch64, build-binary-linux]
+      [build-binary-windows-x86_64, build-binary-windows-aarch64, build-binary-macos-aarch64, build-binary-linux]
     name: check system | conda${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -1799,7 +2081,8 @@ jobs:
         python-version: ["3.8", "3.11"]
         include:
           - { os: "linux", target: "linux", runner: "ubuntu-latest" }
-          - { os: "windows", target: "windows", runner: "windows-latest" }
+          - { os: "windows", target: "windows-x86_64", runner: "windows-latest" }
+          - { os: "windows", target: "windows-aarch64", runner: "github-windows-11-aarch64-4" }
           - { os: "macos", target: "macos-aarch64", runner: "macos-14" }
     steps:
       - uses: actions/checkout@v4
@@ -1869,8 +2152,8 @@ jobs:
 
   system-test-windows-embedded-python-310:
     timeout-minutes: 10
-    needs: build-binary-windows
-    name: "check system | embedded python3.10 on windows"
+    needs: build-binary-windows-x86_64
+    name: "check system | embedded python3.10 on windows x86_64"
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
@@ -1881,7 +2164,7 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-windows-${{ github.sha }}
+          name: uv-windows-x86_64-${{ github.sha }}
 
       # Download embedded Python.
       - name: "Download embedded Python"
@@ -1901,6 +2184,41 @@ jobs:
 
       - name: "Validate embedded Python install"
         run: python ./scripts/check_embedded_python.py --uv ./uv.exe
+
+  system-test-windows-embedded-python-310-aarch64:
+    timeout-minutes: 10
+    needs: build-binary-windows-aarch64
+    name: "check system | embedded python3.10 on windows aarch64"
+    runs-on: github-windows-11-aarch64-4
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-aarch64-${{ github.sha }}
+
+      # Download embedded Python.
+      - name: "Download embedded Python"
+        run: curl -LsSf https://www.python.org/ftp/python/3.11.8/python-3.11.8-embed-arm64.zip -o python-3.11.8-embed-arm64.zip
+
+      - name: "Unzip embedded Python"
+        run: 7z x python-3.11.8-embed-arm64.zip -oembedded-python
+
+      - name: "Show embedded Python contents"
+        run: ls embedded-python
+
+      - name: "Set PATH"
+        run: echo "${{ github.workspace }}\embedded-python" >> $env:GITHUB_PATH
+
+      - name: "Print Python path"
+        run: echo "${{ github.workspace }}\embedded-python" >> $env:GITHUB_PATH; echo $(which python)
+
+      - name: "Validate embedded Python install"
+        run: echo "${{ github.workspace }}\embedded-python" >> $env:GITHUB_PATH; python ./scripts/check_embedded_python.py --uv ./uv.exe
 
   benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds an aarch64 windows build to build for windows on arm. Addresses: #1141

## Test Plan

I build uv for windows aarch64 locally by running `cargo build --target aarch64-pc-windows-msvc`, it worked.
