### PR TITLE
feat: error on non-existent extra

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -94,6 +94,16 @@ impl PyProjectToml {
             .is_some_and(|project| project.version.is_none())
     }
 
+    /// Returns `true` if the key is set dynamically.
+    pub fn is_key_dynamic(&self, key: &str) -> bool {
+        self.project.as_ref().is_some_and(|project| {
+            project
+                .dynamic
+                .as_ref()
+                .is_some_and(|dynamic| dynamic.iter().any(|field| field == key))
+        })
+    }
+
     /// Returns whether the project manifest contains any script table.
     pub fn has_scripts(&self) -> bool {
         if let Some(ref project) = self.project {

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -221,6 +221,8 @@ pub struct Project {
     pub dependencies: Option<Vec<String>>,
     /// The optional dependencies of the project.
     pub optional_dependencies: Option<BTreeMap<ExtraName, Vec<String>>>,
+    /// The dynamic attributes of the project.
+    pub dynamic: Option<Vec<String>>,
 
     /// Used to determine whether a `gui-scripts` section is present.
     #[serde(default, skip_serializing)]
@@ -266,6 +268,7 @@ impl TryFrom<ProjectWire> for Project {
             requires_python: value.requires_python,
             dependencies: value.dependencies,
             optional_dependencies: value.optional_dependencies,
+            dynamic: value.dynamic,
             gui_scripts: value.gui_scripts,
             scripts: value.scripts,
         })

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -1596,7 +1596,8 @@ mod tests {
               "dependencies": [
                 "anyio>=4.3.0,<5"
               ],
-              "optional-dependencies": null
+              "optional-dependencies": null,
+              "dynamic": null
             },
             "pyproject_toml": "[PYPROJECT_TOML]"
           }
@@ -1611,7 +1612,8 @@ mod tests {
             "dependencies": [
               "anyio>=4.3.0,<5"
             ],
-            "optional-dependencies": null
+            "optional-dependencies": null,
+            "dynamic": null
           },
           "tool": null,
           "dependency-groups": null
@@ -1649,7 +1651,8 @@ mod tests {
                   "dependencies": [
                     "anyio>=4.3.0,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -1664,7 +1667,8 @@ mod tests {
                 "dependencies": [
                   "anyio>=4.3.0,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": null,
               "dependency-groups": null
@@ -1702,7 +1706,8 @@ mod tests {
                         "bird-feeder",
                         "tqdm>=4,<5"
                       ],
-                      "optional-dependencies": null
+                      "optional-dependencies": null,
+                      "dynamic": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   },
@@ -1716,7 +1721,8 @@ mod tests {
                         "anyio>=4.3.0,<5",
                         "seeds"
                       ],
-                      "optional-dependencies": null
+                      "optional-dependencies": null,
+                      "dynamic": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   },
@@ -1729,7 +1735,8 @@ mod tests {
                       "dependencies": [
                         "idna==3.6"
                       ],
-                      "optional-dependencies": null
+                      "optional-dependencies": null,
+                      "dynamic": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
@@ -1753,7 +1760,8 @@ mod tests {
                       "bird-feeder",
                       "tqdm>=4,<5"
                     ],
-                    "optional-dependencies": null
+                    "optional-dependencies": null,
+                    "dynamic": null
                   },
                   "tool": {
                     "uv": {
@@ -1819,7 +1827,8 @@ mod tests {
                     "bird-feeder",
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -1833,7 +1842,8 @@ mod tests {
                     "anyio>=4.3.0,<5",
                     "seeds"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -1846,7 +1856,8 @@ mod tests {
                   "dependencies": [
                     "idna==3.6"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -1909,7 +1920,8 @@ mod tests {
                   "dependencies": [
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -1924,7 +1936,8 @@ mod tests {
                 "dependencies": [
                   "tqdm>=4,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": null,
               "dependency-groups": null
@@ -2029,7 +2042,8 @@ mod tests {
                   "dependencies": [
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -2042,7 +2056,8 @@ mod tests {
                   "dependencies": [
                     "idna==3.6"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -2057,7 +2072,8 @@ mod tests {
                 "dependencies": [
                   "tqdm>=4,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": {
                 "uv": {
@@ -2132,7 +2148,8 @@ mod tests {
                   "dependencies": [
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -2145,7 +2162,8 @@ mod tests {
                   "dependencies": [
                     "idna==3.6"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -2160,7 +2178,8 @@ mod tests {
                 "dependencies": [
                   "tqdm>=4,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": {
                 "uv": {
@@ -2236,7 +2255,8 @@ mod tests {
                   "dependencies": [
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -2249,7 +2269,8 @@ mod tests {
                   "dependencies": [
                     "anyio>=4.3.0,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               },
@@ -2262,7 +2283,8 @@ mod tests {
                   "dependencies": [
                     "idna==3.6"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -2277,7 +2299,8 @@ mod tests {
                 "dependencies": [
                   "tqdm>=4,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": {
                 "uv": {
@@ -2353,7 +2376,8 @@ mod tests {
                   "dependencies": [
                     "tqdm>=4,<5"
                   ],
-                  "optional-dependencies": null
+                  "optional-dependencies": null,
+                  "dynamic": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
@@ -2368,7 +2392,8 @@ mod tests {
                 "dependencies": [
                   "tqdm>=4,<5"
                 ],
-                "optional-dependencies": null
+                "optional-dependencies": null,
+                "dynamic": null
               },
               "tool": {
                 "uv": {

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -549,6 +549,15 @@ impl Workspace {
             .collect()
     }
 
+    /// Whether at least one project in the workspace sets the key dynamically.
+    pub fn uses_dynamic_key(&self, key: &str) -> bool {
+        self.pyproject_toml.is_key_dynamic(key)
+            || self
+                .packages
+                .values()
+                .any(|member| member.pyproject_toml.is_key_dynamic(key))
+    }
+
     /// The path to the workspace root, the directory containing the top level `pyproject.toml` with
     /// the `uv.tool.workspace`, or the `pyproject.toml` in an implicit single workspace project.
     pub fn install_path(&self) -> &PathBuf {

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -24,8 +24,8 @@ use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
-    default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError,
-    ProjectInterpreter, ScriptInterpreter,
+    default_dependency_groups, detect_conflicts, ProjectError, ProjectInterpreter,
+    ScriptInterpreter, SpecificationTarget,
 };
 use crate::commands::{diagnostics, ExitStatus, OutputWriter};
 use crate::printer::Printer;
@@ -113,15 +113,15 @@ pub(crate) async fn export(
         let target = match &target {
             ExportTarget::Project(VirtualProject::Project(project)) => {
                 if all_packages {
-                    DependencyGroupsTarget::Workspace(project.workspace())
+                    SpecificationTarget::Workspace(project.workspace())
                 } else {
-                    DependencyGroupsTarget::Project(project)
+                    SpecificationTarget::Project(project)
                 }
             }
             ExportTarget::Project(VirtualProject::NonProject(workspace)) => {
-                DependencyGroupsTarget::Workspace(workspace)
+                SpecificationTarget::Workspace(workspace)
             }
-            ExportTarget::Script(_) => DependencyGroupsTarget::Script,
+            ExportTarget::Script(_) => SpecificationTarget::Script,
         };
         target.validate_dependency_groups(&dev)?;
     }

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -123,7 +123,7 @@ pub(crate) async fn export(
             }
             ExportTarget::Script(_) => DependencyGroupsTarget::Script,
         };
-        target.validate(&dev)?;
+        target.validate_dependency_groups(&dev)?;
     }
 
     // Determine the default groups to include.

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -108,7 +108,7 @@ pub(crate) async fn export(
         ExportTarget::Project(project)
     };
 
-    // Validate that any referenced dependency groups are defined in the workspace.
+    // Validate that any referenced dependency groups and extras are defined in the workspace.
     if !frozen {
         let target = match &target {
             ExportTarget::Project(VirtualProject::Project(project)) => {
@@ -124,6 +124,7 @@ pub(crate) async fn export(
             ExportTarget::Script(_) => SpecificationTarget::Script,
         };
         target.validate_dependency_groups(&dev)?;
+        target.validate_extras(&extras)?;
     }
 
     // Determine the default groups to include.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1756,7 +1756,10 @@ pub(crate) enum DependencyGroupsTarget<'env> {
 impl DependencyGroupsTarget<'_> {
     /// Validate the dependency groups requested by the [`DevGroupsSpecification`].
     #[allow(clippy::result_large_err)]
-    pub(crate) fn validate(self, dev: &DevGroupsSpecification) -> Result<(), ProjectError> {
+    pub(crate) fn validate_dependency_groups(
+        self,
+        dev: &DevGroupsSpecification,
+    ) -> Result<(), ProjectError> {
         for group in dev
             .groups()
             .into_iter()

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1744,16 +1744,16 @@ pub(crate) async fn init_script_python_requirement(
 }
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum DependencyGroupsTarget<'env> {
-    /// The dependency groups can be defined in any workspace member.
+pub(crate) enum SpecificationTarget<'env> {
+    /// The specification applies to any workspace member.
     Workspace(&'env Workspace),
-    /// The dependency groups must be defined in the target project.
+    /// The specification only applies to the target project.
     Project(&'env ProjectWorkspace),
-    /// The dependency groups must be defined in the target script.
+    /// The specification only applies to the target script.
     Script,
 }
 
-impl DependencyGroupsTarget<'_> {
+impl SpecificationTarget<'_> {
     /// Validate the dependency groups requested by the [`DevGroupsSpecification`].
     #[allow(clippy::result_large_err)]
     pub(crate) fn validate_dependency_groups(

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -697,7 +697,7 @@ pub(crate) async fn run(
                             DependencyGroupsTarget::Workspace(workspace)
                         }
                     };
-                    target.validate(&dev)?;
+                    target.validate_dependency_groups(&dev)?;
                 }
 
                 // Determine the default groups to include.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -47,8 +47,8 @@ use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::LockMode;
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
-    default_dependency_groups, validate_project_requires_python, DependencyGroupsTarget,
-    EnvironmentSpecification, ProjectError, ScriptInterpreter, WorkspacePython,
+    default_dependency_groups, validate_project_requires_python, EnvironmentSpecification,
+    ProjectError, ScriptInterpreter, SpecificationTarget, WorkspacePython,
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::{diagnostics, project, ExitStatus};
@@ -688,13 +688,13 @@ pub(crate) async fn run(
                     let target = match &project {
                         VirtualProject::Project(project) => {
                             if all_packages {
-                                DependencyGroupsTarget::Workspace(project.workspace())
+                                SpecificationTarget::Workspace(project.workspace())
                             } else {
-                                DependencyGroupsTarget::Project(project)
+                                SpecificationTarget::Project(project)
                             }
                         }
                         VirtualProject::NonProject(workspace) => {
-                            DependencyGroupsTarget::Workspace(workspace)
+                            SpecificationTarget::Workspace(workspace)
                         }
                     };
                     target.validate_dependency_groups(&dev)?;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -683,7 +683,8 @@ pub(crate) async fn run(
                         .map(|lock| (lock, project.workspace().install_path().to_owned()));
                 }
             } else {
-                // Validate that any referenced dependency groups are defined in the workspace.
+                // Validate that any referenced dependency groups and extras are defined in the
+                // workspace.
                 if !frozen {
                     let target = match &project {
                         VirtualProject::Project(project) => {
@@ -698,6 +699,7 @@ pub(crate) async fn run(
                         }
                     };
                     target.validate_dependency_groups(&dev)?;
+                    target.validate_extras(&extras)?;
                 }
 
                 // Determine the default groups to include.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -32,7 +32,7 @@ use crate::commands::pip::operations::Modifications;
 use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::{
-    default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError,
+    default_dependency_groups, detect_conflicts, ProjectError, SpecificationTarget,
 };
 use crate::commands::{diagnostics, project, ExitStatus};
 use crate::printer::Printer;
@@ -92,12 +92,12 @@ pub(crate) async fn sync(
         let target = match &project {
             VirtualProject::Project(project) => {
                 if all_packages {
-                    DependencyGroupsTarget::Workspace(project.workspace())
+                    SpecificationTarget::Workspace(project.workspace())
                 } else {
-                    DependencyGroupsTarget::Project(project)
+                    SpecificationTarget::Project(project)
                 }
             }
-            VirtualProject::NonProject(workspace) => DependencyGroupsTarget::Workspace(workspace),
+            VirtualProject::NonProject(workspace) => SpecificationTarget::Workspace(workspace),
         };
         target.validate_dependency_groups(&dev)?;
     }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -99,7 +99,7 @@ pub(crate) async fn sync(
             }
             VirtualProject::NonProject(workspace) => DependencyGroupsTarget::Workspace(workspace),
         };
-        target.validate(&dev)?;
+        target.validate_dependency_groups(&dev)?;
     }
 
     // Determine the default groups to include.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -87,7 +87,7 @@ pub(crate) async fn sync(
         VirtualProject::discover(project_dir, &DiscoveryOptions::default()).await?
     };
 
-    // Validate that any referenced dependency groups are defined in the workspace.
+    // Validate that any referenced dependency groups and extras are defined in the workspace.
     if !frozen {
         let target = match &project {
             VirtualProject::Project(project) => {
@@ -100,6 +100,7 @@ pub(crate) async fn sync(
             VirtualProject::NonProject(workspace) => SpecificationTarget::Workspace(workspace),
         };
         target.validate_dependency_groups(&dev)?;
+        target.validate_extras(&extras)?;
     }
 
     // Determine the default groups to include.

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -25,8 +25,8 @@ use crate::commands::pip::resolution_markers;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
-    default_dependency_groups, DependencyGroupsTarget, ProjectError, ProjectInterpreter,
-    ScriptInterpreter,
+    default_dependency_groups, ProjectError, ProjectInterpreter, ScriptInterpreter,
+    SpecificationTarget,
 };
 use crate::commands::reporters::LatestVersionReporter;
 use crate::commands::{diagnostics, ExitStatus};
@@ -76,8 +76,8 @@ pub(crate) async fn tree(
     // Validate that any referenced dependency groups are defined in the target.
     if !frozen {
         let target = match &target {
-            LockTarget::Workspace(workspace) => DependencyGroupsTarget::Workspace(workspace),
-            LockTarget::Script(..) => DependencyGroupsTarget::Script,
+            LockTarget::Workspace(workspace) => SpecificationTarget::Workspace(workspace),
+            LockTarget::Script(..) => SpecificationTarget::Script,
         };
         target.validate_dependency_groups(&dev)?;
     }

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -79,7 +79,7 @@ pub(crate) async fn tree(
             LockTarget::Workspace(workspace) => DependencyGroupsTarget::Workspace(workspace),
             LockTarget::Script(..) => DependencyGroupsTarget::Script,
         };
-        target.validate(&dev)?;
+        target.validate_dependency_groups(&dev)?;
     }
 
     // Determine the default groups to include.

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -4413,11 +4413,17 @@ conflicts = [
         "#,
     )?;
 
-    // I believe there are multiple valid solutions here, but the main
-    // thing is that `x2` should _not_ activate the `idna==3.4` dependency
-    // in `proxy1`. The `--extra=x2` should be a no-op, since there is no
-    // `x2` extra in the top level `pyproject.toml`.
+    // Error out, as x2 extra is only on the child.
     uv_snapshot!(context.filters(), context.sync().arg("--extra=x2"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Extra `x2` is not defined in the project's `optional-dependencies` table
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
## Summary

Closes #10597.

Check for invalid extras specified on the CLI, through either `--extra <extra>` or `--all-extras --no-extra <extra>`

If an usage of dynamic optional dependencies is detected, validation is not performed, as in this case, we cannot determine which extras exist, as this is delegated to the build backend.

This concretely means that we do not perform the validation if:
- for workspace, at least one project uses dynamic optional dependencies
- for project, it uses dynamic optional dependencies

Adding this check required to update quite a lot of things. I've tried to split the changes as much as possible, especially since there are some changes I'm not sure about, in terms of architecture.

First, to my knowledge, optional dependencies work similarly to dependency groups for the validation, so I thought it would be ok to make `DependencyGroupsTarget` more generic by renaming it to `SpecificationTarget`, so that the same logic can be reused both for dependency groups and optional dependencies, but maybe you have a different opinion.

I also needed to add `dynamic` field to `Project`, and a few methods to check the usage of a dynamic key in a project or workspace. Not sure if there are better ways or places to do that.

## Test Plan

Snapshot tests.