### PR TITLE
Update smoke test scripts to fail on first error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,8 +631,6 @@ jobs:
 
       - name: "Smoke test"
         run: |
-          set -e
-
           ./uv venv -v
           ./uv --does-not-exist
           ./uv pip install ruff -v
@@ -658,8 +656,6 @@ jobs:
 
       - name: "Smoke test"
         run: |
-          set -e
-
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
@@ -680,9 +676,6 @@ jobs:
       - name: "Smoke test"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: |
-          $ErrorActionPreference = "Stop"
-          $PSNativeCommandUseErrorActionPreference = $true
-
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,8 @@ jobs:
 
       - name: "Smoke test"
         run: |
+          set -e
+
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
@@ -655,6 +657,8 @@ jobs:
 
       - name: "Smoke test"
         run: |
+          set -e
+
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
@@ -675,6 +679,9 @@ jobs:
       - name: "Smoke test"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,6 +634,7 @@ jobs:
           set -e
 
           ./uv venv -v
+          ./uv --does-not-exist
           ./uv pip install ruff -v
           ./uvx -v ruff --version
           eval "$(./uv generate-shell-completion bash)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,8 @@ jobs:
 
       - name: "Smoke test"
         run: |
+          set -e
+
           ./uv venv -v
           ./uv --does-not-exist
           ./uv pip install ruff -v
@@ -656,6 +658,8 @@ jobs:
 
       - name: "Smoke test"
         run: |
+          set -e
+
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
@@ -676,6 +680,9 @@ jobs:
       - name: "Smoke test"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,7 +634,6 @@ jobs:
           set -e
 
           ./uv venv -v
-          ./uv --does-not-exist
           ./uv pip install ruff -v
           ./uvx -v ruff --version
           eval "$(./uv generate-shell-completion bash)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,8 +631,6 @@ jobs:
 
       - name: "Smoke test"
         run: |
-          set -e
-
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
@@ -657,8 +655,6 @@ jobs:
 
       - name: "Smoke test"
         run: |
-          set -e
-
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,7 @@ jobs:
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
+          ./uv --does-not-exist
           (& ./uv generate-shell-completion powershell) | Out-String | Invoke-Expression
           (& ./uvx --generate-shell-completion powershell) | Out-String | Invoke-Expression
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,7 +685,6 @@ jobs:
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version
-          ./uv --does-not-exist
           (& ./uv generate-shell-completion powershell) | Out-String | Invoke-Expression
           (& ./uvx --generate-shell-completion powershell) | Out-String | Invoke-Expression
 


### PR DESCRIPTION
These continue on failure on Windows, which is annoying.