### PR TITLE
relax error checking around unconditional enabling of conflicting extras

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -12,7 +12,7 @@ use tracing::trace;
 use uv_distribution_types::{
     DerivationChain, DistErrorKind, IndexCapabilities, IndexLocations, IndexUrl, RequestedDist,
 };
-use uv_normalize::{ExtraName, PackageName};
+use uv_normalize::PackageName;
 use uv_pep440::{LocalVersionSlice, Version};
 use uv_platform_tags::Tags;
 use uv_static::EnvVars;
@@ -47,13 +47,6 @@ pub enum ResolveError {
 
     #[error("Attempted to wait on an unregistered task: `{_0}`")]
     UnregisteredTask(String),
-
-    #[error("Found conflicting extra `{extra}` unconditionally enabled in `{requirement}`")]
-    ConflictingExtra {
-        // Boxed because `Requirement` is large.
-        requirement: Box<uv_pypi_types::Requirement>,
-        extra: ExtraName,
-    },
 
     #[error(
         "Requirements contain conflicting URLs for package `{package_name}`{}:\n- {}",

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -1,9 +1,11 @@
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
+use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::path::Path;
 
 use either::Either;
+use itertools::Itertools;
 use petgraph::Graph;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
@@ -265,6 +267,8 @@ pub trait Installable<'lock> {
             }
         }
 
+        let mut all_activated_extras: BTreeSet<(&PackageName, &ExtraName)> =
+            activated_extras.iter().copied().collect();
         while let Some((package, extra)) = queue.pop_front() {
             let deps = if let Some(extra) = extra {
                 Either::Left(
@@ -283,6 +287,7 @@ pub trait Installable<'lock> {
                     let mut extended = activated_extras.to_vec();
                     for extra in &dep.extra {
                         extended.push((&dep.package_id.name, extra));
+                        all_activated_extras.insert((&dep.package_id.name, extra));
                     }
                     activated_extras = Cow::Owned(extended);
                 }
@@ -334,6 +339,32 @@ pub trait Installable<'lock> {
                     if seen.insert((&dep.package_id, Some(extra))) {
                         queue.push_back((dep_dist, Some(extra)));
                     }
+                }
+            }
+        }
+
+        // At time of writing, it's somewhat expected that the set of
+        // conflicting extras is pretty small. With that said, the
+        // time complexity of the following routine is pretty gross.
+        // Namely, `set.contains` is linear in the size of the set,
+        // iteration over all conflicts is also obviously linear in
+        // the number of conflicting sets and then for each of those,
+        // we visit every possible pair of activated extra from above,
+        // which is quadratic in the total number of extras enabled. I
+        // believe the simplest improvement here, if it's necessary, is
+        // to adjust the `Conflicts` internals to own these sorts of
+        // checks. ---AG
+        for set in self.lock().conflicts().iter() {
+            for ((pkg1, extra1), (pkg2, extra2)) in all_activated_extras.iter().tuple_combinations()
+            {
+                if set.contains(pkg1, *extra1) && set.contains(pkg2, *extra2) {
+                    return Err(LockErrorKind::ConflictingExtra {
+                        package1: (*pkg1).clone(),
+                        extra1: (*extra1).clone(),
+                        package2: (*pkg2).clone(),
+                        extra2: (*extra2).clone(),
+                    }
+                    .into());
                 }
             }
         }

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::VecDeque;
 use std::path::Path;
@@ -277,6 +278,14 @@ pub trait Installable<'lock> {
                 Either::Right(package.dependencies.iter())
             };
             for dep in deps {
+                let mut activated_extras = Cow::Borrowed(&*activated_extras);
+                if !dep.extra.is_empty() {
+                    let mut extended = activated_extras.to_vec();
+                    for extra in &dep.extra {
+                        extended.push((&dep.package_id.name, extra));
+                    }
+                    activated_extras = Cow::Owned(extended);
+                }
                 if !dep.complexified_marker.evaluate(
                     marker_env,
                     &activated_extras,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -4903,6 +4903,16 @@ enum LockErrorKind {
         #[source]
         err: uv_distribution::Error,
     },
+    #[error(
+        "Found conflicting extras `{package1}[{extra1}]` \
+         and `{package2}[{extra2}]` enabled simultaneously"
+    )]
+    ConflictingExtra {
+        package1: PackageName,
+        extra1: ExtraName,
+        package2: PackageName,
+        extra2: ExtraName,
+    },
 }
 
 /// An error that occurs when a source string could not be parsed.

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -1191,7 +1191,11 @@ fn extra_unconditional_non_conflicting() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.1.0
+     + idna==3.6
+     + sniffio==1.3.1
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -1047,12 +1047,12 @@ fn extra_unconditional() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Found conflicting extra `extra1` unconditionally enabled in `proxy1[extra1,extra2] @ file://[TEMP_DIR]/proxy1`
+    Resolved 6 packages in [TIME]
     "###);
 
     // An error should occur even when only one conflicting extra is enabled.
