### PR TITLE
docs(python-versions.md): fix spelling

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -53,7 +53,7 @@ This behavior can be
 
 The `.python-version` file can be used to create a default Python version request. uv searches for a
 `.python-version` file in the working directory and each of its parents. Any of the request formats
-described above can be used, though use of a version number is recommended for interopability with
+described above can be used, though use of a version number is recommended for interoperability with
 other tools.
 
 A `.python-version` file can be created in the current directory with the


### PR DESCRIPTION
## Summary

Correct misspelling of `interopability` to `interoperability`.

## Test Plan

N/A