### PR TITLE
Improve log when distutils is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,6 +680,38 @@ jobs:
           echo "$CONDA_PREFIX"
           ./uv pip install anyio
 
+  integration-test-deadnsakes-39-linux:
+    timeout-minutes: 5
+    needs: build-binary-linux
+    name: "integration test | free-threaded on linux"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "install python3.9"
+        run: |
+          sudo add-apt-repository ppa:deadsnakes
+          sudo apt-get update
+          sudo apt-get install python3.9
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Create a virtual environment"
+        run: |
+          ./uv venv -p 3.9 --python-preference only-system
+
+      - name: "Check version"
+        run: |
+          .venv/bin/python --version
+
+      - name: "Check install"
+        run: |
+          ./uv pip install -v anyio
+
   integration-test-free-threaded-linux:
     timeout-minutes: 5
     needs: build-binary-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,7 +686,7 @@ jobs:
     name: "integration test | deadsnakes python3.9 on ubuntu"
     runs-on: ubuntu-latest
     steps:
-      - name: "install python3.9"
+      - name: "Install python3.9"
         run: |
           sudo add-apt-repository ppa:deadsnakes
           sudo apt-get update
@@ -718,7 +718,7 @@ jobs:
     name: "integration test | free-threaded on linux"
     runs-on: ubuntu-latest
     steps:
-      - name: "install python3.13-nogil"
+      - name: "Install python3.13-nogil"
         run: |
           sudo add-apt-repository ppa:deadsnakes
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,7 +680,7 @@ jobs:
           echo "$CONDA_PREFIX"
           ./uv pip install anyio
 
-  integration-test-deadnsakes-39-linux:
+  integration-test-deadsnakes-39-linux:
     timeout-minutes: 5
     needs: build-binary-linux
     name: "integration test | deadsnakes python3.9 on ubuntu"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
   integration-test-deadnsakes-39-linux:
     timeout-minutes: 5
     needs: build-binary-linux
-    name: "integration test | free-threaded on linux"
+    name: "integration test | deadsnakes python3.9 on ubuntu"
     runs-on: ubuntu-latest
     steps:
       - name: "install python3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,9 +708,20 @@ jobs:
         run: |
           .venv/bin/python --version
 
+      - name: "Check install missing distutils"
+        run: |
+          ./uv pip install -v anyio 2>&1 | tee log.txt || true
+          # We should report that distutils is missing
+          grep 'Python installation is missing `distutils`' log.txt
+
+      - name: "Install distutils"
+        run: |
+          sudo apt-get install python3.9-distutils
+
       - name: "Check install"
         run: |
           ./uv pip install -v anyio
+          # Now the install should succeed
 
   integration-test-free-threaded-linux:
     timeout-minutes: 5

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -720,9 +720,15 @@ impl Error {
                 InterpreterError::Encode(_)
                 | InterpreterError::Io(_)
                 | InterpreterError::SpawnFailed { .. } => true,
-                InterpreterError::QueryScript { path, .. }
-                | InterpreterError::UnexpectedResponse { path, .. }
+                InterpreterError::UnexpectedResponse { path, .. }
                 | InterpreterError::StatusCode { path, .. } => {
+                    debug!(
+                        "Skipping bad interpreter at {} from {source}: {err}",
+                        path.display()
+                    );
+                    false
+                }
+                InterpreterError::QueryScript { path, err } => {
                     debug!(
                         "Skipping bad interpreter at {} from {source}: {err}",
                         path.display()

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -606,8 +606,8 @@ pub enum InterpreterInfoError {
     UnsupportedPython,
     #[error("Python installation is missing `distutils`, which is required for packaging on older Python versions. Your system may package it separately, e.g., as `python{python_major}-distutils` or `python{python_major}.{python_minor}-distutils`.")]
     MissingRequiredDistutils {
-        python_major: String,
-        python_minor: String,
+        python_major: usize,
+        python_minor: usize,
     },
 }
 

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -604,6 +604,11 @@ pub enum InterpreterInfoError {
     UnsupportedPythonVersion { python_version: String },
     #[error("Python executable does not support `-I` flag. Please use Python 3.8 or newer.")]
     UnsupportedPython,
+    #[error("Python installation is missing `distutils`, which is required for packaging on older Python versions. Your system may package it separately, e.g., as `python{python_major}-distutils` or `python{python_major}.{python_minor}-distutils`.")]
+    MissingRequiredDistutils {
+        python_major: String,
+        python_minor: String,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/4204 for motivation

This doesn't really reach the user experience I'd expect — i.e., we end up saying a virtual environment "does not exist" which is a little silly. However, I think improving the error messaging on interpreter queries in general should be solved separately. I did one small "general" change in https://github.com/astral-sh/uv/pull/10713/commits/89e11d022222a999a4ba8eb73397ea314a636811 — otherwise we don't show the message at all.