### PR TITLE
Revert "improve shell compatibility of venv activate scripts (#10397)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
           version: ${{ env.SHELLCHECK_VERSION }}
           severity: style
           check_together: "yes"
-          additional_files: activate
 
   cargo-clippy:
     timeout-minutes: 10

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -31,12 +31,9 @@ if [ -n "${BASH_VERSION:+x}" ] ; then
         exit 33
     fi
 elif [ -n "${ZSH_VERSION:+x}" ] ; then
-    # we use eval in these paths to "hide" the fact that these branches
-    # genuinely don't work when run in the wrong shell. Any shell or
-    # linter that eagerly checks them would be right to complain!
-    eval 'SCRIPT_PATH="${(%):-%x}"'
+    SCRIPT_PATH="${(%):-%x}"
 elif [ -n "${KSH_VERSION:+x}" ] ; then
-    eval 'SCRIPT_PATH="${.sh.file}"'
+    SCRIPT_PATH="${.sh.file}"
 fi
 
 deactivate () {
@@ -44,12 +41,12 @@ deactivate () {
 
     # reset old environment variables
     # ! [ -z ${VAR+_} ] returns true if VAR is declared at all
-    if [ -n "${_OLD_VIRTUAL_PATH:+_}" ] ; then
+    if ! [ -z "${_OLD_VIRTUAL_PATH:+_}" ] ; then
         PATH="$_OLD_VIRTUAL_PATH"
         export PATH
         unset _OLD_VIRTUAL_PATH
     fi
-    if [ -n "${_OLD_VIRTUAL_PYTHONHOME+_}" ] ; then
+    if ! [ -z "${_OLD_VIRTUAL_PYTHONHOME+_}" ] ; then
         PYTHONHOME="$_OLD_VIRTUAL_PYTHONHOME"
         export PYTHONHOME
         unset _OLD_VIRTUAL_PYTHONHOME
@@ -60,7 +57,7 @@ deactivate () {
     # we made may not be respected
     hash -r 2>/dev/null
 
-    if [ -n "${_OLD_VIRTUAL_PS1+_}" ] ; then
+    if ! [ -z "${_OLD_VIRTUAL_PS1+_}" ] ; then
         PS1="$_OLD_VIRTUAL_PS1"
         export PS1
         unset _OLD_VIRTUAL_PS1
@@ -78,7 +75,7 @@ deactivate () {
 deactivate nondestructive
 
 VIRTUAL_ENV='{{ VIRTUAL_ENV_DIR }}'
-if { [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]; } && command -v cygpath &> /dev/null ; then
+if ([ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]) && $(command -v cygpath &> /dev/null) ; then
     VIRTUAL_ENV=$(cygpath -u "$VIRTUAL_ENV")
 fi
 export VIRTUAL_ENV
@@ -87,8 +84,6 @@ _OLD_VIRTUAL_PATH="$PATH"
 PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
-# this file is templated, so the constant comparison here actually varies
-# shellcheck disable=SC2050
 if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
     VIRTUAL_ENV_PROMPT="({{ VIRTUAL_PROMPT }}) "
 else
@@ -97,7 +92,7 @@ fi
 export VIRTUAL_ENV_PROMPT
 
 # unset PYTHONHOME if set
-if [ -n "${PYTHONHOME+_}" ] ; then
+if ! [ -z "${PYTHONHOME+_}" ] ; then
     _OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
     unset PYTHONHOME
 fi
@@ -109,7 +104,7 @@ if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
 fi
 
 # Make sure to unalias pydoc if it's already there
-{ alias pydoc 2>/dev/null >/dev/null && unalias pydoc; } || true
+alias pydoc 2>/dev/null >/dev/null && unalias pydoc || true
 
 pydoc () {
     python -m pydoc "$@"


### PR DESCRIPTION
## Summary

This reverts commit 2f7f9ea571f4fa8d2eefbfa4a95f6bc8fd18175c (https://github.com/astral-sh/uv/pull/10397). We're seeing some user-reported failures, so we need to investigate further before re-shipping.

Re-opens https://github.com/astral-sh/uv/issues/7480.

Closes https://github.com/astral-sh/uv/issues/10487.
