### PR TITLE
Avoid resolving symbolic links when querying Python interpreters

### DIFF
--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -14590,6 +14590,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG Found workspace root: `[TEMP_DIR]/`
     DEBUG Adding current workspace member: `[TEMP_DIR]/`
     DEBUG Using Python request `>=3.12` from `requires-python` metadata
+    DEBUG Checking for Python environment at `.venv`
     DEBUG The virtual environment's Python version satisfies `>=3.12`
     DEBUG Using request timeout of [TIME]
     DEBUG Found static `pyproject.toml` for: project @ file://[TEMP_DIR]/

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -3399,8 +3399,8 @@ fn run_linked_environment_path() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    [VENV]/
-    [VENV]/[BIN]/python
+    [TEMP_DIR]/target
+    [TEMP_DIR]/target/[BIN]/python
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
@@ -3414,7 +3414,7 @@ fn run_linked_environment_path() -> Result<()> {
     }, {
         assert_snapshot!(
             black_entrypoint, @r###"
-        #![VENV]/[BIN]/python
+        #![TEMP_DIR]/target/[BIN]/python
         # -*- coding: utf-8 -*-
         import sys
         from black import patched_main

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -3352,6 +3352,8 @@ fn run_gui_script_explicit_unix() -> Result<()> {
 #[test]
 #[cfg(unix)]
 fn run_linked_environment_path() -> Result<()> {
+    use anyhow::Ok;
+
     let context = TestContext::new("3.12")
         .with_filtered_virtualenv_bin()
         .with_filtered_python_names();
@@ -3363,7 +3365,7 @@ fn run_linked_environment_path() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["iniconfig"]
+        dependencies = ["black"]
         "#,
     )?;
 
@@ -3378,26 +3380,53 @@ fn run_linked_environment_path() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + iniconfig==2.0.0
+    Resolved 8 packages in [TIME]
+    Prepared 6 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     "###);
 
-    // Using `uv run` should
+    // `sys.prefix` and `sys.executable` should be from the `target` directory
     uv_snapshot!(context.filters(), context.run()
-        .env_remove("VIRTUAL_ENV")  // Ignore the test context virtual environment activation
+        .env_remove("VIRTUAL_ENV")  // Ignore the test context's active virtual environment
         .env(EnvVars::UV_PROJECT_ENVIRONMENT, "target")
-        .arg("python").arg("-c").arg("import sys; print(sys.executable)"), @r###"
+        .arg("python").arg("-c").arg("import sys; print(sys.prefix); print(sys.executable)"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
+    [VENV]/
     [VENV]/[BIN]/python
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Audited 1 package in [TIME]
+    Resolved 8 packages in [TIME]
+    Audited 6 packages in [TIME]
     "###);
+
+    // And, similarly, the entrypoint should use `target`
+    let black_entrypoint = context.read("target/bin/black");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            black_entrypoint, @r###"
+        #![VENV]/[BIN]/python
+        # -*- coding: utf-8 -*-
+        import sys
+        from black import patched_main
+        if __name__ == "__main__":
+            if sys.argv[0].endswith("-script.pyw"):
+                sys.argv[0] = sys.argv[0][:-11]
+            elif sys.argv[0].endswith(".exe"):
+                sys.argv[0] = sys.argv[0][:-4]
+            sys.exit(patched_main())
+        "###
+        );
+    });
 
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/11048

This brings the `PythonEnvironment::from_root` behavior in-line with the rest of uv Python discovery behavior (and in-line with pip). It's not clear why we were canonicalizing the path in the first place here.
