### PR TITLE
Only move the `.cargo` directory if it exists

### DIFF
--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -47,7 +47,9 @@ New-Item $Tmp -ItemType Directory
 
 # Move Cargo to the dev drive
 New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
-Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+if (Test-Path "C:/Users/runneradmin/.cargo") {
+    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+}
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `


### PR DESCRIPTION
which it usually does... but on some runners it can be missing now?
