### PR TITLE
Avoid attempting to patch macOS dylib for non-macOS installs

### DIFF
--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -519,15 +519,17 @@ impl ManagedPythonInstallation {
     /// See <https://github.com/astral-sh/uv/issues/10598> for more information.
     pub fn ensure_dylib_patched(&self) -> Result<(), macos_dylib::Error> {
         if cfg!(target_os = "macos") {
-            if *self.implementation() == ImplementationName::CPython {
-                let dylib_path = self.python_dir().join("lib").join(format!(
-                    "{}python{}{}{}",
-                    std::env::consts::DLL_PREFIX,
-                    self.key.version().python_version(),
-                    self.key.variant().suffix(),
-                    std::env::consts::DLL_SUFFIX
-                ));
-                macos_dylib::patch_dylib_install_name(dylib_path)?;
+            if self.key().os.is_like_darwin() {
+                if *self.implementation() == ImplementationName::CPython {
+                    let dylib_path = self.python_dir().join("lib").join(format!(
+                        "{}python{}{}{}",
+                        std::env::consts::DLL_PREFIX,
+                        self.key.version().python_version(),
+                        self.key.variant().suffix(),
+                        std::env::consts::DLL_SUFFIX
+                    ));
+                    macos_dylib::patch_dylib_install_name(dylib_path)?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

For example, `cargo run python install cpython-3.12.8-linux-x86_64_v3-gnu` (on macOS) shouldn't attempt to patch the dylib. At present, it leads to this warning:

```
warning: Failed to patch the install name of the dynamic library for /Users/crmarsh/.local/share/uv/python/cpython-3.12.8-linux-x86_64_v3-gnu/bin/python3.12. This may cause issues when building Python native extensions.
Underlying error: Failed to update the install name of the Python dynamic library located at `/Users/crmarsh/.local/share/uv/python/cpython-3.12.8-linux-x86_64_v3-gnu/lib/libpython3.12.dylib`
```
