### PR TITLE
docs(git): add subdirectory example

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -321,7 +321,19 @@ dependencies = ["httpx"]
 httpx = { git = "https://github.com/encode/httpx", rev = "326b9431c761e1ef1e00b9f760d1f654c8db48c6" }
 ```
 
-A `subdirectory` may be specified if the package isn't in the repository root.
+A `subdirectory` may be specified if the package isn't in the repository root:
+
+```console
+$ uv add git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain
+```
+
+```toml title="pyproject.toml"
+[project]
+dependencies = ["langchain"]
+
+[tool.uv.sources]
+langchain = { git = "https://github.com/langchain-ai/langchain", subdirectory = "libs/langchain" }
+```
 
 ### URL
 


### PR DESCRIPTION
## Summary

Closes #10889.

As kinda hinted in the issue, would adding a `--subdirectory` flag to `uv add` make sense? This would IMO be more discoverable.

## Test Plan

Ran the command added to the documentation:

```console
$ uv add git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain
Resolved 40 packages in 203ms
   Built langchain @ git+https://github.com/langchain-ai/langchain@f2ea62f63209130bfc56b1fe7d0fa7c299bbf352#subdirectory=libs/langchain
Prepared 19 packages in 837ms
Installed 37 packages in 14ms
[...]
```