### PR TITLE
Add elvish activation script

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate.elv
+++ b/crates/uv-virtualenv/src/activator/activate.elv
@@ -1,0 +1,17 @@
+use path
+use edit
+
+var venv-path = (path:join '{{ VIRTUAL_ENV_DIR }}' '{{ BIN_NAME }}')
+
+var paths-bak = $paths
+set paths = [venv-path $@paths]
+
+set-env VIRTUAL_ENV '{{ VIRTUAL_ENV_DIR }}'
+set-env VIRTUAL_ENV_PROMPT '{{ VIRTUAL_PROMPT }}'
+
+edit:add-var deactivate~ {
+  set paths = $paths-bak
+  unset-env VIRTUAL_ENV
+  unset-env VIRTUAL_ENV_PROMPT
+  edit:del-var deactivate~
+}

--- a/crates/uv-virtualenv/src/activator/activate.elv
+++ b/crates/uv-virtualenv/src/activator/activate.elv
@@ -1,10 +1,9 @@
 use path
-use edit
 
-var venv-path = (path:join '{{ VIRTUAL_ENV_DIR }}' '{{ BIN_NAME }}')
+var venv-bin = (path:join '{{ VIRTUAL_ENV_DIR }}' '{{ BIN_NAME }}')
 
 var paths-bak = $paths
-set paths = [venv-path $@paths]
+set paths = [$venv-bin $@paths]
 
 set-env VIRTUAL_ENV '{{ VIRTUAL_ENV_DIR }}'
 set-env VIRTUAL_ENV_PROMPT '{{ VIRTUAL_PROMPT }}'

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -23,6 +23,7 @@ use crate::{Error, Prompt};
 const ACTIVATE_TEMPLATES: &[(&str, &str)] = &[
     ("activate", include_str!("activator/activate")),
     ("activate.csh", include_str!("activator/activate.csh")),
+    ("activate.elv", include_str!("activator/activate.elv")),
     ("activate.fish", include_str!("activator/activate.fish")),
     ("activate.nu", include_str!("activator/activate.nu")),
     ("activate.ps1", include_str!("activator/activate.ps1")),


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Supports activation script for elvish

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I filled the template variables manually and tried in a project. It works well.

```shell
D:\Projects\Python\project-name on  main [?] is 📦 v0.1.0 via 🐍 v3.13.1 
❯ python -V
Python 3.13.1

D:\Projects\Python\project-name on  main [?] is 📦 v0.1.0 via 🐍 v3.13.1 
❯ source .venv\Scripts\activate.elv

D:\Projects\Python\project-name on  main [?] is 📦 v0.1.0 via 🐍 v3.12.8 (project-name) 
❯ python -V
Python 3.12.8

D:\Projects\Python\project-name on  main [?] is 📦 v0.1.0 via 🐍 v3.12.8 (project-name) 
❯ deactivate

D:\Projects\Python\project-name on  main [?] is 📦 v0.1.0 via 🐍 v3.13.1 
❯ python -V
Python 3.13.1
```

<!-- How was it tested? -->
