### PR TITLE
Add support for `pypy_73`-style tags

### DIFF
--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -392,7 +392,7 @@ impl Implementation {
             },
             // Ex) `pypy39_pp73`
             Self::PyPy => AbiTag::PyPy {
-                python_version,
+                python_version: Some(python_version),
                 implementation_version,
             },
             // Ex) `graalpy310_graalpy240_310_native

--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -464,7 +464,7 @@ impl RequiresPython {
                     python_version: (2, ..),
                     ..
                 } | AbiTag::PyPy {
-                    python_version: (2, ..),
+                    python_version: None | Some((2, ..)),
                     ..
                 } | AbiTag::GraalPy {
                     python_version: (2, ..),
@@ -478,7 +478,7 @@ impl RequiresPython {
                 ..
             }
             | AbiTag::PyPy {
-                python_version: (3, minor),
+                python_version: Some((3, minor)),
                 ..
             }
             | AbiTag::GraalPy {


### PR DESCRIPTION
## Summary

I'm inferring that these are like... the older tag format? See, e.g.:

```
soxbindings-0.0.1-pp27-pypy_73-macosx_10_9_x86_64.whl
soxbindings-0.0.1-pp27-pypy_73-manylinux2010_x86_64.whl
soxbindings-0.0.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl
soxbindings-0.0.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl
```
