### PR TITLE
Percent-decode URLs in canonical comparisons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,6 +4752,7 @@ dependencies = [
  "hex",
  "seahash",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,6 +4750,7 @@ name = "uv-cache-key"
 version = "0.0.1"
 dependencies = [
  "hex",
+ "memchr",
  "seahash",
  "url",
  "urlencoding",

--- a/crates/uv-cache-key/Cargo.toml
+++ b/crates/uv-cache-key/Cargo.toml
@@ -20,3 +20,4 @@ workspace = true
 hex = { workspace = true }
 seahash = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }

--- a/crates/uv-cache-key/Cargo.toml
+++ b/crates/uv-cache-key/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 hex = { workspace = true }
+memchr = { workspace = true }
 seahash = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/uv-cache-key/src/canonical_url.rs
+++ b/crates/uv-cache-key/src/canonical_url.rs
@@ -26,11 +26,6 @@ impl CanonicalUrl {
             return Self(url);
         }
 
-        // If the URL has no host, then it's not a valid URL anyway.
-        if !url.has_host() {
-            return Self(url);
-        }
-
         // Strip credentials.
         let _ = url.set_password(None);
         let _ = url.set_username("");
@@ -74,6 +69,11 @@ impl CanonicalUrl {
                 };
                 url.path_segments_mut().unwrap().pop().push(&last);
             }
+        }
+
+        // Decode any percent-encoded characters in the path.
+        if let Ok(path) = urlencoding::decode(url.path()).map(|path| path.to_string()) {
+            url.set_path(&path);
         }
 
         Self(url)

--- a/crates/uv-distribution-types/src/any.rs
+++ b/crates/uv-distribution-types/src/any.rs
@@ -1,6 +1,8 @@
 use std::hash::Hash;
 
+use uv_cache_key::CanonicalUrl;
 use uv_normalize::PackageName;
+use uv_pep440::Version;
 
 use crate::cached::CachedDist;
 use crate::installed::InstalledDist;
@@ -8,19 +10,29 @@ use crate::{InstalledMetadata, InstalledVersion, Name};
 
 /// A distribution which is either installable, is a wheel in our cache or is already installed.
 ///
-/// Note equality and hash operations are only based on the name and version, not the kind.
+/// Note equality and hash operations are only based on the name and canonical version, not the
+/// kind.
 #[derive(Debug, Clone, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum LocalDist {
-    Cached(CachedDist),
-    Installed(InstalledDist),
+    Cached(CachedDist, CanonicalVersion),
+    Installed(InstalledDist, CanonicalVersion),
+}
+
+impl LocalDist {
+    fn canonical_version(&self) -> &CanonicalVersion {
+        match self {
+            Self::Cached(_, version) => version,
+            Self::Installed(_, version) => version,
+        }
+    }
 }
 
 impl Name for LocalDist {
     fn name(&self) -> &PackageName {
         match self {
-            Self::Cached(dist) => dist.name(),
-            Self::Installed(dist) => dist.name(),
+            Self::Cached(dist, _) => dist.name(),
+            Self::Installed(dist, _) => dist.name(),
         }
     }
 }
@@ -28,33 +40,53 @@ impl Name for LocalDist {
 impl InstalledMetadata for LocalDist {
     fn installed_version(&self) -> InstalledVersion {
         match self {
-            Self::Cached(dist) => dist.installed_version(),
-            Self::Installed(dist) => dist.installed_version(),
+            Self::Cached(dist, _) => dist.installed_version(),
+            Self::Installed(dist, _) => dist.installed_version(),
         }
     }
 }
 
 impl From<CachedDist> for LocalDist {
     fn from(dist: CachedDist) -> Self {
-        Self::Cached(dist)
+        let version = CanonicalVersion::from(dist.installed_version());
+        Self::Cached(dist, version)
     }
 }
 
 impl From<InstalledDist> for LocalDist {
     fn from(dist: InstalledDist) -> Self {
-        Self::Installed(dist)
+        let version = CanonicalVersion::from(dist.installed_version());
+        Self::Installed(dist, version)
     }
 }
 
 impl Hash for LocalDist {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name().hash(state);
-        self.installed_version().hash(state);
+        self.canonical_version().hash(state);
     }
 }
 
 impl PartialEq for LocalDist {
     fn eq(&self, other: &Self) -> bool {
-        self.name() == other.name() && self.installed_version() == other.installed_version()
+        self.name() == other.name() && self.canonical_version() == other.canonical_version()
+    }
+}
+
+/// Like [`InstalledVersion`], but with [`CanonicalUrl`] to ensure robust URL comparisons.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CanonicalVersion {
+    Version(Version),
+    Url(CanonicalUrl, Version),
+}
+
+impl From<InstalledVersion<'_>> for CanonicalVersion {
+    fn from(installed_version: InstalledVersion<'_>) -> Self {
+        match installed_version {
+            InstalledVersion::Version(version) => Self::Version(version.clone()),
+            InstalledVersion::Url(url, version) => {
+                Self::Url(CanonicalUrl::new(url), version.clone())
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR adds an additional normalization step to `CanonicalUrl` whereby we now percent-decode the path, to ensure that (e.g.) `torch-2.5.1%2Bcpu.cxx11.abi-cp39-cp39-linux_x86_64.whl` and `torch-2.5.1+cpu.cxx11.abi-cp39-cp39-linux_x86_64.whl` are considered equal. Further, when generating the "reinstall" report, we use the canonical URL rather than the verbatim URL.

In making this change, I also learned that we don't apply any of the normalization passes to `file://` URLs. I inadvertently removed it in https://github.com/astral-sh/uv/pull/3010/commits/93d606aba20c39149390a9191879e82194ea4e91, since setting the password or URL on ` file://` URL errors -- but now suppress those errors anyway.

Closes https://github.com/astral-sh/uv/issues/11082.

## Test Plan

- Downloaded a [PyTorch wheel](https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.1%2Bcpu.cxx11.abi-cp39-cp39-linux_x86_64.whl)
- `python3.9 -m pip install torch-2.5.1+cpu.cxx11.abi-cp39-cp39-linux_x86_64.whl --platform linux_x86_64 --target foo --no-deps`
- `cargo run pip install torch-2.5.1+cpu.cxx11.abi-cp39-cp39-linux_x86_64.whl --python-platform linux --python-version 3.9 --target foo --no-deps`
- Verified that the package had the `~` symbol for the reinstall.