### PR TITLE
docs(workspaces): remove build-system

### DIFF
--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -41,10 +41,6 @@ bird-feeder = { workspace = true }
 [tool.uv.workspace]
 members = ["packages/*"]
 exclude = ["packages/seeds"]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 ```
 
 Every directory included by the `members` globs (and not excluded by the `exclude` globs) must


### PR DESCRIPTION
## Summary

Unless I'm doing something wrong, specifying `hatchling` as a build system here results in `ValueError: Unable to determine which files to ship`

## Test Plan

Following the instructions of the document.

## Additional

Don't hesitate to discard