### PR TITLE
Use Hashbrown's raw entry API to reduce hashes and clone in priority

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -34,6 +34,8 @@ pub use yanks::AllowedYanks;
 /// `ConflictItemRef`. i.e., We can avoid allocs on lookups.
 type FxHashbrownSet<T> = hashbrown::HashSet<T, rustc_hash::FxBuildHasher>;
 
+type FxHashbrownMap<K, V> = hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>;
+
 mod candidate_selector;
 mod dependency_mode;
 mod dependency_provider;

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -354,3 +354,9 @@ impl std::fmt::Display for PubGrubPackageInner {
         }
     }
 }
+
+impl From<&PubGrubPackage> for PubGrubPackage {
+    fn from(package: &PubGrubPackage) -> Self {
+        package.clone()
+    }
+}


### PR DESCRIPTION
## Summary

I'm open to not merging this -- I was kind of just interested in what the API looked like. But the idea is: we can avoid hashing values twice and unnecessarily cloning within the priority map by using the raw entry API.
