### PR TITLE
make test filter permissive of bdist.win32

### DIFF
--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1464,7 +1464,7 @@ fn tool_install_uninstallable() {
         .into_iter()
         .chain([
             (r"exit code: 1", "exit status: 1"),
-            (r"bdist\.[^/\\\s]+-[^/\\\s]+", "bdist.linux-x86_64"),
+            (r"bdist\.[^/\\\s]+(-[^/\\\s]+)?", "bdist.linux-x86_64"),
             (r"\\\.", ""),
             (r"#+", "#"),
         ])


### PR DESCRIPTION
I swear a few days ago there were way more of this filter but now there's only one so *shrug*.