### PR TITLE
feature(python list): added --format param to uv python list

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -35,6 +35,15 @@ pub enum VersionFormat {
     Json,
 }
 
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+pub enum PythonListFormat {
+    /// Display the version as plain text.
+    #[default]
+    Text,
+    /// Display the version as JSON.
+    Json,
+}
+
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum ListFormat {
     /// Display the list of packages in a human-readable table.
@@ -4288,6 +4297,10 @@ pub struct PythonListArgs {
     /// By default, these display as `<download available>`.
     #[arg(long)]
     pub show_urls: bool,
+
+    /// Select the output format between: `text` (default)  or `json`.
+    #[arg(long, value_enum, default_value_t = PythonListFormat::default())]
+    pub format: PythonListFormat,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4298,7 +4298,7 @@ pub struct PythonListArgs {
     #[arg(long)]
     pub show_urls: bool,
 
-    /// Select the output format between: `text` (default)  or `json`.
+    /// Select the output format between: `text` (default) or `json`.
     #[arg(long, value_enum, default_value_t = PythonListFormat::default())]
     pub format: PythonListFormat,
 }

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -217,19 +217,17 @@ pub(crate) async fn list(
                             ..Default::default()
                         };
                     }
-                    Either::Right(url) => {
-                        return PrintData {
-                            key: key.to_string(),
-                            version: key.version().to_string(),
-                            url: Some(url.to_string()),
-                            arch: key.arch().to_string(),
-                            implementation: key.implementation().to_string(),
-                            os: key.os().to_string(),
-                            variant: key.variant().to_string(),
-                            libc: key.libc().to_string(),
-                            ..Default::default()
-                        };
-                    }
+                    Either::Right(url) => PrintData {
+                        key: key.to_string(),
+                        version: key.version().to_string(),
+                        url: Some((*url).to_string()),
+                        arch: key.arch().to_string(),
+                        implementation: key.implementation().to_string(),
+                        os: key.os().to_string(),
+                        variant: key.variant().to_string(),
+                        libc: key.libc().to_string(),
+                        ..Default::default()
+                    },
                 })
                 .collect();
             writeln!(printer.stdout(), "{}", serde_json::to_string(&data)?)?;

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1114,6 +1114,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.all_platforms,
                 args.all_arches,
                 args.show_urls,
+                args.format,
                 globals.python_preference,
                 globals.python_downloads,
                 &cache,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -16,8 +16,8 @@ use uv_cli::{
     AddArgs, ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe,
     PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
     PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
-    PythonPinArgs, PythonUninstallArgs, RemoveArgs, RunArgs, SyncArgs, ToolDirArgs,
-    ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs,
+    PythonListFormat, PythonPinArgs, PythonUninstallArgs, RemoveArgs, RunArgs, SyncArgs,
+    ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs,
 };
 use uv_client::Connectivity;
 use uv_configuration::{
@@ -737,6 +737,7 @@ pub(crate) struct PythonListSettings {
     pub(crate) all_arches: bool,
     pub(crate) all_versions: bool,
     pub(crate) show_urls: bool,
+    pub(crate) format: PythonListFormat,
 }
 
 impl PythonListSettings {
@@ -750,6 +751,7 @@ impl PythonListSettings {
             only_installed,
             only_downloads,
             show_urls,
+            format,
         } = args;
 
         let kinds = if only_installed {
@@ -766,6 +768,7 @@ impl PythonListSettings {
             all_arches,
             all_versions,
             show_urls,
+            format,
         }
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4571,6 +4571,16 @@ uv python list [OPTIONS]
 
 <p>See <code>--project</code> to only change the project root directory.</p>
 
+</dd><dt><code>--format</code> <i>format</i></dt><dd><p>Select the output format between: <code>text</code> (default) or <code>json</code></p>
+
+<p>[default: text]</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>text</code>:  Display the version as plain text</li>
+
+<li><code>json</code>:  Display the version as JSON</li>
+</ul>
 </dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
 </dd><dt><code>--native-tls</code></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I use `uv` for automation on remote hosts and it would be useful to have it be able to tell me the supported versions of python (for the remote machine) in a machine readable manner so I do not need to parse `uv python list`.

This change adds `--format (json|text)` to `uv python list` to make it's output machine readable

Loosely related:

- https://github.com/astral-sh/uv/issues/411

## Test Plan

Manually tested via

```
# quick inspection without pretty print
cargo run -- python list --format json
```

### Short example of output (trimmed down)

Cmd: `cargo run -- python list --format json | jq '.[:2]'`

```json
[
  {
    "key": "cpython-3.13.1+freethreaded-linux-x86_64-gnu",
    "version": "3.13.1",
    "version_parts": {
      "major": 3,
      "minor": 13,
      "patch": 1
    },
    "path": null,
    "symlink": null,
    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241219/cpython-3.13.1%2B20241219-x86_64-unknown-linux-gnu-freethreaded%2Bpgo%2Blto-full.tar.zst",
    "os": "linux",
    "variant": "freethreaded",
    "implementation": "cpython",
    "arch": "x86_64",
    "libc": "gnu"
  },
  {
    "key": "cpython-3.13.1-linux-x86_64-gnu",
    "version": "3.13.1",
    "version_parts": {
      "major": 3,
      "minor": 13,
      "patch": 1
    },
    "path": "/usr/bin/python3.13",
    "symlink": null,
    "url": null,
    "os": "linux",
    "variant": "default",
    "implementation": "cpython",
    "arch": "x86_64",
    "libc": "gnu"
  }
]
```
