### PR TITLE
All (virtual) packages must have a priority

### DIFF
--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -46,3 +46,16 @@ impl DependencyProvider for UvDependencyProvider {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn priority_size() {
+        assert_eq!(
+            size_of::<<UvDependencyProvider as DependencyProvider>::Priority>(),
+            24
+        );
+    }
+}

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -18,7 +18,7 @@ impl DependencyProvider for UvDependencyProvider {
     type VS = Range<Version>;
     type M = UnavailableReason;
     /// Main priority and tiebreak for virtual packages.
-    type Priority = (Option<PubGrubPriority>, Option<PubGrubTiebreaker>);
+    type Priority = (PubGrubPriority, PubGrubTiebreaker);
     type Err = Infallible;
 
     fn prioritize(


### PR DESCRIPTION
To ensure deterministic resolution, each (virtual) package needs to be registered on discovery (as dependency of another package), before we query it for prioritization.

Also adds a test for priority value size, prioritization is performance critical in pubgrub.

Not sure what is going with the transformers snapshot.