### PR TITLE
Update documentation for activating virtual environments in different shell

### DIFF
--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -45,7 +45,7 @@ $ uv pip install ruff
 
 The virtual environment can be "activated" to make its packages available:
 
-=== "macOS and Linux (bash/zsh)"
+=== "macOS and Linux"
 
     ```console
     $ source .venv/bin/activate
@@ -57,18 +57,29 @@ The virtual environment can be "activated" to make its packages available:
     $ .venv\Scripts\activate
     ```
 
-=== "Alternative shells"
+!!! note
 
-    ```console
-    # For fish shell
-    $ source .venv/bin/activate.fish
+    The default activation script on Unix is for POSIX compliant shells like `sh`, `bash`, or `zsh`.
+    There are additional activation scripts for common alternative shells.
 
-    # For csh/tcsh
-    $ source .venv/bin/activate.csh
+    === "fish"
 
-    # For Nushell
-    $ use .venv\Scripts\activate.nu
-    ```
+        ```console
+        $ source .venv/bin/activate.fish
+        ```
+
+    === "csh / tcsh"
+
+
+        ```console
+        $ source .venv/bin/activate.csh
+        ```
+
+    === "Nushell"
+
+        ```console
+        $ use .venv\Scripts\activate.nu
+        ```
 
 ## Using arbitrary Python environments
 

--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -45,7 +45,7 @@ $ uv pip install ruff
 
 The virtual environment can be "activated" to make its packages available:
 
-=== "macOS and Linux"
+=== "macOS and Linux (bash/zsh)"
 
     ```console
     $ source .venv/bin/activate
@@ -55,6 +55,19 @@ The virtual environment can be "activated" to make its packages available:
 
     ```console
     $ .venv\Scripts\activate
+    ```
+
+=== "Alternative shells"
+
+    ```console
+    # For fish shell
+    $ source .venv/bin/activate.fish
+
+    # For csh/tcsh
+    $ source .venv/bin/activate.csh
+
+    # For Nushell
+    $ use .venv\Scripts\activate.nu
     ```
 
 ## Using arbitrary Python environments


### PR DESCRIPTION
## Add activation commands for fish shell and other alternative shells

While trying to use uv with fish shell, I encountered an issue as `source .venv/bin/activate` didn't work. The documentation didn't specify that fish shell requires using `source .venv/bin/activate.fish` instead. I created issue #10986 to address this.

This PR improves the documentation by:
- Adding the correct activation command for fish shell: `source .venv/bin/activate.fish`
- Adding the correct activation command for Nushell: `use .venv\Scripts\activate.nu`
- Adding the correct activation command for Tcsh: `use .venv/bin/activate.csh`

This will help users of alternative shells to properly activate their virtual environments without encountering the same confusion I experienced.

Fixes #10986