### PR TITLE
Explain build frontend vs. build backend

### DIFF
--- a/docs/concepts/projects/build.md
+++ b/docs/concepts/projects/build.md
@@ -8,6 +8,13 @@ distributions (wheels). The former is typically a `.tar.gz` or `.zip` file conta
 source code along with some additional metadata, while the latter is a `.whl` file containing
 pre-built artifacts that can be installed directly.
 
+!!! important
+
+    When running `uv build`, uv is the build frontend and only determines the Python version. The
+    contents of the files and their filenames are determined by the build backend, as defined
+    in `[build-system]`. Information about build configuration can be bound in the respective tool's
+    documentation.
+
 ## Using `uv build`
 
 `uv build` can be used to build both source distributions and binary distributions for your project.

--- a/docs/concepts/projects/build.md
+++ b/docs/concepts/projects/build.md
@@ -10,10 +10,11 @@ pre-built artifacts that can be installed directly.
 
 !!! important
 
-    When running `uv build`, uv is the build frontend and only determines the Python version. The
-    contents of the files and their filenames are determined by the build backend, as defined
-    in `[build-system]`. Information about build configuration can be found in the respective tool's
-    documentation.
+    When using `uv build`, uv acts as a [build frontend](https://peps.python.org/pep-0517/#terminology-and-goals)
+    and only determines the Python version to use and invokes the build backend. The details of
+    the builds, such as the included files and the distribution filenames, are determined by the build
+    backend, as defined in [`[build-system]`](./config.md#build-systems). Information about build
+    configuration can be found in the respective tool's documentation.
 
 ## Using `uv build`
 

--- a/docs/concepts/projects/build.md
+++ b/docs/concepts/projects/build.md
@@ -12,7 +12,7 @@ pre-built artifacts that can be installed directly.
 
     When running `uv build`, uv is the build frontend and only determines the Python version. The
     contents of the files and their filenames are determined by the build backend, as defined
-    in `[build-system]`. Information about build configuration can be bound in the respective tool's
+    in `[build-system]`. Information about build configuration can be found in the respective tool's
     documentation.
 
 ## Using `uv build`


### PR DESCRIPTION
We regularly get questions why `uv build` is missing certain files or using the wrong build tag, when that's done by the build backend and part of the build backend's docs. I tried to clarify this difference and to redirect users to look at the tool's docs instead of wondering why uv's docs don't explain that.