### PR TITLE
Fix `UV_FIND_LINKS` delimiter to split on commas

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4593,6 +4593,7 @@ pub struct IndexArgs {
         long,
         short,
         env = EnvVars::UV_FIND_LINKS,
+        value_delimiter = ',',
         value_parser = parse_find_links,
         help_heading = "Index options"
     )]


### PR DESCRIPTION
#8061 incorrectly claims to change the delimiter for `UV_FIND_LINKS` from spaces to commas. In reality, it prevents `UV_FIND_LINKS` from being split. This commit fixes that.