### PR TITLE
docs: manually bump pre-commit refs

### DIFF
--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -16,7 +16,7 @@ pre-commit, add the following to the `.pre-commit-config.yaml`:
 ```yaml title=".pre-commit-config.yaml"
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.5.8
+  rev: 0.5.21
   hooks:
     - id: uv-lock
 ```
@@ -26,7 +26,7 @@ To keep your `requirements.txt` file updated using pre-commit:
 ```yaml title=".pre-commit-config.yaml"
 - repo: https://github.com/astral-sh/uv-pre-commit
   # uv version.
-  rev: 0.5.8
+  rev: 0.5.21
   hooks:
     - id: uv-export
 ```


### PR DESCRIPTION
## Summary

rooster should pick those up, but those 2 references were added to 0.5.8 while a 0.5.9 was already released (https://github.com/astral-sh/uv/commit/f5add0ca5e2711396e033741375049d0454730f4), so they never got bumped automatically.

I've searched for other cases like this in the documentation on other versions, just in case, and it seems that this is the only case.