### PR TITLE
Remove `import re` from entrypoint wrapper scripts

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -26,6 +26,8 @@ use crate::{Error, Layout};
 /// Wrapper script template function
 ///
 /// <https://github.com/pypa/pip/blob/7f8a6844037fb7255cfd0d34ff8e8cf44f2598d4/src/pip/_vendor/distlib/scripts.py#L41-L48>
+///
+/// Script template slightly modified: removed `import re`, allowing scripts that never import `re` to load faster.
 fn get_script_launcher(entry_point: &Script, shebang: &str) -> String {
     let Script {
         module, function, ..
@@ -36,11 +38,13 @@ fn get_script_launcher(entry_point: &Script, shebang: &str) -> String {
     format!(
         r#"{shebang}
 # -*- coding: utf-8 -*-
-import re
 import sys
 from {module} import {import_name}
 if __name__ == "__main__":
-    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+    if sys.argv[0].endswith("-script.pyw"):
+        sys.argv[0] = sys.argv[0][:-11]
+    elif sys.argv[0].endswith(".exe"):
+        sys.argv[0] = sys.argv[0][:-4]
     sys.exit({function}())
 "#
     )

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -62,11 +62,13 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -135,11 +137,13 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(bin_dir.join("flask")).unwrap(), @r###"
         #![TEMP_DIR]/tools/flask/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from flask.cli import main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(main())
         "###);
     });
@@ -327,11 +331,13 @@ fn tool_install_version() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -409,11 +415,13 @@ fn tool_install_editable() {
         assert_snapshot!(fs_err::read_to_string(&executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(main())
         "###);
 
@@ -705,11 +713,13 @@ fn tool_install_editable_from() {
         assert_snapshot!(fs_err::read_to_string(&executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(main())
         "###);
 
@@ -856,11 +866,13 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
     });
@@ -1218,11 +1230,13 @@ fn tool_install_force() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python3
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -1545,11 +1559,13 @@ fn tool_install_unnamed_package() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -1658,11 +1674,13 @@ fn tool_install_unnamed_from() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -1747,11 +1765,13 @@ fn tool_install_unnamed_with() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from black import patched_main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(patched_main())
         "###);
 
@@ -2618,11 +2638,13 @@ fn tool_install_malformed_dist_info() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/babel/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from babel.messages.frontend import main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(main())
         "###);
 
@@ -2696,11 +2718,13 @@ fn tool_install_settings() {
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
         #![TEMP_DIR]/tools/flask/bin/python
         # -*- coding: utf-8 -*-
-        import re
         import sys
         from flask.cli import main
         if __name__ == "__main__":
-            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
             sys.exit(main())
         "###);
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This removes `import re` from the wrapper script of installed tools, so that small tools that never `import re` themselves are allowed to load faster.

This was offered to `distlib` but was rejected https://github.com/pypa/distlib/pull/239. That discussion includes all the relevant performance measurements for this change.

Here's the corresponding `pip` issue https://github.com/pypa/pip/issues/13165 and `pip` PR https://github.com/pypa/pip/pull/13166

The motivation for this change was [this discussion](https://discuss.python.org/t/make-more-of-the-standard-library-import-on-demand/76311) on Python Discourse.

## Test Plan

<!-- How was it tested? -->

Ran
```console
cargo build
./target/debug/uv tool install black
black --version
# observed that installed black runs succesfully
cat ~/.local/bin/black
# observed that the wrapper script no longer imports `re` module
```

