### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report an error or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please review [our guide on interacting with the issue tracker](https://github.com/astral-sh/uv/issues/9452) before opening a new issue.**
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A clear and concise description of the bug, including [a minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example).
+        If we cannot reproduce the bug, it is unlikely that we will be able to help you.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Platform
+      description: What operating system and architecture are you using? (see `uname -orsm`)
+      placeholder: e.g., macOS 14 arm64, Windows 11 x86_64, Ubuntu 20.04 amd64
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Version
+      description: What version of uv are you using? (see `uv version`)
+      placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Python version
+      description: What version of Python are you using? (see `uv run python --version`)
+      placeholder: e.g., Python 3.12.6
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yaml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please review [our guide on interacting with the issue tracker](https://github.com/astral-sh/uv/issues/9452) before opening a new issue.**
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A clear and concise description of what new feature or behavior you would like to see. If applicable, please describe the current behavior as well.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Example
+      description: Provide an example of how the user experience would change or how the new feature would be used.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -1,0 +1,31 @@
+name: Question
+description: Ask a question about uv
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please review [our guide on interacting with the issue tracker](https://github.com/astral-sh/uv/issues/9452) before opening a new issue.**
+
+  - type: textarea
+    attributes:
+      label: Question
+      description: Describe your question in detail.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Platform
+      description: What operating system and architecture are you using? (see `uname -orsm`)
+      placeholder: e.g., macOS 14 arm64, Windows 11 x86_64, Ubuntu 20.04 amd64
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Version
+      description: What version of uv are you using? (see `uv version`)
+      placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://docs.astral.sh/uv
+    about: Please consult the documentation before creating an issue.
+  - name: Community
+    url: https://discord.com/invite/astral-sh
+    about: Join our Discord community to ask questions and collaborate.


### PR DESCRIPTION
Demo at https://github.com/zanieb/uv/issues

I think the next steps are to

- Move the "Build failures" document to a dedicated "Troubleshooting" section
- Add more documentation on how to create an MRE
- Add more troubleshooting pages