### PR TITLE
docs: suggest copy linking for GitLab integration guide

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -16,12 +16,9 @@ variables:
   UV_VERSION: 0.5
   PYTHON_VERSION: 3.12
   BASE_LAYER: bookworm-slim
-
-stages:
-  - analysis
+  UV_LINK_MODE: copy
 
 uv:
-  stage: analysis
   image: ghcr.io/astral-sh/uv:$UV_VERSION-python$PYTHON_VERSION-$BASE_LAYER
   script:
     # your `uv` commands

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -17,7 +17,7 @@ variables:
   PYTHON_VERSION: 3.12
   BASE_LAYER: bookworm-slim
   # GitLab CI creates a separate mountpoint for the build directory,
-  # so we need to copy instead of hardlinking.
+  # so we need to copy instead of using hard links.
   UV_LINK_MODE: copy
 
 uv:

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -16,6 +16,8 @@ variables:
   UV_VERSION: 0.5
   PYTHON_VERSION: 3.12
   BASE_LAYER: bookworm-slim
+  # GitLab CI creates a separate mountpoint for the build directory,
+  # so we need to copy instead of hardlinking.
   UV_LINK_MODE: copy
 
 uv:


### PR DESCRIPTION
## Summary

Hardlinking does not work in that context and raises a warning.

Setting the link mode to copy makes the warning go away.

## Test Plan

Tested on gitlab.com and our self-hosted GitLab instance.

Before changing the link mode:

https://gitlab.com/fgreinacher/uv-test/-/jobs/8986967570

After changing the link mode:

https://gitlab.com/fgreinacher/uv-test/-/jobs/8987026307.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)
