### PR TITLE
Respect environment variable credentials for indexes outside root

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -236,16 +236,12 @@ impl LoweredRequirement {
                                 .find(|Index { name, .. }| {
                                     name.as_ref().is_some_and(|name| *name == index)
                                 })
+                                .map(|Index { url: index, .. }| index.clone())
                             else {
                                 return Err(LoweringError::MissingIndex(
                                     requirement.name.clone(),
                                     index,
                                 ));
-                            };
-                            let url = if let Some(credentials) = index.credentials() {
-                                credentials.apply(index.url.clone().into_url())
-                            } else {
-                                index.url.clone().into_url()
                             };
                             let conflict = project_name.and_then(|project_name| {
                                 if let Some(extra) = extra {
@@ -256,7 +252,12 @@ impl LoweredRequirement {
                                     })
                                 }
                             });
-                            let source = registry_source(&requirement, url, conflict, lower_bound);
+                            let source = registry_source(
+                                &requirement,
+                                index.into_url(),
+                                conflict,
+                                lower_bound,
+                            );
                             (source, marker)
                         }
                         Source::Workspace {
@@ -464,19 +465,20 @@ impl LoweredRequirement {
                                 .find(|Index { name, .. }| {
                                     name.as_ref().is_some_and(|name| *name == index)
                                 })
+                                .map(|Index { url: index, .. }| index.clone())
                             else {
                                 return Err(LoweringError::MissingIndex(
                                     requirement.name.clone(),
                                     index,
                                 ));
                             };
-                            let url = if let Some(credentials) = index.credentials() {
-                                credentials.apply(index.url.clone().into_url())
-                            } else {
-                                index.url.clone().into_url()
-                            };
                             let conflict = None;
-                            let source = registry_source(&requirement, url, conflict, lower_bound);
+                            let source = registry_source(
+                                &requirement,
+                                index.into_url(),
+                                conflict,
+                                lower_bound,
+                            );
                             (source, marker)
                         }
                         Source::Workspace { .. } => {

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -236,12 +236,16 @@ impl LoweredRequirement {
                                 .find(|Index { name, .. }| {
                                     name.as_ref().is_some_and(|name| *name == index)
                                 })
-                                .map(|Index { url: index, .. }| index.clone())
                             else {
                                 return Err(LoweringError::MissingIndex(
                                     requirement.name.clone(),
                                     index,
                                 ));
+                            };
+                            let url = if let Some(credentials) = index.credentials() {
+                                credentials.apply(index.url.clone().into_url())
+                            } else {
+                                index.url.clone().into_url()
                             };
                             let conflict = project_name.and_then(|project_name| {
                                 if let Some(extra) = extra {
@@ -252,12 +256,7 @@ impl LoweredRequirement {
                                     })
                                 }
                             });
-                            let source = registry_source(
-                                &requirement,
-                                index.into_url(),
-                                conflict,
-                                lower_bound,
-                            );
+                            let source = registry_source(&requirement, url, conflict, lower_bound);
                             (source, marker)
                         }
                         Source::Workspace {
@@ -465,20 +464,19 @@ impl LoweredRequirement {
                                 .find(|Index { name, .. }| {
                                     name.as_ref().is_some_and(|name| *name == index)
                                 })
-                                .map(|Index { url: index, .. }| index.clone())
                             else {
                                 return Err(LoweringError::MissingIndex(
                                     requirement.name.clone(),
                                     index,
                                 ));
                             };
+                            let url = if let Some(credentials) = index.credentials() {
+                                credentials.apply(index.url.clone().into_url())
+                            } else {
+                                index.url.clone().into_url()
+                            };
                             let conflict = None;
-                            let source = registry_source(
-                                &requirement,
-                                index.into_url(),
-                                conflict,
-                                lower_bound,
-                            );
+                            let source = registry_source(&requirement, url, conflict, lower_bound);
                             (source, marker)
                         }
                         Source::Workspace { .. } => {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -468,6 +468,12 @@ async fn do_lock(
         }
     }
 
+    for index in target.indexes() {
+        if let Some(credentials) = index.credentials() {
+            uv_auth::store_credentials(index.raw_url(), credentials);
+        }
+    }
+
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
         .native_tls(native_tls)

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -363,8 +363,8 @@ pub(super) async fn do_sync(
         }
     }
 
-    // Populate credentials from the workspace.
-    store_credentials_from_workspace(target);
+    // Populate credentials from the target.
+    store_credentials_from_target(target);
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
@@ -522,7 +522,14 @@ fn apply_editable_mode(resolution: Resolution, editable: EditableMode) -> Resolu
 ///
 /// These credentials can come from any of `tool.uv.sources`, `tool.uv.dev-dependencies`,
 /// `project.dependencies`, and `project.optional-dependencies`.
-fn store_credentials_from_workspace(target: InstallTarget<'_>) {
+fn store_credentials_from_target(target: InstallTarget<'_>) {
+    // Iterate over any idnexes in the target.
+    for index in target.indexes() {
+        if let Some(credentials) = index.credentials() {
+            store_credentials(index.raw_url(), credentials);
+        }
+    }
+
     // Iterate over any sources in the target.
     for source in target.sources() {
         match source {


### PR DESCRIPTION
## Summary

We now respect environment variable-based authentication when the explicit index is defined outside of the workspace root. This applies to both local and Git-based projects.

Closes https://github.com/astral-sh/uv/issues/10680.
