### PR TITLE
Patch embedded install path for Python dylib on macOS during `python install`

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -5,9 +5,7 @@ use tracing::{debug, info};
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
-use uv_fs::Simplified as _;
 use uv_pep440::{Prerelease, Version};
-use uv_warnings::warn_user;
 
 use crate::discovery::{
     find_best_python_installation, find_python_installation, EnvironmentPreference, PythonRequest,
@@ -168,15 +166,7 @@ impl PythonInstallation {
         installed.ensure_sysconfig_patched()?;
         installed.ensure_canonical_executables()?;
         if let Err(e) = installed.ensure_dylib_patched() {
-            warn_user!(
-                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.",
-                installed.executable().simplified_display(),
-            );
-            debug!(
-                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.\n{}",
-                installed.executable().simplified_display(),
-                e
-            );
+            e.warn_user(&installed);
         }
 
         Ok(Self {

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -165,6 +165,7 @@ impl PythonInstallation {
         installed.ensure_externally_managed()?;
         installed.ensure_sysconfig_patched()?;
         installed.ensure_canonical_executables()?;
+        installed.ensure_dylib_patched()?;
 
         Ok(Self {
             source: PythonSource::Managed,

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -30,6 +30,7 @@ mod implementation;
 mod installation;
 mod interpreter;
 mod libc;
+pub mod macos_dylib;
 pub mod managed;
 #[cfg(windows)]
 mod microsoft_store;

--- a/crates/uv-python/src/macos_dylib.rs
+++ b/crates/uv-python/src/macos_dylib.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use uv_fs::Simplified as _;
+
+pub fn patch_dylib_install_name(dylib: PathBuf) -> Result<(), Error> {
+    // Check that `install_name_tool` is available before
+    // trying to run it.
+    if std::process::Command::new("install_name_tool")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    let output = std::process::Command::new("install_name_tool")
+        .arg("-id")
+        .arg(&dylib)
+        .arg(&dylib)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(Error::RenameError { dylib, stderr });
+    }
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("`install_name_tool` is not available on this system.
+This utility is part of macOS Developer Tools. Please ensure that the Xcode Command Line Tools are installed by running:
+
+    xcode-select --install
+
+If `install_name_tool` is missing even after installing the tools, ensure the command line tools are properly configured:
+
+    sudo xcode-select --reset
+
+For more information, see: https://developer.apple.com/xcode/")]
+    MissingInstallNameTool,
+    #[error("`install_name_tool` failed to update the install name of the Python dynamic library located at `{}`", dylib.user_display())]
+    RenameError { dylib: PathBuf, stderr: String },
+}

--- a/crates/uv-python/src/macos_dylib.rs
+++ b/crates/uv-python/src/macos_dylib.rs
@@ -1,23 +1,24 @@
-use std::path::PathBuf;
+use std::{io::ErrorKind, path::PathBuf};
 
 use uv_fs::Simplified as _;
 
 pub fn patch_dylib_install_name(dylib: PathBuf) -> Result<(), Error> {
-    // Check that `install_name_tool` is available before
-    // trying to run it.
-    if std::process::Command::new("install_name_tool")
-        .arg("--version")
-        .output()
-        .is_err()
-    {
-        return Ok(());
-    }
-
-    let output = std::process::Command::new("install_name_tool")
+    let output = match std::process::Command::new("install_name_tool")
         .arg("-id")
         .arg(&dylib)
         .arg(&dylib)
-        .output()?;
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) => {
+            let e = if e.kind() == ErrorKind::NotFound {
+                Error::MissingInstallNameTool
+            } else {
+                e.into()
+            };
+            return Err(e);
+        }
+    };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -36,12 +37,8 @@ This utility is part of macOS Developer Tools. Please ensure that the Xcode Comm
 
     xcode-select --install
 
-If `install_name_tool` is missing even after installing the tools, ensure the command line tools are properly configured:
-
-    sudo xcode-select --reset
-
 For more information, see: https://developer.apple.com/xcode/")]
     MissingInstallNameTool,
-    #[error("`install_name_tool` failed to update the install name of the Python dynamic library located at `{}`", dylib.user_display())]
+    #[error("Failed to update the install name of the Python dynamic library located at `{}`", dylib.user_display())]
     RenameError { dylib: PathBuf, stderr: String },
 }

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -628,7 +628,7 @@ impl ManagedPythonInstallation {
 }
 
 /// Generate a platform portion of a key from the environment.
-fn platform_key_from_env() -> Result<String, Error> {
+pub fn platform_key_from_env() -> Result<String, Error> {
     let os = Os::from_env();
     let arch = Arch::from_env();
     let libc = Libc::from_env()?;

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -517,7 +517,7 @@ impl ManagedPythonInstallation {
     /// link to the correct location for the Python library.
     ///
     /// See <https://github.com/astral-sh/uv/issues/10598> for more information.
-    pub fn ensure_dylib_patched(&self) -> Result<(), Error> {
+    pub fn ensure_dylib_patched(&self) -> Result<(), macos_dylib::Error> {
         if cfg!(target_os = "macos") {
             if *self.implementation() == ImplementationName::CPython {
                 let dylib_path = self.python_dir().join("lib").join(format!(

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -313,15 +313,7 @@ pub(crate) async fn install(
         installation.ensure_sysconfig_patched()?;
         installation.ensure_canonical_executables()?;
         if let Err(e) = installation.ensure_dylib_patched() {
-            warn_user!(
-                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.",
-                installation.executable().simplified_display(),
-            );
-            debug!(
-                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.\n{}",
-                installation.executable().simplified_display(),
-                e
-            );
+            e.warn_user(installation);
         }
 
         if preview.is_disabled() {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -312,6 +312,7 @@ pub(crate) async fn install(
         installation.ensure_externally_managed()?;
         installation.ensure_sysconfig_patched()?;
         installation.ensure_canonical_executables()?;
+        installation.ensure_dylib_patched()?;
 
         if preview.is_disabled() {
             debug!("Skipping installation of Python executables, use `--preview` to enable.");

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -312,7 +312,17 @@ pub(crate) async fn install(
         installation.ensure_externally_managed()?;
         installation.ensure_sysconfig_patched()?;
         installation.ensure_canonical_executables()?;
-        installation.ensure_dylib_patched()?;
+        if let Err(e) = installation.ensure_dylib_patched() {
+            warn_user!(
+                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.",
+                installation.executable().simplified_display(),
+            );
+            debug!(
+                "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.\n{}",
+                installation.executable().simplified_display(),
+                e
+            );
+        }
 
         if preview.is_disabled() {
             debug!("Skipping installation of Python executables, use `--preview` to enable.");

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -881,6 +881,7 @@ fn python_install_preview_broken_link() {
 #[test]
 fn python_dylib_install_name_is_patched_on_install() {
     use assert_cmd::assert::OutputAssertExt;
+    use uv_python::managed::platform_key_from_env;
 
     let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_python_keys();
 
@@ -888,14 +889,17 @@ fn python_dylib_install_name_is_patched_on_install() {
     context
         .python_install()
         .arg("--preview")
-        .arg("3.13")
+        .arg("3.13.1")
         .assert()
         .success();
 
     let dylib = context
         .temp_dir
         .child("managed")
-        .child("cpython-3.13.1-macos-aarch64-none")
+        .child(format!(
+            "cpython-3.13.1-{}",
+            platform_key_from_env().unwrap()
+        ))
         .child("lib")
         .child(format!(
             "{}python3.13{}",


### PR DESCRIPTION
## Summary

Fixes #10598 

## Test Plan

Looking for input here @zanieb. How/where would you include tests for this?
More broadly: do we want a failure to perform the rename to be a hard error? Or should it start out as a warning?
