### PR TITLE
Show 'closest' tag in tag incompatibility error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,6 +5019,7 @@ dependencies = [
  "fs-err 3.0.0",
  "itertools 0.14.0",
  "jiff",
+ "owo-colors",
  "petgraph",
  "rkyv",
  "rustc-hash",

--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -177,6 +177,8 @@ impl WheelFilename {
             name,
             version,
             build_tag,
+            // TODO(charlie): Consider storing structured tags here. We need to benchmark to
+            // understand whether it's impactful.
             python_tag: python_tag.split('.').map(String::from).collect(),
             abi_tag: abi_tag.split('.').map(String::from).collect(),
             platform_tag: platform_tag.split('.').map(String::from).collect(),

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
+owo-colors = { workspace = true }
 petgraph = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use uv_distribution_filename::{BuildTag, WheelFilename};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::{MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString};
-use uv_platform_tags::{IncompatibleTag, TagPriority, Tags};
+use uv_platform_tags::{AbiTag, IncompatibleTag, TagPriority, Tags};
 use uv_pypi_types::{HashDigest, Yanked};
 
 use crate::{
@@ -167,7 +167,11 @@ impl IncompatibleDist {
         }
     }
 
-    pub fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+    pub fn context_message(
+        &self,
+        tags: Option<&Tags>,
+        requires_python: Option<AbiTag>,
+    ) -> Option<String> {
         match self {
             Self::Wheel(incompatibility) => match incompatibility {
                 IncompatibleWheel::Tag(IncompatibleTag::Python) => {
@@ -179,8 +183,8 @@ impl IncompatibleDist {
                     Some(format!("(e.g., `{tag}`)", tag = tag.cyan()))
                 }
                 IncompatibleWheel::Tag(IncompatibleTag::AbiPythonVersion) => {
-                    let tag = tags?.abi_tag().map(ToString::to_string)?;
-                    Some(format!("(e.g., `{tag}`)", tag = tag.cyan()))
+                    let tag = requires_python?;
+                    Some(format!("(e.g., `{tag}`)"))
                 }
                 IncompatibleWheel::Tag(IncompatibleTag::Platform) => {
                     let tag = tags?.platform_tag().map(ToString::to_string)?;

--- a/crates/uv-platform-tags/src/abi_tag.rs
+++ b/crates/uv-platform-tags/src/abi_tag.rs
@@ -1,0 +1,445 @@
+use std::fmt::Formatter;
+use std::str::FromStr;
+
+/// A tag to represent the ABI compatibility of a Python distribution.
+///
+/// This is the second segment in the wheel filename, following the language tag. For example,
+/// in `cp39-none-manylinux_2_24_x86_64.whl`, the ABI tag is `none`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AbiTag {
+    /// Ex) `none`
+    None,
+    /// Ex) `abi3`
+    Abi3,
+    /// Ex) `cp39m`, `cp310t`
+    CPython {
+        gil_disabled: bool,
+        python_version: (u8, u8),
+    },
+    /// Ex) `pypy39_pp73`
+    PyPy {
+        python_version: (u8, u8),
+        implementation_version: (u8, u8),
+    },
+    /// Ex) `graalpy310_graalpy240_310_native`
+    GraalPy {
+        python_version: (u8, u8),
+        implementation_version: (u8, u8),
+    },
+    /// Ex) `pyston38-pyston_23`
+    Pyston {
+        python_version: (u8, u8),
+        implementation_version: (u8, u8),
+    },
+}
+
+impl std::fmt::Display for AbiTag {
+    /// Format an [`AbiTag`] as a string.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Abi3 => write!(f, "abi3"),
+            Self::CPython {
+                gil_disabled,
+                python_version: (major, minor),
+            } => {
+                if *minor <= 7 {
+                    write!(f, "cp{major}{minor}m")
+                } else if *gil_disabled {
+                    // https://peps.python.org/pep-0703/#build-configuration-changes
+                    // Python 3.13+ only, but it makes more sense to just rely on the sysconfig var.
+                    write!(f, "cp{major}{minor}t")
+                } else {
+                    write!(f, "cp{major}{minor}")
+                }
+            }
+            Self::PyPy {
+                python_version: (py_major, py_minor),
+                implementation_version: (impl_major, impl_minor),
+            } => {
+                write!(f, "pypy{py_major}{py_minor}_pp{impl_major}{impl_minor}")
+            }
+            Self::GraalPy {
+                python_version: (py_major, py_minor),
+                implementation_version: (impl_major, impl_minor),
+            } => {
+                write!(
+                    f,
+                    "graalpy{py_major}{py_minor}_graalpy{impl_major}{impl_minor}_{py_major}{py_minor}native"
+                )
+            }
+            Self::Pyston {
+                python_version: (py_major, py_minor),
+                implementation_version: (impl_major, impl_minor),
+            } => {
+                write!(
+                    f,
+                    "pyston{py_major}{py_minor}-pyston_{impl_major}{impl_minor}"
+                )
+            }
+        }
+    }
+}
+
+impl FromStr for AbiTag {
+    type Err = ParseAbiTagError;
+
+    /// Parse an [`AbiTag`] from a string.
+    #[allow(clippy::cast_possible_truncation)]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        /// Parse a Python version from a string (e.g., convert `39` into `(3, 9)`).
+        fn parse_python_version(
+            version_str: &str,
+            implementation: &'static str,
+            full_tag: &str,
+        ) -> Result<(u8, u8), ParseAbiTagError> {
+            let major = version_str
+                .chars()
+                .next()
+                .ok_or_else(|| ParseAbiTagError::MissingMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .to_digit(10)
+                .ok_or_else(|| ParseAbiTagError::InvalidMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })? as u8;
+            let minor = version_str
+                .get(1..)
+                .ok_or_else(|| ParseAbiTagError::MissingMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .parse::<u8>()
+                .map_err(|_| ParseAbiTagError::InvalidMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?;
+            Ok((major, minor))
+        }
+
+        /// Parse an implementation version from a string (e.g., convert `37` into `(3, 7)`).
+        fn parse_impl_version(
+            version_str: &str,
+            implementation: &'static str,
+            full_tag: &str,
+        ) -> Result<(u8, u8), ParseAbiTagError> {
+            let major = version_str
+                .chars()
+                .next()
+                .ok_or_else(|| ParseAbiTagError::MissingImplMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .to_digit(10)
+                .ok_or_else(|| ParseAbiTagError::InvalidImplMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })? as u8;
+            let minor = version_str
+                .get(1..)
+                .ok_or_else(|| ParseAbiTagError::MissingImplMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .parse::<u8>()
+                .map_err(|_| ParseAbiTagError::InvalidImplMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?;
+            Ok((major, minor))
+        }
+
+        if s == "none" {
+            Ok(Self::None)
+        } else if s == "abi3" {
+            Ok(Self::Abi3)
+        } else if let Some(cp) = s.strip_prefix("cp") {
+            // Ex) `cp39m`, `cp310t`
+            let version_end = cp.find(|c: char| !c.is_ascii_digit()).unwrap_or(cp.len());
+            let version_str = &cp[..version_end];
+            let (major, minor) = parse_python_version(version_str, "CPython", s)?;
+            let gil_disabled = cp.ends_with('t');
+            Ok(Self::CPython {
+                gil_disabled,
+                python_version: (major, minor),
+            })
+        } else if let Some(rest) = s.strip_prefix("pypy") {
+            // Ex) `pypy39_pp73`
+            let version_end = rest
+                .find('_')
+                .ok_or_else(|| ParseAbiTagError::InvalidFormat {
+                    implementation: "PyPy",
+                    tag: s.to_string(),
+                })?;
+            let version_str = &rest[..version_end];
+            let (major, minor) = parse_python_version(version_str, "PyPy", s)?;
+            let rest = rest[version_end + 1..].strip_prefix("pp").ok_or_else(|| {
+                ParseAbiTagError::InvalidFormat {
+                    implementation: "PyPy",
+                    tag: s.to_string(),
+                }
+            })?;
+            let (impl_major, impl_minor) = parse_impl_version(rest, "PyPy", s)?;
+            Ok(Self::PyPy {
+                python_version: (major, minor),
+                implementation_version: (impl_major, impl_minor),
+            })
+        } else if let Some(rest) = s.strip_prefix("graalpy") {
+            // Ex) `graalpy310_graalpy240_310_native`
+            let version_end = rest
+                .find('_')
+                .ok_or_else(|| ParseAbiTagError::InvalidFormat {
+                    implementation: "GraalPy",
+                    tag: s.to_string(),
+                })?;
+            let version_str = &rest[..version_end];
+            let (major, minor) = parse_python_version(version_str, "GraalPy", s)?;
+            let rest = rest[version_end + 1..]
+                .strip_prefix("graalpy")
+                .ok_or_else(|| ParseAbiTagError::InvalidFormat {
+                    implementation: "GraalPy",
+                    tag: s.to_string(),
+                })?;
+            let (impl_major, impl_minor) = parse_impl_version(rest, "GraalPy", s)?;
+            Ok(Self::GraalPy {
+                python_version: (major, minor),
+                implementation_version: (impl_major, impl_minor),
+            })
+        } else if let Some(rest) = s.strip_prefix("pyston") {
+            // Ex) `pyston38-pyston_23`
+            let version_end = rest
+                .find('-')
+                .ok_or_else(|| ParseAbiTagError::InvalidFormat {
+                    implementation: "Pyston",
+                    tag: s.to_string(),
+                })?;
+            let version_str = &rest[..version_end];
+            let (major, minor) = parse_python_version(version_str, "Pyston", s)?;
+            let rest = rest[version_end + 1..]
+                .strip_prefix("pyston_")
+                .ok_or_else(|| ParseAbiTagError::InvalidFormat {
+                    implementation: "Pyston",
+                    tag: s.to_string(),
+                })?;
+            let (impl_major, impl_minor) = parse_impl_version(rest, "Pyston", s)?;
+            Ok(Self::Pyston {
+                python_version: (major, minor),
+                implementation_version: (impl_major, impl_minor),
+            })
+        } else {
+            Err(ParseAbiTagError::UnknownFormat(s.to_string()))
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ParseAbiTagError {
+    #[error("Unknown ABI tag format: {0}")]
+    UnknownFormat(String),
+    #[error("Missing major version in {implementation} ABI tag: {tag}")]
+    MissingMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid major version in {implementation} ABI tag: {tag}")]
+    InvalidMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Missing minor version in {implementation} ABI tag: {tag}")]
+    MissingMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid minor version in {implementation} ABI tag: {tag}")]
+    InvalidMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid {implementation} ABI tag format: {tag}")]
+    InvalidFormat {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Missing implementation major version in {implementation} ABI tag: {tag}")]
+    MissingImplMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid implementation major version in {implementation} ABI tag: {tag}")]
+    InvalidImplMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Missing implementation minor version in {implementation} ABI tag: {tag}")]
+    MissingImplMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid implementation minor version in {implementation} ABI tag: {tag}")]
+    InvalidImplMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::abi_tag::{AbiTag, ParseAbiTagError};
+
+    #[test]
+    fn none_abi() {
+        assert_eq!(AbiTag::from_str("none"), Ok(AbiTag::None));
+        assert_eq!(AbiTag::None.to_string(), "none");
+    }
+
+    #[test]
+    fn abi3() {
+        assert_eq!(AbiTag::from_str("abi3"), Ok(AbiTag::Abi3));
+        assert_eq!(AbiTag::Abi3.to_string(), "abi3");
+    }
+
+    #[test]
+    fn cpython_abi() {
+        let tag = AbiTag::CPython {
+            gil_disabled: false,
+            python_version: (3, 9),
+        };
+        assert_eq!(AbiTag::from_str("cp39"), Ok(tag));
+        assert_eq!(tag.to_string(), "cp39");
+
+        let tag = AbiTag::CPython {
+            gil_disabled: false,
+            python_version: (3, 7),
+        };
+        assert_eq!(AbiTag::from_str("cp37m"), Ok(tag));
+        assert_eq!(tag.to_string(), "cp37m");
+
+        let tag = AbiTag::CPython {
+            gil_disabled: true,
+            python_version: (3, 13),
+        };
+        assert_eq!(AbiTag::from_str("cp313t"), Ok(tag));
+        assert_eq!(tag.to_string(), "cp313t");
+
+        assert_eq!(
+            AbiTag::from_str("cpXY"),
+            Err(ParseAbiTagError::MissingMajorVersion {
+                implementation: "CPython",
+                tag: "cpXY".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pypy_abi() {
+        let tag = AbiTag::PyPy {
+            python_version: (3, 9),
+            implementation_version: (7, 3),
+        };
+        assert_eq!(AbiTag::from_str("pypy39_pp73"), Ok(tag));
+        assert_eq!(tag.to_string(), "pypy39_pp73");
+
+        assert_eq!(
+            AbiTag::from_str("pypy39"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "PyPy",
+                tag: "pypy39".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("pypy39_73"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "PyPy",
+                tag: "pypy39_73".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("pypy39_ppXY"),
+            Err(ParseAbiTagError::InvalidImplMajorVersion {
+                implementation: "PyPy",
+                tag: "pypy39_ppXY".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn graalpy_abi() {
+        let tag = AbiTag::GraalPy {
+            python_version: (3, 10),
+            implementation_version: (2, 40),
+        };
+        assert_eq!(AbiTag::from_str("graalpy310_graalpy240"), Ok(tag));
+        assert_eq!(tag.to_string(), "graalpy310_graalpy240_310native");
+
+        assert_eq!(
+            AbiTag::from_str("graalpy310"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "GraalPy",
+                tag: "graalpy310".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("graalpy310_240"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "GraalPy",
+                tag: "graalpy310_240".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("graalpy310_graalpyXY"),
+            Err(ParseAbiTagError::InvalidImplMajorVersion {
+                implementation: "GraalPy",
+                tag: "graalpy310_graalpyXY".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pyston_abi() {
+        let tag = AbiTag::Pyston {
+            python_version: (3, 8),
+            implementation_version: (2, 3),
+        };
+        assert_eq!(AbiTag::from_str("pyston38-pyston_23"), Ok(tag));
+        assert_eq!(tag.to_string(), "pyston38-pyston_23");
+
+        assert_eq!(
+            AbiTag::from_str("pyston38"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "Pyston",
+                tag: "pyston38".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("pyston38_23"),
+            Err(ParseAbiTagError::InvalidFormat {
+                implementation: "Pyston",
+                tag: "pyston38_23".to_string()
+            })
+        );
+        assert_eq!(
+            AbiTag::from_str("pyston38-pyston_XY"),
+            Err(ParseAbiTagError::InvalidImplMajorVersion {
+                implementation: "Pyston",
+                tag: "pyston38-pyston_XY".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_abi() {
+        assert_eq!(
+            AbiTag::from_str("unknown"),
+            Err(ParseAbiTagError::UnknownFormat("unknown".to_string()))
+        );
+        assert_eq!(
+            AbiTag::from_str(""),
+            Err(ParseAbiTagError::UnknownFormat(String::new()))
+        );
+    }
+}

--- a/crates/uv-platform-tags/src/language_tag.rs
+++ b/crates/uv-platform-tags/src/language_tag.rs
@@ -1,0 +1,367 @@
+use std::fmt::Formatter;
+use std::str::FromStr;
+
+/// A tag to represent the language and implementation of the Python interpreter.
+///
+/// This is the first segment in the wheel filename. For example, in `cp39-none-manylinux_2_24_x86_64.whl`,
+/// the language tag is `cp39`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LanguageTag {
+    /// Ex) `none`
+    None,
+    /// Ex) `py3`, `py39`
+    Python { major: u8, minor: Option<u8> },
+    /// Ex) `cp39`
+    CPython { python_version: (u8, u8) },
+    /// Ex) `pp39`
+    PyPy { python_version: (u8, u8) },
+    /// Ex) `graalpy310`
+    GraalPy { python_version: (u8, u8) },
+    /// Ex) `pt38`
+    Pyston { python_version: (u8, u8) },
+}
+
+impl std::fmt::Display for LanguageTag {
+    /// Format a [`LanguageTag`] as a string.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Python { major, minor } => {
+                if let Some(minor) = minor {
+                    write!(f, "py{major}{minor}")
+                } else {
+                    write!(f, "py{major}")
+                }
+            }
+            Self::CPython {
+                python_version: (major, minor),
+            } => {
+                write!(f, "cp{major}{minor}")
+            }
+            Self::PyPy {
+                python_version: (major, minor),
+            } => {
+                write!(f, "pp{major}{minor}")
+            }
+            Self::GraalPy {
+                python_version: (major, minor),
+            } => {
+                write!(f, "graalpy{major}{minor}")
+            }
+            Self::Pyston {
+                python_version: (major, minor),
+            } => {
+                write!(f, "pt{major}{minor}")
+            }
+        }
+    }
+}
+
+impl FromStr for LanguageTag {
+    type Err = ParseLanguageTagError;
+
+    /// Parse a [`LanguageTag`] from a string.
+    #[allow(clippy::cast_possible_truncation)]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        /// Parse a Python version from a string (e.g., convert `39` into `(3, 9)`).
+        fn parse_python_version(
+            version_str: &str,
+            implementation: &'static str,
+            full_tag: &str,
+        ) -> Result<(u8, u8), ParseLanguageTagError> {
+            let major = version_str
+                .chars()
+                .next()
+                .ok_or_else(|| ParseLanguageTagError::MissingMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .to_digit(10)
+                .ok_or_else(|| ParseLanguageTagError::InvalidMajorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })? as u8;
+            let minor = version_str
+                .get(1..)
+                .ok_or_else(|| ParseLanguageTagError::MissingMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?
+                .parse::<u8>()
+                .map_err(|_| ParseLanguageTagError::InvalidMinorVersion {
+                    implementation,
+                    tag: full_tag.to_string(),
+                })?;
+            Ok((major, minor))
+        }
+
+        if s == "none" {
+            Ok(Self::None)
+        } else if let Some(py) = s.strip_prefix("py") {
+            if py.len() == 1 {
+                // Ex) `py3`
+                let major = py
+                    .chars()
+                    .next()
+                    .ok_or_else(|| ParseLanguageTagError::MissingMajorVersion {
+                        implementation: "Python",
+                        tag: s.to_string(),
+                    })?
+                    .to_digit(10)
+                    .ok_or_else(|| ParseLanguageTagError::InvalidMajorVersion {
+                        implementation: "Python",
+                        tag: s.to_string(),
+                    })? as u8;
+                Ok(Self::Python { major, minor: None })
+            } else {
+                // Ex) `py39`
+                let (major, minor) = parse_python_version(py, "Python", s)?;
+                Ok(Self::Python {
+                    major,
+                    minor: Some(minor),
+                })
+            }
+        } else if let Some(cp) = s.strip_prefix("cp") {
+            // Ex) `cp39`
+            let (major, minor) = parse_python_version(cp, "CPython", s)?;
+            Ok(Self::CPython {
+                python_version: (major, minor),
+            })
+        } else if let Some(pp) = s.strip_prefix("pp") {
+            // Ex) `pp39`
+            let (major, minor) = parse_python_version(pp, "PyPy", s)?;
+            Ok(Self::PyPy {
+                python_version: (major, minor),
+            })
+        } else if let Some(graalpy) = s.strip_prefix("graalpy") {
+            // Ex) `graalpy310`
+            let (major, minor) = parse_python_version(graalpy, "GraalPy", s)?;
+            Ok(Self::GraalPy {
+                python_version: (major, minor),
+            })
+        } else if let Some(pt) = s.strip_prefix("pt") {
+            // Ex) `pt38`
+            let (major, minor) = parse_python_version(pt, "Pyston", s)?;
+            Ok(Self::Pyston {
+                python_version: (major, minor),
+            })
+        } else {
+            Err(ParseLanguageTagError::UnknownFormat(s.to_string()))
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ParseLanguageTagError {
+    #[error("Unknown language tag format: {0}")]
+    UnknownFormat(String),
+    #[error("Missing major version in {implementation} language tag: {tag}")]
+    MissingMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid major version in {implementation} language tag: {tag}")]
+    InvalidMajorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Missing minor version in {implementation} language tag: {tag}")]
+    MissingMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+    #[error("Invalid minor version in {implementation} language tag: {tag}")]
+    InvalidMinorVersion {
+        implementation: &'static str,
+        tag: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::language_tag::ParseLanguageTagError;
+    use crate::LanguageTag;
+
+    #[test]
+    fn none() {
+        assert_eq!(LanguageTag::from_str("none"), Ok(LanguageTag::None));
+        assert_eq!(LanguageTag::None.to_string(), "none");
+    }
+
+    #[test]
+    fn python_language() {
+        let tag = LanguageTag::Python {
+            major: 3,
+            minor: None,
+        };
+        assert_eq!(LanguageTag::from_str("py3"), Ok(tag));
+        assert_eq!(tag.to_string(), "py3");
+
+        let tag = LanguageTag::Python {
+            major: 3,
+            minor: Some(9),
+        };
+        assert_eq!(LanguageTag::from_str("py39"), Ok(tag));
+        assert_eq!(tag.to_string(), "py39");
+
+        assert_eq!(
+            LanguageTag::from_str("py"),
+            Err(ParseLanguageTagError::MissingMajorVersion {
+                implementation: "Python",
+                tag: "py".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("pyX"),
+            Err(ParseLanguageTagError::InvalidMajorVersion {
+                implementation: "Python",
+                tag: "pyX".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("py3X"),
+            Err(ParseLanguageTagError::InvalidMinorVersion {
+                implementation: "Python",
+                tag: "py3X".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn cpython_language() {
+        let tag = LanguageTag::CPython {
+            python_version: (3, 9),
+        };
+        assert_eq!(LanguageTag::from_str("cp39"), Ok(tag));
+        assert_eq!(tag.to_string(), "cp39");
+
+        assert_eq!(
+            LanguageTag::from_str("cp"),
+            Err(ParseLanguageTagError::MissingMajorVersion {
+                implementation: "CPython",
+                tag: "cp".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("cpX"),
+            Err(ParseLanguageTagError::InvalidMajorVersion {
+                implementation: "CPython",
+                tag: "cpX".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("cp3X"),
+            Err(ParseLanguageTagError::InvalidMinorVersion {
+                implementation: "CPython",
+                tag: "cp3X".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pypy_language() {
+        let tag = LanguageTag::PyPy {
+            python_version: (3, 9),
+        };
+        assert_eq!(LanguageTag::from_str("pp39"), Ok(tag));
+        assert_eq!(tag.to_string(), "pp39");
+
+        assert_eq!(
+            LanguageTag::from_str("pp"),
+            Err(ParseLanguageTagError::MissingMajorVersion {
+                implementation: "PyPy",
+                tag: "pp".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("ppX"),
+            Err(ParseLanguageTagError::InvalidMajorVersion {
+                implementation: "PyPy",
+                tag: "ppX".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("pp3X"),
+            Err(ParseLanguageTagError::InvalidMinorVersion {
+                implementation: "PyPy",
+                tag: "pp3X".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn graalpy_language() {
+        let tag = LanguageTag::GraalPy {
+            python_version: (3, 10),
+        };
+        assert_eq!(LanguageTag::from_str("graalpy310"), Ok(tag));
+        assert_eq!(tag.to_string(), "graalpy310");
+
+        assert_eq!(
+            LanguageTag::from_str("graalpy"),
+            Err(ParseLanguageTagError::MissingMajorVersion {
+                implementation: "GraalPy",
+                tag: "graalpy".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("graalpyX"),
+            Err(ParseLanguageTagError::InvalidMajorVersion {
+                implementation: "GraalPy",
+                tag: "graalpyX".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("graalpy3X"),
+            Err(ParseLanguageTagError::InvalidMinorVersion {
+                implementation: "GraalPy",
+                tag: "graalpy3X".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pyston_language() {
+        let tag = LanguageTag::Pyston {
+            python_version: (3, 8),
+        };
+        assert_eq!(LanguageTag::from_str("pt38"), Ok(tag));
+        assert_eq!(tag.to_string(), "pt38");
+
+        assert_eq!(
+            LanguageTag::from_str("pt"),
+            Err(ParseLanguageTagError::MissingMajorVersion {
+                implementation: "Pyston",
+                tag: "pt".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("ptX"),
+            Err(ParseLanguageTagError::InvalidMajorVersion {
+                implementation: "Pyston",
+                tag: "ptX".to_string()
+            })
+        );
+        assert_eq!(
+            LanguageTag::from_str("pt3X"),
+            Err(ParseLanguageTagError::InvalidMinorVersion {
+                implementation: "Pyston",
+                tag: "pt3X".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_language() {
+        assert_eq!(
+            LanguageTag::from_str("unknown"),
+            Err(ParseLanguageTagError::UnknownFormat("unknown".to_string()))
+        );
+        assert_eq!(
+            LanguageTag::from_str(""),
+            Err(ParseLanguageTagError::UnknownFormat(String::new()))
+        );
+    }
+}

--- a/crates/uv-platform-tags/src/lib.rs
+++ b/crates/uv-platform-tags/src/lib.rs
@@ -1,5 +1,9 @@
+pub use abi_tag::AbiTag;
+pub use language_tag::LanguageTag;
 pub use platform::{Arch, Os, Platform, PlatformError};
 pub use tags::{IncompatibleTag, TagCompatibility, TagPriority, Tags, TagsError};
 
+mod abi_tag;
+mod language_tag;
 mod platform;
 mod tags;

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -323,6 +323,22 @@ impl Tags {
             .map(|abis| abis.contains_key(abi_tag))
             .unwrap_or(false)
     }
+
+    /// Returns an iterator over all (Python, ABI, platform, priority) tuples.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str, TagPriority)> + '_ {
+        self.map.iter().flat_map(|(python_tag, abi_tags)| {
+            abi_tags.iter().flat_map(move |(abi_tag, platform_tags)| {
+                platform_tags.iter().map(move |(platform_tag, priority)| {
+                    (
+                        python_tag.as_str(),
+                        abi_tag.as_str(),
+                        platform_tag.as_str(),
+                        *priority,
+                    )
+                })
+            })
+        })
+    }
 }
 
 /// The priority of a platform tag.

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 use std::fmt::Formatter;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::{cmp, num::NonZeroU32};
 
@@ -302,60 +301,28 @@ impl Tags {
         max_compatibility
     }
 
-    /// Return the highest-priority Python tag.
+    /// Return the highest-priority Python tag for the [`Tags`].
     pub fn python_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(py, _, _)| py.as_str())
     }
 
-    /// Return the highest-priority ABI tag.
+    /// Return the highest-priority ABI tag for the [`Tags`].
     pub fn abi_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(_, abi, _)| abi.as_str())
     }
 
-    /// Return the highest-priority platform tag.
+    /// Return the highest-priority platform tag for the [`Tags`].
     pub fn platform_tag(&self) -> Option<&str> {
         self.best.as_ref().map(|(_, _, platform)| platform.as_str())
     }
 
-    pub fn abi_tags(&self, python_tag: &str) -> impl Iterator<Item = &str> + '_ {
-        self.map
-            .get(python_tag)
-            .into_iter()
-            .flat_map(|abis| abis.keys().map(String::as_str))
-    }
-
+    /// Returns `true` if the given language and ABI tags are compatible with the current
+    /// environment.
     pub fn is_compatible_abi<'a>(&'a self, python_tag: &'a str, abi_tag: &'a str) -> bool {
         self.map
             .get(python_tag)
             .map(|abis| abis.contains_key(abi_tag))
             .unwrap_or(false)
-    }
-
-    // pub fn python_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.keys().map(String::as_str)
-    // }
-    //
-    // pub fn abi_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.values().flat_map(|abis| abis.keys().map(String::as_str))
-    // }
-    //
-    // pub fn platform_tags(&self) -> impl Iterator<Item = &str> + '_ {
-    //     self.map.values().flat_map(|abis| abis.values().flat_map(|platforms| platforms.keys().map(String::as_str)))
-    // }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &str, TagPriority)> + '_ {
-        self.map.iter().flat_map(|(python_tag, abi_tags)| {
-            abi_tags.iter().flat_map(move |(abi_tag, platform_tags)| {
-                platform_tags.iter().map(move |(platform_tag, priority)| {
-                    (
-                        python_tag.as_str(),
-                        abi_tag.as_str(),
-                        platform_tag.as_str(),
-                        *priority,
-                    )
-                })
-            })
-        })
     }
 }
 

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -7,7 +7,6 @@ use rustc_hash::FxHashMap;
 
 use crate::{AbiTag, Arch, LanguageTag, Os, Platform, PlatformError};
 
-
 #[derive(Debug, thiserror::Error)]
 pub enum TagsError {
     #[error(transparent)]

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -236,6 +236,7 @@ impl CandidateSelector {
                             return Some(Candidate {
                                 name: package_name,
                                 version,
+                                prioritized: None,
                                 dist: CandidateDist::Compatible(CompatibleDist::InstalledDist(
                                     dist,
                                 )),
@@ -302,6 +303,7 @@ impl CandidateSelector {
                 return Some(Candidate {
                     name: package_name,
                     version,
+                    prioritized: None,
                     dist: CandidateDist::Compatible(CompatibleDist::InstalledDist(dist)),
                     choice_kind: VersionChoiceKind::Installed,
                 });
@@ -583,6 +585,8 @@ pub(crate) struct Candidate<'a> {
     name: &'a PackageName,
     /// The version of the package.
     version: &'a Version,
+    /// The prioritized distribution for the package.
+    prioritized: Option<&'a PrioritizedDist>,
     /// The distributions to use for resolving and installing the package.
     dist: CandidateDist<'a>,
     /// Whether this candidate was selected from a preference.
@@ -599,6 +603,7 @@ impl<'a> Candidate<'a> {
         Self {
             name,
             version,
+            prioritized: Some(dist),
             dist: CandidateDist::from(dist),
             choice_kind,
         }
@@ -631,6 +636,11 @@ impl<'a> Candidate<'a> {
     /// Return the distribution for the candidate.
     pub(crate) fn dist(&self) -> &CandidateDist<'a> {
         &self.dist
+    }
+
+    /// Return the prioritized distribution for the candidate.
+    pub(crate) fn prioritized(&self) -> Option<&PrioritizedDist> {
+        self.prioritized
     }
 }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -14,10 +14,12 @@ use uv_distribution_types::{
 };
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{LocalVersionSlice, Version};
+use uv_platform_tags::Tags;
 use uv_static::EnvVars;
 
 use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
+use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
 use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter};
@@ -27,7 +29,7 @@ use crate::resolution::ConflictingDistributionError;
 use crate::resolver::{
     MetadataUnavailable, ResolverEnvironment, UnavailablePackage, UnavailableReason,
 };
-use crate::Options;
+use crate::{InMemoryIndex, Options};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
@@ -130,9 +132,9 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
 pub(crate) type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>;
 
 /// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
-#[derive(Debug)]
 pub struct NoSolutionError {
     error: pubgrub::NoSolutionError<UvDependencyProvider>,
+    index: InMemoryIndex,
     available_versions: FxHashMap<PackageName, BTreeSet<Version>>,
     available_indexes: FxHashMap<PackageName, BTreeSet<IndexUrl>>,
     selector: CandidateSelector,
@@ -142,7 +144,9 @@ pub struct NoSolutionError {
     unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
     incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, MetadataUnavailable>>,
     fork_urls: ForkUrls,
+    fork_indexes: ForkIndexes,
     env: ResolverEnvironment,
+    tags: Option<Tags>,
     workspace_members: BTreeSet<PackageName>,
     options: Options,
 }
@@ -151,6 +155,7 @@ impl NoSolutionError {
     /// Create a new [`NoSolutionError`] from a [`pubgrub::NoSolutionError`].
     pub(crate) fn new(
         error: pubgrub::NoSolutionError<UvDependencyProvider>,
+        index: InMemoryIndex,
         available_versions: FxHashMap<PackageName, BTreeSet<Version>>,
         available_indexes: FxHashMap<PackageName, BTreeSet<IndexUrl>>,
         selector: CandidateSelector,
@@ -160,12 +165,15 @@ impl NoSolutionError {
         unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
         incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, MetadataUnavailable>>,
         fork_urls: ForkUrls,
+        fork_indexes: ForkIndexes,
         env: ResolverEnvironment,
+        tags: Option<Tags>,
         workspace_members: BTreeSet<PackageName>,
         options: Options,
     ) -> Self {
         Self {
             error,
+            index,
             available_versions,
             available_indexes,
             selector,
@@ -175,7 +183,9 @@ impl NoSolutionError {
             unavailable_packages,
             incomplete_packages,
             fork_urls,
+            fork_indexes,
             env,
+            tags,
             workspace_members,
             options,
         }
@@ -328,6 +338,28 @@ impl NoSolutionError {
     }
 }
 
+impl std::fmt::Debug for NoSolutionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NoSolutionError")
+            .field("error", &self.error)
+            .field("available_versions", &self.available_versions)
+            .field("available_indexes", &self.available_indexes)
+            .field("selector", &self.selector)
+            .field("python_requirement", &self.python_requirement)
+            .field("index_locations", &self.index_locations)
+            .field("index_capabilities", &self.index_capabilities)
+            .field("unavailable_packages", &self.unavailable_packages)
+            .field("incomplete_packages", &self.incomplete_packages)
+            .field("fork_urls", &self.fork_urls)
+            .field("fork_indexes", &self.fork_indexes)
+            .field("env", &self.env)
+            .field("tags", &self.tags)
+            .field("workspace_members", &self.workspace_members)
+            .field("options", &self.options)
+            .finish()
+    }
+}
+
 impl std::error::Error for NoSolutionError {}
 
 impl std::fmt::Display for NoSolutionError {
@@ -337,6 +369,7 @@ impl std::fmt::Display for NoSolutionError {
             available_versions: &self.available_versions,
             python_requirement: &self.python_requirement,
             workspace_members: &self.workspace_members,
+            tags: self.tags.as_ref(),
         };
 
         // Transform the error tree for reporting
@@ -385,6 +418,7 @@ impl std::fmt::Display for NoSolutionError {
         let mut additional_hints = IndexSet::default();
         formatter.generate_hints(
             &tree,
+            &self.index,
             &self.selector,
             &self.index_locations,
             &self.index_capabilities,
@@ -392,7 +426,9 @@ impl std::fmt::Display for NoSolutionError {
             &self.unavailable_packages,
             &self.incomplete_packages,
             &self.fork_urls,
+            &self.fork_indexes,
             &self.env,
+            self.tags.as_ref(),
             &self.workspace_members,
             &self.options,
             &mut additional_hints,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -340,22 +340,41 @@ impl NoSolutionError {
 
 impl std::fmt::Debug for NoSolutionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // Include every field except `index`, which doesn't implement `Debug`.
+        let Self {
+            error,
+            index: _,
+            available_versions,
+            available_indexes,
+            selector,
+            python_requirement,
+            index_locations,
+            index_capabilities,
+            unavailable_packages,
+            incomplete_packages,
+            fork_urls,
+            fork_indexes,
+            env,
+            tags,
+            workspace_members,
+            options,
+        } = self;
         f.debug_struct("NoSolutionError")
-            .field("error", &self.error)
-            .field("available_versions", &self.available_versions)
-            .field("available_indexes", &self.available_indexes)
-            .field("selector", &self.selector)
-            .field("python_requirement", &self.python_requirement)
-            .field("index_locations", &self.index_locations)
-            .field("index_capabilities", &self.index_capabilities)
-            .field("unavailable_packages", &self.unavailable_packages)
-            .field("incomplete_packages", &self.incomplete_packages)
-            .field("fork_urls", &self.fork_urls)
-            .field("fork_indexes", &self.fork_indexes)
-            .field("env", &self.env)
-            .field("tags", &self.tags)
-            .field("workspace_members", &self.workspace_members)
-            .field("options", &self.options)
+            .field("error", error)
+            .field("available_versions", available_versions)
+            .field("available_indexes", available_indexes)
+            .field("selector", selector)
+            .field("python_requirement", python_requirement)
+            .field("index_locations", index_locations)
+            .field("index_capabilities", index_capabilities)
+            .field("unavailable_packages", unavailable_packages)
+            .field("incomplete_packages", incomplete_packages)
+            .field("fork_urls", fork_urls)
+            .field("fork_indexes", fork_indexes)
+            .field("env", env)
+            .field("tags", tags)
+            .field("workspace_members", workspace_members)
+            .field("options", options)
             .finish()
     }
 }
@@ -428,7 +447,6 @@ impl std::fmt::Display for NoSolutionError {
             &self.fork_urls,
             &self.fork_indexes,
             &self.env,
-            self.tags.as_ref(),
             &self.workspace_members,
             &self.options,
             &mut additional_hints,

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -128,7 +128,10 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                             } else {
                                 reason.singular_message()
                             };
-                            let context = reason.context_message(self.tags);
+                            let context = reason.context_message(
+                                self.tags,
+                                self.python_requirement.target().abi_tag(),
+                            );
                             if let Some(context) = context {
                                 format!("{}{}{}", range, Padded::new(" ", &message, " "), context)
                             } else {

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -766,6 +766,7 @@ impl PubGrubReportFormatter<'_> {
                         package: package.clone(),
                         version: candidate.version().clone(),
                         tags,
+                        closest: self.tags.and_then(|tags| prioritized.closest_tag(tags)),
                     })
                 }
             }
@@ -791,6 +792,7 @@ impl PubGrubReportFormatter<'_> {
                         package: package.clone(),
                         version: candidate.version().clone(),
                         tags,
+                        closest: self.tags.and_then(|tags| prioritized.closest_tag(tags)),
                     })
                 }
             }
@@ -817,6 +819,7 @@ impl PubGrubReportFormatter<'_> {
                         package: package.clone(),
                         version: candidate.version().clone(),
                         tags,
+                        closest: self.tags.and_then(|tags| prioritized.closest_tag(tags)),
                     })
                 }
             }
@@ -1130,6 +1133,8 @@ pub(crate) enum PubGrubHint {
         version: Version,
         // excluded from `PartialEq` and `Hash`
         tags: BTreeSet<LanguageTag>,
+        // excluded from `PartialEq` and `Hash`
+        closest: Option<(LanguageTag, AbiTag, String)>,
     },
     /// No wheels are available for a package, and using source distributions was disabled.
     AbiTags {
@@ -1138,6 +1143,8 @@ pub(crate) enum PubGrubHint {
         version: Version,
         // excluded from `PartialEq` and `Hash`
         tags: BTreeSet<AbiTag>,
+        // excluded from `PartialEq` and `Hash`
+        closest: Option<(LanguageTag, AbiTag, String)>,
     },
     /// No wheels are available for a package, and using source distributions was disabled.
     PlatformTags {
@@ -1146,6 +1153,8 @@ pub(crate) enum PubGrubHint {
         version: Version,
         // excluded from `PartialEq` and `Hash`
         tags: Vec<String>,
+        // excluded from `PartialEq` and `Hash`
+        closest: Option<(LanguageTag, AbiTag, String)>,
     },
 }
 
@@ -1587,55 +1596,103 @@ impl std::fmt::Display for PubGrubHint {
                 package,
                 version,
                 tags,
+                closest,
             } => {
                 let s = if tags.len() == 1 { "" } else { "s" };
-                write!(
-                    f,
-                    "{}{} Wheels are available for `{}` ({}) with the following Python tag{s}: {}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    package.cyan(),
-                    format!("v{version}").cyan(),
-                    tags.iter()
-                        .map(|tag| format!("`{}`", tag.cyan()))
-                        .join(", "),
-                )
+                if let Some((py, abi, platform)) = closest {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) with the following Python tag{s}: {}. The closest match is `{}`.",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                        format!("{py}-{abi}-{platform}").cyan(),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) with the following Python tag{s}: {}",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                    )
+                }
             }
             Self::AbiTags {
                 package,
                 version,
                 tags,
+                closest,
             } => {
                 let s = if tags.len() == 1 { "" } else { "s" };
-                write!(
-                    f,
-                    "{}{} Wheels are available for `{}` ({}) with the following ABI tag{s}: {}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    package.cyan(),
-                    format!("v{version}").cyan(),
-                    tags.iter()
-                        .map(|tag| format!("`{}`", tag.cyan()))
-                        .join(", "),
-                )
+                if let Some((py, abi, platform)) = closest {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) with the following ABI tag{s}: {}. The closest match is `{}`.",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                        format!("{py}-{abi}-{platform}").cyan(),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) with the following ABI tag{s}: {}",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                    )
+                }
             }
             Self::PlatformTags {
                 package,
                 version,
                 tags,
+                closest,
             } => {
                 let s = if tags.len() == 1 { "" } else { "s" };
-                write!(
-                    f,
-                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    package.cyan(),
-                    format!("v{version}").cyan(),
-                    tags.iter()
-                        .map(|tag| format!("`{}`", tag.cyan()))
-                        .join(", "),
-                )
+                if let Some((py, abi, platform)) = closest {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}. The closest match is `{}`.",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                        format!("{py}-{abi}-{platform}").cyan(),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                    )
+                }
             }
         }
     }

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,8 +1,10 @@
-use crate::resolver::{MetadataUnavailable, VersionFork};
 use std::fmt::{Display, Formatter};
+
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_platform_tags::Tags;
+
+use crate::resolver::{MetadataUnavailable, VersionFork};
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,10 +1,9 @@
 use std::fmt::{Display, Formatter};
 
+use crate::resolver::{MetadataUnavailable, VersionFork};
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
-use uv_platform_tags::Tags;
-
-use crate::resolver::{MetadataUnavailable, VersionFork};
+use uv_platform_tags::{AbiTag, Tags};
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -82,10 +81,14 @@ impl UnavailableVersion {
         }
     }
 
-    pub(crate) fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+    pub(crate) fn context_message(
+        &self,
+        tags: Option<&Tags>,
+        requires_python: Option<AbiTag>,
+    ) -> Option<String> {
         match self {
             UnavailableVersion::IncompatibleDist(invalid_dist) => {
-                invalid_dist.context_message(tags)
+                invalid_dist.context_message(tags, requires_python)
             }
             UnavailableVersion::InvalidMetadata => None,
             UnavailableVersion::InconsistentMetadata => None,

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,9 +1,8 @@
+use crate::resolver::{MetadataUnavailable, VersionFork};
 use std::fmt::{Display, Formatter};
-
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
-
-use crate::resolver::{MetadataUnavailable, VersionFork};
+use uv_platform_tags::Tags;
 
 /// The reason why a package or a version cannot be used.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -78,6 +77,19 @@ impl UnavailableVersion {
             UnavailableVersion::InvalidStructure => format!("have {self}"),
             UnavailableVersion::Offline => format!("need {self}"),
             UnavailableVersion::RequiresPython(..) => format!("require {self}"),
+        }
+    }
+
+    pub(crate) fn context_message(&self, tags: Option<&Tags>) -> Option<String> {
+        match self {
+            UnavailableVersion::IncompatibleDist(invalid_dist) => {
+                invalid_dist.context_message(tags)
+            }
+            UnavailableVersion::InvalidMetadata => None,
+            UnavailableVersion::InconsistentMetadata => None,
+            UnavailableVersion::InvalidStructure => None,
+            UnavailableVersion::Offline => None,
+            UnavailableVersion::RequiresPython(..) => None,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -831,9 +831,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             forks.len(),
             if forks.len() == 1 { "" } else { "s" }
         );
-        for fork in &forks {
-            debug!("{:?}", fork.env);
-        }
         assert!(forks.len() >= 2);
         // This is a somewhat tortured technique to ensure
         // that our resolver state is only cloned as much
@@ -1222,11 +1219,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             CandidateDist::Compatible(dist) => dist,
             CandidateDist::Incompatible(incompatibility) => {
                 // If the version is incompatible because no distributions are compatible, exit early.
-                //
-                // In this case, we _do_ want to know the set of available tags.
                 return Ok(Some(ResolverVersion::Unavailable(
                     candidate.version().clone(),
-                    // TODO(charlie): This clone should be avoidable.
+                    // TODO(charlie): We can avoid this clone; the candidate is dropped here and
+                    // owns the incompatibility.
                     UnavailableVersion::IncompatibleDist(incompatibility.clone()),
                 )));
             }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6756,7 +6756,7 @@ fn lock_requires_python_no_wheels() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag (e.g., `cp312`) and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
 
           hint: Wheels are available for `dearpygui` (v1.9.1) with the following ABI tags: `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     "###);

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6757,6 +6757,8 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: Wheels are available for `dearpygui` (v1.9.1) with the following ABI tags: `cp37m`, `cp38`, `cp39`, `cp310`, `cp311`
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13944,8 +13944,12 @@ fn invalid_platform() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag, we can conclude that open3d<=0.15.2 cannot be used.
-          And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag and you require open3d, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`), we can conclude that open3d<=0.15.2 cannot be used.
+          And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: cp36m, cp37m, cp38, cp39
+
+          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: macosx_11_0_x86_64, macosx_13_0_arm64, manylinux_2_27_aarch64, manylinux_2_27_x86_64, win_amd64
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13947,9 +13947,9 @@ fn invalid_platform() -> Result<()> {
       ╰─▶ Because only open3d<=0.18.0 is available and open3d<=0.15.2 has no wheels with a matching Python ABI tag (e.g., `cp310`), we can conclude that open3d<=0.15.2 cannot be used.
           And because open3d>=0.16.0,<=0.18.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`) and you require open3d, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: cp36m, cp37m, cp38, cp39
+          hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
-          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: macosx_11_0_x86_64, macosx_13_0_arm64, manylinux_2_27_aarch64, manylinux_2_27_x86_64, win_amd64
+          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `win_amd64`
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13949,7 +13949,7 @@ fn invalid_platform() -> Result<()> {
 
           hint: Wheels are available for `open3d` (v0.15.2) with the following ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
-          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `win_amd64`
+          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `win_amd64`. The closest match is `cp310-cp310-win_amd64`.
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4129,7 +4129,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
           hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
@@ -4174,6 +4174,8 @@ fn no_sdist_no_wheels_with_matching_python() {
       × No solution found when resolving dependencies:
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `package-a` (v1.0.0) with the following Python tag: `graalpy310`
     "###);
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4132,7 +4132,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
+          hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`. The closest match is `py3-none-macosx_10_0_ppc64`.
     "###);
 
     assert_not_installed(
@@ -4175,7 +4175,7 @@ fn no_sdist_no_wheels_with_matching_python() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `package-a` (v1.0.0) with the following Python tag: `graalpy310`
+          hint: Wheels are available for `package-a` (v1.0.0) with the following Python tag: `graalpy310`. The closest match is `graalpy310-none-any`.
     "###);
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4132,7 +4132,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `package-a` (v1.0.0) on the following platforms: macosx_10_0_ppc64
+          hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
     "###);
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4088,7 +4088,7 @@ fn no_sdist_no_wheels_with_matching_abi() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python ABI tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python ABI tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
     "###);
 
@@ -4129,8 +4129,10 @@ fn no_sdist_no_wheels_with_matching_platform() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
+
+          hint: Wheels are available for `package-a` (v1.0.0) on the following platforms: macosx_10_0_ppc64
     "###);
 
     assert_not_installed(
@@ -4170,7 +4172,7 @@ fn no_sdist_no_wheels_with_matching_python() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag, we can conclude that all versions of package-a cannot be used.
+      ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching Python implementation tag (e.g., `cp38`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
     "###);
 


### PR DESCRIPTION
## Summary

Here's an example from `torch` on my M3:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of torch are available:
          torch==1.0.0
          torch==1.0.1
          torch==1.1.0
          torch==1.2.0
          torch==1.3.0
          torch==1.3.1
          torch==1.4.0
          torch==1.5.0
          torch==1.5.1
          torch==1.6.0
          torch==1.7.0
          torch==1.7.1
          torch==1.8.0
          torch==1.8.1
          torch==1.9.0
          torch==1.9.1
          torch==1.10.0
          torch==1.10.1
          torch==1.10.2
          torch==1.11.0
          torch==1.12.0
          torch==1.12.1
          torch==1.13.0
          torch==1.13.1
          torch==2.0.0
          torch==2.0.1
          torch==2.1.0
          torch==2.1.1
          torch==2.1.2
          torch==2.2.0
          torch==2.2.1
          torch==2.2.2
          torch==2.3.0
          torch==2.3.1
          torch==2.4.0
          torch==2.4.1
          torch==2.5.0
          torch==2.5.1
      and torch<=2.4.1 has no wheels with a matching Python ABI tag (e.g., `cp313`), we can conclude that torch<=2.4.1 cannot be used.
      And because torch>=2.5.0 has no wheels with a matching platform tag (e.g., `macosx_14_0_arm64`) and you require torch, we can conclude that your requirements are unsatisfiable.

      hint: Wheels are available for `torch` (v2.4.1) with the following ABI tags: `cp38`, `cp39`, `cp310`, `cp311`, `cp312`. The closest match is `cp312-none-macosx_11_0_arm64`.

      hint: Wheels are available for `torch` (v2.5.1) on the following platform: `manylinux1_x86_64`. The closest match is `cp313-cp313-manylinux1_x86_64`.
```
