### PR TITLE
Fix outdated comment in `Cargo.toml` for `performance` feature

### DIFF
--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -134,7 +134,7 @@ ignored = [
 
 [features]
 default = ["python", "python-managed", "pypi", "git", "performance", "crates-io"]
-# Use better memory allocators, etc. — also turns-on self-update.
+# Use better memory allocators, etc.
 performance = [
     "performance-memory-allocator",
     "performance-flate2-backend",


### PR DESCRIPTION
It really does not look like this turns on self-update
