### PR TITLE
Make build backend type annotations more generic

### DIFF
--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -18,7 +18,8 @@ them while IDEs and type checker can see through the quotes.
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any, Mapping, Sequence  # noqa:I001
+    from collections.abc import Mapping  # noqa:I001
+    from typing import Any, Sequence  # noqa:I001
 
 
 def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> None:

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -18,7 +18,7 @@ them while IDEs and type checker can see through the quotes.
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any, Mapping  # noqa:I001
+    from typing import Any, Mapping, Sequence  # noqa:I001
 
 
 def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> None:
@@ -28,7 +28,9 @@ def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> 
         print("Warning: Config settings are not supported", file=sys.stderr)
 
 
-def call(args: "list[str]", config_settings: "Mapping[Any, Any] | None" = None) -> str:
+def call(
+    args: "Sequence[str]", config_settings: "Mapping[Any, Any] | None" = None
+) -> str:
     """Invoke a uv subprocess and return the filename from stdout."""
     import shutil
     import subprocess
@@ -40,7 +42,7 @@ def call(args: "list[str]", config_settings: "Mapping[Any, Any] | None" = None) 
     if uv_bin is None:
         raise RuntimeError("uv was not properly installed")
     # Forward stderr, capture stdout for the filename
-    result = subprocess.run([uv_bin] + args, stdout=subprocess.PIPE)
+    result = subprocess.run([uv_bin, *args], stdout=subprocess.PIPE)
     if result.returncode != 0:
         sys.exit(result.returncode)
     # If there was extra stdout, forward it (there should not be extra stdout)
@@ -75,7 +77,7 @@ def build_wheel(
 
 def get_requires_for_build_sdist(
     config_settings: "Mapping[Any, Any] | None" = None,
-) -> "list[str]":
+) -> "Sequence[str]":
     """PEP 517 hook `get_requires_for_build_sdist`."""
     warn_config_settings(config_settings)
     return []
@@ -83,7 +85,7 @@ def get_requires_for_build_sdist(
 
 def get_requires_for_build_wheel(
     config_settings: "Mapping[Any, Any] | None" = None,
-) -> "list[str]":
+) -> "Sequence[str]":
     """PEP 517 hook `get_requires_for_build_wheel`."""
     warn_config_settings(config_settings)
     return []
@@ -111,7 +113,7 @@ def build_editable(
 
 def get_requires_for_build_editable(
     config_settings: "Mapping[Any, Any] | None" = None,
-) -> "list[str]":
+) -> "Sequence[str]":
     """PEP 660 hook `get_requires_for_build_editable`."""
     warn_config_settings(config_settings)
     return []

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -18,8 +18,8 @@ them while IDEs and type checker can see through the quotes.
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from collections.abc import Mapping  # noqa:I001
-    from typing import Any, Sequence  # noqa:I001
+    from collections.abc import Mapping, Sequence  # noqa:I001
+    from typing import Any  # noqa:I001
 
 
 def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> None:

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -18,17 +18,17 @@ them while IDEs and type checker can see through the quotes.
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from typing import Any  # noqa:I001
+    from typing import Any, Mapping  # noqa:I001
 
 
-def warn_config_settings(config_settings: "dict[Any, Any] | None" = None) -> None:
+def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> None:
     import sys
 
     if config_settings:
         print("Warning: Config settings are not supported", file=sys.stderr)
 
 
-def call(args: "list[str]", config_settings: "dict[Any, Any] | None" = None) -> str:
+def call(args: "list[str]", config_settings: "Mapping[Any, Any] | None" = None) -> str:
     """Invoke a uv subprocess and return the filename from stdout."""
     import shutil
     import subprocess
@@ -54,7 +54,7 @@ def call(args: "list[str]", config_settings: "dict[Any, Any] | None" = None) -> 
 
 
 def build_sdist(
-    sdist_directory: str, config_settings: "dict[Any, Any] | None" = None
+    sdist_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 517 hook `build_sdist`."""
     args = ["build-backend", "build-sdist", sdist_directory]
@@ -63,7 +63,7 @@ def build_sdist(
 
 def build_wheel(
     wheel_directory: str,
-    config_settings: "dict[Any, Any] | None" = None,
+    config_settings: "Mapping[Any, Any] | None" = None,
     metadata_directory: "str | None" = None,
 ) -> str:
     """PEP 517 hook `build_wheel`."""
@@ -74,7 +74,7 @@ def build_wheel(
 
 
 def get_requires_for_build_sdist(
-    config_settings: "dict[Any, Any] | None" = None,
+    config_settings: "Mapping[Any, Any] | None" = None,
 ) -> "list[str]":
     """PEP 517 hook `get_requires_for_build_sdist`."""
     warn_config_settings(config_settings)
@@ -82,7 +82,7 @@ def get_requires_for_build_sdist(
 
 
 def get_requires_for_build_wheel(
-    config_settings: "dict[Any, Any] | None" = None,
+    config_settings: "Mapping[Any, Any] | None" = None,
 ) -> "list[str]":
     """PEP 517 hook `get_requires_for_build_wheel`."""
     warn_config_settings(config_settings)
@@ -90,7 +90,7 @@ def get_requires_for_build_wheel(
 
 
 def prepare_metadata_for_build_wheel(
-    metadata_directory: str, config_settings: "dict[Any, Any] | None" = None
+    metadata_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 517 hook `prepare_metadata_for_build_wheel`."""
     args = ["build-backend", "prepare-metadata-for-build-wheel", metadata_directory]
@@ -99,7 +99,7 @@ def prepare_metadata_for_build_wheel(
 
 def build_editable(
     wheel_directory: str,
-    config_settings: "dict[Any, Any] | None" = None,
+    config_settings: "Mapping[Any, Any] | None" = None,
     metadata_directory: "str | None" = None,
 ) -> str:
     """PEP 660 hook `build_editable`."""
@@ -110,7 +110,7 @@ def build_editable(
 
 
 def get_requires_for_build_editable(
-    config_settings: "dict[Any, Any] | None" = None,
+    config_settings: "Mapping[Any, Any] | None" = None,
 ) -> "list[str]":
     """PEP 660 hook `get_requires_for_build_editable`."""
     warn_config_settings(config_settings)
@@ -118,7 +118,7 @@ def get_requires_for_build_editable(
 
 
 def prepare_metadata_for_build_editable(
-    metadata_directory: str, config_settings: "dict[Any, Any] | None" = None
+    metadata_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 660 hook `prepare_metadata_for_build_editable`."""
     args = ["build-backend", "prepare-metadata-for-build-editable", metadata_directory]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

As a follow-up to https://github.com/astral-sh/uv/pull/10434, this PR makes the dictionary type annotations more generic with the `typing.Mapping` abstract class. 

In theory, this allows `typing.TypedDict` to be passed. However, note that in practice, the uv build backend is set up to reject if anything is actually passed to this optional parameter 😄 

Suggested in https://github.com/astral-sh/uv/pull/10434#issuecomment-2584357031


## Test Plan

- `uvx ruff check --select ANN python/` checks typing is complete
- `uvx mypy --strict python/` checks typing is consistent