### PR TITLE
Add test coverage for use of `git` without feature flag

### DIFF
--- a/crates/uv/tests/it/branching_urls.rs
+++ b/crates/uv/tests/it/branching_urls.rs
@@ -621,6 +621,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
 /// ]
 /// ```
 #[test]
+#[cfg(feature = "git")]
 fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -703,6 +704,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
 /// ]
 /// ```
 #[test]
+#[cfg(feature = "git")]
 fn branching_urls_of_different_sources_conflict() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -4545,6 +4545,7 @@ fn add_repeat() -> Result<()> {
 
 /// Add from requirement file.
 #[test]
+#[cfg(feature = "git")]
 fn add_requirements_file() -> Result<()> {
     let context = TestContext::new("3.12").with_filtered_counts();
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -10768,6 +10768,7 @@ fn lock_mismatched_sources() -> Result<()> {
 ///
 /// See: <https://github.com/astral-sh/uv/issues/4604>
 #[test]
+#[cfg(feature = "git")]
 fn lock_mismatched_versions() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -28,7 +28,7 @@ mod export;
 
 mod help;
 
-#[cfg(all(feature = "python", feature = "pypi"))]
+#[cfg(all(feature = "python", feature = "pypi", feature = "git"))]
 mod init;
 
 #[cfg(all(feature = "python", feature = "pypi"))]

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -6812,6 +6812,7 @@ fn verify_hashes_editable() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "git")]
 fn tool_uv_sources() -> Result<()> {
     let context = TestContext::new("3.12");
     // Use a subdir to test path normalization.
@@ -8262,6 +8263,7 @@ fn cyclic_build_dependency() {
 }
 
 #[test]
+#[cfg(feature = "git")]
 fn direct_url_json_git_default() -> Result<()> {
     let context = TestContext::new("3.12");
     let requirements_txt = context.temp_dir.child("requirements.txt");
@@ -8299,6 +8301,7 @@ fn direct_url_json_git_default() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "git")]
 fn direct_url_json_git_tag() -> Result<()> {
     let context = TestContext::new("3.12");
     let requirements_txt = context.temp_dir.child("requirements.txt");

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -581,6 +581,7 @@ fn run_pythonw_script() -> Result<()> {
 
 /// Run a PEP 723-compatible script with `tool.uv` metadata.
 #[test]
+#[cfg(feature = "git")]
 fn run_pep723_script_metadata() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -3183,6 +3183,7 @@ fn sync_custom_environment_path() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "git")]
 fn sync_workspace_custom_environment_path() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -5276,7 +5277,7 @@ fn sync_derivation_chain_group() -> Result<()> {
 
 /// See: <https://github.com/astral-sh/uv/issues/9743>
 #[test]
-#[cfg(feature = "slow-tests")]
+#[cfg(all(feature = "slow-tests", feature = "git"))]
 fn sync_stale_egg_info() -> Result<()> {
     let context = TestContext::new("3.13");
 


### PR DESCRIPTION
Shoves a broken `git` executable onto the front of the `PATH` in the test context when the `git` feature is disabled so they fail if they're missing the feature-gate.