### PR TITLE
Add remaining Python type annotations to build backend

### DIFF
--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -17,7 +17,7 @@ them while IDEs and type checker can see through the quotes.
 """
 
 
-def warn_config_settings(config_settings: "dict | None" = None):
+def warn_config_settings(config_settings: "dict | None" = None) -> None:
     import sys
 
     if config_settings:
@@ -49,7 +49,7 @@ def call(args: "list[str]", config_settings: "dict | None" = None) -> str:
     return stdout[-1].strip()
 
 
-def build_sdist(sdist_directory: str, config_settings: "dict | None" = None):
+def build_sdist(sdist_directory: str, config_settings: "dict | None" = None) -> str:
     """PEP 517 hook `build_sdist`."""
     args = ["build-backend", "build-sdist", sdist_directory]
     return call(args, config_settings)
@@ -67,13 +67,13 @@ def build_wheel(
     return call(args, config_settings)
 
 
-def get_requires_for_build_sdist(config_settings: "dict | None" = None):
+def get_requires_for_build_sdist(config_settings: "dict | None" = None) -> "list[str]":
     """PEP 517 hook `get_requires_for_build_sdist`."""
     warn_config_settings(config_settings)
     return []
 
 
-def get_requires_for_build_wheel(config_settings: "dict | None" = None):
+def get_requires_for_build_wheel(config_settings: "dict | None" = None) -> "list[str]":
     """PEP 517 hook `get_requires_for_build_wheel`."""
     warn_config_settings(config_settings)
     return []
@@ -81,7 +81,7 @@ def get_requires_for_build_wheel(config_settings: "dict | None" = None):
 
 def prepare_metadata_for_build_wheel(
     metadata_directory: str, config_settings: "dict | None" = None
-):
+) -> str:
     """PEP 517 hook `prepare_metadata_for_build_wheel`."""
     args = ["build-backend", "prepare-metadata-for-build-wheel", metadata_directory]
     return call(args, config_settings)
@@ -91,7 +91,7 @@ def build_editable(
     wheel_directory: str,
     config_settings: "dict | None" = None,
     metadata_directory: "str | None" = None,
-):
+) -> str:
     """PEP 660 hook `build_editable`."""
     args = ["build-backend", "build-editable", wheel_directory]
     if metadata_directory:
@@ -99,7 +99,9 @@ def build_editable(
     return call(args, config_settings)
 
 
-def get_requires_for_build_editable(config_settings: "dict | None" = None):
+def get_requires_for_build_editable(
+    config_settings: "dict | None" = None,
+) -> "list[str]":
     """PEP 660 hook `get_requires_for_build_editable`."""
     warn_config_settings(config_settings)
     return []
@@ -107,7 +109,7 @@ def get_requires_for_build_editable(config_settings: "dict | None" = None):
 
 def prepare_metadata_for_build_editable(
     metadata_directory: str, config_settings: "dict | None" = None
-):
+) -> str:
     """PEP 660 hook `prepare_metadata_for_build_editable`."""
     args = ["build-backend", "prepare-metadata-for-build-editable", metadata_directory]
     return call(args, config_settings)

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -59,7 +59,7 @@ def build_wheel(
     wheel_directory: str,
     config_settings: "dict | None" = None,
     metadata_directory: "str | None" = None,
-):
+) -> str:
     """PEP 517 hook `build_wheel`."""
     args = ["build-backend", "build-wheel", wheel_directory]
     if metadata_directory:


### PR DESCRIPTION
## Summary

This PR add remaining Python type annotations to build backend, specifically in `python/uv/_build_backend.py`.

## Test Plan

- [x] Running `ruff check --select ANN python/` checks that annotations are available everywhere.<br><br>Adding this into `ruff.toml` would cause all of the scripts to get checked, which I could update if requested, but currently is out of scope.
- [x] Running `uvx mypy python/` checks that there are no conflicts.
- [ ] Running `uvx mypy --strict python/` gives the following:

  ```
  python/uv/_build_backend.py:20: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:27: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:52: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:58: error: Function is missing a return type annotation  [no-untyped-def]
  python/uv/_build_backend.py:60: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:70: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:76: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:83: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:92: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:103: error: Missing type parameters for generic type "dict"  [type-arg]
  python/uv/_build_backend.py:111: error: Missing type parameters for generic type "dict"  [type-arg]
  Found 11 errors in 1 file (checked 4 source files)
  ```
  
  
  I.e., it would like the `dict` annotations to be more specific. However, https://peps.python.org/pep-0517/#config-settings does not make it clear if there's a requirement here for what the key/value pairs are. It does suggest that they **SHOULD** be strings.

