### PR TITLE
Update `uv python install --reinstall` to reinstall all previous versions

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -28,6 +28,7 @@ use crate::implementation::{
 };
 use crate::installation::PythonInstallationKey;
 use crate::libc::LibcDetectionError;
+use crate::managed::ManagedPythonInstallation;
 use crate::platform::{self, Arch, Libc, Os};
 use crate::{Interpreter, PythonRequest, PythonVersion, VersionRequest};
 
@@ -341,6 +342,23 @@ impl PythonDownloadRequest {
             }
         }
         true
+    }
+}
+
+impl From<&ManagedPythonInstallation> for PythonDownloadRequest {
+    fn from(installation: &ManagedPythonInstallation) -> Self {
+        let key = installation.key();
+        Self::new(
+            Some(VersionRequest::from(&key.version())),
+            match &key.implementation {
+                LenientImplementationName::Known(implementation) => Some(*implementation),
+                LenientImplementationName::Unknown(name) => unreachable!("Managed Python installations are expected to always have known implementation names, found {name}"),
+            },
+            Some(key.arch),
+            Some(key.os),
+            Some(key.libc),
+            Some(key.prerelease.is_some()),
+        )
     }
 }
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -54,7 +54,7 @@ fn python_install() {
     "###);
 
     // You can opt-in to a reinstall
-    uv_snapshot!(context.filters(), context.python_install().arg("--reinstall"), @r###"
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13").arg("--reinstall"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -88,6 +88,82 @@ fn python_install() {
     Searching for Python versions matching: Python 3.13
     Uninstalled Python 3.13.1 in [TIME]
      - cpython-3.13.1-[PLATFORM]
+    "###);
+}
+
+#[test]
+fn python_reinstall() {
+    let context: TestContext = TestContext::new_with_versions(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs();
+
+    // Install a couple versions
+    uv_snapshot!(context.filters(), context.python_install().arg("3.12").arg("3.13"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed 2 versions in [TIME]
+     + cpython-3.12.8-[PLATFORM]
+     + cpython-3.13.1-[PLATFORM]
+    "###);
+
+    // Reinstall a single version
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13").arg("--reinstall"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.13.1 in [TIME]
+     ~ cpython-3.13.1-[PLATFORM]
+    "###);
+
+    // Reinstall multiple versions
+    uv_snapshot!(context.filters(), context.python_install().arg("--reinstall"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed 2 versions in [TIME]
+     ~ cpython-3.12.8-[PLATFORM]
+     ~ cpython-3.13.1-[PLATFORM]
+    "###);
+}
+
+#[test]
+fn python_reinstall_patch() {
+    let context: TestContext = TestContext::new_with_versions(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs();
+
+    // Install a couple patch versions
+    uv_snapshot!(context.filters(), context.python_install().arg("3.12.6").arg("3.12.7"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed 2 versions in [TIME]
+     + cpython-3.12.6-[PLATFORM]
+     + cpython-3.12.7-[PLATFORM]
+    "###);
+
+    // Reinstall all "3.12" versions
+    // TODO(zanieb): This doesn't work today, because we need this to install the "latest" as there
+    // is no workflow for `--upgrade` yet
+    uv_snapshot!(context.filters(), context.python_install().arg("3.12").arg("--reinstall"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.12.8 in [TIME]
+     + cpython-3.12.8-[PLATFORM]
     "###);
 }
 


### PR DESCRIPTION
Since we're shipping substantive updates to Python versions frequently, I want to lower the bar for reinstalling with the latest distributions.

There's a follow-up task that's documented in a test case at https://github.com/astral-sh/uv/pull/11072/files#diff-f499c776e1d8cc5e55d7620786e32e8732b675abd98e246c0971130f5de9ed50R157-R158