### PR TITLE
Make running uv version error clearer

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -233,7 +233,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         let package_version = uv_pep440::Version::from_str(uv_version::version())?;
         if !required_version.contains(&package_version) {
             return Err(anyhow::anyhow!(
-                "Required version `{required_version}` does not match the running version `{package_version}`",
+                "Required uv version `{required_version}` does not match the running version `{package_version}`",
             ));
         }
     }


### PR DESCRIPTION
The existing error for when the installed uv version does not match the required version might be confusing, hopefully this makes it clearer.