### PR TITLE
Upgrade zlib-ng

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,2 @@
 [alias]
 dev = "run --package uv-dev --features dev"
-
-# statically link the C runtime so the executable does not depend on
-# that shared/dynamic library.
-#
-# See: https://github.com/astral-sh/ruff/issues/11503
-[target.'cfg(all(target_env = "msvc", target_os = "windows"))']
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.16"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
+checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
 dependencies = [
  "cmake",
  "libc",
@@ -5282,7 +5282,6 @@ name = "uv-performance-flate2-backend"
 version = "0.1.0"
 dependencies = [
  "flate2",
- "libz-ng-sys",
 ]
 
 [[package]]

--- a/crates/uv-performance-flate2-backend/Cargo.lock
+++ b/crates/uv-performance-flate2-backend/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.16"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
+checksum = "7cee1488e961a80d172564fd6fcda11d8a4ac6672c06fe008e9213fa60520c2b"
 dependencies = [
  "cmake",
  "libc",
@@ -98,7 +98,6 @@ name = "uv-performance-flate2-backend"
 version = "0.1.0"
 dependencies = [
  "flate2",
- "libz-ng-sys",
 ]
 
 [[package]]

--- a/crates/uv-performance-flate2-backend/Cargo.toml
+++ b/crates/uv-performance-flate2-backend/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2021"
 doctest = false
 
 # Use `zlib-ng` on all supported platforms.
-[target.'cfg(not(any(target_arch = "s390x", target_arch = "powerpc64", target_os = "freebsd")))'.dependencies]
+[target.'cfg(not(any(target_arch = "s390x", target_os = "freebsd")))'.dependencies]
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib-ng"] }
-# See: https://github.com/rust-lang/libz-sys/issues/225
-libz-ng-sys = { version = "<1.1.20" }
 
 # Use `zlib-rs` everywhere else.
-[target.'cfg(any(target_arch = "s390x", target_arch = "powerpc64", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_arch = "s390x", target_os = "freebsd"))'.dependencies]
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib-rs"] }


### PR DESCRIPTION
## Summary

If we remove this static linking, we can upgrade `zlib-ng`, which in turn lets us enable it on PowerPC.