### PR TITLE
Create `main.py` instead of `hello.py` in `uv init`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -803,12 +803,13 @@ impl InitProjectKind {
                 generate_package_scripts(name, path, build_backend, false)?;
             }
         } else {
-            // Create `hello.py` if it doesn't exist
-            // TODO(zanieb): Only create `hello.py` if there are no other Python files?
-            let hello_py = path.join("hello.py");
-            if !hello_py.try_exists()? && !bare {
+            // Create `app.py` if it doesn't exist
+            // (This isn't intended to be a particularly special or magical filename, just nice)
+            // TODO(zanieb): Only create `app.py` if there are no other Python files?
+            let app_py = path.join("app.py");
+            if !app_py.try_exists()? && !bare {
                 fs_err::write(
-                    path.join("hello.py"),
+                    path.join("app.py"),
                     indoc::formatdoc! {r#"
                     def main():
                         print("Hello from {name}!")

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -803,13 +803,13 @@ impl InitProjectKind {
                 generate_package_scripts(name, path, build_backend, false)?;
             }
         } else {
-            // Create `app.py` if it doesn't exist
+            // Create `main.py` if it doesn't exist
             // (This isn't intended to be a particularly special or magical filename, just nice)
-            // TODO(zanieb): Only create `app.py` if there are no other Python files?
-            let app_py = path.join("app.py");
-            if !app_py.try_exists()? && !bare {
+            // TODO(zanieb): Only create `main.py` if there are no other Python files?
+            let main_py = path.join("main.py");
+            if !main_py.try_exists()? && !bare {
                 fs_err::write(
-                    path.join("app.py"),
+                    path.join("main.py"),
                     indoc::formatdoc! {r#"
                     def main():
                         print("Hello from {name}!")

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -120,7 +120,7 @@ fn init_application() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let hello_py = child.join("hello.py");
+    let app_py = child.join("app.py");
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app"), @r###"
     success: true
@@ -148,7 +148,7 @@ fn init_application() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(hello_py)?;
+    let hello = fs_err::read_to_string(app_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -164,7 +164,7 @@ fn init_application() -> Result<()> {
         );
     });
 
-    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("hello.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("app.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -181,7 +181,7 @@ fn init_application() -> Result<()> {
     Ok(())
 }
 
-/// When `hello.py` already exists, we don't create it again
+/// When `app.py` already exists, we don't create it again
 #[test]
 fn init_application_hello_exists() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -190,8 +190,8 @@ fn init_application_hello_exists() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let hello_py = child.child("hello.py");
-    hello_py.touch()?;
+    let app_py = child.child("app.py");
+    app_py.touch()?;
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app"), @r###"
     success: true
@@ -219,7 +219,7 @@ fn init_application_hello_exists() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(hello_py)?;
+    let hello = fs_err::read_to_string(app_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -231,7 +231,7 @@ fn init_application_hello_exists() -> Result<()> {
     Ok(())
 }
 
-/// When other Python files already exists, we still create `hello.py`
+/// When other Python files already exists, we still create `app.py`
 #[test]
 fn init_application_other_python_exists() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -240,7 +240,7 @@ fn init_application_other_python_exists() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let hello_py = child.join("hello.py");
+    let app_py = child.join("app.py");
     let other_py = child.child("foo.py");
     other_py.touch()?;
 
@@ -270,7 +270,7 @@ fn init_application_other_python_exists() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(hello_py)?;
+    let hello = fs_err::read_to_string(app_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -610,15 +610,15 @@ fn init_script() -> Result<()> {
     let child = context.temp_dir.child("foo");
     child.create_dir_all()?;
 
-    let script = child.join("hello.py");
+    let script = child.join("app.py");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--script").arg("hello.py"), @r###"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--script").arg("app.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Initialized script at `hello.py`
+    Initialized script at `app.py`
     "###);
 
     let script = fs_err::read_to_string(&script)?;
@@ -634,7 +634,7 @@ fn init_script() -> Result<()> {
 
 
         def main() -> None:
-            print("Hello from hello.py!")
+            print("Hello from app.py!")
 
 
         if __name__ == "__main__":
@@ -643,11 +643,11 @@ fn init_script() -> Result<()> {
         );
     });
 
-    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("hello.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("app.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Hello from hello.py!
+    Hello from app.py!
 
     ----- stderr -----
     "###);
@@ -1021,7 +1021,7 @@ fn init_application_current_dir() -> Result<()> {
     "###);
 
     let pyproject = fs_err::read_to_string(dir.join("pyproject.toml"))?;
-    let hello_py = fs_err::read_to_string(dir.join("hello.py"))?;
+    let app_py = fs_err::read_to_string(dir.join("app.py"))?;
 
     insta::with_settings!({
         filters => context.filters(),
@@ -1043,7 +1043,7 @@ fn init_application_current_dir() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            hello_py, @r###"
+            app_py, @r###"
         def main():
             print("Hello from foo!")
 

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -120,7 +120,7 @@ fn init_application() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let app_py = child.join("app.py");
+    let main_py = child.join("main.py");
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app"), @r###"
     success: true
@@ -148,7 +148,7 @@ fn init_application() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(app_py)?;
+    let hello = fs_err::read_to_string(main_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -164,7 +164,7 @@ fn init_application() -> Result<()> {
         );
     });
 
-    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("app.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("main.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -181,7 +181,7 @@ fn init_application() -> Result<()> {
     Ok(())
 }
 
-/// When `app.py` already exists, we don't create it again
+/// When `main.py` already exists, we don't create it again
 #[test]
 fn init_application_hello_exists() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -190,8 +190,8 @@ fn init_application_hello_exists() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let app_py = child.child("app.py");
-    app_py.touch()?;
+    let main_py = child.child("main.py");
+    main_py.touch()?;
 
     uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--app"), @r###"
     success: true
@@ -219,7 +219,7 @@ fn init_application_hello_exists() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(app_py)?;
+    let hello = fs_err::read_to_string(main_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -231,7 +231,7 @@ fn init_application_hello_exists() -> Result<()> {
     Ok(())
 }
 
-/// When other Python files already exists, we still create `app.py`
+/// When other Python files already exists, we still create `main.py`
 #[test]
 fn init_application_other_python_exists() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -240,7 +240,7 @@ fn init_application_other_python_exists() -> Result<()> {
     child.create_dir_all()?;
 
     let pyproject_toml = child.join("pyproject.toml");
-    let app_py = child.join("app.py");
+    let main_py = child.join("main.py");
     let other_py = child.child("foo.py");
     other_py.touch()?;
 
@@ -270,7 +270,7 @@ fn init_application_other_python_exists() -> Result<()> {
         );
     });
 
-    let hello = fs_err::read_to_string(app_py)?;
+    let hello = fs_err::read_to_string(main_py)?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -610,15 +610,15 @@ fn init_script() -> Result<()> {
     let child = context.temp_dir.child("foo");
     child.create_dir_all()?;
 
-    let script = child.join("app.py");
+    let script = child.join("main.py");
 
-    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--script").arg("app.py"), @r###"
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--script").arg("main.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Initialized script at `app.py`
+    Initialized script at `main.py`
     "###);
 
     let script = fs_err::read_to_string(&script)?;
@@ -634,7 +634,7 @@ fn init_script() -> Result<()> {
 
 
         def main() -> None:
-            print("Hello from app.py!")
+            print("Hello from main.py!")
 
 
         if __name__ == "__main__":
@@ -643,11 +643,11 @@ fn init_script() -> Result<()> {
         );
     });
 
-    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("app.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("python").arg("main.py"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Hello from app.py!
+    Hello from main.py!
 
     ----- stderr -----
     "###);
@@ -1021,7 +1021,7 @@ fn init_application_current_dir() -> Result<()> {
     "###);
 
     let pyproject = fs_err::read_to_string(dir.join("pyproject.toml"))?;
-    let app_py = fs_err::read_to_string(dir.join("app.py"))?;
+    let main_py = fs_err::read_to_string(dir.join("main.py"))?;
 
     insta::with_settings!({
         filters => context.filters(),
@@ -1043,7 +1043,7 @@ fn init_application_current_dir() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            app_py, @r###"
+            main_py, @r###"
         def main():
             print("Hello from foo!")
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -22,7 +22,7 @@ Applications are the default target for `uv init`, but can also be specified wit
 $ uv init example-app
 ```
 
-The project includes a `pyproject.toml`, a sample file (`hello.py`), a readme, and a Python version
+The project includes a `pyproject.toml`, a sample file (`app.py`), a readme, and a Python version
 pin file (`.python-version`).
 
 ```console
@@ -30,7 +30,7 @@ $ tree example-app
 example-app
 ├── .python-version
 ├── README.md
-├── hello.py
+├── app.py
 └── pyproject.toml
 ```
 
@@ -49,7 +49,7 @@ dependencies = []
 
 The sample file defines a `main` function with some standard boilerplate:
 
-```python title="hello.py"
+```python title="app.py"
 def main():
     print("Hello from example-app!")
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 Python files can be executed with `uv run`:
 
 ```console
-$ uv run hello.py
+$ uv run app.py
 Hello from example-project!
 ```
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -22,7 +22,7 @@ Applications are the default target for `uv init`, but can also be specified wit
 $ uv init example-app
 ```
 
-The project includes a `pyproject.toml`, a sample file (`app.py`), a readme, and a Python version
+The project includes a `pyproject.toml`, a sample file (`main.py`), a readme, and a Python version
 pin file (`.python-version`).
 
 ```console
@@ -30,7 +30,7 @@ $ tree example-app
 example-app
 ├── .python-version
 ├── README.md
-├── app.py
+├── main.py
 └── pyproject.toml
 ```
 
@@ -49,7 +49,7 @@ dependencies = []
 
 The sample file defines a `main` function with some standard boilerplate:
 
-```python title="app.py"
+```python title="main.py"
 def main():
     print("Hello from example-app!")
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 Python files can be executed with `uv run`:
 
 ```console
-$ uv run app.py
+$ uv run main.py
 Hello from example-project!
 ```
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -32,14 +32,14 @@ uv will create the following files:
 .
 ├── .python-version
 ├── README.md
-├── app.py
+├── main.py
 └── pyproject.toml
 ```
 
-The `app.py` file contains a simple "Hello world" program. Try it out with `uv run`:
+The `main.py` file contains a simple "Hello world" program. Try it out with `uv run`:
 
 ```console
-$ uv run app.py
+$ uv run main.py
 Hello from hello-world!
 ```
 
@@ -60,7 +60,7 @@ A complete listing would look like:
 │   └── pyvenv.cfg
 ├── .python-version
 ├── README.md
-├── app.py
+├── main.py
 ├── pyproject.toml
 └── uv.lock
 ```

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -32,14 +32,14 @@ uv will create the following files:
 .
 ├── .python-version
 ├── README.md
-├── hello.py
+├── app.py
 └── pyproject.toml
 ```
 
-The `hello.py` file contains a simple "Hello world" program. Try it out with `uv run`:
+The `app.py` file contains a simple "Hello world" program. Try it out with `uv run`:
 
 ```console
-$ uv run hello.py
+$ uv run app.py
 Hello from hello-world!
 ```
 
@@ -60,7 +60,7 @@ A complete listing would look like:
 │   └── pyvenv.cfg
 ├── .python-version
 ├── README.md
-├── hello.py
+├── app.py
 ├── pyproject.toml
 └── uv.lock
 ```


### PR DESCRIPTION
Initially it seemed like `app.py` might be slightly more desirable but people seem to overwhelmingly favour `main.py` as a good "generic" name.

Fixes #7782
