### PR TITLE
Shrink `Dist` from 352 to 288 bytes

### DIFF
--- a/crates/uv-client/tests/it/remote_metadata.rs
+++ b/crates/uv-client/tests/it/remote_metadata.rs
@@ -21,7 +21,7 @@ async fn remote_metadata_with_and_without_cache() -> Result<()> {
         let filename = WheelFilename::from_str(url.rsplit_once('/').unwrap().1)?;
         let dist = BuiltDist::DirectUrl(DirectUrlBuiltDist {
             filename,
-            location: Url::parse(url).unwrap(),
+            location: Box::new(Url::parse(url).unwrap()),
             url: VerbatimUrl::from_str(url).unwrap(),
         });
         let capabilities = IndexCapabilities::default();

--- a/crates/uv-dev/src/wheel_metadata.rs
+++ b/crates/uv-dev/src/wheel_metadata.rs
@@ -33,7 +33,7 @@ pub(crate) async fn wheel_metadata(args: WheelMetadataArgs) -> Result<()> {
         .wheel_metadata(
             &BuiltDist::DirectUrl(DirectUrlBuiltDist {
                 filename,
-                location: archive.url,
+                location: Box::new(archive.url),
                 url: args.url,
             }),
             &capabilities,

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -250,7 +250,7 @@ pub struct DirectUrlBuiltDist {
     /// `https://example.org/packages/flask-3.0.0-py3-none-any.whl`
     pub filename: WheelFilename,
     /// The URL without the subdirectory fragment.
-    pub location: Url,
+    pub location: Box<Url>,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,
 }
@@ -363,7 +363,7 @@ impl Dist {
 
                 Ok(Self::Built(BuiltDist::DirectUrl(DirectUrlBuiltDist {
                     filename,
-                    location,
+                    location: Box::new(location),
                     url,
                 })))
             }
@@ -1343,8 +1343,8 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 352, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 352, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 288, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 288, "{}", size_of::<BuiltDist>());
         assert!(
             size_of::<SourceDist>() <= 264,
             "{}",

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1343,10 +1343,10 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 352, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 352, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 344, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 344, "{}", size_of::<BuiltDist>());
         assert!(
-            size_of::<SourceDist>() <= 264,
+            size_of::<SourceDist>() <= 256,
             "{}",
             size_of::<SourceDist>()
         );

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1343,10 +1343,10 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 344, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 344, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 352, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 352, "{}", size_of::<BuiltDist>());
         assert!(
-            size_of::<SourceDist>() <= 256,
+            size_of::<SourceDist>() <= 264,
             "{}",
             size_of::<SourceDist>()
         );

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1820,7 +1820,7 @@ impl Package {
                         });
                         let direct_dist = DirectUrlBuiltDist {
                             filename,
-                            location: url.clone(),
+                            location: Box::new(url.clone()),
                             url: VerbatimUrl::from_url(url),
                         };
                         let built_dist = BuiltDist::DirectUrl(direct_dist);


### PR DESCRIPTION
Found this when looking at #10385. Since we're constructing a lot of `Dist`s, we should keep it small.