### PR TITLE
Use faster disjointness check for markers

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -1412,8 +1412,7 @@ impl Edges {
         // not the resulting edges.
         for (left_range, left_child) in left_edges {
             for (right_range, right_child) in right_edges {
-                let intersection = right_range.intersection(left_range);
-                if intersection.is_empty() {
+                if right_range.is_disjoint(left_range) {
                     continue;
                 }
 


### PR DESCRIPTION
Motivated by #10438. Ideally we wouldn't be calling this code that much in the first place, but it's the more idiomatic way to write this code.

Crude-ish benchmark based on #10438 with the `without_markers` patched out:

```
hyperfine --warmup 1 "./uv-1 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8" "./uv-2 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8"
Benchmark 1: ./uv-1 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8
  Time (mean ± σ):      1.229 s ±  0.018 s    [User: 1.206 s, System: 0.111 s]
  Range (min … max):    1.211 s …  1.269 s    10 runs

Benchmark 2: ./uv-2 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8
  Time (mean ± σ):     873.8 ms ±   5.1 ms    [User: 851.2 ms, System: 112.5 ms]
  Range (min … max):   865.2 ms … 880.4 ms    10 runs

Summary
  ./uv-2 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8 ran
    1.41 ± 0.02 times faster than ./uv-1 pip compile scripts/requirements/airflow2-req.in -c scripts/requirements/airflow2-constraints.txt --universal --python-version 3.8
```