### PR TITLE
Include build tag in rendered wheel filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5010,6 +5010,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-platform-tags",
+ "uv-small-str",
 ]
 
 [[package]]

--- a/crates/uv-distribution-filename/Cargo.toml
+++ b/crates/uv-distribution-filename/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-platform-tags = { workspace = true }
+uv-small-str = { workspace = true }
 
 rkyv = { workspace = true, features = ["smallvec-1"] }
 serde = { workspace = true }

--- a/crates/uv-distribution-filename/src/build_tag.rs
+++ b/crates/uv-distribution-filename/src/build_tag.rs
@@ -1,6 +1,7 @@
 use std::num::ParseIntError;
 use std::str::FromStr;
-use std::sync::Arc;
+
+use uv_small_str::SmallString;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BuildTagError {
@@ -33,7 +34,7 @@ pub enum BuildTagError {
     rkyv::Serialize,
 )]
 #[rkyv(derive(Debug))]
-pub struct BuildTag(u64, Option<Arc<str>>);
+pub struct BuildTag(u64, Option<SmallString>);
 
 impl FromStr for BuildTag {
     type Err = BuildTagError;
@@ -57,6 +58,18 @@ impl FromStr for BuildTag {
             None => (s, None),
         };
 
-        Ok(BuildTag(prefix.parse::<u64>()?, suffix.map(Arc::from)))
+        Ok(BuildTag(
+            prefix.parse::<u64>()?,
+            suffix.map(SmallString::from),
+        ))
+    }
+}
+
+impl std::fmt::Display for BuildTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.1 {
+            Some(suffix) => write!(f, "{}{}", self.0, suffix),
+            None => write!(f, "{}", self.0),
+        }
     }
 }

--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -407,6 +407,9 @@ pub struct WheelTagLarge {
 
 impl Display for WheelTagLarge {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(build_tag) = &self.build_tag {
+            write!(f, "{build_tag}-")?;
+        }
         write!(
             f,
             "{}-{}-{}",


### PR DESCRIPTION
## Summary

I don't think this had an impact in practice, but it is "wrong" to omit these. Confirmed that the cache (for example) now includes the build tag (as in, `mkl_fft-1.3.8-72-cp310-cp310-manylinux2014_x86_64`).
