### PR TITLE
Store unsupported tags in wheel filename

### DIFF
--- a/crates/uv-distribution-filename/src/lib.rs
+++ b/crates/uv-distribution-filename/src/lib.rs
@@ -7,7 +7,7 @@ pub use build_tag::{BuildTag, BuildTagError};
 pub use egg::{EggInfoFilename, EggInfoFilenameError};
 pub use extension::{DistExtension, ExtensionError, SourceDistExtension};
 pub use source_dist::{SourceDistFilename, SourceDistFilenameError};
-pub use wheel::{TagSet, WheelFilename, WheelFilenameError};
+pub use wheel::{WheelFilename, WheelFilenameError};
 
 mod build_tag;
 mod egg;
@@ -15,6 +15,7 @@ mod extension;
 mod source_dist;
 mod splitter;
 mod wheel;
+mod wheel_tag;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DistFilename {
@@ -97,13 +98,9 @@ impl Display for DistFilename {
 #[cfg(test)]
 mod tests {
     use crate::WheelFilename;
-    use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag};
 
     #[test]
     fn wheel_filename_size() {
-        assert_eq!(size_of::<WheelFilename>(), 72);
-        assert_eq!(size_of::<LanguageTag>(), 16);
-        assert_eq!(size_of::<AbiTag>(), 16);
-        assert_eq!(size_of::<PlatformTag>(), 16);
+        assert_eq!(size_of::<WheelFilename>(), 48);
     }
 }

--- a/crates/uv-distribution-filename/src/snapshots/uv_distribution_filename__wheel__tests__ok_build_tag.snap
+++ b/crates/uv-distribution-filename/src/snapshots/uv_distribution_filename__wheel__tests__ok_build_tag.snap
@@ -28,6 +28,7 @@ Ok(
                 platform_tag: [
                     Any,
                 ],
+                repr: "202206090410-py3-none-any",
             },
         },
     },

--- a/crates/uv-distribution-filename/src/snapshots/uv_distribution_filename__wheel__tests__ok_multiple_tags.snap
+++ b/crates/uv-distribution-filename/src/snapshots/uv_distribution_filename__wheel__tests__ok_multiple_tags.snap
@@ -38,6 +38,7 @@ Ok(
                         arch: X86_64,
                     },
                 ],
+                repr: "cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64",
             },
         },
     },

