### PR TITLE
Reduce distribution size to 200 bytes

### DIFF
--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -291,7 +291,7 @@ pub struct DirectUrlSourceDist {
     /// like using e.g. `foo @ https://github.com/org/repo/archive/master.zip`
     pub name: PackageName,
     /// The URL without the subdirectory fragment.
-    pub location: Url,
+    pub location: Box<Url>,
     /// The subdirectory within the archive in which the source distribution is located.
     pub subdirectory: Option<PathBuf>,
     /// The file extension, e.g. `tar.gz`, `zip`, etc.
@@ -370,7 +370,7 @@ impl Dist {
             DistExtension::Source(ext) => {
                 Ok(Self::Source(SourceDist::DirectUrl(DirectUrlSourceDist {
                     name,
-                    location,
+                    location: Box::new(location),
                     subdirectory,
                     ext,
                     url,
@@ -1343,10 +1343,10 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 232, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 216, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 200, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 200, "{}", size_of::<BuiltDist>());
         assert!(
-            size_of::<SourceDist>() <= 232,
+            size_of::<SourceDist>() <= 176,
             "{}",
             size_of::<SourceDist>()
         );

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2035,7 +2035,7 @@ impl Package {
                 });
                 let direct_dist = DirectUrlSourceDist {
                     name: self.id.name.clone(),
-                    location,
+                    location: Box::new(location),
                     subdirectory: subdirectory.clone(),
                     ext,
                     url: VerbatimUrl::from_url(url),


### PR DESCRIPTION
## Summary

The last of these optimizations. The limit is now `RegistryBuiltDist` which includes `sdist: Option<RegistrySourceDist>`.
