### PR TITLE
Avoid Docker rate limits by logging into DockerHub

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           submodules: recursive
 
+      # Login to DockerHub first, to avoid rate-limiting
+      - uses: docker/login-action@v3
+        with:
+          username: astralshbot
+          password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -108,6 +114,12 @@ jobs:
       - docker-build
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
     steps:
+      # Login to DockerHub first, to avoid rate-limiting
+      - uses: docker/login-action@v3
+        with:
+          username: astralshbot
+          password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -180,6 +192,12 @@ jobs:
           - python:3.9-slim-bookworm,python3.9-bookworm-slim
           - python:3.8-slim-bookworm,python3.8-bookworm-slim
     steps:
+      # Login to DockerHub first, to avoid rate-limiting
+      - uses: docker/login-action@v3
+        with:
+          username: astralshbot
+          password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -266,6 +284,12 @@ jobs:
       - docker-publish-extra
     if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
     steps:
+      # Login to DockerHub first, to avoid rate-limiting
+      - uses: docker/login-action@v3
+        with:
+          username: astralshbot
+          password: ${{ secrets.DOCKERHUB_TOKEN_RO }}
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The latest release flaked failing to fetch the buildx image, which is reportedly due to rate limits. Last I checked, DockerHub enforces much stricter limits on unauthenticated requests. I added a bot account and a corresponding read-only token.