--- a/crates/uv-distribution-filename/src/wheel_tag.rs
+++ b/crates/uv-distribution-filename/src/wheel_tag.rs
@@ -1,0 +1,115 @@
+use std::fmt::{Display, Formatter};
+
+use crate::BuildTag;
+use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag};
+use uv_small_str::SmallString;
+
+/// A [`SmallVec`] type for storing tags.
+///
+/// Wheels tend to include a single language, ABI, and platform tag, so we use a [`SmallVec`] with a
+/// capacity of 1 to optimize for this common case.
+pub(crate) type TagSet<T> = smallvec::SmallVec<[T; 3]>;
+
+/// The portion of the wheel filename following the name and version: the optional build tag, along
+/// with the Python tag(s), ABI tag(s), and platform tag(s).
+///
+/// Most wheels consist of a single Python, ABI, and platform tag (and no build tag). We represent
+/// such wheels with [`WheelTagSmall`], a variant with a smaller memory footprint and (generally)
+/// zero allocations. The [`WheelTagLarge`] variant is used for wheels with multiple tags, a build
+/// tag, or an unsupported tag (i.e., a tag that can't be represented by [`LanguageTag`],
+/// [`AbiTag`], or [`PlatformTag`]). (Unsupported tags are filtered out, but retained in the display
+/// representation of [`WheelTagLarge`].)
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
+pub(crate) enum WheelTag {
+    Small { small: WheelTagSmall },
+    Large { large: Box<WheelTagLarge> },
+}
+
+impl Display for WheelTag {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Small { small } => write!(f, "{small}"),
+            Self::Large { large } => write!(f, "{large}"),
+        }
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
+#[allow(clippy::struct_field_names)]
+pub(crate) struct WheelTagSmall {
+    /// The Python tag, e.g., `py3` in `1.2.3-py3-none-any`.
+    pub(crate) python_tag: LanguageTag,
+    /// The ABI tag, e.g., `none` in `1.2.3-py3-none-any`.
+    pub(crate) abi_tag: AbiTag,
+    /// The platform tag, e.g., `none` in `1.2.3-py3-none-any`.
+    pub(crate) platform_tag: PlatformTag,
+}
+
+impl Display for WheelTagSmall {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}-{}-{}",
+            self.python_tag, self.abi_tag, self.platform_tag
+        )
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
+#[allow(clippy::struct_field_names)]
+pub(crate) struct WheelTagLarge {
+    /// The optional build tag, e.g., `73` in `1.2.3-73-py3-none-any`.
+    pub(crate) build_tag: Option<BuildTag>,
+    /// The Python tag(s), e.g., `py3` in `1.2.3-73-py3-none-any`.
+    pub(crate) python_tag: TagSet<LanguageTag>,
+    /// The ABI tag(s), e.g., `none` in `1.2.3-73-py3-none-any`.
+    pub(crate) abi_tag: TagSet<AbiTag>,
+    /// The platform tag(s), e.g., `none` in `1.2.3-73-py3-none-any`.
+    pub(crate) platform_tag: TagSet<PlatformTag>,
+    /// The string representation of the tag.
+    ///
+    /// Preserves any unsupported tags that were filtered out when parsing the wheel filename.
+    pub(crate) repr: SmallString,
+}
+
+impl Display for WheelTagLarge {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.repr)
+    }
+}

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1343,8 +1343,8 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(size_of::<Dist>() <= 208, "{}", size_of::<Dist>());
-        assert!(size_of::<BuiltDist>() <= 208, "{}", size_of::<BuiltDist>());
+        assert!(size_of::<Dist>() <= 200, "{}", size_of::<Dist>());
+        assert!(size_of::<BuiltDist>() <= 200, "{}", size_of::<BuiltDist>());
         assert!(
             size_of::<SourceDist>() <= 176,
             "{}",

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -523,20 +523,20 @@ impl PrioritizedDist {
     }
 
     /// Returns the set of all Python tags for the distribution.
-    pub fn python_tags(&self) -> BTreeSet<&LanguageTag> {
+    pub fn python_tags(&self) -> BTreeSet<LanguageTag> {
         self.0
             .wheels
             .iter()
-            .flat_map(|(wheel, _)| wheel.filename.python_tags().iter())
+            .flat_map(|(wheel, _)| wheel.filename.python_tags().iter().copied())
             .collect()
     }
 
     /// Returns the set of all ABI tags for the distribution.
-    pub fn abi_tags(&self) -> BTreeSet<&AbiTag> {
+    pub fn abi_tags(&self) -> BTreeSet<AbiTag> {
         self.0
             .wheels
             .iter()
-            .flat_map(|(wheel, _)| wheel.filename.abi_tags().iter())
+            .flat_map(|(wheel, _)| wheel.filename.abi_tags().iter().copied())
             .collect()
     }
 
@@ -547,7 +547,7 @@ impl PrioritizedDist {
         for (wheel, _) in &self.0.wheels {
             for wheel_py in wheel.filename.python_tags() {
                 for wheel_abi in wheel.filename.abi_tags() {
-                    if tags.is_compatible_abi(wheel_py, wheel_abi) {
+                    if tags.is_compatible_abi(*wheel_py, *wheel_abi) {
                         candidates.extend(wheel.filename.platform_tags().iter());
                     }
                 }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -298,13 +298,13 @@ impl Tags {
     }
 
     /// Return the highest-priority Python tag for the [`Tags`].
-    pub fn python_tag(&self) -> Option<&LanguageTag> {
-        self.best.as_ref().map(|(python, _, _)| python)
+    pub fn python_tag(&self) -> Option<LanguageTag> {
+        self.best.as_ref().map(|(python, _, _)| *python)
     }
 
     /// Return the highest-priority ABI tag for the [`Tags`].
-    pub fn abi_tag(&self) -> Option<&AbiTag> {
-        self.best.as_ref().map(|(_, abi, _)| abi)
+    pub fn abi_tag(&self) -> Option<AbiTag> {
+        self.best.as_ref().map(|(_, abi, _)| *abi)
     }
 
     /// Return the highest-priority platform tag for the [`Tags`].
@@ -314,10 +314,10 @@ impl Tags {
 
     /// Returns `true` if the given language and ABI tags are compatible with the current
     /// environment.
-    pub fn is_compatible_abi(&self, python_tag: &LanguageTag, abi_tag: &AbiTag) -> bool {
+    pub fn is_compatible_abi(&self, python_tag: LanguageTag, abi_tag: AbiTag) -> bool {
         self.map
-            .get(python_tag)
-            .map(|abis| abis.contains_key(abi_tag))
+            .get(&python_tag)
+            .map(|abis| abis.contains_key(&abi_tag))
             .unwrap_or(false)
     }
 }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -744,12 +744,8 @@ impl PubGrubReportFormatter<'_> {
         match tag {
             IncompatibleTag::Invalid => None,
             IncompatibleTag::Python => {
-                let best = tags.and_then(Tags::python_tag).cloned();
-                let tags = prioritized
-                    .python_tags()
-                    .into_iter()
-                    .cloned()
-                    .collect::<BTreeSet<_>>();
+                let best = tags.and_then(Tags::python_tag);
+                let tags = prioritized.python_tags();
                 if tags.is_empty() {
                     None
                 } else {
@@ -762,7 +758,7 @@ impl PubGrubReportFormatter<'_> {
                 }
             }
             IncompatibleTag::Abi | IncompatibleTag::AbiPythonVersion => {
-                let best = tags.and_then(Tags::abi_tag).cloned();
+                let best = tags.and_then(Tags::abi_tag);
                 let tags = prioritized
                     .abi_tags()
                     .into_iter()
@@ -774,8 +770,7 @@ impl PubGrubReportFormatter<'_> {
                     // In that case, the wheel isn't compatible, but when solving for Python 3.13,
                     // the `cp312` Python tag _can_ be compatible (e.g., for `cp312-abi3-macosx_11_0_arm64.whl`),
                     // so this is considered an ABI incompatibility rather than Python incompatibility.
-                    .filter(|tag| **tag != AbiTag::None)
-                    .cloned()
+                    .filter(|tag| *tag != AbiTag::None)
                     .collect::<BTreeSet<_>>();
                 if tags.is_empty() {
                     None
@@ -1581,7 +1576,7 @@ impl std::fmt::Display for PubGrubHint {
                 tags,
                 best,
             } => {
-                if let Some(best) = best.as_ref() {
+                if let Some(best) = best {
                     let s = if tags.len() == 1 { "" } else { "s" };
                     let best = if let Some(pretty) = best.pretty() {
                         format!("{} (`{}`)", pretty.cyan(), best.cyan())
@@ -1621,7 +1616,7 @@ impl std::fmt::Display for PubGrubHint {
                 tags,
                 best,
             } => {
-                if let Some(best) = best.as_ref() {
+                if let Some(best) = best {
                     let s = if tags.len() == 1 { "" } else { "s" };
                     let best = if let Some(pretty) = best.pretty() {
                         format!("{} (`{}`)", pretty.cyan(), best.cyan())


### PR DESCRIPTION
## Summary

We can retain the small-size advantage of our new tags by moving the "unknown tag" case into `WheelTagLarge`. This ensures that we can still represent unknown tags, but avoid paying the cost for them.
