### PR TITLE
Update name of "Build binary" job to highlight that these are the "release" binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -4,7 +4,7 @@
 #
 # Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a local
 # artifacts job within `cargo-dist`.
-name: "Build binaries"
+name: "Build release binaries"
 
 on:
   workflow_call:


### PR DESCRIPTION
I found this confusing since we have `build binary` jobs in regular CI 