### PR TITLE
Speed up file pins

### DIFF
--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -10,15 +10,14 @@ use crate::candidate_selector::Candidate;
 /// For example, given `Flask==3.0.0`, the [`FilePins`] would contain a mapping from `Flask` to
 /// `3.0.0` to the specific wheel or source distribution archive that was pinned for that version.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct FilePins(FxHashMap<PackageName, FxHashMap<uv_pep440::Version, ResolvedDist>>);
+pub(crate) struct FilePins(FxHashMap<(PackageName, uv_pep440::Version), ResolvedDist>);
 
 impl FilePins {
     /// Pin a candidate package.
     pub(crate) fn insert(&mut self, candidate: &Candidate, dist: &CompatibleDist) {
-        self.0.entry(candidate.name().clone()).or_default().insert(
-            candidate.version().clone(),
-            dist.for_installation().to_owned(),
-        );
+        self.0
+            .entry((candidate.name().clone(), candidate.version().clone()))
+            .or_insert_with(|| dist.for_installation().to_owned());
     }
 
     /// Return the pinned file for the given package name and version, if it exists.
@@ -27,6 +26,7 @@ impl FilePins {
         name: &PackageName,
         version: &uv_pep440::Version,
     ) -> Option<&ResolvedDist> {
-        self.0.get(name)?.get(version)
+        // Inserts are common while reads are rare, so the clone here is overall faster.
+        self.0.get(&(name.clone(), version.clone()))
     }
 }


### PR DESCRIPTION
Ref https://github.com/astral-sh/uv/issues/10344

Avoid the nested hashmap, file pinning is called in the version selection hot loop.

```
$ hyperfine --warmup 1 --prepare "uv venv -p 3.12" "./uv-2 pip compile scripts/requirements/airflow.in" "./uv-1 pip compile scripts/requirements/airflow.in"
    Finished `profiling` profile [optimized + debuginfo] target(s) in 0.12s
Benchmark 1: ./uv-2 pip compile scripts/requirements/airflow.in
  Time (mean ± σ):     420.1 ms ±   4.7 ms    [User: 585.4 ms, System: 195.1 ms]
  Range (min … max):   413.1 ms … 429.2 ms    10 runs

Benchmark 2: ./uv-1 pip compile scripts/requirements/airflow.in
  Time (mean ± σ):     473.0 ms ±   4.9 ms    [User: 654.4 ms, System: 209.4 ms]
  Range (min … max):   468.0 ms … 481.1 ms    10 runs

Summary
  ./uv-2 pip compile scripts/requirements/airflow.in ran
    1.13 ± 0.02 times faster than ./uv-1 pip compile scripts/requirements/airflow.in
```
