### PR TITLE
Show expected and available ABI tags in resolver errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,6 +5019,7 @@ dependencies = [
  "fs-err 3.0.0",
  "itertools 0.14.0",
  "jiff",
+ "owo-colors",
  "petgraph",
  "rkyv",
  "rustc-hash",

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
+owo-colors = { workspace = true }
 petgraph = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use uv_distribution_filename::{BuildTag, WheelFilename};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::{MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString};
-use uv_platform_tags::{IncompatibleTag, TagPriority, Tags};
+use uv_platform_tags::{AbiTag, IncompatibleTag, TagPriority, Tags};
 use uv_pypi_types::{HashDigest, Yanked};
 
 use crate::{
@@ -167,7 +167,11 @@ impl IncompatibleDist {
         }
     }
 
-    pub fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+    pub fn context_message(
+        &self,
+        tags: Option<&Tags>,
+        requires_python: Option<AbiTag>,
+    ) -> Option<String> {
         match self {
             Self::Wheel(incompatibility) => match incompatibility {
                 IncompatibleWheel::Tag(IncompatibleTag::Python) => {
@@ -179,7 +183,7 @@ impl IncompatibleDist {
                     Some(format!("(e.g., `{tag}`)", tag = tag.cyan()))
                 }
                 IncompatibleWheel::Tag(IncompatibleTag::AbiPythonVersion) => {
-                    let tag = tags?.abi_tag().map(ToString::to_string)?;
+                    let tag = requires_python?;
                     Some(format!("(e.g., `{tag}`)", tag = tag.cyan()))
                 }
                 IncompatibleWheel::Tag(IncompatibleTag::Platform) => {

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 use std::fmt::Formatter;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::{cmp, num::NonZeroU32};
 
@@ -302,60 +301,28 @@ impl Tags {
         max_compatibility
     }
 
-    /// Return the highest-priority Python tag.
+    /// Return the highest-priority Python tag for the [`Tags`].
     pub fn python_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(py, _, _)| py.as_str())
     }
 
-    /// Return the highest-priority ABI tag.
+    /// Return the highest-priority ABI tag for the [`Tags`].
     pub fn abi_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(_, abi, _)| abi.as_str())
     }
 
-    /// Return the highest-priority platform tag.
+    /// Return the highest-priority platform tag for the [`Tags`].
     pub fn platform_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(_, _, platform)| platform.as_str())
     }
 
-    pub fn abi_tags(&self, python_tag: &str) -> impl Iterator<Item = &str> + '_ {
-        self.map
-            .get(python_tag)
-            .into_iter()
-            .flat_map(|abis| abis.keys().map(String::as_str))
-    }
-
+    /// Returns `true` if the given language and ABI tags are compatible with the current
+    /// environment.
     pub fn is_compatible_abi<'a>(&'a self, python_tag: &'a str, abi_tag: &'a str) -> bool {
         self.map
             .get(python_tag)
             .map(|abis| abis.contains_key(abi_tag))
             .unwrap_or(false)
-    }
-
-    // pub fn python_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.keys().map(String::as_str)
-    // }
-    //
-    // pub fn abi_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.values().flat_map(|abis| abis.keys().map(String::as_str))
-    // }
-    //
-    // pub fn platform_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.values().flat_map(|abis| abis.values().flat_map(|platforms| platforms.keys().map(String::as_str)))
-    // }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str, TagPriority)> + '_ {
-        self.map.iter().flat_map(|(python_tag, abi_tags)| {
-            abi_tags.iter().flat_map(move |(abi_tag, platform_tags)| {
-                platform_tags.iter().map(move |(platform_tag, priority)| {
-                    (
-                        python_tag.as_str(),
-                        abi_tag.as_str(),
-                        platform_tag.as_str(),
-                        *priority,
-                    )
-                })
-            })
-        })
     }
 }
 

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -7,7 +7,6 @@ use rustc_hash::FxHashMap;
 
 use crate::{AbiTag, Arch, LanguageTag, Os, Platform, PlatformError};
 
