### PR TITLE
Fix ruff linting warnings from generated template files for extension modules

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1055,12 +1055,14 @@ fn generate_package_scripts(
         indoc::formatdoc! {r#"
         from {module_name}._core import hello_from_bin
 
+
         def hello() -> str:
             return hello_from_bin()
         "#}
     } else {
         indoc::formatdoc! {r#"
         from {module_name}._core import hello_from_bin
+
 
         def main() -> None:
             print(hello_from_bin())

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1069,8 +1069,6 @@ fn generate_package_scripts(
 
     // .pyi file for binary script
     let pyi_contents = indoc::indoc! {r"
-        from __future__ import annotations
-
         def hello_from_bin() -> str: ...
     "};
 

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2776,8 +2776,6 @@ fn init_app_build_backend_maturin() -> Result<()> {
     }, {
         assert_snapshot!(
             pyi_contents, @r###"
-        from __future__ import annotations
-
         def hello_from_bin() -> str: ...
         "###
         );
@@ -2906,8 +2904,6 @@ fn init_app_build_backend_scikit() -> Result<()> {
     }, {
         assert_snapshot!(
             pyi_contents, @r###"
-        from __future__ import annotations
-
         def hello_from_bin() -> str: ...
         "###
         );
@@ -3029,8 +3025,6 @@ fn init_lib_build_backend_maturin() -> Result<()> {
     }, {
         assert_snapshot!(
             pyi_contents, @r###"
-        from __future__ import annotations
-
         def hello_from_bin() -> str: ...
         "###
         );
@@ -3156,8 +3150,6 @@ fn init_lib_build_backend_scikit() -> Result<()> {
     }, {
         assert_snapshot!(
             pyi_contents, @r###"
-        from __future__ import annotations
-
         def hello_from_bin() -> str: ...
         "###
         );

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2764,6 +2764,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
             init, @r###"
         from foo._core import hello_from_bin
 
+
         def main() -> None:
             print(hello_from_bin())
         "###
@@ -2892,6 +2893,7 @@ fn init_app_build_backend_scikit() -> Result<()> {
             init, @r###"
         from foo._core import hello_from_bin
 
+
         def main() -> None:
             print(hello_from_bin())
         "###
@@ -3012,6 +3014,7 @@ fn init_lib_build_backend_maturin() -> Result<()> {
         assert_snapshot!(
             init, @r###"
         from foo._core import hello_from_bin
+
 
         def hello() -> str:
             return hello_from_bin()
@@ -3137,6 +3140,7 @@ fn init_lib_build_backend_scikit() -> Result<()> {
         assert_snapshot!(
             init, @r###"
         from foo._core import hello_from_bin
+
 
         def hello() -> str:
             return hello_from_bin()

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -279,6 +279,7 @@ And the Python module imports it:
 ```python title="src/example_ext/__init__.py"
 from example_ext._core import hello_from_bin
 
+
 def main() -> None:
     print(hello_from_bin())
 ```


### PR DESCRIPTION
## Summary

This PR fixes two ruff linting issues in the generated template files when using: `uv init --build-backend` for extension modules.

1. Removes unnecessary `from __future__ import annotations` imports from generated .pyi files ([PYI044](https://docs.astral.sh/ruff/rules/future-annotations-in-stub/))
2. Adds missing blank line after `hello_from_bin` import to comply with isort formatting ([I001](https://docs.astral.sh/ruff/rules/unsorted-imports/))

## Test Plan

```bash
cargo run -- init --build-backend scikit-build-core example-ext
uvx ruff check example-ext --select ALL

cargo run -- init --build-backend maturin example-ext
uvx ruff check example-ext --select ALL
```

## Remaining warnings

There are still warnings remainings in the generated `__init__.py` files:
- [D104](https://docs.astral.sh/ruff/rules/undocumented-public-package/) Missing docstring in public package
- [D103](https://docs.astral.sh/ruff/rules/undocumented-public-function/) Missing docstring in public function
- [T201](https://docs.astral.sh/ruff/rules/print/) `print` found