### PR TITLE
replace backoff with backon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,16 +295,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
 dependencies = [
- "futures-core",
- "getrandom",
- "instant",
- "pin-project-lite",
- "rand",
+ "fastrand",
+ "gloo-timers",
  "tokio",
 ]
 
@@ -1370,6 +1367,18 @@ dependencies = [
  "bitflags 2.6.0",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5055,7 +5064,7 @@ dependencies = [
 name = "uv-fs"
 version = "0.0.1"
 dependencies = [
- "backoff",
+ "backon",
  "cachedir",
  "dunce",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.9.1" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
 axoupdater = { version = "0.9.0", default-features = false }
-backoff = { version = "0.4.0" }
+backon = { version = "1.3.0" }
 base64 = { version = "0.22.1" }
 bitflags = { version = "2.6.0" }
 boxcar = { version = "0.2.5" }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -38,9 +38,9 @@ winsafe = { workspace = true }
 rustix = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-backoff = { workspace = true }
+backon = { workspace = true }
 junction = { workspace = true }
 
 [features]
 default = []
-tokio = ["dep:tokio", "fs-err/tokio", "backoff/tokio"]
+tokio = ["dep:tokio", "fs-err/tokio"]


### PR DESCRIPTION
This should be essentially the exact same behaviour, but backon is a total API redesign, so things had to be expressed slightly differently. Overall I think the code is more readable, which is nice.

Fixes #10001 