### PR TITLE
Deactivate tracing for choose version

### DIFF
--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -67,3 +67,6 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { version = "1.40.0" }
 toml = { workspace = true }
+
+[features]
+tracing-durations-export = []

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1013,7 +1013,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     ///
     /// Returns `None` when there are no versions in the given range, rejecting the current partial
     /// solution.
-    #[instrument(skip_all, fields(%package))]
+    // TODO(konsti): re-enable tracing. This trace is crucial to understanding the
+    // tracing-durations-export diagrams, but it took ~5% resolver thread runtime for apache-airflow
+    // when I last measured.
+    #[cfg_attr(feature = "tracing-durations-export", instrument(skip_all, fields(%package)))]
     fn choose_version(
         &self,
         package: &PubGrubPackage,

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -142,6 +142,7 @@ performance = [
 ]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]
 performance-flate2-backend = ["dep:uv-performance-flate2-backend"]
+tracing-durations-export = ["dep:tracing-durations-export", "uv-resolver/tracing-durations-export"]
 
 # Introduces a dependency on a local Python installation.
 python = []


### PR DESCRIPTION
Ref https://github.com/astral-sh/uv/issues/10344

This trace is crucial to understanding the tracing-durations-export diagrams, but it took ~5% resolver thread runtime for apache-airflow (profiling information). It looks neutral in hyperfine (below noise threshold)