### PR TITLE
Make metadata deserialization failures non-fatal in the cache

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -793,7 +793,7 @@ impl CacheBucket {
         match self {
             // Note that when bumping this, you'll also need to bump it
             // in crates/uv/tests/cache_prune.rs.
-            Self::SourceDistributions => "sdists-v6",
+            Self::SourceDistributions => "sdists-v7",
             Self::FlatIndex => "flat-index-v2",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v4",

--- a/crates/uv/tests/it/cache_prune.rs
+++ b/crates/uv/tests/it/cache_prune.rs
@@ -348,7 +348,7 @@ fn prune_stale_revision() -> Result<()> {
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
-    DEBUG Removing dangling source revision: [CACHE_DIR]/sdists-v6/[ENTRY]
+    DEBUG Removing dangling source revision: [CACHE_DIR]/sdists-v7/[ENTRY]
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
     "###);


### PR DESCRIPTION
## Summary

If we fail to deserialize cached metadata in the cache, we should just ignore it, rather than failing.

Ideally, this never happens. If it does, it means we missed a cache version bump. But if it does happen, it should still be non-fatal.

Closes https://github.com/astral-sh/uv/issues/11043.

Closes https://github.com/astral-sh/uv/issues/11101.

## Test Plan

Prior to this PR, the following would fail:

- `uvx uv@0.5.25 venv --python 3.12 --cache-dir foo`
- `uvx uv@0.5.25 pip install ./scripts/packages/hatchling_dynamic --no-deps --python 3.12 --cache-dir foo`
- `uvx uv@0.5.18 venv --python 3.12 --cache-dir foo`
- `uvx uv@0.5.18 pip install ./scripts/packages/hatchling_dynamic --no-deps --python 3.12 --cache-dir foo`

We can't go back and fix 0.5.18, but this will prevent such regressions in the future.
