### PR TITLE
Print dependencies in uv pip list.

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1975,6 +1975,24 @@ pub struct PipListArgs {
     #[arg(long, overrides_with("outdated"), hide = true)]
     pub no_outdated: bool,
 
+    /// List each package's required packages.
+    ///
+    /// This is only allowed when the output format is `json`.
+    #[arg(long, overrides_with("no_requires"))]
+    pub requires: bool,
+
+    #[arg(long, overrides_with("requires"), hide = true)]
+    pub no_requires: bool,
+
+    /// List which packages require each package.
+    ///
+    /// This is only allowed when the output format is `json`.
+    #[arg(long, overrides_with("no_required_by"))]
+    pub required_by: bool,
+
+    #[arg(long, overrides_with("required_by"), hide = true)]
+    pub no_required_by: bool,
+
     /// Validate the Python environment, to detect packages with missing dependencies and other
     /// issues.
     #[arg(long, overrides_with("no_strict"))]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -649,6 +649,8 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 &args.exclude,
                 &args.format,
                 args.outdated,
+                args.requires,
+                args.required_by,
                 args.settings.prerelease,
                 args.settings.index_locations,
                 args.settings.index_strategy,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1960,6 +1960,8 @@ pub(crate) struct PipListSettings {
     pub(crate) exclude: Vec<PackageName>,
     pub(crate) format: ListFormat,
     pub(crate) outdated: bool,
+    pub(crate) requires: bool,
+    pub(crate) required_by: bool,
     pub(crate) settings: PipSettings,
 }
 
@@ -1973,6 +1975,10 @@ impl PipListSettings {
             format,
             outdated,
             no_outdated,
+            requires,
+            no_requires,
+            required_by,
+            no_required_by,
             strict,
             no_strict,
             fetch,
@@ -1987,6 +1993,8 @@ impl PipListSettings {
             exclude,
             format,
             outdated: flag(outdated, no_outdated).unwrap_or(false),
+            requires: flag(requires, no_requires).unwrap_or(false),
+            required_by: flag(required_by, no_required_by).unwrap_or(false),
             settings: PipSettings::combine(
                 PipOptions {
                     python: python.and_then(Maybe::into_option),


### PR DESCRIPTION
## Summary

This is controlled by the `--requires` and `--required-by` flags and only works when the output format is JSON.

This addresses part of https://github.com/astral-sh/uv/issues/4711, but I agree with https://github.com/astral-sh/uv/issues/4711#issuecomment-2205099775 that it belongs in `uv pip list` instead of `uv pip tree`. A few notes about this:

1. I picked `--requires` and `--required-by` to match the `Requires` and `Required-By` fields that appear in the output of `uv pip show`.
2. I decided to return the dependencies as objects with a single field called `name`. This leaves the door open to add more fields to each dependency in the future, such as installed version and requested versions.

I'm hoping to get some early feedback on this PR to test the temperature of this approach, before I proceed. The remaining work as I see it currently includes:

- [ ] Add tests for this feature.
- [ ] Add documentation for this feature.
- [ ] Better error messages (e.g. if used with the default column format, perhaps suggest `uv pip tree` instead).
- [ ] Any code review suggestions (I'm a Rust novice).

## Test Plan

<!-- How was it tested? -->
