### PR TITLE
Update docs on how to use `UV_PROJECT_ENVIRONMENT` to use the system python environment

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -170,7 +170,8 @@ environment. If an environment is not present at the provided path, uv will crea
 
 This option can be used to write to the system Python environment, though it is not recommended.
 `uv sync` will remove extraneous packages from the environment by default and, as such, may leave
-the system in a broken state.
+the system in a broken state. To use the system Python environment, set
+`UV_PROJECT_ENVIRONMENT=/usr/local`.
 
 !!! important
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -170,8 +170,17 @@ environment. If an environment is not present at the provided path, uv will crea
 
 This option can be used to write to the system Python environment, though it is not recommended.
 `uv sync` will remove extraneous packages from the environment by default and, as such, may leave
-the system in a broken state. For example, you can use `UV_PROJECT_ENVIRONMENT=/usr/local` on
-most Debian-based systems.
+the system in a broken state.
+
+To target the system environment, set `UV_PROJECT_ENVIRONMENT` to the prefix of the Python
+installation. For example, on Debian-based systems, this is usually `/usr/local`:
+
+```console
+$ python -c "import sysconfig; print(sysconfig.get_config_var('prefix'))"
+/usr/local
+```
+
+To target this environment, you'd export `UV_PROJECT_ENVIRONMENT=/usr/local`.
 
 !!! important
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -170,8 +170,8 @@ environment. If an environment is not present at the provided path, uv will crea
 
 This option can be used to write to the system Python environment, though it is not recommended.
 `uv sync` will remove extraneous packages from the environment by default and, as such, may leave
-the system in a broken state. To use the system Python environment, set
-`UV_PROJECT_ENVIRONMENT=/usr/local`.
+the system in a broken state. As an example, you can use `UV_PROJECT_ENVIRONMENT=/usr/local` on
+most Debian-based systems.
 
 !!! important
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -170,7 +170,7 @@ environment. If an environment is not present at the provided path, uv will crea
 
 This option can be used to write to the system Python environment, though it is not recommended.
 `uv sync` will remove extraneous packages from the environment by default and, as such, may leave
-the system in a broken state. As an example, you can use `UV_PROJECT_ENVIRONMENT=/usr/local` on
+the system in a broken state. For example, you can use `UV_PROJECT_ENVIRONMENT=/usr/local` on
 most Debian-based systems.
 
 !!! important


### PR DESCRIPTION
## Summary

The docs did mention that you could set the `UV_PROJECT_ENVIRONMENT` variable to point Uv to use the system Python environment (e.g. for use in CI or Docker), but it did not document _how_.

Reference: https://github.com/astral-sh/uv/pull/6834#issuecomment-2319253359

