### PR TITLE
Add feature-gate to ecosystem tests and disable on Windows CI

### DIFF
--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -133,7 +133,7 @@ ignored = [
 ]
 
 [features]
-default = ["python", "python-managed", "pypi", "git", "performance", "crates-io"]
+default = ["python", "python-managed", "pypi", "git", "performance", "crates-io", "test-ecosystem"]
 # Use better memory allocators, etc.
 performance = [
     "performance-memory-allocator",
@@ -156,5 +156,7 @@ pypi = []
 git = []
 # Introduces a dependency on crates.io.
 crates-io = []
+# Includes test cases that require ecosystem packages
+test-ecosystem = []
 # Adds self-update functionality.
 self-update = ["axoupdater", "uv-cli/self-update"]

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -17,7 +17,7 @@ mod cache_clean;
 #[cfg(all(feature = "python", feature = "pypi"))]
 mod cache_prune;
 
-#[cfg(all(feature = "python", feature = "pypi"))]
+#[cfg(all(feature = "python", feature = "pypi", feature = "test-ecosystem"))]
 mod ecosystem;
 
 #[cfg(all(feature = "python", feature = "pypi"))]


### PR DESCRIPTION
These tests should be platform independent and are particularly expensive to run
