### PR TITLE
Sort extras and groups when comparing lockfile requirements

### DIFF
--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15078,6 +15078,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG Using request timeout of [TIME]
     DEBUG Found static `requires-dist` for: [TEMP_DIR]/
     DEBUG No workspace root found, using project root
+    DEBUG Static `requires-dist` for `project==0.1.0 @ editable+.` is out-of-date; falling back to distribution database
     DEBUG Found static `pyproject.toml` for: project @ file://[TEMP_DIR]/
     DEBUG No workspace root found, using project root
     DEBUG Ignoring existing lockfile due to mismatched requirements for: `project==0.1.0`


### PR DESCRIPTION
## Summary

The linked issue actually isn't a bug on main anymore, but it does require us to take the "slow" path, since setuptools seems to reorder the extras. This PR adds another normalization step which lets us take the fast path: https://github.com/astral-sh/uv/issues/10855.
