### PR TITLE
Ignore target in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,7 @@
-.venv
+.venv/
+debug/
+target/
+target-alpine/
 CHANGELOG.md
 PREVIEW-CHANGELOG.md
 docs/reference/cli.md


### PR DESCRIPTION
The [Prettier docs](https://prettier.io/docs/en/ignore.html) say that it should respect `.gitignore`, but in my experience it's... not? So `npx prettier --prose-wrap always --write "**/*.md"` keeps reformatting a bunch of files in `target`, slowing things down.