### PR TITLE
Provide `pyproject.toml` path for parse errors in `uv venv`

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -27,7 +27,7 @@ use uv_resolver::{ExcludeNewer, FlatIndex};
 use uv_settings::PythonInstallMirrors;
 use uv_shell::{shlex_posix, shlex_windows, Shell};
 use uv_types::{AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, HashStrategy};
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceError};
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
@@ -162,8 +162,16 @@ async fn venv_impl(
             Err(WorkspaceError::MissingProject(_)) => None,
             Err(WorkspaceError::MissingPyprojectToml) => None,
             Err(WorkspaceError::NonWorkspace(_)) => None,
+            Err(WorkspaceError::Toml(path, err)) => {
+                warn_user!(
+                    "Failed to parse `{}` during environment creation:\n{}",
+                    path.user_display().cyan(),
+                    textwrap::indent(&err.to_string(), "  ")
+                );
+                None
+            }
             Err(err) => {
-                warn_user_once!("{err}");
+                warn_user!("{err}");
                 None
             }
         }

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -535,7 +535,13 @@ fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
         |         ^
       expected `.`, `=`
 
-    warning: Failed to parse: `pyproject.toml`
+    warning: Failed to parse `pyproject.toml` during environment creation:
+      TOML parse error at line 1, column 9
+        |
+      1 | invalid toml
+        |         ^
+      expected `.`, `=`
+
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     Activate with: source .venv/[BIN]/activate


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/10522.

## Test Plan

```
❯ cargo run venv
warning: Failed to parse `pyproject.toml` during environment creation:
  TOML parse error at line 1, column 1
    |
  1 | [project]
    | ^^^^^^^^^
  `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list

Using CPython 3.13.0
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
```