-
 #[derive(Debug, thiserror::Error)]
 pub enum TagsError {
     #[error(transparent)]

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -236,6 +236,7 @@ impl CandidateSelector {
                             return Some(Candidate {
                                 name: package_name,
                                 version,
+                                prioritized: None,
                                 dist: CandidateDist::Compatible(CompatibleDist::InstalledDist(
                                     dist,
                                 )),
@@ -302,6 +303,7 @@ impl CandidateSelector {
                 return Some(Candidate {
                     name: package_name,
                     version,
+                    prioritized: None,
                     dist: CandidateDist::Compatible(CompatibleDist::InstalledDist(dist)),
                     choice_kind: VersionChoiceKind::Installed,
                 });
@@ -583,6 +585,8 @@ pub(crate) struct Candidate<'a> {
     name: &'a PackageName,
     /// The version of the package.
     version: &'a Version,
+    /// The prioritized distribution for the package.
+    prioritized: Option<&'a PrioritizedDist>,
     /// The distributions to use for resolving and installing the package.
     dist: CandidateDist<'a>,
     /// Whether this candidate was selected from a preference.
@@ -599,6 +603,7 @@ impl<'a> Candidate<'a> {
         Self {
             name,
             version,
+            prioritized: Some(dist),
             dist: CandidateDist::from(dist),
             choice_kind,
         }
@@ -631,6 +636,11 @@ impl<'a> Candidate<'a> {
     /// Return the distribution for the candidate.
     pub(crate) fn dist(&self) -> &CandidateDist<'a> {
         &self.dist
+    }
+
+    /// Return the prioritized distribution for the candidate.
+    pub(crate) fn prioritized(&self) -> Option<&PrioritizedDist> {
+        self.prioritized
     }
 }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -14,10 +14,12 @@ use uv_distribution_types::{
 };
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{LocalVersionSlice, Version};
+use uv_platform_tags::Tags;
 use uv_static::EnvVars;
 
 use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
+use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
 use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter};
@@ -27,7 +29,7 @@ use crate::resolution::ConflictingDistributionError;
 use crate::resolver::{
     MetadataUnavailable, ResolverEnvironment, UnavailablePackage, UnavailableReason,
 };
-use crate::Options;
+use crate::{InMemoryIndex, Options};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
@@ -130,9 +132,9 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
 pub(crate) type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>;
 
 /// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
-#[derive(Debug)]
 pub struct NoSolutionError {
     error: pubgrub::NoSolutionError<UvDependencyProvider>,
+    index: InMemoryIndex,
     available_versions: FxHashMap<PackageName, BTreeSet<Version>>,
     available_indexes: FxHashMap<PackageName, BTreeSet<IndexUrl>>,
     selector: CandidateSelector,
@@ -142,7 +144,9 @@ pub struct NoSolutionError {
     unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
     incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, MetadataUnavailable>>,
     fork_urls: ForkUrls,
+    fork_indexes: ForkIndexes,
     env: ResolverEnvironment,
+    tags: Option<Tags>,
     workspace_members: BTreeSet<PackageName>,
     options: Options,
 }
@@ -151,6 +155,7 @@ impl NoSolutionError {
     /// Create a new [`NoSolutionError`] from a [`pubgrub::NoSolutionError`].
     pub(crate) fn new(
         error: pubgrub::NoSolutionError<UvDependencyProvider>,
+        index: InMemoryIndex,
         available_versions: FxHashMap<PackageName, BTreeSet<Version>>,
         available_indexes: FxHashMap<PackageName, BTreeSet<IndexUrl>>,
         selector: CandidateSelector,
@@ -160,12 +165,15 @@ impl NoSolutionError {
         unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
         incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, MetadataUnavailable>>,
         fork_urls: ForkUrls,
+        fork_indexes: ForkIndexes,
         env: ResolverEnvironment,
+        tags: Option<Tags>,
         workspace_members: BTreeSet<PackageName>,
         options: Options,
     ) -> Self {
         Self {
             error,
+            index,
             available_versions,
             available_indexes,
             selector,
@@ -175,7 +183,9 @@ impl NoSolutionError {
             unavailable_packages,
             incomplete_packages,
             fork_urls,
+            fork_indexes,
             env,
+            tags,
             workspace_members,
             options,
         }
@@ -328,6 +338,28 @@ impl NoSolutionError {
     }
 }
 
+impl std::fmt::Debug for NoSolutionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoSolutionError")
+            .field("error", &self.error)
+            .field("available_versions", &self.available_versions)
+            .field("available_indexes", &self.available_indexes)
+            .field("selector", &self.selector)
+            .field("python_requirement", &self.python_requirement)
+            .field("index_locations", &self.index_locations)
+            .field("index_capabilities", &self.index_capabilities)
+            .field("unavailable_packages", &self.unavailable_packages)
+            .field("incomplete_packages", &self.incomplete_packages)
+            .field("fork_urls", &self.fork_urls)
+            .field("fork_indexes", &self.fork_indexes)
+            .field("env", &self.env)
+            .field("tags", &self.tags)
+            .field("workspace_members", &self.workspace_members)
+            .field("options", &self.options)
+            .finish()
+    }
+}
+
 impl std::error::Error for NoSolutionError {}
 
 impl std::fmt::Display for NoSolutionError {
@@ -337,6 +369,7 @@ impl std::fmt::Display for NoSolutionError {
             available_versions: &self.available_versions,
             python_requirement: &self.python_requirement,
             workspace_members: &self.workspace_members,
+            tags: self.tags.as_ref(),
         };
 
         // Transform the error tree for reporting
@@ -385,6 +418,7 @@ impl std::fmt::Display for NoSolutionError {
         let mut additional_hints = IndexSet::default();
         formatter.generate_hints(
             &tree,
+            &self.index,
             &self.selector,
             &self.index_locations,
             &self.index_capabilities,
@@ -392,7 +426,9 @@ impl std::fmt::Display for NoSolutionError {
             &self.unavailable_packages,
             &self.incomplete_packages,
             &self.fork_urls,
+            &self.fork_indexes,
             &self.env,
+            self.tags.as_ref(),
             &self.workspace_members,
             &self.options,
             &mut additional_hints,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -340,22 +340,41 @@ impl NoSolutionError {
 
 impl std::fmt::Debug for NoSolutionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Include every field except `index`, which doesn't implement `Debug`.
+        let Self {
+            error,
+            index: _,
+            available_versions,
+            available_indexes,
+            selector,
+            python_requirement,
+            index_locations,
+            index_capabilities,
+            unavailable_packages,
+            incomplete_packages,
+            fork_urls,
+            fork_indexes,
+            env,
+            tags,
+            workspace_members,
+            options,
+        } = self;
         f.debug_struct("NoSolutionError")
-            .field("error", &self.error)
-            .field("available_versions", &self.available_versions)
-            .field("available_indexes", &self.available_indexes)
-            .field("selector", &self.selector)
-            .field("python_requirement", &self.python_requirement)
-            .field("index_locations", &self.index_locations)
-            .field("index_capabilities", &self.index_capabilities)
-            .field("unavailable_packages", &self.unavailable_packages)
-            .field("incomplete_packages", &self.incomplete_packages)
-            .field("fork_urls", &self.fork_urls)
-            .field("fork_indexes", &self.fork_indexes)
-            .field("env", &self.env)
-            .field("tags", &self.tags)
-            .field("workspace_members", &self.workspace_members)
-            .field("options", &self.options)
+            .field("error", error)
+            .field("available_versions", available_versions)
+            .field("available_indexes", available_indexes)
+            .field("selector", selector)
+            .field("python_requirement", python_requirement)
+            .field("index_locations", index_locations)
+            .field("index_capabilities", index_capabilities)
+            .field("unavailable_packages", unavailable_packages)
+            .field("incomplete_packages", incomplete_packages)
+            .field("fork_urls", fork_urls)
+            .field("fork_indexes", fork_indexes)
+            .field("env", env)
+            .field("tags", tags)
+            .field("workspace_members", workspace_members)
+            .field("options", options)
             .finish()
     }
 }
@@ -428,7 +447,6 @@ impl std::fmt::Display for NoSolutionError {
             &self.fork_urls,
             &self.fork_indexes,
             &self.env,
-            self.tags.as_ref(),
             &self.workspace_members,
             &self.options,
             &mut additional_hints,

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -128,7 +128,10 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                             } else {
                                 reason.singular_message()
                             };
-                            let context = reason.context_message(self.tags);
+                            let context = reason.context_message(
+                                self.tags,
+                                self.python_requirement.target().abi_tag(),
+                            );
                             if let Some(context) = context {
                                 format!("{}{}{}", range, Padded::new(" ", &message, " "), context)
                             } else {
@@ -567,12 +570,12 @@ impl PubGrubReportFormatter<'_> {
                         output_hints,
                     );
 
-                    // Check for unavailable versions due to `--no-build` or `--no-binary`.
                     if let UnavailableReason::Version(UnavailableVersion::IncompatibleDist(
                         incompatibility,
                     )) = reason
                     {
                         match incompatibility {
+                            // Check for unavailable versions due to `--no-build` or `--no-binary`.
                             IncompatibleDist::Wheel(IncompatibleWheel::NoBinary) => {
                                 output_hints.insert(PubGrubHint::NoBinary {
                                     package: package.clone(),
@@ -585,6 +588,7 @@ impl PubGrubReportFormatter<'_> {
                                     option: options.build_options.no_build().clone(),
                                 });
                             }
+                            // Check for unavailable versions due to incompatible tags.
                             IncompatibleDist::Wheel(IncompatibleWheel::Tag(tag)) => {
                                 if let Some(hint) = self.tag_hint(
                                     package,

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,8 +1,10 @@
-use crate::resolver::{MetadataUnavailable, VersionFork};
 use std::fmt::{Display, Formatter};
+
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_platform_tags::Tags;
+
+use crate::resolver::{MetadataUnavailable, VersionFork};
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,10 +1,9 @@
 use std::fmt::{Display, Formatter};
 
+use crate::resolver::{MetadataUnavailable, VersionFork};
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
-use uv_platform_tags::Tags;
-
-use crate::resolver::{MetadataUnavailable, VersionFork};
+use uv_platform_tags::{AbiTag, Tags};
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -82,10 +81,14 @@ impl UnavailableVersion {
         }
     }
 
-    pub(crate) fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+    pub(crate) fn context_message(
+        &self,
+        tags: Option<&Tags>,
+        requires_python: Option<AbiTag>,
+    ) -> Option<String> {
         match self {
             UnavailableVersion::IncompatibleDist(invalid_dist) => {
-                invalid_dist.context_message(tags)
+                invalid_dist.context_message(tags, requires_python)
             }
             UnavailableVersion::InvalidMetadata => None,
             UnavailableVersion::InconsistentMetadata => None,

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,9 +1,8 @@
+use crate::resolver::{MetadataUnavailable, VersionFork};
 use std::fmt::{Display, Formatter};
-
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
-
-use crate::resolver::{MetadataUnavailable, VersionFork};
+use uv_platform_tags::Tags;
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -78,6 +77,19 @@ impl UnavailableVersion {
             UnavailableVersion::InvalidStructure => format!("have {self}"),
             UnavailableVersion::Offline => format!("need {self}"),
             UnavailableVersion::RequiresPython(..) => format!("require {self}"),
+        }
+    }
+
+    pub(crate) fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+        match self {
+            UnavailableVersion::IncompatibleDist(invalid_dist) => {
+                invalid_dist.context_message(tags)
+            }
+            UnavailableVersion::InvalidMetadata => None,
+            UnavailableVersion::InconsistentMetadata => None,
+            UnavailableVersion::InvalidStructure => None,
+            UnavailableVersion::Offline => None,
+            UnavailableVersion::RequiresPython(..) => None,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -831,9 +831,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             forks.len(),
             if forks.len() == 1 { "" } else { "s" }
         );
-        for fork in &forks {
-            debug!("{:?}", fork.env);
-        }
         assert!(forks.len() >= 2);
         // This is a somewhat tortured technique to ensure
         // that our resolver state is only cloned as much
@@ -1222,11 +1219,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             CandidateDist::Compatible(dist) => dist,
             CandidateDist::Incompatible(incompatibility) => {
                 // If the version is incompatible because no distributions are compatible, exit early.
-                //
-                // In this case, we _do_ want to know the set of available tags.
                 return Ok(Some(ResolverVersion::Unavailable(
                     candidate.version().clone(),
-                    // TODO(charlie): This clone should be avoidable.
+                    // TODO(charlie): We can avoid this clone; the candidate is dropped here and
+                    // owns the incompatibility.
                     UnavailableVersion::IncompatibleDist(incompatibility.clone()),
                 )));
             }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6756,7 +6756,7 @@ fn lock_requires_python_no_wheels() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag (e.g., `cp312`) and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
 
           hint: Wheels are available for `dearpygui` (v1.9.1) with the following ABI tags: `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     "###);

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6757,6 +6757,8 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: Wheels are available for `dearpygui` (v1.9.1) with the following ABI tags: `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13944,8 +13944,12 @@ fn invalid_platform() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag, we can conclude that open3d<=0.15.2 cannot be used.
-          And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag and you require open3d, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`), we can conclude that open3d<=0.15.2 cannot be used.
+          And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: cp36m, cp37m, cp38, cp39
+
+          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: macosx_11_0_x86_64, macosx_13_0_arm64, manylinux_2_27_aarch64, manylinux_2_27_x86_64, win_amd64
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13947,9 +13947,9 @@ fn invalid_platform() -> Result<()> {
       ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`), we can conclude that open3d<=0.15.2 cannot be used.
           And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: cp36m, cp37m, cp38, cp39
+          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
-          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: macosx_11_0_x86_64, macosx_13_0_arm64, manylinux_2_27_aarch64, manylinux_2_27_x86_64, win_amd64
+          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `win_amd64`
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4129,7 +4129,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
           hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
@@ -4174,6 +4174,8 @@ fn no_sdist_no_wheels_with_matching_python() {
       × No solution found when resolving dependencies:
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `package-a` (v1.0.0) with the following Python tag: `graalpy310`
     "###);
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4132,7 +4132,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `package-a` (v1.0.0) on the following platforms: macosx_10_0_ppc64
+          hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
     "###);
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4088,7 +4088,7 @@ fn no_sdist_no_wheels_with_matching_abi() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python ABI tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python ABI tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
     "###);
 
@@ -4129,8 +4129,10 @@ fn no_sdist_no_wheels_with_matching_platform() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `package-a` (v1.0.0) on the following platforms: macosx_10_0_ppc64
     "###);
 
     assert_not_installed(
@@ -4170,7 +4172,7 @@ fn no_sdist_no_wheels_with_matching_python() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
     "###);
 


### PR DESCRIPTION
## Summary

The idea here is to show both (1) an example of a compatible tag and (2) the tags that were available, whenever we fail to resolve due to an abscence of matching wheels.

Closes https://github.com/astral-sh/uv/issues/2777.
