### PR TITLE
[uv-settings]: Correct behavior for relative find-links paths when run from a subdir 

### DIFF
--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -168,14 +168,14 @@ impl Index {
         Credentials::from_url(self.url.url())
     }
 
-    pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
+    /// Resolve the index relative to the given root directory.
+    pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
         if let IndexUrl::Path(ref url) = self.url {
             if let Some(given) = url.given() {
-                if let Ok(new_url) = IndexUrl::parse(given, Some(root_dir)) {
-                    self.url = new_url;
-                }
+                self.url = IndexUrl::parse(given, Some(root_dir))?;
             }
         }
+        Ok(self)
     }
 }
 

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::str::FromStr;
 
 use thiserror::Error;
@@ -165,6 +166,16 @@ impl Index {
 
         // Otherwise, extract the credentials from the URL.
         Credentials::from_url(self.url.url())
+    }
+
+    pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
+        if let IndexUrl::Path(ref url) = self.url {
+            if let Some(given) = url.given() {
+                if let Ok(new_url) = IndexUrl::parse(given, Some(root_dir)) {
+                    self.url = new_url;
+                }
+            }
+        }
     }
 }
 

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -3,6 +3,7 @@
 //! flags set.
 
 use serde::{Deserialize, Deserializer, Serialize};
+use std::path::Path;
 
 use crate::{Index, IndexUrl};
 
