### PR TITLE
Re-enable zlib-ng on all platforms (except s390x, PowerPC, and FreeBSD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.16"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
+checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.21"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
+checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
 dependencies = [
  "cmake",
  "libc",
@@ -5282,6 +5282,7 @@ name = "uv-performance-flate2-backend"
 version = "0.1.0"
 dependencies = [
  "flate2",
+ "libz-ng-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5282,7 +5282,6 @@ name = "uv-performance-flate2-backend"
 version = "0.1.0"
 dependencies = [
  "flate2",
- "libz-ng-sys",
 ]
 
 [[package]]

--- a/crates/uv-performance-flate2-backend/Cargo.lock
+++ b/crates/uv-performance-flate2-backend/Cargo.lock
@@ -9,10 +9,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "cc"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -30,8 +48,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "libz-rs-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]
@@ -51,6 +86,12 @@ checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "uv-performance-flate2-backend"

--- a/crates/uv-performance-flate2-backend/Cargo.lock
+++ b/crates/uv-performance-flate2-backend/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.21"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
+checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
 dependencies = [
  "cmake",
  "libc",
@@ -98,6 +98,7 @@ name = "uv-performance-flate2-backend"
 version = "0.1.0"
 dependencies = [
  "flate2",
+ "libz-ng-sys",
 ]
 
 [[package]]

--- a/crates/uv-performance-flate2-backend/Cargo.toml
+++ b/crates/uv-performance-flate2-backend/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 [lib]
 doctest = false
 
-# Use `zlib-rs` everywhere else.
-[target.'cfg(any(target_os = "freebsd"))'.dependencies]
-flate2 = { version = "1.0.28", default-features = false, features = ["zlib-rs"] }
-
 # Use `zlib-ng` on all supported platforms.
-[target.'cfg(not(any(target_os = "freebsd")))'.dependencies]
+[target.'cfg(not(any(target_arch = "s390x", target_arch = "powerpc64", target_os = "freebsd")))'.dependencies]
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib-ng"] }
+# See: https://github.com/rust-lang/libz-sys/issues/225
+libz-ng-sys = { version = "<1.1.20" }
+
+# Use `zlib-rs` everywhere else.
+[target.'cfg(any(target_arch = "s390x", target_arch = "powerpc64", target_os = "freebsd"))'.dependencies]
+flate2 = { version = "1.0.28", default-features = false, features = ["zlib-rs"] }

--- a/crates/uv-performance-flate2-backend/Cargo.toml
+++ b/crates/uv-performance-flate2-backend/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2021"
 [lib]
 doctest = false
 
-# Use `zlib-ng` on x86_64 targets, apart from FreeBSD.
-[target.'cfg(all(target_arch = "x86_64", not(target_os = "freebsd")))'.dependencies]
-flate2 = { version = "1.0.28", default-features = false, features = ["zlib-ng"] }
-# See: https://github.com/rust-lang/libz-sys/issues/225
-libz-ng-sys = { version = "<1.1.20" }
-
 # Use `zlib-rs` everywhere else.
-[target.'cfg(not(all(target_arch = "x86_64", not(target_os = "freebsd"))))'.dependencies]
+[target.'cfg(any(target_os = "freebsd"))'.dependencies]
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib-rs"] }
+
+# Use `zlib-ng` on all supported platforms.
+[target.'cfg(not(any(target_os = "freebsd")))'.dependencies]
+flate2 = { version = "1.0.28", default-features = false, features = ["zlib-ng"] }


### PR DESCRIPTION
PowerPC seems to build without errors if we upgrade `zlib-ng`, but upgrading `zlib-ng` causes Windows to break (https://github.com/rust-lang/libz-sys/issues/225), and Cargo doesn't let us include two different versions.

s390x fails because it can't find `stfle`. It's possible that we could fix this by by upgrading our manylinux version and/or by upgrading GCC (which may necessitate upgrading our manylinux version), but I don't know if it's fixable without one of those things? And it's not worth bumping compatibility for that reason. \cc @konstin 