### PR TITLE
uv-pep440: fix bad merge

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -4000,11 +4000,11 @@ mod tests {
     #[test]
     fn preserve_trailing_zeros() {
         let v1: Version = "1.2.0".parse().unwrap();
-        assert_eq!(v1.release(), &[1, 2, 0]);
+        assert_eq!(&*v1.release(), &[1, 2, 0]);
         assert_eq!(v1.to_string(), "1.2.0");
 
         let v2: Version = "1.2".parse().unwrap();
-        assert_eq!(v2.release(), &[1, 2]);
+        assert_eq!(&*v2.release(), &[1, 2]);
         assert_eq!(v2.to_string(), "1.2");
     }
 }


### PR DESCRIPTION
This happened as a result of #10345 and #10362 being merged
independently. The latter used the old `Version::release` API, but the
former changed the `Version::release` API. This PR tweaks the new test
to use the new API (i.e., force a deref on the proxy type).
