### PR TITLE
Update `riscv64` Python downloads to allow install on `riscv64gc`

### DIFF
--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -124,7 +124,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Some(Prerelease { kind: PrereleaseKind::Alpha, number: 4 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -376,7 +376,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Some(Prerelease { kind: PrereleaseKind::Alpha, number: 4 }),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -1024,7 +1024,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -1348,7 +1348,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -2752,7 +2752,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5416,7 +5416,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8260,7 +8260,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12202,7 +12202,7 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64),
+                family: target_lexicon::Architecture::Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc),
                 variant: None,
             },
             os: Os(target_lexicon::OperatingSystem::Linux),

--- a/crates/uv-python/template-download-metadata.py
+++ b/crates/uv-python/template-download-metadata.py
@@ -74,7 +74,10 @@ def prepare_arch(arch: dict) -> tuple[str, str]:
         case "armv7":
             family = "Arm(target_lexicon::ArmArchitecture::Armv7)"
         case "riscv64":
-            family = "Riscv64(target_lexicon::Riscv64Architecture::Riscv64)"
+            # The `gc` variant of riscv64 is the common base instruction set and
+            # is the target in `python-build-standalone`
+            # See https://github.com/astral-sh/python-build-standalone/issues/504
+            family = "Riscv64(target_lexicon::Riscv64Architecture::Riscv64gc)"
         case value:
             family = value.capitalize()
     variant = (


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/10883