### PR TITLE
Disable `.egg-info` tests via `slow-tests` feature on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,8 @@ jobs:
       - name: "Cargo test"
         run: |
           cargo nextest run \
-            --features python-patch \
+            --no-default-features \
+            --features python,python-managed,pypi,git,performance,crates-io \
             --workspace \
             --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
 
@@ -272,8 +273,13 @@ jobs:
           # Avoid permission errors during concurrent tests
           # See https://github.com/astral-sh/uv/issues/6940
           UV_LINK_MODE: copy
+        shell: bash
         run: |
-          cargo nextest run --no-default-features --features python,pypi,python-managed --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
+          cargo nextest run \
+            --no-default-features \
+            --features python,pypi,python-managed \
+            --workspace \
+            --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
   # Separate jobs for the nightly crate
   windows-trampoline-check:

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -133,7 +133,7 @@ ignored = [
 ]
 
 [features]
-default = ["python", "python-managed", "pypi", "git", "performance", "crates-io", "test-ecosystem"]
+default = ["python", "python-managed", "pypi", "git", "performance", "crates-io", "slow-tests", "test-ecosystem"]
 # Use better memory allocators, etc.
 performance = [
     "performance-memory-allocator",
@@ -156,6 +156,8 @@ pypi = []
 git = []
 # Introduces a dependency on crates.io.
 crates-io = []
+# Include "slow" test cases.
+slow-tests = []
 # Includes test cases that require ecosystem packages
 test-ecosystem = []
 # Adds self-update functionality.

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -7675,7 +7675,7 @@ fn switch_platform() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/pull/6714>
 #[test]
-#[cfg(unix)]
+#[cfg(feature = "slow-tests")]
 fn stale_egg_info() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -7675,6 +7675,7 @@ fn switch_platform() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/pull/6714>
 #[test]
+#[cfg(unix)]
 fn stale_egg_info() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -5276,6 +5276,7 @@ fn sync_derivation_chain_group() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/issues/9743>
 #[test]
+#[cfg(unix)]
 fn sync_stale_egg_info() -> Result<()> {
     let context = TestContext::new("3.13");
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -5276,7 +5276,7 @@ fn sync_derivation_chain_group() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/issues/9743>
 #[test]
-#[cfg(unix)]
+#[cfg(feature = "slow-tests")]
 fn sync_stale_egg_info() -> Result<()> {
     let context = TestContext::new("3.13");
 


### PR DESCRIPTION
## Summary

These are super slow on Windows and it's not critical to test them on that platform. Let's just do the lazy thing.
