### PR TITLE
typo: unnecessary backslashes to represent brackets in markdown

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -71,7 +71,7 @@ hello = "example:app"
 ### Plugin entry points
 
 Projects may define entry points for plugin discovery in the
-[`\[project.entry-points\]`](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata)
+[`[project.entry-points]`](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata)
 table of the `pyproject.toml`.
 
 For example, to register the `example-plugin-a` package as a plugin for `example`:


### PR DESCRIPTION
There is a small typo in the doc which could mislead users: reference to a table in `pyproject.toml` currently appears as [`\[project.entry-points\]`](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata) while it should be  [`[project.entry-points]`](https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata).

Backslashes are appearing because they weren't supposed to be used on code representation in Markdown.
