### PR TITLE
Accept requirements in `uv remove`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3272,7 +3272,7 @@ pub struct AddArgs {
 pub struct RemoveArgs {
     /// The names of the dependencies to remove (e.g., `ruff`).
     #[arg(required = true)]
-    pub packages: Vec<PackageName>,
+    pub packages: Vec<Requirement<VerbatimParsedUrl>>,
 
     /// Remove the packages from the development dependency group.
     ///

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1,6 +1,8 @@
-use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
 use url::Url;
+
 use uv_cache_info::CacheKey;
 use uv_configuration::{
     ConfigSettings, IndexStrategy, KeyringProviderType, PackageNameSpecifier, RequiredVersion,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -5,6 +5,7 @@ use std::process;
 use std::str::FromStr;
 
 use url::Url;
+
 use uv_cache::{CacheArgs, Refresh};
 use uv_cli::comma::CommaSeparatedRequirements;
 use uv_cli::{
@@ -1250,6 +1251,11 @@ impl RemoveSettings {
             .clone()
             .map(|fs| fs.install_mirrors.clone())
             .unwrap_or_default();
+
+        let packages = packages
+            .into_iter()
+            .map(|requirement| requirement.name)
+            .collect();
 
         Self {
             locked,


### PR DESCRIPTION
## Summary

This allows, e.g., `uv remove flask[dotenv]` to remove `flask`. Like `pip install` and `uv pip install`, the content after the package name has no effect.

Closes https://github.com/astral-sh/uv/issues/9764.
