### PR TITLE
Improve performance of our test drive in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Dev Drive using ReFS
+      - name: Setup Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
@@ -260,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Dev Drive using ReFS
+      - name: Setup Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
@@ -333,7 +333,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Dev Drive using ReFS
+      - name: Setup Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
@@ -522,7 +522,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Dev Drive using ReFS
+      - name: Setup Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -5,11 +5,25 @@ $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 20GB |
 					Mount-VHD -Passthru |
 					Initialize-Disk -Passthru |
 					New-Partition -AssignDriveLetter -UseMaximumSize |
-					Format-Volume -FileSystem ReFS -Confirm:$false -Force
-
-Write-Output $Volume
+					Format-Volume -FileSystem ReFS -DevDrive -Confirm:$false -Force
 
 $Drive = "$($Volume.DriveLetter):"
+
+# Set the drive as trusted
+# See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-designate-a-dev-drive-as-trusted
+fsutil devdrv trust $Drive
+# Disable antivirus filtering on dev drives
+# See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-configure-additional-filters-on-dev-drive
+fsutil devdrv enable /disallowAv
+
+# Remount so the filtering takes effect
+Dismount-VHD -Path C:/uv_dev_drive.vhdx
+Mount-VHD -Path C:/uv_dev_drive.vhdx
+
+# Show some debug information
+Write-Output $Volume
+fsutil devdrv query $Drive
+
 $Tmp = "$($Drive)/uv-tmp"
 
 # Create the directory ahead of time in an attempt to avoid race-conditions

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -5,7 +5,7 @@ $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 20GB |
 					Mount-VHD -Passthru |
 					Initialize-Disk -Passthru |
 					New-Partition -AssignDriveLetter -UseMaximumSize |
-					Format-Volume -FileSystem ReFS -DevDrive -Confirm:$false -Force
+					Format-Volume -DevDrive -Confirm:$false -Force
 
 $Drive = "$($Volume.DriveLetter):"
 

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -12,11 +12,12 @@ $Drive = "$($Volume.DriveLetter):"
 # Set the drive as trusted
 # See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-designate-a-dev-drive-as-trusted
 fsutil devdrv trust $Drive
+
 # Disable antivirus filtering on dev drives
 # See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-configure-additional-filters-on-dev-drive
 fsutil devdrv enable /disallowAv
 
-# Remount so the filtering takes effect
+# Remount so the changes take effect
 Dismount-VHD -Path C:/uv_dev_drive.vhdx
 Mount-VHD -Path C:/uv_dev_drive.vhdx
 
@@ -24,6 +25,7 @@ Mount-VHD -Path C:/uv_dev_drive.vhdx
 Write-Output $Volume
 fsutil devdrv query $Drive
 
+# Configure a temporary directory
 $Tmp = "$($Drive)/uv-tmp"
 
 # Create the directory ahead of time in an attempt to avoid race-conditions


### PR DESCRIPTION
Previously, we couldn't use a DevDrive (https://github.com/astral-sh/uv/pull/3522#issuecomment-2111448930) because our Windows version was not sufficient.

Recently, I upgraded our larger runners to Windows 2025 preview (https://github.com/astral-sh/uv/pull/10298) which I presume has support for this.

I removed ReFS in https://github.com/astral-sh/uv/pull/10651/commits/953c3535c3754f580ecd8da55637756f58606567 which didn't seem to do anything to performance.

I also found some notes on "trusted" DevDrives and "disabling anti-virus filtering" which I simply have to try.