### PR TITLE
docs: github actions example: remove unneeded install step

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -182,9 +182,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up Python
-        run: uv python install
-
       - name: Install the project
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
* Previously had uv python install, then uv sync --all-extras --dev
* If we are going to use sync for dev dependencies, then the install step is unneccessary

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
