### PR TITLE
Deduplicate `GitSha` and `GitOid` types

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -40,7 +40,7 @@ use uv_distribution_types::{
 };
 use uv_extract::hash::Hasher;
 use uv_fs::{rename_with_retry, write_atomic, LockedFile};
-use uv_git::{GitHubRepository, GitSha};
+use uv_git::{GitHubRepository, GitOid};
 use uv_metadata::read_archive_metadata;
 use uv_normalize::PackageName;
 use uv_pep440::{release_specifiers_to_ranges, Version};
@@ -1783,7 +1783,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Attempts to fetch the `pyproject.toml` from the resolved commit using the GitHub API.
     async fn github_metadata(
         &self,
-        commit: GitSha,
+        commit: GitOid,
         source: &BuildableSource<'_>,
         resource: &GitSourceUrl<'_>,
         client: &ManagedClient<'_>,

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -18,8 +18,7 @@ use uv_fs::Simplified;
 use uv_static::EnvVars;
 use uv_version::version;
 
-use crate::sha::GitOid;
-use crate::{GitHubRepository, GitSha};
+use crate::{GitHubRepository, GitOid};
 
 /// A file indicates that if present, `git reset` has been done and a repo
 /// checkout is ready to go. See [`GitCheckout::reset`] for why we need this.
@@ -32,6 +31,7 @@ pub enum GitError {
     #[error(transparent)]
     Other(#[from] which::Error),
 }
+
 /// A global cache of the result of `which git`.
 pub static GIT: LazyLock<Result<PathBuf, GitError>> = LazyLock::new(|| {
     which::which("git").map_err(|e| match e {
@@ -123,10 +123,10 @@ impl GitReference {
         }
     }
 
-    /// Returns the precise [`GitSha`] of this reference, if it's a full commit.
-    pub(crate) fn as_sha(&self) -> Option<GitSha> {
+    /// Returns the precise [`GitOid`] of this reference, if it's a full commit.
+    pub(crate) fn as_sha(&self) -> Option<GitOid> {
         if let Self::FullCommit(rev) = self {
-            Some(GitSha::from_str(rev).expect("Full commit should be exactly 40 characters"))
+            Some(GitOid::from_str(rev).expect("Full commit should be exactly 40 characters"))
         } else {
             None
         }

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -3,17 +3,17 @@ use url::Url;
 pub use crate::credentials::{store_credentials_from_url, GIT_STORE};
 pub use crate::git::{GitReference, GIT};
 pub use crate::github::GitHubRepository;
+pub use crate::oid::{GitOid, OidParseError};
 pub use crate::resolver::{
     GitResolver, GitResolverError, RepositoryReference, ResolvedRepositoryReference,
 };
-pub use crate::sha::{GitSha, OidParseError};
 pub use crate::source::{Fetch, GitSource, Reporter};
 
 mod credentials;
 mod git;
 mod github;
+mod oid;
 mod resolver;
-mod sha;
 mod source;
 
 /// A URL reference to a Git repository.
@@ -25,7 +25,7 @@ pub struct GitUrl {
     /// The reference to the commit to use, which could be a branch, tag or revision.
     reference: GitReference,
     /// The precise commit to use, if known.
-    precise: Option<GitSha>,
+    precise: Option<GitOid>,
 }
 
 impl GitUrl {
@@ -40,7 +40,7 @@ impl GitUrl {
     }
 
     /// Create a new [`GitUrl`] from a repository URL and a precise commit.
-    pub fn from_commit(repository: Url, reference: GitReference, precise: GitSha) -> Self {
+    pub fn from_commit(repository: Url, reference: GitReference, precise: GitOid) -> Self {
         Self {
             repository,
             reference,
@@ -48,9 +48,9 @@ impl GitUrl {
         }
     }
 
-    /// Set the precise [`GitSha`] to use for this Git URL.
+    /// Set the precise [`GitOid`] to use for this Git URL.
     #[must_use]
-    pub fn with_precise(mut self, precise: GitSha) -> Self {
+    pub fn with_precise(mut self, precise: GitOid) -> Self {
         self.precise = Some(precise);
         self
     }
@@ -73,7 +73,7 @@ impl GitUrl {
     }
 
     /// Return the precise commit, if known.
-    pub fn precise(&self) -> Option<GitSha> {
+    pub fn precise(&self) -> Option<GitOid> {
         self.precise
     }
 }

--- a/crates/uv-git/src/oid.rs
+++ b/crates/uv-git/src/oid.rs
@@ -3,80 +3,24 @@ use std::str::{self, FromStr};
 
 use thiserror::Error;
 
-/// A complete Git SHA, i.e., a 40-character hexadecimal representation of a Git commit.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct GitSha(GitOid);
-
-impl GitSha {
-    /// Return the Git SHA as a string.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    /// Return a truncated representation, i.e., the first 16 characters of the SHA.
-    pub fn as_short_str(&self) -> &str {
-        &self.0.as_str()[..16]
-    }
-}
-
-impl From<GitSha> for GitOid {
-    fn from(value: GitSha) -> Self {
-        value.0
-    }
-}
-
-impl From<GitOid> for GitSha {
-    fn from(value: GitOid) -> Self {
-        Self(value)
-    }
-}
-
-impl Display for GitSha {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl FromStr for GitSha {
-    type Err = OidParseError;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(GitOid::from_str(value)?))
-    }
-}
-
-impl serde::Serialize for GitSha {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.as_str().serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for GitSha {
-    fn deserialize<D>(deserializer: D) -> Result<GitSha, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        GitSha::from_str(&value).map_err(serde::de::Error::custom)
-    }
-}
-
 /// Unique identity of any Git object (commit, tree, blob, tag).
 ///
 /// Note this type does not validate whether the input is a valid hash.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct GitOid {
+pub struct GitOid {
     len: usize,
     bytes: [u8; 40],
 }
 
 impl GitOid {
     /// Return the string representation of an object ID.
-    pub(crate) fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         str::from_utf8(&self.bytes[..self.len]).unwrap()
+    }
+
+    /// Return a truncated representation, i.e., the first 16 characters of the SHA.
+    pub fn as_short_str(&self) -> &str {
+        &self.as_str()[..16]
     }
 }
 
@@ -113,6 +57,25 @@ impl FromStr for GitOid {
 impl Display for GitOid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+impl serde::Serialize for GitOid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for GitOid {
+    fn deserialize<D>(deserializer: D) -> Result<GitOid, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        GitOid::from_str(&value).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/uv-pypi-types/src/parsed_url.rs
+++ b/crates/uv-pypi-types/src/parsed_url.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use url::{ParseError, Url};
 
 use uv_distribution_filename::{DistExtension, ExtensionError};
-use uv_git::{GitReference, GitSha, GitUrl, OidParseError};
+use uv_git::{GitOid, GitReference, GitUrl, OidParseError};
 use uv_pep508::{
     looks_like_git_repository, Pep508Url, UnnamedRequirementUrl, VerbatimUrl, VerbatimUrlError,
 };
@@ -23,7 +23,7 @@ pub enum ParsedUrlError {
     #[error("Invalid path in file URL: `{0}`")]
     InvalidFileUrl(String),
     #[error("Failed to parse Git reference from URL: `{0}`")]
-    GitShaParse(String, #[source] OidParseError),
+    GitOidParse(String, #[source] OidParseError),
     #[error("Not a valid URL: `{0}`")]
     UrlParse(String, #[source] ParseError),
     #[error(transparent)]
@@ -247,7 +247,7 @@ impl ParsedGitUrl {
     pub fn from_source(
         repository: Url,
         reference: GitReference,
-        precise: Option<GitSha>,
+        precise: Option<GitOid>,
         subdirectory: Option<PathBuf>,
     ) -> Self {
         let url = if let Some(precise) = precise {
@@ -275,7 +275,7 @@ impl TryFrom<Url> for ParsedGitUrl {
             .unwrap_or(url_in.as_str());
         let url = Url::parse(url).map_err(|err| ParsedUrlError::UrlParse(url.to_string(), err))?;
         let url = GitUrl::try_from(url)
-            .map_err(|err| ParsedUrlError::GitShaParse(url_in.to_string(), err))?;
+            .map_err(|err| ParsedUrlError::GitOidParse(url_in.to_string(), err))?;
         Ok(Self { url, subdirectory })
     }
 }

--- a/crates/uv-pypi-types/src/requirement.rs
+++ b/crates/uv-pypi-types/src/requirement.rs
@@ -8,7 +8,7 @@ use url::Url;
 use uv_distribution_filename::DistExtension;
 
 use uv_fs::{relative_to, PortablePath, PortablePathBuf, CWD};
-use uv_git::{GitReference, GitSha, GitUrl};
+use uv_git::{GitOid, GitReference, GitUrl};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::{
@@ -406,7 +406,7 @@ pub enum RequirementSource {
         /// Optionally, the revision, tag, or branch to use.
         reference: GitReference,
         /// The precise commit to use, if known.
-        precise: Option<GitSha>,
+        precise: Option<GitOid>,
         /// The path to the source distribution if it is not in the repository root.
         subdirectory: Option<PathBuf>,
         /// The PEP 508 style url in the format
@@ -823,7 +823,7 @@ impl TryFrom<RequirementSourceWire> for RequirementSource {
                     };
                 }
 
-                let precise = repository.fragment().map(GitSha::from_str).transpose()?;
+                let precise = repository.fragment().map(GitOid::from_str).transpose()?;
 
                 // Clear out any existing state.
                 repository.set_fragment(None);

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -31,7 +31,7 @@ use uv_distribution_types::{
     RemoteSource, ResolvedDist, StaticMetadata, ToUrlError, UrlString,
 };
 use uv_fs::{relative_to, PortablePath, PortablePathBuf};
-use uv_git::{GitReference, GitSha, RepositoryReference, ResolvedRepositoryReference};
+use uv_git::{GitOid, GitReference, RepositoryReference, ResolvedRepositoryReference};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::{split_scheme, MarkerEnvironment, MarkerTree, VerbatimUrl, VerbatimUrlError};
@@ -3192,7 +3192,7 @@ struct DirectSource {
 /// canonical ordering of package entries.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 struct GitSource {
-    precise: GitSha,
+    precise: GitOid,
     subdirectory: Option<PathBuf>,
     kind: GitSourceKind,
 }
@@ -3219,7 +3219,7 @@ impl GitSource {
                 _ => continue,
             };
         }
-        let precise = GitSha::from_str(url.fragment().ok_or(GitSourceError::MissingSha)?)
+        let precise = GitOid::from_str(url.fragment().ok_or(GitSourceError::MissingSha)?)
             .map_err(|_| GitSourceError::InvalidSha)?;
 
         Ok(GitSource {
@@ -3587,7 +3587,7 @@ fn locked_git_url(git_dist: &GitSourceDist) -> Url {
             .git
             .precise()
             .as_ref()
-            .map(GitSha::to_string)
+            .map(GitOid::to_string)
             .as_deref(),
     );
 


### PR DESCRIPTION
## Summary

I think this split is leftover from using `libgit2`. I kept `Oid` since that seems to be the official terminology.
