### PR TITLE
Move `cargo` to the Dev Drive in Windows CI

### DIFF
--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -45,6 +45,10 @@ $Tmp = "$($Drive)\uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
+# Move Cargo to the dev drive
+New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
+Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `
 	"TMP=$($Tmp)" `
@@ -53,5 +57,6 @@ Write-Output `
 	"RUSTUP_HOME=$($Drive)/.rustup" `
 	"CARGO_HOME=$($Drive)/.cargo" `
 	"UV_WORKSPACE=$($Drive)/uv" `
+	"PATH=$($Drive)/.cargo/bin;$env:PATH" `
 	>> $env:GITHUB_ENV
 


### PR DESCRIPTION
This successfully changed the nextest install to target the dev drive

```
info: cargo-nextest installed at /e/.cargo/bin/cargo-nextest.exe
```