### PR TITLE
Allow installation of manylinux wheels on loongarch64

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -165,8 +165,10 @@ impl Arch {
             Self::X86 | Self::X86_64 => Some(5),
             // manylinux_2_31
             Self::Riscv64 => Some(31),
+            // manylinux_2_36
+            Self::LoongArch64 => Some(36),
             // unsupported
-            Self::Powerpc | Self::Armv5TEL | Self::Armv6L | Self::LoongArch64 => None,
+            Self::Powerpc | Self::Armv5TEL | Self::Armv6L => None,
         }
     }
 


### PR DESCRIPTION
# Summary
auditwheel is capable of generating loongarch64 wheels for manylinux_2_38 and above. Here we modify uv-platform-tags so that those wheels can be installed using uv.

- https://github.com/pypa/auditwheel/pull/522

# Test Plan
```yaml
      - name: Setup QEMU
        run: docker run --rm --privileged ghcr.io/loong64/qemu-user-static --reset -p yes

      - name: Build wheels
        uses: loong64/cibuildwheel@main
        env:
          CIBW_MANYLINUX_LOONGARCH64_IMAGE: manylinux_2_38
          CIBW_ARCHS: loongarch64
```

- https://github.com/loong64/pypi
- https://gitlab.com/loong64/pypi/-/packages/