### PR TITLE
Log memory stats on timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +3774,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "tagu"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5186,6 +5208,7 @@ dependencies = [
  "rayon",
  "rustc-hash",
  "same-file",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.11",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,10 @@ sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
 spdx = { version = "0.10.6" }
 syn = { version = "2.0.77" }
+# Platform information
 sys-info = { version = "0.9.1" }
+# Runtime information
+sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 tar = { version = "0.4.43" }
 target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.14.0" }

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -41,6 +41,7 @@ futures = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 same-file = { workspace = true }
+sysinfo = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Counter to #10672, i'm trying to log memory stats on a bytecode compilation timeout for #6105.

Not polished since this is debug output.

Example:

```
error: Failed to bytecode-compile Python file in: .venv/lib/python3.13/site-packages
  Caused by: Bytecode timed out (0.02s) compiling file: `/home/konsti/projects/uv/.venv/lib/python3.13/site-packages/plotly/graph_objs/_figurewidget.py`. Total memory: 67172139008 bytes, used memory: 20386217984 bytes, total swap: 0 bytes, used swap: 0 bytes.
```
