### PR TITLE
Error when workspace contains conflicting Python requirements

### DIFF
--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -75,6 +75,11 @@ impl RequiresPython {
                 }
             })?;
 
+        // If the intersection is empty, return `None`.
+        if range.is_empty() {
+            return None;
+        }
+
         // Convert back to PEP 440 specifiers.
         let specifiers = VersionSpecifiers::from_release_only_bounds(range.iter());
 

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tracing::instrument;
 
 use crate::commands::pip::operations;
-use crate::commands::project::find_requires_python;
+use crate::commands::project::{find_requires_python, ProjectError};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -69,6 +69,8 @@ enum Error {
     BuildDispatch(AnyErrorBuild),
     #[error(transparent)]
     BuildFrontend(#[from] uv_build_frontend::Error),
+    #[error(transparent)]
+    Project(#[from] ProjectError),
     #[error("Failed to write message")]
     Fmt(#[from] fmt::Error),
     #[error("Can't use `--force-pep517` with `--list`")]
@@ -464,7 +466,7 @@ async fn build_package(
     // (3) `Requires-Python` in `pyproject.toml`
     if interpreter_request.is_none() {
         if let Ok(workspace) = workspace {
-            interpreter_request = find_requires_python(workspace)
+            interpreter_request = find_requires_python(workspace)?
                 .as_ref()
                 .map(RequiresPython::specifiers)
                 .map(|specifiers| {

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -499,7 +499,12 @@ async fn init_project(
         };
 
         (requires_python, python_request)
-    } else if let Some(requires_python) = workspace.as_ref().and_then(find_requires_python) {
+    } else if let Some(requires_python) = workspace
+        .as_ref()
+        .map(find_requires_python)
+        .transpose()?
+        .flatten()
+    {
         // (3) `requires-python` from the workspace
         debug!("Using Python version from project workspace");
         let python_request = PythonRequest::Version(VersionRequest::Range(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -418,7 +418,7 @@ async fn do_lock(
 
     // Determine the supported Python range. If no range is defined, and warn and default to the
     // current minor version.
-    let requires_python = target.requires_python();
+    let requires_python = target.requires_python()?;
 
     let requires_python = if let Some(requires_python) = requires_python {
         if requires_python.is_unbounded() {

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -188,14 +188,15 @@ impl<'lock> LockTarget<'lock> {
     }
 
     /// Return the `Requires-Python` bound for the [`LockTarget`].
-    pub(crate) fn requires_python(self) -> Option<RequiresPython> {
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn requires_python(self) -> Result<Option<RequiresPython>, ProjectError> {
         match self {
             Self::Workspace(workspace) => find_requires_python(workspace),
-            Self::Script(script) => script
+            Self::Script(script) => Ok(script
                 .metadata
                 .requires_python
                 .as_ref()
-                .map(RequiresPython::from_specifiers),
+                .map(RequiresPython::from_specifiers)),
         }
     }
 

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -256,7 +256,7 @@ fn assert_pin_compatible_with_project(pin: &Pin, virtual_project: &VirtualProjec
                 project_workspace.project_name(),
                 project_workspace.workspace().install_path().display()
             );
-            let requires_python = find_requires_python(project_workspace.workspace());
+            let requires_python = find_requires_python(project_workspace.workspace())?;
             (requires_python, "project")
         }
         VirtualProject::NonProject(workspace) => {
@@ -264,7 +264,7 @@ fn assert_pin_compatible_with_project(pin: &Pin, virtual_project: &VirtualProjec
                 "Discovered virtual workspace at: {}",
                 workspace.install_path().display()
             );
-            let requires_python = find_requires_python(workspace);
+            let requires_python = find_requires_python(workspace)?;
             (requires_python, "workspace")
         }
     };


### PR DESCRIPTION
## Summary

If members define disjoint Python requirements, we should error. Right now, it seems that it maps to unbounded and leads to weird behavior.

Closes https://github.com/astral-sh/uv/issues/10835.
