### PR TITLE
Invalidate lockfile when static versions change

### DIFF
--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -87,12 +87,14 @@ impl Metadata {
             name: metadata.name,
             requires_dist: metadata.requires_dist,
             provides_extras: metadata.provides_extras,
+            dynamic: metadata.dynamic,
         };
         let RequiresDist {
             name,
             requires_dist,
             provides_extras,
             dependency_groups,
+            dynamic,
         } = RequiresDist::from_project_maybe_workspace(
             requires_dist,
             install_path,
@@ -111,7 +113,7 @@ impl Metadata {
             requires_python: metadata.requires_python,
             provides_extras,
             dependency_groups,
-            dynamic: metadata.dynamic,
+            dynamic,
         })
     }
 }

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -21,6 +21,7 @@ pub struct RequiresDist {
     pub requires_dist: Vec<uv_pypi_types::Requirement>,
     pub provides_extras: Vec<ExtraName>,
     pub dependency_groups: BTreeMap<GroupName, Vec<uv_pypi_types::Requirement>>,
+    pub dynamic: bool,
 }
 
 impl RequiresDist {
@@ -36,6 +37,7 @@ impl RequiresDist {
                 .collect(),
             provides_extras: metadata.provides_extras,
             dependency_groups: BTreeMap::default(),
+            dynamic: metadata.dynamic,
         }
     }
 
@@ -245,6 +247,7 @@ impl RequiresDist {
             requires_dist,
             dependency_groups,
             provides_extras: metadata.provides_extras,
+            dynamic: metadata.dynamic,
         })
     }
 
@@ -314,6 +317,7 @@ impl From<Metadata> for RequiresDist {
             requires_dist: metadata.requires_dist,
             provides_extras: metadata.provides_extras,
             dependency_groups: metadata.dependency_groups,
+            dynamic: metadata.dynamic,
         }
     }
 }

--- a/crates/uv-pypi-types/src/metadata/requires_dist.rs
+++ b/crates/uv-pypi-types/src/metadata/requires_dist.rs
@@ -21,6 +21,7 @@ pub struct RequiresDist {
     pub name: PackageName,
     pub requires_dist: Vec<Requirement<VerbatimParsedUrl>>,
     pub provides_extras: Vec<ExtraName>,
+    pub dynamic: bool,
 }
 
 impl RequiresDist {
@@ -34,12 +35,15 @@ impl RequiresDist {
 
         // If any of the fields we need were declared as dynamic, we can't use the `pyproject.toml`
         // file.
-        let dynamic = project.dynamic.unwrap_or_default();
-        for field in dynamic {
+        let mut dynamic = false;
+        for field in project.dynamic.unwrap_or_default() {
             match field.as_str() {
                 "dependencies" => return Err(MetadataError::DynamicField("dependencies")),
                 "optional-dependencies" => {
                     return Err(MetadataError::DynamicField("optional-dependencies"))
+                }
+                "version" => {
+                    dynamic = true;
                 }
                 _ => (),
             }
@@ -83,6 +87,7 @@ impl RequiresDist {
             name,
             requires_dist,
             provides_extras,
+            dynamic,
         })
     }
 }


### PR DESCRIPTION
## Summary

We should only be ignoring changes in `version` for dynamic projects; for static projects, it should still be enforced. We should also be invalidating the lockfile if a project goes from static to dynamic or vice versa.

Closes #10852.
