### PR TITLE
Discard insufficient fork markers

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -991,7 +991,7 @@ impl ValidatedLock {
         } else {
             MarkerTree::TRUE
         };
-        // We respect requires-python in addition to the environments the user specified.
+        // When a user defines environments, they are implicitly constrained by requires-python.
         environments_union.and(requires_python.to_marker_tree());
         if !fork_markers_union.negate().is_disjoint(environments_union) {
             warn_user!(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -25,7 +25,6 @@ use uv_distribution_types::{
 use uv_git::ResolvedRepositoryReference;
 use uv_normalize::{GroupName, PackageName};
 use uv_pep440::Version;
-use uv_pep508::MarkerTree;
 use uv_pypi_types::{Conflicts, Requirement, SupportedEnvironments};
 use uv_python::{Interpreter, PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
 use uv_requirements::upgrade::{read_lock_requirements, LockedRequirements};
@@ -966,34 +965,7 @@ impl ValidatedLock {
             return Ok(Self::Versions(lock));
         }
 
-        // Catch a lockfile where the union of fork markers doesn't cover the supported
-        // environments.
-        //
-        // We subset by requires-python, since the space outside of it does not matter. The fork
-        // markers however should contain the requires-python value, if they don't it wouldn't be
-        // a problem on sync, but it indicates a broken lockfile where we should recompute the
-        // fork-markers (the versions are preserved, so the churn is low).
-        let fork_markers_union = if lock.fork_markers().is_empty() {
-            requires_python.to_marker_tree()
-        } else {
-            let mut fork_markers_union = MarkerTree::FALSE;
-            for fork_marker in lock.fork_markers() {
-                fork_markers_union.or(fork_marker.pep508());
-            }
-            fork_markers_union
-        };
-        let mut environments_union = if let Some(environments) = environments {
-            let mut environments_union = MarkerTree::FALSE;
-            for fork_marker in environments.as_markers() {
-                environments_union.or(*fork_marker);
-            }
-            environments_union
-        } else {
-            MarkerTree::TRUE
-        };
-        // When a user defines environments, they are implicitly constrained by requires-python.
-        environments_union.and(requires_python.to_marker_tree());
-        if !fork_markers_union.negate().is_disjoint(environments_union) {
+        if let Err((fork_markers_union, environments_union)) = lock.check_marker_coverage() {
             warn_user!(
                 "Ignoring existing lockfile due to fork markers not covering the supported environments: `{}` vs `{}`",
                 fork_markers_union.try_to_string().unwrap_or("true".to_string()),


### PR DESCRIPTION
In #10669, a pyproject.toml with requires-python but no environment had a lockfile covering only a subset of the requires-python space:

```toml
resolution-markers = [
    "python_full_version >= '3.10' and platform_python_implementation == 'CPython'",
    "python_full_version == '3.9.*'",
    "python_full_version < '3.9'",
]
```

This marker set is invalid, we have to reject the lockfile. (We can still use the versions though, to avoid churn).

Part 1/2 of #10669