### PR TITLE
Add markdownlint settings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 100
+  },
+  "MD014": false,
+  "MD046": false
+}


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In VSCode with Markdownlint (<https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint>) and default rules enabled, it'd autocorrect a few things that do not seem to be what the project wants for its doc. For instance:

### [`MD014` - Dollar signs used before commands without showing output](https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md)

Would correct

````md
```console
$ winget install --id=astral-sh.uv -e
```
````

to

````md
```console
winget install --id=astral-sh.uv -e
```
````

### [`MD046` - Code block style](https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md)

Says [installation.md](https://github.com/astral-sh/uv/blob/main/docs/getting-started/installation.md) uses inconsistent code block style.

Seems the doc must use it for it to look good with mkdocs?

## Test Plan

Affects developer experience.
