### PR TITLE
Avoid returning `Some` for narrowing no-ops

### DIFF
--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -100,6 +100,8 @@ impl PythonRequirement {
 
     /// Narrow the [`PythonRequirement`] to the given version, if it's stricter (i.e., greater)
     /// than the current `Requires-Python` minimum.
+    ///
+    /// Returns `None` if the given range is not narrower than the current range.
     pub fn narrow(&self, target: &RequiresPythonRange) -> Option<Self> {
         Some(Self {
             exact: self.exact.clone(),

--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -115,7 +115,12 @@ impl RequiresPython {
     }
 
     /// Narrow the [`RequiresPython`] by computing the intersection with the given range.
+    ///
+    /// Returns `None` if the given range is not narrower than the current range.
     pub fn narrow(&self, range: &RequiresPythonRange) -> Option<Self> {
+        if *range == self.range {
+            return None;
+        }
         let lower = if range.0 >= self.range.0 {
             Some(&range.0)
         } else {

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -690,17 +690,14 @@ mod tests {
     }
 
     /// Inside a fork whose marker's Python requirement is equal
-    /// to our Requires-Python means that narrowing produces a
-    /// result, but is unchanged from what we started with.
+    /// to our Requires-Python means that narrowing does not produce
+    /// a result.
     #[test]
     fn narrow_python_requirement_forking_no_op() {
         let pyreq = python_requirement("3.10");
         let resolver_env = ResolverEnvironment::universal(vec![])
             .narrow_environment(marker("python_version >= '3.10'"));
-        assert_eq!(
-            resolver_env.narrow_python_requirement(&pyreq),
-            Some(python_requirement("3.10")),
-        );
+        assert_eq!(resolver_env.narrow_python_requirement(&pyreq), None);
     }
 
     /// In this test, we narrow a more relaxed requirement compared to the


### PR DESCRIPTION
The net effect here is (I think) just that we end up logging more "narrowing" outcomes than we have in practice.