### PR TITLE
Force a niche into `VersionSmall`

### DIFF
--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1343,10 +1343,10 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 352, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 352, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 344, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 344, "{}", size_of::<BuiltDist>());
         assert!(
-            size_of::<SourceDist>() <= 264,
+            size_of::<SourceDist>() <= 256,
             "{}",
             size_of::<SourceDist>()
         );

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1343,10 +1343,10 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 344, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 344, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 352, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 352, "{}", size_of::<BuiltDist>());
         assert!(
-            size_of::<SourceDist>() <= 256,
+            size_of::<SourceDist>() <= 264,
             "{}",
             size_of::<SourceDist>()
         );


### PR DESCRIPTION
Force a niche into the aligned type so the [`Version`] enum is two words instead of three (x86_64). Rustc currently fails to optimize this on its own.