### PR TITLE
Push priorities to pubgrub and solve virtual package with the strongest constraints first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,6 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=648aa343486e5529953153781fc86025c73c4a61#648aa343486e5529953153781fc86025c73c4a61"
 dependencies = [
  "indexmap",
  "log",
@@ -5799,7 +5798,6 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "version-ranges"
 version = "0.1.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=648aa343486e5529953153781fc86025c73c4a61#648aa343486e5529953153781fc86025c73c4a61"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,13 +2741,14 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
+source = "git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization#f58a60f683bfcc83fce374d721eb0e181050ac58"
 dependencies = [
  "indexmap",
  "log",
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.11",
- "version-ranges 0.1.1",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4581,7 +4582,7 @@ dependencies = [
  "uv-virtualenv",
  "uv-warnings",
  "uv-workspace",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
+ "version-ranges",
  "walkdir",
  "which",
  "zip",
@@ -4668,7 +4669,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
+ "version-ranges",
  "walkdir",
  "zip",
 ]
@@ -5045,7 +5046,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -5274,7 +5275,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.1.14",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -5300,7 +5301,7 @@ dependencies = [
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -5794,13 +5795,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "version-ranges"
-version = "0.1.1"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "version-ranges"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.11",
- "version-ranges",
+ "version-ranges 0.1.1",
 ]
 
 [[package]]
@@ -4581,7 +4581,7 @@ dependencies = [
  "uv-virtualenv",
  "uv-warnings",
  "uv-workspace",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
  "walkdir",
  "which",
  "zip",
@@ -4668,7 +4668,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
  "walkdir",
  "zip",
 ]
@@ -5045,7 +5045,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
 ]
 
 [[package]]
@@ -5274,7 +5274,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.1.14",
  "unscanny",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
 ]
 
 [[package]]
@@ -5300,7 +5300,7 @@ dependencies = [
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization)",
 ]
 
 [[package]]
@@ -5798,6 +5798,14 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 [[package]]
 name = "version-ranges"
 version = "0.1.1"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "version-ranges"
