### PR TITLE
Fix git-tag cache-key reader in case of slashes (#10467)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,6 +4739,7 @@ dependencies = [
  "thiserror 2.0.9",
  "toml",
  "tracing",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -23,3 +23,4 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+walkdir = { workspace = true }

--- a/crates/uv-cache-info/src/git_info.rs
+++ b/crates/uv-cache-info/src/git_info.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
 use tracing::warn;
 use walkdir::WalkDir;
 
@@ -93,16 +94,12 @@ impl Tags {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    warn!("Failed to read git tags: {err}");
+                    warn!("Failed to read Git tags: {err}");
                     continue;
                 }
             };
             let path = entry.path();
-            let is_file = entry
-                .metadata()
-                .map_or(false, |metadata| metadata.is_file());
-
-            if !is_file {
+            if !entry.file_type().is_file() {
                 continue;
             }
             if let Ok(Some(tag)) = path.strip_prefix(&git_tags_path).map(|name| name.to_str()) {

--- a/crates/uv-cache-info/src/git_info.rs
+++ b/crates/uv-cache-info/src/git_info.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use tracing::warn;
+use walkdir::WalkDir;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum GitInfoError {
@@ -80,24 +82,31 @@ impl Tags {
             .find(|git_dir| git_dir.exists())
             .ok_or_else(|| GitInfoError::MissingGitDir(path.to_path_buf()))?;
 
-        let git_refs_path =
-            git_refs(&git_dir).ok_or_else(|| GitInfoError::MissingRefs(git_dir.clone()))?;
+        let git_tags_path = git_refs(&git_dir)
+            .ok_or_else(|| GitInfoError::MissingRefs(git_dir.clone()))?
+            .join("tags");
 
         let mut tags = BTreeMap::new();
 
         // Map each tag to its commit.
-        let read_dir = match fs_err::read_dir(git_refs_path.join("tags")) {
-            Ok(read_dir) => read_dir,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(Self(tags));
-            }
-            Err(err) => return Err(err.into()),
-        };
-        for entry in read_dir {
-            let entry = entry?;
+        for entry in WalkDir::new(&git_tags_path).contents_first(true) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(err) => {
+                    warn!("Failed to read git tags: {err}");
+                    continue;
+                }
+            };
             let path = entry.path();
-            if let Some(tag) = path.file_name().and_then(|name| name.to_str()) {
-                let commit = fs_err::read_to_string(&path)?.trim().to_string();
+            let is_file = entry
+                .metadata()
+                .map_or(false, |metadata| metadata.is_file());
+
+            if !is_file {
+                continue;
+            }
+            if let Ok(Some(tag)) = path.strip_prefix(&git_tags_path).map(|name| name.to_str()) {
+                let commit = fs_err::read_to_string(path)?.trim().to_string();
 
                 // The commit should be 40 hexadecimal characters.
                 if commit.len() != 40 {


### PR DESCRIPTION
## Summary

The assumption that all tags are listed under a flat `.git/ref/tags` structure was wrong. Git creates a hierarchy of directories for tags containing slashes. To fix the cache key calculation, we need to recursively traverse all files under that folder instead.

## Test Plan

1. Create an `uv` project with git-tag cache-keys;
2. Add any tag with slash;
3. Run `uv sync` and see uv_cache_info error in verbose log;
4. `uv sync` doesn't trigger reinstall on next tag addition or removal;
5. With fix applied, reinstall triggers on every tag update and there are no errors in the log.

Fixes #10467