### PR TITLE
uv-pep440: adds an explicit test for trailing zeros

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -3961,4 +3961,18 @@ mod tests {
             VersionBloatedDebug(self)
         }
     }
+
+    /// This explicitly tests that we preserve trailing zeros in a version
+    /// string. i.e., Both `1.2` and `1.2.0` round-trip, with the former
+    /// lacking a trailing zero and the latter including it.
+    #[test]
+    fn preserve_trailing_zeros() {
+        let v1: Version = "1.2.0".parse().unwrap();
+        assert_eq!(v1.release(), &[1, 2, 0]);
+        assert_eq!(v1.to_string(), "1.2.0");
+
+        let v2: Version = "1.2".parse().unwrap();
+        assert_eq!(v2.release(), &[1, 2]);
+        assert_eq!(v2.to_string(), "1.2");
+    }
 }


### PR DESCRIPTION
Basically, this explicitly checks that parsing a `1.2.0` into a
`Version` will roundtrip back to a `1.2.0`, and that parsing a `1.2`
will roundtrip back to a `1.2`.

I think this case is included in the other tests in this module, but
this test makes the behavior more clearly intentional I think.

Ref #10345
