### PR TITLE
Make `version` an optional field on installable distribution type

### DIFF
--- a/crates/uv-distribution-types/src/dist_error.rs
+++ b/crates/uv-distribution-types/src/dist_error.rs
@@ -126,7 +126,7 @@ impl DerivationChain {
                             dist.name().clone(),
                             extra.clone(),
                             group.clone(),
-                            dist.version().clone(),
+                            dist.version().cloned(),
                             Ranges::empty(),
                         ));
                         let target = edge.source();
@@ -191,7 +191,7 @@ pub struct DerivationStep {
     /// The enabled dependency group of the package, if any.
     pub group: Option<GroupName>,
     /// The version of the package.
-    pub version: Version,
+    pub version: Option<Version>,
     /// The constraints applied to the subsequent package in the chain.
     pub range: Ranges<Version>,
 }
@@ -202,7 +202,7 @@ impl DerivationStep {
         name: PackageName,
         extra: Option<ExtraName>,
         group: Option<GroupName>,
-        version: Version,
+        version: Option<Version>,
         range: Ranges<Version>,
     ) -> Self {
         Self {

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -220,14 +220,19 @@ impl Edge {
 impl From<&ResolvedDist> for RequirementSource {
     fn from(resolved_dist: &ResolvedDist) -> Self {
         match resolved_dist {
-            ResolvedDist::Installable { dist, version } => match dist {
-                Dist::Built(BuiltDist::Registry(wheels)) => RequirementSource::Registry {
-                    specifier: uv_pep440::VersionSpecifiers::from(
-                        uv_pep440::VersionSpecifier::equals_version(version.clone()),
-                    ),
-                    index: Some(wheels.best_wheel().index.url().clone()),
-                    conflict: None,
-                },
+            ResolvedDist::Installable { dist, .. } => match dist {
+                Dist::Built(BuiltDist::Registry(wheels)) => {
+                    let wheel = wheels.best_wheel();
+                    RequirementSource::Registry {
+                        specifier: uv_pep440::VersionSpecifiers::from(
+                            uv_pep440::VersionSpecifier::equals_version(
+                                wheel.filename.version.clone(),
+                            ),
+                        ),
+                        index: Some(wheel.index.url().clone()),
+                        conflict: None,
+                    }
+                }
                 Dist::Built(BuiltDist::DirectUrl(wheel)) => {
                     let mut location = wheel.url.to_url();
                     location.set_fragment(None);

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -345,7 +345,10 @@ pub trait Installable<'lock> {
             build_options,
         )?;
         let version = package.version().clone();
-        let dist = ResolvedDist::Installable { dist, version };
+        let dist = ResolvedDist::Installable {
+            dist,
+            version: Some(version),
+        };
         let hashes = package.hashes();
         Ok(Node::Dist {
             dist,
@@ -362,7 +365,10 @@ pub trait Installable<'lock> {
             &BuildOptions::default(),
         )?;
         let version = package.version().clone();
-        let dist = ResolvedDist::Installable { dist, version };
+        let dist = ResolvedDist::Installable {
+            dist,
+            version: Some(version),
+        };
         let hashes = package.hashes();
         Ok(Node::Dist {
             dist,

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -443,7 +443,7 @@ impl ResolverOutput {
             (
                 ResolvedDist::Installable {
                     dist,
-                    version: version.clone(),
+                    version: Some(version.clone()),
                 },
                 hashes,
                 Some(metadata),

--- a/crates/uv-resolver/src/resolver/derivation.rs
+++ b/crates/uv-resolver/src/resolver/derivation.rs
@@ -54,7 +54,7 @@ impl DerivationChainBuilder {
                                     name.clone(),
                                     p1.extra().cloned(),
                                     p1.dev().cloned(),
-                                    version.clone(),
+                                    Some(version.clone()),
                                     v2.clone(),
                                 ));
 

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -296,52 +296,86 @@ fn format_chain(name: &PackageName, version: Option<&Version>, chain: &Derivatio
             range.filter(|range| *range != Ranges::empty() && *range != Ranges::full())
         {
             if let Some(extra) = &step.extra {
-                // Ex) `flask[dotenv]>=1.0.0` (v1.2.3)
-                format!(
-                    "`{}{}` ({})",
-                    format!("{}[{}]", step.name, extra).cyan(),
-                    range.cyan(),
-                    format!("v{}", step.version).cyan(),
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask[dotenv]>=1.0.0` (v1.2.3)
+                    format!(
+                        "`{}{}` ({})",
+                        format!("{}[{}]", step.name, extra).cyan(),
+                        range.cyan(),
+                        format!("v{version}").cyan(),
+                    )
+                } else {
+                    // Ex) `flask[dotenv]>=1.0.0`
+                    format!(
+                        "`{}{}`",
+                        format!("{}[{}]", step.name, extra).cyan(),
+                        range.cyan(),
+                    )
+                }
             } else if let Some(group) = &step.group {
-                // Ex) `flask:dev>=1.0.0` (v1.2.3)
-                format!(
-                    "`{}{}` ({})",
-                    format!("{}:{}", step.name, group).cyan(),
-                    range.cyan(),
-                    format!("v{}", step.version).cyan(),
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask:dev>=1.0.0` (v1.2.3)
+                    format!(
+                        "`{}{}` ({})",
+                        format!("{}:{}", step.name, group).cyan(),
+                        range.cyan(),
+                        format!("v{version}").cyan(),
+                    )
+                } else {
+                    // Ex) `flask:dev>=1.0.0`
+                    format!(
+                        "`{}{}`",
+                        format!("{}:{}", step.name, group).cyan(),
+                        range.cyan(),
+                    )
+                }
             } else {
-                // Ex) `flask>=1.0.0` (v1.2.3)
-                format!(
-                    "`{}{}` ({})",
-                    step.name.cyan(),
-                    range.cyan(),
-                    format!("v{}", step.version).cyan(),
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask>=1.0.0` (v1.2.3)
+                    format!(
+                        "`{}{}` ({})",
+                        step.name.cyan(),
+                        range.cyan(),
+                        format!("v{version}").cyan(),
+                    )
+                } else {
+                    // Ex) `flask>=1.0.0`
+                    format!("`{}{}`", step.name.cyan(), range.cyan(),)
+                }
             }
         } else {
             if let Some(extra) = &step.extra {
-                // Ex) `flask[dotenv]` (v1.2.3)
-                format!(
-                    "`{}` ({})",
-                    format!("{}[{}]", step.name, extra).cyan(),
-                    format!("v{}", step.version).cyan(),
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask[dotenv]` (v1.2.3)
+                    format!(
+                        "`{}` ({})",
+                        format!("{}[{}]", step.name, extra).cyan(),
+                        format!("v{version}").cyan(),
+                    )
+                } else {
+                    // Ex) `flask[dotenv]`
+                    format!("`{}`", format!("{}[{}]", step.name, extra).cyan(),)
+                }
             } else if let Some(group) = &step.group {
-                // Ex) `flask:dev` (v1.2.3)
-                format!(
-                    "`{}` ({})",
-                    format!("{}:{}", step.name, group).cyan(),
-                    format!("v{}", step.version).cyan(),
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask:dev` (v1.2.3)
+                    format!(
+                        "`{}` ({})",
+                        format!("{}:{}", step.name, group).cyan(),
+                        format!("v{version}").cyan(),
+                    )
+                } else {
+                    // Ex) `flask:dev`
+                    format!("`{}`", format!("{}:{}", step.name, group).cyan(),)
+                }
             } else {
-                // Ex) `flask` (v1.2.3)
-                format!(
-                    "`{}` ({})",
-                    step.name.cyan(),
-                    format!("v{}", step.version).cyan()
-                )
+                if let Some(version) = step.version.as_ref() {
+                    // Ex) `flask` (v1.2.3)
+                    format!("`{}` ({})", step.name.cyan(), format!("v{version}").cyan())
+                } else {
+                    // Ex) `flask`
+                    format!("`{}`", step.name.cyan())
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

I previously made this required, but we now need to be able to create these from a lockfile that _omits_ versions for dynamic source trees. They should still be present in most cases, but it's best-effort.
