### PR TITLE
Show non-critical Python discovery errors if no other interpreter is found

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -983,7 +983,9 @@ pub(crate) fn find_python_installation(
         if !result.as_ref().err().map_or(true, Error::is_critical) {
             // Track the first non-critical error
             if first_error.is_none() {
-                first_error = Some(result);
+                if let Err(err) = result {
+                    first_error = Some(err);
+                }
             }
             continue;
         }
@@ -1039,8 +1041,8 @@ pub(crate) fn find_python_installation(
 
     // If we found a Python, but it was unusable for some reason, report that instead of saying we
     // couldn't find any Python interpreters.
-    if let Some(result) = first_error {
-        return result;
+    if let Some(err) = first_error {
+        return Err(err);
     }
 
     Ok(Err(PythonNotFound {

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -977,9 +977,14 @@ pub(crate) fn find_python_installation(
 ) -> Result<FindPythonResult, Error> {
     let installations = find_python_installations(request, environments, preference, cache);
     let mut first_prerelease = None;
+    let mut first_error = None;
     for result in installations {
         // Iterate until the first critical error or happy result
         if !result.as_ref().err().map_or(true, Error::is_critical) {
+            // Track the first non-critical error
+            if first_error.is_none() {
+                first_error = Some(result);
+            }
             continue;
         }
 
@@ -1030,6 +1035,12 @@ pub(crate) fn find_python_installation(
     // If we only found pre-releases, they're implicitly allowed and we should return the first one.
     if let Some(installation) = first_prerelease {
         return Ok(Ok(installation));
+    }
+
+    // If we found a Python, but it was unusable for some reason, report that instead of saying we
+    // couldn't find any Python interpreters.
+    if let Some(result) = first_error {
+        return result;
     }
 
     Ok(Err(PythonNotFound {

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -720,43 +720,25 @@ impl Error {
                 InterpreterError::Encode(_)
                 | InterpreterError::Io(_)
                 | InterpreterError::SpawnFailed { .. } => true,
-                InterpreterError::UnexpectedResponse { path, .. }
-                | InterpreterError::StatusCode { path, .. } => {
-                    debug!(
-                        "Skipping bad interpreter at {} from {source}: {err}",
-                        path.display()
-                    );
-                    false
-                }
-                InterpreterError::QueryScript { path, err } => {
-                    debug!(
-                        "Skipping bad interpreter at {} from {source}: {err}",
-                        path.display()
-                    );
-                    false
-                }
+                InterpreterError::UnexpectedResponse { .. }
+                | InterpreterError::StatusCode { .. } => false,
+                InterpreterError::QueryScript { .. } => false,
                 InterpreterError::NotFound(path) => {
                     // If the interpreter is from an active, valid virtual environment, we should
                     // fail because it's broken
-                    if let Some(Ok(true)) = matches!(source, PythonSource::ActiveEnvironment)
-                        .then(|| {
-                            path.parent()
-                                .and_then(Path::parent)
-                                .map(|path| path.join("pyvenv.cfg").try_exists())
-                        })
-                        .flatten()
-                    {
-                        true
-                    } else {
-                        trace!("Skipping missing interpreter at {}", path.display());
-                        false
-                    }
+                    matches!(
+                        matches!(source, PythonSource::ActiveEnvironment)
+                            .then(|| {
+                                path.parent()
+                                    .and_then(Path::parent)
+                                    .map(|path| path.join("pyvenv.cfg").try_exists())
+                            })
+                            .flatten(),
+                        Some(Ok(true)),
+                    )
                 }
             },
-            Error::VirtualEnv(VirtualEnvError::MissingPyVenvCfg(path)) => {
-                trace!("Skipping broken virtualenv at {}", path.display());
-                false
-            }
+            Error::VirtualEnv(VirtualEnvError::MissingPyVenvCfg(_)) => false,
             _ => true,
         }
     }
@@ -965,6 +947,30 @@ pub fn find_python_installations<'a>(
     }
 }
 
+/// Show a debug log for an error causing us to skip an interpreter
+fn debug_show_skipped(err: &Error) {
+    // Display that we're skipping the interpreter
+    match err {
+        Error::Query(err, path, source) => match &**err {
+            InterpreterError::NotFound(_) => {
+                trace!("Skipping missing interpreter at {}", path.display());
+            }
+            _ => {
+                debug!(
+                    "Skipping bad interpreter at {} from {source}: {err}",
+                    path.display()
+                );
+            }
+        },
+        Error::VirtualEnv(VirtualEnvError::MissingPyVenvCfg(path)) => {
+            trace!("Skipping broken virtualenv at {}", path.display());
+        }
+        _ => {
+            debug!("Skipping interpreter: {err}");
+        }
+    }
+}
+
 /// Find a Python installation that satisfies the given request.
 ///
 /// If an error is encountered while locating or inspecting a candidate installation,
@@ -978,19 +984,33 @@ pub(crate) fn find_python_installation(
     let installations = find_python_installations(request, environments, preference, cache);
     let mut first_prerelease = None;
     let mut first_error = None;
+    let mut show_first_error = true;
     for result in installations {
-        // Iterate until the first critical error or happy result
+        // Skip non-critical errors
         if !result.as_ref().err().map_or(true, Error::is_critical) {
             // Track the first non-critical error
-            if first_error.is_none() {
-                if let Err(err) = result {
+            if let Err(err) = result {
+                if let Some(ref first) = first_error {
+                    if show_first_error {
+                        debug_show_skipped(first);
+                        show_first_error = false;
+                    }
+                    debug_show_skipped(&err);
+                } else {
                     first_error = Some(err);
                 }
             }
             continue;
         }
 
-        // If it's an error, we're done.
+        if let Some(ref first) = first_error {
+            if show_first_error {
+                debug_show_skipped(first);
+                show_first_error = false;
+            }
+        }
+
+        // If it's a critical error, we're done.
         let Ok(Ok(ref installation)) = result else {
             return result;
         };

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -111,7 +111,7 @@ mod tests {
 
     use crate::{
         discovery::{
-            find_best_python_installation, find_python_installation, EnvironmentPreference,
+            self, find_best_python_installation, find_python_installation, EnvironmentPreference,
         },
         PythonPreference,
     };
@@ -589,11 +589,10 @@ mod tests {
                 PythonPreference::default(),
                 &context.cache,
             )
-        })?;
+        });
         assert!(
-            matches!(result, Err(PythonNotFound { .. })),
-            // TODO(zanieb): We could improve the error handling to hint this to the user
-            "If only Python 2 is available, we should not find a python; got {result:?}"
+            matches!(result, Err(discovery::Error::Query(..))),
+            "If only Python 2 is available, we should report the interpreter query error; got {result:?}"
         );
 
         Ok(())

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -636,7 +636,7 @@ impl TestContext {
             .env(EnvVars::UV_PREVIEW, "1")
             .env(EnvVars::UV_PYTHON_INSTALL_DIR, "")
             .current_dir(&self.temp_dir);
-        self.add_shared_args(&mut command, true);
+        self.add_shared_args(&mut command, false);
         command
     }
 

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -51,7 +51,10 @@ fn missing_requirements_txt() {
 
 #[test]
 fn missing_venv() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12")
+        .with_filtered_virtualenv_bin()
+        .with_filtered_python_names();
+
     let requirements = context.temp_dir.child("requirements.txt");
     requirements.write_str("anyio")?;
     fs::remove_dir_all(&context.venv)?;
@@ -62,8 +65,8 @@ fn missing_venv() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-      Caused by: Python interpreter not found at `[VENV]/bin/python3`
+    error: Failed to inspect Python interpreter from active virtual environment at `.venv/[BIN]/python`
+      Caused by: Python interpreter not found at `[VENV]/[BIN]/python`
     "###);
 
     assert!(predicates::path::missing().eval(&context.venv));

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -62,6 +62,19 @@ fn missing_venv() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+      Caused by: Python interpreter not found at `[VENV]/bin/python3`
+    "###);
+
+    assert!(predicates::path::missing().eval(&context.venv));
+
+    // If not "active", we hint to create one
+    uv_snapshot!(context.filters(), context.pip_sync().arg("requirements.txt").env_remove("VIRTUAL_ENV"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
     error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
     "###);
 

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -28,7 +28,8 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found in virtual environments, managed installations, or search path
+        error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+          Caused by: Python interpreter not found at `[VENV]/bin/python3`
         "###);
     }
 
@@ -124,7 +125,8 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found for PyPy in virtual environments, managed installations, or search path
+        error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+          Caused by: Python interpreter not found at `[VENV]/bin/python3`
         "###);
     }
 
@@ -536,7 +538,8 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for Python 4.2 in virtual environments, managed installations, or search path
+    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+      Caused by: Python interpreter not found at `[VENV]/bin/python3`
     "###);
 
     // Request a low version with a range
@@ -546,7 +549,8 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for Python <3.0 in virtual environments, managed installations, or search path
+    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+      Caused by: Python interpreter not found at `[VENV]/bin/python3`
     "###);
 
     // Request free-threaded Python on unsupported version

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -28,8 +28,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-          Caused by: Python interpreter not found at `[VENV]/bin/python3`
+        error: No interpreter found in virtual environments, managed installations, or search path
         "###);
     }
 
@@ -125,8 +124,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-          Caused by: Python interpreter not found at `[VENV]/bin/python3`
+        error: No interpreter found for PyPy in virtual environments, managed installations, or search path
         "###);
     }
 
@@ -538,8 +536,7 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-      Caused by: Python interpreter not found at `[VENV]/bin/python3`
+    error: No interpreter found for Python 4.2 in virtual environments, managed installations, or search path
     "###);
 
     // Request a low version with a range
@@ -549,8 +546,7 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-      Caused by: Python interpreter not found at `[VENV]/bin/python3`
+    error: No interpreter found for Python <3.0 in virtual environments, managed installations, or search path
     "###);
 
     // Request free-threaded Python on unsupported version
@@ -573,7 +569,7 @@ fn python_find_venv_invalid() {
         .with_filtered_virtualenv_bin();
 
     // We find the virtual environment
-    uv_snapshot!(context.filters(), context.python_find(), @r###"
+    uv_snapshot!(context.filters(), context.python_find().env(EnvVars::VIRTUAL_ENV, context.venv.as_os_str()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -585,7 +581,7 @@ fn python_find_venv_invalid() {
     // If the binaries are missing from a virtual environment, we fail
     fs_err::remove_dir_all(venv_bin_path(&context.venv)).unwrap();
 
-    uv_snapshot!(context.filters(), context.python_find(), @r###"
+    uv_snapshot!(context.filters(), context.python_find().env(EnvVars::VIRTUAL_ENV, context.venv.as_os_str()), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -596,7 +592,7 @@ fn python_find_venv_invalid() {
     "###);
 
     // Unless the virtual environment is not active
-    uv_snapshot!(context.filters(), context.python_find().env_remove(EnvVars::VIRTUAL_ENV), @r###"
+    uv_snapshot!(context.filters(), context.python_find(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -608,7 +604,7 @@ fn python_find_venv_invalid() {
     // If there's not a `pyvenv.cfg` file, it's also non-fatal, we ignore the environment
     fs_err::remove_file(context.venv.join("pyvenv.cfg")).unwrap();
 
-    uv_snapshot!(context.filters(), context.python_find(), @r###"
+    uv_snapshot!(context.filters(), context.python_find().env(EnvVars::VIRTUAL_ENV, context.venv.as_os_str()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
Previously, these errors would only be visible in the debug logs as "Skipping bad interpreter ..." which can lead us to making some ridiculous claims like "There is no virtual environment" or "Python is not installed" when really we just failed to query the interpreter for some reason.

We show the first error, sort of arbitrarily — but I think it matches user expectation, i.e., this would be the first Python on your PATH.

Related to #10713 