### PR TITLE
Add meta titles to documents in guides, excluding integration documents.

### DIFF
--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -1,5 +1,5 @@
 ---
-title: Install and Manage Python
+title: Installing and Managing Python
 description:
   Guide to install specific Python versions, manage existing installations, and automate downloads
   with uv.

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -1,8 +1,8 @@
 ---
-title: Installing and Managing Python
+title: Installing and managing Python
 description:
-  Guide to install specific Python versions, manage existing installations, and automate downloads
-  with uv.
+  A guide to using uv to install Python, including requesting specific versions, automatic
+  installation, viewing installed versions, and more.
 ---
 
 # Installing Python

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -1,3 +1,10 @@
+---
+title: Install and Manage Python
+description:
+  Guide to install specific Python versions, manage existing installations, and automate downloads
+  with uv.
+---
+
 # Installing Python
 
 If Python is already installed on your system, uv will

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -1,8 +1,8 @@
 ---
 title: Working on projects
 description:
-  Guide to create, manage, and build Python projects with uv, including dependencies and
-  distributions.
+  A guide to using uv to create and manage Python projects, including adding dependencies, running
+  commands, and building publishable distributions.
 ---
 
 # Working on projects

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -1,3 +1,10 @@
+---
+title: Working on projects
+description:
+  Guide to create, manage, and build Python projects with uv, including dependencies and
+  distributions.
+---
+
 # Working on projects
 
 uv supports managing Python projects, which define their dependencies in a `pyproject.toml` file.

--- a/docs/guides/publish.md
+++ b/docs/guides/publish.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing a package
-description: Guide to build and publish Python packages using uv
+description: A guide to using uv to build and publish Python packages to a package index, like PyPI.
 ---
 
 # Publishing a package

--- a/docs/guides/publish.md
+++ b/docs/guides/publish.md
@@ -1,3 +1,8 @@
+---
+title: Publishing a package
+description: Guide to build and publish Python packages using uv
+---
+
 # Publishing a package
 
 uv supports building Python packages into source and binary distributions via `uv build` and

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -1,3 +1,10 @@
+---
+title: Run Scripts
+description:
+  Run Python scripts quickly and manage dependencies efficiently using uv. Learn about inline
+  metadata and more.
+---
+
 # Running scripts
 
 A Python script is a file intended for standalone execution, e.g., with `python <script>.py`. Using

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -1,8 +1,8 @@
 ---
-title: Run Scripts
+title: Running scripts
 description:
-  Run Python scripts quickly and manage dependencies efficiently using uv. Learn about inline
-  metadata and more.
+  A guide to using uv to run Python scripts, including support for inline dependency metadata,
+  reproducible scripts, and more.
 ---
 
 # Running scripts

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,3 +1,8 @@
+---
+title: Using tools
+description: Guide to run, install, and upgrade Python tools using uv.
+---
+
 # Using tools
 
 Many Python packages provide applications that can be used as tools. uv has specialized support for

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -1,6 +1,8 @@
 ---
 title: Using tools
-description: Guide to run, install, and upgrade Python tools using uv.
+description:
+  A guide to using uv to run tools published as Python packages, including one-off invocations with
+  uvx, requesting specific tool versions, installing tools, upgrading tools, and more.
 ---
 
 # Using tools


### PR DESCRIPTION
## Summary
Add meta titles to documents in guides, excluding integration documents.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
``uvx --with-requirements docs/requirements.txt -- mkdocs build --strict -f mkdocs.public.yml``
<details>
 <summary>Build Result</summary>

* ``guides/install-python``
```html
...
<meta name="description" content="Guide to install specific Python versions, manage existing installations, and automate downloads with uv.">
...
<title>Install and Manage Python | uv</title>
...
```
* ``guides/projects``
```html
...
<meta name="description" content="Guide to create, manage, and build Python projects with uv, including dependencies and distributions.">
...
<title>Working on projects | uv</title>
...
```
* ``guides/publish``
```html
...
<meta name="description" content="Guide to build and publish Python packages using uv">
...
<title>Publishing a package | uv</title>
...
```
* ``guides/scripts``
```html
...
<meta name="description" content="Run Python scripts quickly and manage dependencies efficiently using uv. Learn about inline metadata and more.">
...
<title>Run Scripts | uv</title>
...
```
* ``guides/tools``
```html
...
<meta name="description" content="Guide to run, install, and upgrade Python tools using uv.">
...
<title>Using tools | uv</title>
...
```
</details>