### PR TITLE
Allow reading `--with-requirements` from stdin in `uv add` and `uv run`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -98,11 +98,6 @@ pub(crate) async fn add(
             RequirementsSource::SetupCfg(_) => {
                 bail!("Adding requirements from a `setup.cfg` is not supported in `uv add`");
             }
-            RequirementsSource::RequirementsTxt(path) => {
-                if path == Path::new("-") {
-                    bail!("Reading requirements from stdin is not supported in `uv add`");
-                }
-            }
             _ => {}
         }
     }

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_types)]
+
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -4610,6 +4612,17 @@ fn add_requirements_file() -> Result<()> {
         "###
         );
     });
+
+    // Passing stdin should succeed
+    uv_snapshot!(context.filters(), context.add().arg("-r").arg("-").stdin(std::fs::File::open(requirements_txt)?), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Audited [N] packages in [TIME]
+    "###);
 
     // Passing a `setup.py` should fail.
     uv_snapshot!(context.filters(), context.add().arg("-r").arg("setup.py"), @r###"


### PR DESCRIPTION
For some reason this was banned when originally added (I did not see discussion about it). I think it's fine to allow. With `uv run`, there's a bit of nuance because we also allow the script to be read from stdin.