+version = "0.1.1"
+source = "git+https://github.com/astral-sh/pubgrub?branch=konsti%2Fsimplify-prioritization#f58a60f683bfcc83fce374d721eb0e181050ac58"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ unicode-width = { version = "0.1.13" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 urlencoding = { version = "2.1.3" }
-version-ranges = { path = "../pubgrub/version-ranges" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", branch = "konsti/simplify-prioritization" }
 walkdir = { version = "2.5.0" }
 which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ petgraph = { version = "0.7.1" }
 platform-info = { version = "2.0.3" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.17.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "648aa343486e5529953153781fc86025c73c4a61" }
+pubgrub = { path = "../pubgrub" }
 quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }
@@ -177,7 +177,7 @@ unicode-width = { version = "0.1.13" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
 urlencoding = { version = "2.1.3" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "648aa343486e5529953153781fc86025c73c4a61" }
+version-ranges = { path = "../pubgrub/version-ranges" }
 walkdir = { version = "2.5.0" }
 which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ petgraph = { version = "0.7.1" }
 platform-info = { version = "2.0.3" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.17.0", default-features = false, features = ["flate2"] }
-pubgrub = { path = "../pubgrub" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", branch = "konsti/simplify-prioritization" }
 quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -4,7 +4,7 @@ use pubgrub::{Dependencies, DependencyProvider, PackageResolutionStatistics, Ran
 
 use uv_pep440::Version;
 
-use crate::pubgrub::{PubGrubPackage, PubGrubPriority, PubGrubTiebreaker};
+use crate::pubgrub::{PubGrubPackage, PubGrubPriority, PubGrubVirtualPriority};
 use crate::resolver::UnavailableReason;
 
 /// We don't use a dependency provider, we interact with state directly, but we still need this one
@@ -18,7 +18,7 @@ impl DependencyProvider for UvDependencyProvider {
     type VS = Range<Version>;
     type M = UnavailableReason;
     /// Main priority and tiebreak for virtual packages.
-    type Priority = (PubGrubPriority, PubGrubTiebreaker);
+    type Priority = (PubGrubPriority, PubGrubVirtualPriority);
     type Err = Infallible;
 
     fn prioritize(

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -4,7 +4,7 @@ use pubgrub::{Dependencies, DependencyProvider, PackageResolutionStatistics, Ran
 
 use uv_pep440::Version;
 
-use crate::pubgrub::{PubGrubPackage, PubGrubPriority, PubGrubVirtualPriority};
+use crate::pubgrub::{PubGrubPackage, PubGrubPriority};
 use crate::resolver::UnavailableReason;
 
 /// We don't use a dependency provider, we interact with state directly, but we still need this one
@@ -17,8 +17,9 @@ impl DependencyProvider for UvDependencyProvider {
     type V = Version;
     type VS = Range<Version>;
     type M = UnavailableReason;
-    /// Main priority and tiebreak for virtual packages.
-    type Priority = (PubGrubPriority, PubGrubVirtualPriority);
+    /// Main priority and the priority for only virtual packages, to use the strongest constraints
+    /// per package name first.
+    type Priority = (PubGrubPriority, PubGrubPriority);
     type Err = Infallible;
 
     fn prioritize(
@@ -55,7 +56,7 @@ mod tests {
     fn priority_size() {
         assert_eq!(
             size_of::<<UvDependencyProvider as DependencyProvider>::Priority>(),
-            24
+            32
         );
     }
 }

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -1,9 +1,7 @@
 pub(crate) use crate::pubgrub::dependencies::PubGrubDependency;
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
-pub(crate) use crate::pubgrub::priority::{
-    PubGrubPriorities, PubGrubPriority, PubGrubVirtualPriority,
-};
+pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority};
 pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
 
 mod dependencies;

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -1,7 +1,9 @@
 pub(crate) use crate::pubgrub::dependencies::PubGrubDependency;
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
-pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority, PubGrubTiebreaker};
+pub(crate) use crate::pubgrub::priority::{
+    PubGrubPriorities, PubGrubPriority, PubGrubVirtualPriority,
+};
 pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
 
 mod dependencies;

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -39,7 +39,7 @@ pub(crate) struct PubGrubPriorities {
     // `Id` is half a word on 64-bit platforms.
     // b) Keep the order of virtual packages deterministic, using their index in the `SmallVec`.
     package_priority: FxHashbrownMap<PackageName, SmallVec<[Id<PubGrubPackage>; 4]>>,
-    lookup: Vec<(PubGrubPriority, PubGrubVirtualPriority)>,
+    lookup: Vec<(PubGrubPriority, PubGrubPriority)>,
 }
 
 impl PubGrubPriorities {
@@ -58,19 +58,19 @@ impl PubGrubPriorities {
             &mut slf.lookup,
             root,
             PubGrubPriority::Root,
-            PubGrubVirtualPriority::from(0),
+            PubGrubPriority::Singleton(Reverse(2)),
         );
         Self::insert_lookup(
             &mut slf.lookup,
             target_python,
             PubGrubPriority::Root,
-            PubGrubVirtualPriority::from(1),
+            PubGrubPriority::Singleton(Reverse(1)),
         );
         Self::insert_lookup(
             &mut slf.lookup,
             installed_python,
             PubGrubPriority::Root,
-            PubGrubVirtualPriority::from(2),
+            PubGrubPriority::Singleton(Reverse(0)),
         );
         slf
     }
@@ -83,7 +83,7 @@ impl PubGrubPriorities {
         version: &Range<Version>,
         urls: &ForkUrls,
     ) -> Option<(
-        <UvDependencyProvider as DependencyProvider>::Priority,
+        PubGrubPriority,
         impl IntoIterator<Item = Id<PubGrubPackage>>,
     )> {
         // The root package and Python constraints have no explicit priority, the root package is
@@ -96,20 +96,6 @@ impl PubGrubPriorities {
                 // Preserve the original index.
                 let old_priority = self.lookup[entry.get()[0].into_raw()].0;
                 let index = Self::get_index(&old_priority).unwrap_or(len);
-
-                // If not present, register the virtual package
-                if !entry.get().contains(&package_id) {
-                    let virtual_priority = PubGrubVirtualPriority::from(
-                        u32::try_from(entry.get().len()).expect("less than 2**32 packages"),
-                    );
-                    Self::insert_lookup(
-                        &mut self.lookup,
-                        package_id,
-                        old_priority,
-                        virtual_priority,
-                    );
-                    entry.get_mut().push(package_id);
-                }
 
                 // Compute the priority.
                 let new_priority = if urls.get(name).is_some() {
@@ -125,33 +111,35 @@ impl PubGrubPriorities {
                         old_priority,
                         PubGrubPriority::ConflictEarly(_) | PubGrubPriority::ConflictLate(_)
                     ) {
+                        // If not present, register the virtual package
+                        if !entry.get().contains(&package_id) {
+                            Self::insert_lookup(
+                                &mut self.lookup,
+                                package_id,
+                                old_priority,
+                                old_priority,
+                            );
+                            entry.get_mut().push(package_id);
+                        }
+
                         return None;
                     }
                     PubGrubPriority::Unspecified(Reverse(index))
                 };
+
+                // If not present, register the virtual package
+                if !entry.get().contains(&package_id) {
+                    Self::insert_lookup(&mut self.lookup, package_id, new_priority, new_priority);
+                    entry.get_mut().push(package_id);
+                }
 
                 // If necessary, update the priorities for all virtual packages of this package name
                 if new_priority > old_priority {
                     for virtual_package in entry.get() {
                         self.lookup[virtual_package.into_raw()].0 = new_priority;
                     }
-                    let virtual_priority = entry
-                        .get()
-                        .iter()
-                        .position(|x| *x == package_id)
-                        .map(|x| u32::try_from(x).expect("less than 2**32 packages"))
-                        .unwrap_or_else(|| {
-                            if cfg!(debug_assertions) {
-                                panic!("Virtual package not known: `{package}`")
-                            } else {
-                                u32::MAX
-                            }
-                        });
                     // TODO(konsti): Avoid the clone
-                    return Some((
-                        (new_priority, PubGrubVirtualPriority::from(virtual_priority)),
-                        entry.get().clone(),
-                    ));
+                    return Some((new_priority, entry.get().clone()));
                 }
             }
             EntryRef::Vacant(entry) => {
@@ -168,12 +156,7 @@ impl PubGrubPriorities {
 
                 // Insert the virtual package
                 entry.insert(smallvec![package_id]);
-                Self::insert_lookup(
-                    &mut self.lookup,
-                    package_id,
-                    priority,
-                    PubGrubVirtualPriority::from(0),
-                );
+                Self::insert_lookup(&mut self.lookup, package_id, priority, priority);
             }
         }
         None
@@ -181,18 +164,15 @@ impl PubGrubPriorities {
 
     /// The virtual package
     fn insert_lookup(
-        lookup: &mut Vec<(PubGrubPriority, PubGrubVirtualPriority)>,
+        lookup: &mut Vec<(PubGrubPriority, PubGrubPriority)>,
         package_id: Id<PubGrubPackage>,
         priority: PubGrubPriority,
-        virtual_priority: PubGrubVirtualPriority,
+        virtual_priority: PubGrubPriority,
     ) {
         if lookup.len() <= package_id.into_raw() {
             lookup.reserve(package_id.into_raw() + 1);
             lookup.extend(iter::repeat_n(
-                (
-                    PubGrubPriority::Sentinel,
-                    PubGrubVirtualPriority::from(u32::MAX),
-                ),
+                (PubGrubPriority::Sentinel, PubGrubPriority::Sentinel),
                 package_id.into_raw() - lookup.len(),
             ));
             lookup.push((priority, virtual_priority));
@@ -248,12 +228,7 @@ impl PubGrubPriorities {
             EntryRef::Vacant(entry) => {
                 let priority = PubGrubPriority::ConflictEarly(Reverse(len));
                 entry.insert(smallvec![package_id]);
-                Self::insert_lookup(
-                    &mut self.lookup,
-                    package_id,
-                    priority,
-                    PubGrubVirtualPriority::from(0),
-                );
+                Self::insert_lookup(&mut self.lookup, package_id, priority, priority);
                 true
             }
             EntryRef::Occupied(entry) => {
@@ -298,12 +273,7 @@ impl PubGrubPriorities {
             EntryRef::Vacant(entry) => {
                 let priority = PubGrubPriority::ConflictLate(Reverse(len));
                 entry.insert(smallvec![package_id]);
-                Self::insert_lookup(
-                    &mut self.lookup,
-                    package_id,
-                    priority,
-                    PubGrubVirtualPriority::from(0),
-                );
+                Self::insert_lookup(&mut self.lookup, package_id, priority, priority);
                 true
             }
             EntryRef::Occupied(entry) => {
@@ -361,13 +331,4 @@ pub(crate) enum PubGrubPriority {
 
     /// The value is not yet determined and must not be read.
     Sentinel,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct PubGrubVirtualPriority(Reverse<u32>);
-
-impl From<u32> for PubGrubVirtualPriority {
-    fn from(value: u32) -> Self {
-        Self(Reverse(value))
-    }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2642,14 +2642,12 @@ impl ForkState {
                     .insert(package_id, package, version, &self.fork_urls);
             if let Some((new_priority, packages)) = new_priority {
                 for package_id in packages {
-                    // We must not add the current package since pubgrub is unaware that this
-                    // package is being decided.
-                    if package_id == self.next {
-                        continue;
-                    }
-                    self.pubgrub
-                        .partial_solution
-                        .update_priority(package_id, new_priority);
+                    // Update only the main package priority, the virtual package still has the
+                    // same priority
+                    self.pubgrub.partial_solution.update_priority(
+                        package_id,
+                        (new_priority, self.priorities.get(package_id).1),
+                    );
                 }
             }
         }

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -836,8 +836,8 @@ fn extra_incompatible_with_extra() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because package-a[extra-c]==1.0.0 depends on package-b==2.0.0 and package-a[extra-b]==1.0.0 depends on package-b==1.0.0, we can conclude that package-a[extra-b]==1.0.0 and package-a[extra-c]==1.0.0 are incompatible.
-          And because only package-a[extra-b]==1.0.0 is available and only package-a[extra-c]==1.0.0 is available, we can conclude that all versions of package-a[extra-b] and all versions of package-a[extra-c] are incompatible.
+      ╰─▶ Because only package-a[extra-b]==1.0.0 is available and package-a[extra-b]==1.0.0 depends on package-b==1.0.0, we can conclude that all versions of package-a[extra-b] depend on package-b==1.0.0.
+          And because package-a[extra-c]==1.0.0 depends on package-b==2.0.0 and only package-a[extra-c]==1.0.0 is available, we can conclude that all versions of package-a[extra-b] and all versions of package-a[extra-c] are incompatible.
           And because you require package-a[extra-b] and package-a[extra-c], we can conclude that your requirements are unsatisfiable.
     "###);
 

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -836,8 +836,8 @@ fn extra_incompatible_with_extra() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a[extra-b]==1.0.0 is available and package-a[extra-b]==1.0.0 depends on package-b==1.0.0, we can conclude that all versions of package-a[extra-b] depend on package-b==1.0.0.
-          And because package-a[extra-c]==1.0.0 depends on package-b==2.0.0 and only package-a[extra-c]==1.0.0 is available, we can conclude that all versions of package-a[extra-b] and all versions of package-a[extra-c] are incompatible.
+      ╰─▶ Because package-a[extra-c]==1.0.0 depends on package-b==2.0.0 and package-a[extra-b]==1.0.0 depends on package-b==1.0.0, we can conclude that package-a[extra-b]==1.0.0 and package-a[extra-c]==1.0.0 are incompatible.
+          And because only package-a[extra-b]==1.0.0 is available and only package-a[extra-c]==1.0.0 is available, we can conclude that all versions of package-a[extra-b] and all versions of package-a[extra-c] are incompatible.
           And because you require package-a[extra-b] and package-a[extra-c], we can conclude that your requirements are unsatisfiable.
     "###);
 


### PR DESCRIPTION
We were updating package priorities in without syncing them with pubgrub, so uv and pubgrub were getting out of sync. Surprisingly, this didn't cause any apparent differences in resolution, I expected this would change at least our ecosystem cases. It's potentially breaking through any time we change something in either uv or pubgrub.

We fix this by pushing updates to pubgrub. We couldn't previously u this because the way priority updates were tracked through the decision level. Instead, we switch to tracking the packages whose derivations changed in a set, based on https://github.com/pubgrub-rs/pubgrub/compare/dev...Eh2406:pubgrub:stop-prioritize. Since uv priorities don't depend on the ranges, we can speed this up further by not using this set in uv. In pubgrub, we can upstream this and use it as a correctness fix to also reprioritize when the conflict tracker changed, which is currently not handled.

I thought I had a performance regression that would be fixed by making pubgrub priorities fast by using the package ids as index. This turned out to be insufficient and the perf bottleneck had to be fixed on the pubgrub side.

Inside a package, we switch to processing the virtual package with the strongest constraint first, to avoid missing constraints:

Say we first see `a; python_version ">=3.9"` and then `a==1; python_version ">=3.10"`. We would currently assign a the wrong version (e.g. `a==2` ) through deciding `a; python_version ">=3.9"` first, then fix it up when we see `a==1; python_version ">=3.10"` right after.

This is a potentially breaking change in that it can change the resolution in edge cases.