@@ -1078,12 +1078,12 @@ fn extra_unconditional() -> Result<()> {
         "#,
     )?;
     uv_snapshot!(context.filters(), context.lock(), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Found conflicting extra `extra1` unconditionally enabled in `proxy1[extra1] @ file://[TEMP_DIR]/proxy1`
+    Resolved 6 packages in [TIME]
     "###);
 
     // And same thing for the other extra.
@@ -1110,12 +1110,12 @@ fn extra_unconditional() -> Result<()> {
         "#,
     )?;
     uv_snapshot!(context.filters(), context.lock(), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Found conflicting extra `extra2` unconditionally enabled in `proxy1[extra2] @ file://[TEMP_DIR]/proxy1`
+    Resolved 6 packages in [TIME]
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -1016,10 +1016,6 @@ fn extra_unconditional() -> Result<()> {
 
         [tool.uv.sources]
         proxy1 = { workspace = true }
-
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
         "#,
     )?;
 
@@ -1054,8 +1050,16 @@ fn extra_unconditional() -> Result<()> {
     ----- stderr -----
     Resolved 6 packages in [TIME]
     "###);
+    // This should error since we're enabling two conflicting extras.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
 
-    // An error should occur even when only one conflicting extra is enabled.
+    ----- stderr -----
+    error: Found conflicting extras `proxy1[extra1]` and `proxy1[extra2]` enabled simultaneously
+    "###);
+
     root_pyproject_toml.write_str(
         r#"
         [project]
@@ -1071,10 +1075,6 @@ fn extra_unconditional() -> Result<()> {
 
         [tool.uv.sources]
         proxy1 = { workspace = true }
-
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
         "#,
     )?;
     uv_snapshot!(context.filters(), context.lock(), @r###"
@@ -1084,6 +1084,20 @@ fn extra_unconditional() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
+    "###);
+    // This is fine because we are only enabling one
+    // extra, and thus, there is no conflict.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.1.0
+     + idna==3.6
+     + sniffio==1.3.1
     "###);
 
     // And same thing for the other extra.
@@ -1102,11 +1116,6 @@ fn extra_unconditional() -> Result<()> {
 
         [tool.uv.sources]
         proxy1 = { workspace = true }
-
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-
         "#,
     )?;
     uv_snapshot!(context.filters(), context.lock(), @r###"
@@ -1116,6 +1125,20 @@ fn extra_unconditional() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
+    "###);
+    // This is fine because we are only enabling one
+    // extra, and thus, there is no conflict.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - anyio==4.1.0
+     + anyio==4.2.0
     "###);
 
     Ok(())


### PR DESCRIPTION
When I first added conflicting extras, I made `package[foo]` a hard
error during resolution whenever `foo` was declared as a conflicting
extra. This was a conservative approach meant to prevent cases where
conflicts occurred non-locally throughout the dependency tree.

However, as #9942 and #10590 seem to suggest, this ends up making
some use cases impossible. For example, it prevents the ability
to encapsulate the conflicting extras of a package from a parent
dependent. This overall makes conflicting extras much less flexible.

So in this PR, we remove that error checking. But doing so ends up
making it possible to install multiple versions of the same package
into the same environment. So we "recapture" the error check at
installation time instead of resolution time. This affords us more
flexibility, but it now means that we can generate lock files that will
*always* fail to install.

This is best reviewed commit-by-commit.

Fixes #9942, Fixes #10590