@@ -10,6 +11,12 @@ macro_rules! impl_index {
     ($name:ident, $from:expr) => {
         #[derive(Debug, Clone, Eq, PartialEq)]
         pub struct $name(Index);
+
+        impl $name {
+            pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
+                self.0.adjust_relative_paths(root_dir);
+            }
+        }
 
         impl From<$name> for Index {
             fn from(value: $name) -> Self {

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -13,8 +13,8 @@ macro_rules! impl_index {
         pub struct $name(Index);
 
         impl $name {
-            pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
-                self.0.adjust_relative_paths(root_dir);
+            pub fn relative_to(self, root_dir: &Path) -> Result<Self, crate::IndexUrlError> {
+                Ok(Self(self.0.relative_to(root_dir)?))
             }
         }
 

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -104,15 +104,13 @@ impl FilesystemOptions {
     /// Load a [`FilesystemOptions`] from a directory, preferring a `uv.toml` file over a
     /// `pyproject.toml` file.
     pub fn from_directory(dir: &Path) -> Result<Option<Self>, Error> {
-        let abs_dir_path = std::path::absolute(dir)?;
-
         // Read a `uv.toml` file in the current directory.
         let path = dir.join("uv.toml");
         match fs_err::read_to_string(&path) {
             Ok(content) => {
-                let mut options: Options = toml::from_str(&content)
-                    .map_err(|err| Error::UvToml(path.clone(), Box::new(err)))?;
-                options.adjust_relative_paths(abs_dir_path.as_path());
+                let options = toml::from_str::<Options>(&content)
+                    .map_err(|err| Error::UvToml(path.clone(), Box::new(err)))?
+                    .relative_to(&std::path::absolute(dir)?)?;
 
                 // If the directory also contains a `[tool.uv]` table in a `pyproject.toml` file,
                 // warn.
@@ -150,7 +148,7 @@ impl FilesystemOptions {
                     );
                     return Ok(None);
                 };
-                let Some(mut options) = tool.uv else {
+                let Some(options) = tool.uv else {
                     tracing::debug!(
                         "Skipping `pyproject.toml` in `{}` (no `[tool.uv]` section)",
                         dir.display()
@@ -158,8 +156,9 @@ impl FilesystemOptions {
                     return Ok(None);
                 };
 
+                let options = options.relative_to(&std::path::absolute(dir)?)?;
+
                 tracing::debug!("Found workspace configuration at `{}`", path.display());
-                options.adjust_relative_paths(abs_dir_path.as_path());
                 return Ok(Some(Self(options)));
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -255,22 +254,14 @@ fn system_config_file() -> Option<PathBuf> {
 
 /// Load [`Options`] from a `uv.toml` file.
 fn read_file(path: &Path) -> Result<Options, Error> {
-    let abs_file_path = std::path::absolute(path)?;
     let content = fs_err::read_to_string(path)?;
-    let mut options: Options =
-        toml::from_str(&content).map_err(|err| Error::UvToml(path.to_path_buf(), Box::new(err)))?;
-    if let Some(parent_dir) = abs_file_path.parent() {
-        options.adjust_relative_paths(parent_dir);
+    let options = toml::from_str::<Options>(&content)
+        .map_err(|err| Error::UvToml(path.to_path_buf(), Box::new(err)))?;
+    let options = if let Some(parent) = std::path::absolute(path)?.parent() {
+        options.relative_to(parent)?
     } else {
-        return Err(Error::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!(
-                "Configuration path '{}' has no parent directory",
-                path.display()
-            ),
-        )));
-    }
-
+        options
+    };
     Ok(options)
 }
 
@@ -310,6 +301,9 @@ fn validate_uv_toml(path: &Path, options: &Options) -> Result<(), Error> {
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Index(#[from] uv_distribution_types::IndexUrlError),
 
     #[error("Failed to parse: `{}`", _0.user_display())]
     PyprojectToml(PathBuf, #[source] Box<toml::de::Error>),

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf, path::Path};
+use std::{fmt::Debug, num::NonZeroUsize, path::Path, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf};
+use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf, path::Path};
 
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -143,6 +143,10 @@ impl Options {
             top_level,
             ..Default::default()
         }
+    }
+
+    pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
+        self.top_level.adjust_relative_paths(root_dir);
     }
 }
 
@@ -721,6 +725,16 @@ pub struct ResolverInstallerOptions {
         "#
     )]
     pub no_binary_package: Option<Vec<PackageName>>,
+}
+
+impl ResolverInstallerOptions {
+    pub fn adjust_relative_paths(&mut self, root_dir: &Path) {
+        if let Some(find_links) = &mut self.find_links {
+            for find_link in find_links {
+                find_link.adjust_relative_paths(root_dir);
+            }
+        }
+    }
 }
 
 /// Shared settings, relevant to all operations that might create managed python installations.

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -149,6 +149,7 @@ impl Options {
     pub fn relative_to(self, root_dir: &Path) -> Result<Self, IndexUrlError> {
         Ok(Self {
             top_level: self.top_level.relative_to(root_dir)?,
+            pip: self.pip.map(|pip| pip.relative_to(root_dir)).transpose()?,
             ..self
         })
     }
@@ -735,6 +736,28 @@ impl ResolverInstallerOptions {
     /// Resolve the [`ResolverInstallerOptions`] relative to the given root directory.
     pub fn relative_to(self, root_dir: &Path) -> Result<Self, IndexUrlError> {
         Ok(Self {
+            index: self
+                .index
+                .map(|index| {
+                    index
+                        .into_iter()
+                        .map(|index| index.relative_to(root_dir))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
+            index_url: self
+                .index_url
+                .map(|index_url| index_url.relative_to(root_dir))
+                .transpose()?,
+            extra_index_url: self
+                .extra_index_url
+                .map(|extra_index_url| {
+                    extra_index_url
+                        .into_iter()
+                        .map(|extra_index_url| extra_index_url.relative_to(root_dir))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
             find_links: self
                 .find_links
                 .map(|find_links| {
@@ -1504,6 +1527,46 @@ pub struct PipOptions {
         "#
     )]
     pub reinstall_package: Option<Vec<PackageName>>,
+}
+
+impl PipOptions {
+    /// Resolve the [`PipOptions`] relative to the given root directory.
+    pub fn relative_to(self, root_dir: &Path) -> Result<Self, IndexUrlError> {
+        Ok(Self {
+            index: self
+                .index
+                .map(|index| {
+                    index
+                        .into_iter()
+                        .map(|index| index.relative_to(root_dir))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
+            index_url: self
+                .index_url
+                .map(|index_url| index_url.relative_to(root_dir))
+                .transpose()?,
+            extra_index_url: self
+                .extra_index_url
+                .map(|extra_index_url| {
+                    extra_index_url
+                        .into_iter()
+                        .map(|extra_index_url| extra_index_url.relative_to(root_dir))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
+            find_links: self
+                .find_links
+                .map(|find_links| {
+                    find_links
+                        .into_iter()
+                        .map(|find_link| find_link.relative_to(root_dir))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?,
+            ..self
+        })
+    }
 }
 
 impl From<ResolverInstallerOptions> for ResolverOptions {


### PR DESCRIPTION
## One-liner
Relative find-links configuration to local path from a pyproject.toml or uv.toml is now relative to the config file
## Summary
### Background
One can configure find-links in a `pyproject.toml` or `uv.toml` file, which are located from the cli arg, system directory, user directory, or by traversing parent directories until one is encountered.

This PR addresses the following scenario:
- A project directory which includes a `pyproject.toml` or `uv.toml` file
- The config file includes a `find-links` option. (eg under `[tool.uv]` for `pyproject.toml`)
- The `find-links` option is configured to point to a local subdirectory in the project: `packages/`
- There is a subdirectory called `subdir`, which is the current working directory
- I run `uv run my_script.py`. This will locate the `pyproject.toml` in the parent directory
### Current Behavior
- uv tries to use the path `subdir/packages/` to find packages, and fails.
### New Behavior
- uv tries to use the path `packages/` to find the packages, and succeeds
- Specifically, any relative local find-links path will resolve to be relative to the configuration file.

### Why is this behavior change OK?
- I believe no one depends on the behavior that a relative find-links when running in a subdir will refer to different directories each time
- Thus this change only allows a more common use case which didn't work previously.

## Test Plan
- I re-created the setup mentioned above:
```
UvTest/
├── packages/
│   ├── colorama-0.4.6-py2.py3-none-any.whl
│   └── tqdm-4.67.1-py3-none-any.whl
├── subdir/
│   └── my_script.py
└── pyproject.toml
```
```toml 
# pyproject.toml
[project]
name = "uvtest"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.12"
dependencies = [
    "tqdm>=4.67.1",
]

[tool.uv]
offline = true
no-index = true
find-links = ["packages/"]
```
- With working directory under `subdir`, previously, running `uv sync --offline` would fail resolving the tdqm package, and after the change it succeeds.
- Additionally, one can use `uv sync --show-settings` to show the actually-resolved settings - now having the desired path in `flat_index.url.path`

## Alternative designs considered
- I considered modifying the `impl Deserialize for IndexUrl` to parse ahead of time directly with a base directory by having a custom `Deserializer` with a base dir field, but it seems to contradict the design of the serde `Deserialize` trait - which should work with all `Deserializer`s

## Future work
- Support for adjusting all other local-relative paths in `Options` would be desired, but is out of scope for the current PR.