### PR TITLE
Ignore lockfile in ecosystem tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -2,12 +2,12 @@
 #![allow(dead_code, unreachable_pub)]
 
 use std::borrow::BorrowMut;
-use std::env;
 use std::ffi::OsString;
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output};
 use std::str::FromStr;
+use std::{env, io};
 
 use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_fs::assert::PathAssert;
@@ -948,6 +948,14 @@ impl TestContext {
     pub fn copy_ecosystem_project(&self, name: &str) {
         let project_dir = PathBuf::from(format!("../../ecosystem/{name}"));
         self.temp_dir.copy_from(project_dir, &["*"]).unwrap();
+        // If there is a (gitignore) lockfile, remove it.
+        if let Err(err) = fs_err::remove_file(self.temp_dir.join("uv.lock")) {
+            assert_eq!(
+                err.kind(),
+                io::ErrorKind::NotFound,
+                "Failed to remove uv.lock: {err}"
+            );
+        }
     }
 
     /// Creates a way to compare the changes made to a lock file.

--- a/crates/uv/tests/it/ecosystem.rs
+++ b/crates/uv/tests/it/ecosystem.rs
@@ -110,7 +110,6 @@ fn lock_ecosystem_package(python_version: &str, name: &str) -> Result<()> {
         name,
         Some(common::WindowsFilters::Platform),
     );
-    assert_snapshot!(format!("{name}-uv-lock-output"), snapshot);
 
     let lock = context.read("uv.lock");
     insta::with_settings!({
@@ -118,6 +117,8 @@ fn lock_ecosystem_package(python_version: &str, name: &str) -> Result<()> {
     }, {
         assert_snapshot!(format!("{name}-lock-file"), lock);
     });
+
+    assert_snapshot!(format!("{name}-uv-lock-output"), snapshot);
 
     Ok(())
 }


### PR DESCRIPTION
The ecosystem tests can fail when there is a (gitignored) `uv.lock` in `ecosystem/<name>/uv.lock`.

Moving the snapshots means we're seeing the actual lock difference.