### PR TITLE
Remove missing host short-circuit from canonical URL construction

### DIFF
--- a/crates/uv-cache-key/src/canonical_url.rs
+++ b/crates/uv-cache-key/src/canonical_url.rs
@@ -26,11 +26,6 @@ impl CanonicalUrl {
             return Self(url);
         }
 
-        // If the URL has no host, then it's not a valid URL anyway.
-        if !url.has_host() {
-            return Self(url);
-        }
-
         // Strip credentials.
         let _ = url.set_password(None);
         let _ = url.set_username("");


### PR DESCRIPTION
This was added in 93d606aba20c39149390a9191879e82194ea4e91 when `Url::set_password` (and username) were unwrapped but now we just ignore those errors (those functions require the URL to have a host).

Removed this to see if it changed any tests and figured I'd commit it, @charliermarsh is poking at it so maybe he's changing behavior that relies on removing this to allow canonicalization of `file://` URLs (which don't have a host).