### PR TITLE
tests: update snapshots again

### DIFF
--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -7099,6 +7099,7 @@ fn add_index() -> Result<()> {
         name = "markupsafe"
         version = "2.1.5"
         source = { registry = "https://download.pytorch.org/whl/cu121" }
+        sdist = { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5.tar.gz" }
         wheels = [
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1" },
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4" },

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15083,6 +15083,7 @@ fn lock_repeat_named_index_cli() -> Result<()> {
         name = "markupsafe"
         version = "2.1.5"
         source = { registry = "https://download.pytorch.org/whl/cu121" }
+        sdist = { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5.tar.gz" }
         wheels = [
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1" },
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4" },
@@ -17702,6 +17703,7 @@ fn lock_multiple_sources_index_disjoint_markers() -> Result<()> {
         name = "markupsafe"
         version = "2.1.5"
         source = { registry = "https://download.pytorch.org/whl/cu118" }
+        sdist = { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5.tar.gz" }
         wheels = [
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1" },
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4" },
@@ -17834,6 +17836,7 @@ fn lock_multiple_sources_index_mixed() -> Result<()> {
         name = "markupsafe"
         version = "2.1.5"
         source = { registry = "https://download.pytorch.org/whl/cu118" }
+        sdist = { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5.tar.gz" }
         wheels = [
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1" },
             { url = "https://download.pytorch.org/whl/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4" },

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -7482,7 +7482,7 @@ fn universal_platform_fork() -> Result<()> {
     #    uv pip compile --cache-dir [CACHE_DIR] requirements.in --universal
     filelock==3.13.1
         # via torch
-    fsspec==2024.2.0
+    fsspec==2024.6.1
         # via torch
     jinja2==3.1.4
         # via torch
@@ -7490,9 +7490,9 @@ fn universal_platform_fork() -> Result<()> {
         # via jinja2
     mpmath==1.3.0
         # via sympy
-    networkx==3.2.1
+    networkx==3.3
         # via torch
-    setuptools==70.0.0
+    setuptools==70.2.0
         # via torch
     sympy==1.13.1
         # via torch


### PR DESCRIPTION
It looks like an sdist got uploaded after-the-fact for `MarkupSafe
2.1.5` and this has changed some of our lock files.
