### PR TITLE
Use 32-core Windows runner for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
     timeout-minutes: 15
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
-    runs-on: github-windows-2025-x86_64-16
+    runs-on: github-windows-2025-x86_64-32
     name: "cargo test | windows"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Historically, this has not been worth it; worth a try though

- 73cade13862c88bf2d5344759e9b1b7035b63743 (latest `main`): 7m 39s (test) / 9m 24s (total)
- 8325fae996c513d46976bede99761ce2a64735e4 (based on `main`): 6m 18s / 8m 11s
- e12e35f1de4493bb586c7dee93f66d8432002c40 (based on other dev-drive improvements): 5m 47s / 6m 59s

Something like a 25% improvement?