### PR TITLE
Update documentation for running in a container

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -18,10 +18,10 @@ description:
 
 uv provides both *distroful* and *distroless* Docker images. *distroful* images ship operating system files, while *distroless* images ship only the `uv` binaries.
 
-For example, to run a uv command in a container that uses an alpine-based image:
+For example, to run a uv command in a container that uses a debian-based image:
 
 ```console
-$ docker run --rm -it ghcr.io/astral-sh/uv:alpine uv --help
+$ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help
 ```
 
 The following are distroless tags:

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -18,11 +18,11 @@ description:
 
 uv provides both _distroless_ Docker images, which are useful for
 [copying uv binaries](#installing-uv) into your own image builds, and images derived from popular
-base images, which are useful for running using uv in a container. The distroless images do not
-contain anything but the uv binaries. In contrast, the derived images include an operating system
-with uv pre-installed.
+base images, which are useful for using uv in a container. The distroless images do not contain
+anything but the uv binaries. In contrast, the derived images include an operating system with uv
+pre-installed.
 
-For example, to run a uv command in a container that uses a Debian-based image:
+As a basic example, to run uv in a container using a Debian-based image:
 
 ```console
 $ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -16,22 +16,26 @@ description:
 
 ### Running uv in a container
 
-uv provides both *distroful* and *distroless* Docker images. *distroful* images ship operating system files, while *distroless* images ship only the `uv` binaries.
+uv provides both _distroless_ Docker images, which are useful for
+[copying uv binaries](#installing-uv) into your own image builds, and images derived from popular
+base images, which are useful for running using uv in a container. The distroless images do not
+contain anything but the uv binaries. In contrast, the derived images include an operating system
+with uv pre-installed.
 
-For example, to run a uv command in a container that uses a debian-based image:
+For example, to run a uv command in a container that uses a Debian-based image:
 
 ```console
 $ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help
 ```
 
-The following are distroless tags:
+The distroless images are available:
 
 - `ghcr.io/astral-sh/uv:latest`
 - `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.5.25`
 - `ghcr.io/astral-sh/uv:{major}.{minor}`, e.g., `ghcr.io/astral-sh/uv:0.5` (the latest patch
   version)
 
-And these are the distroful tags:
+And the following derived images are available:
 
 <!-- prettier-ignore -->
 - Based on `alpine:3.20`:
@@ -66,7 +70,7 @@ And these are the distroful tags:
     - `ghcr.io/astral-sh/uv:python3.8-bookworm-slim`
 <!-- prettier-ignore-end -->
 
-As with the distroless image, each image is published with uv version tags as
+As with the distroless image, each derived image is published with uv version tags as
 `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}-{base}` and
 `ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.5.25-alpine`.
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -14,21 +14,21 @@ description:
     Check out the [`uv-docker-example`](https://github.com/astral-sh/uv-docker-example) project for
     an example of best practices when using uv to build an application in Docker.
 
-### Running uv in a container
-
 uv provides both _distroless_ Docker images, which are useful for
 [copying uv binaries](#installing-uv) into your own image builds, and images derived from popular
 base images, which are useful for using uv in a container. The distroless images do not contain
 anything but the uv binaries. In contrast, the derived images include an operating system with uv
 pre-installed.
 
-As a basic example, to run uv in a container using a Debian-based image:
+As an example, to run uv in a container using a Debian-based image:
 
 ```console
 $ docker run --rm -it ghcr.io/astral-sh/uv:debian uv --help
 ```
 
-The distroless images are available:
+### Available images
+
+The following distroless images are available:
 
 - `ghcr.io/astral-sh/uv:latest`
 - `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.5.25`

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -16,23 +16,22 @@ description:
 
 ### Running uv in a container
 
-A Docker image is published with a built version of uv available. To run a uv command in a
-container:
+uv provides both *distroful* and *distroless* Docker images. *distroful* images ship operating system files, while *distroless* images ship only the `uv` binaries.
+
+For example, to run a uv command in a container that uses an alpine-based image:
 
 ```console
-$ docker run ghcr.io/astral-sh/uv --help
+$ docker run --rm -it ghcr.io/astral-sh/uv:alpine uv --help
 ```
 
-### Available images
-
-uv provides a distroless Docker image including the `uv` binary. The following tags are published:
+The following are distroless tags:
 
 - `ghcr.io/astral-sh/uv:latest`
 - `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.5.25`
 - `ghcr.io/astral-sh/uv:{major}.{minor}`, e.g., `ghcr.io/astral-sh/uv:0.5` (the latest patch
   version)
 
-In addition, uv publishes the following images:
+And these are the distroful tags:
 
 <!-- prettier-ignore -->
 - Based on `alpine:3.20`:


### PR DESCRIPTION
This PR rewords the instructions for using uv in a container. I'm a new user and was somewhat confused by it, so I've rewritten it as I'd have liked to have read it.

It makes it more clear what distroless means, to avoid confusion with other projects that ship OS files with an image with its tag name clear of qualifiers(`astral-sh/uv`, in this case). An example of that is caddy, which ships with alpine.

This also modifies the original example to use a distroful image instead of distroless one while #8635 doesn't get resolved.