### PR TITLE
Use explicit _GLibCVersion tuple in uv-python crate

### DIFF
--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -204,13 +204,13 @@ def _is_compatible(arch: str, version: _GLibCVersion) -> bool:
     return True
 
 
-_LEGACY_MANYLINUX_MAP = {
+_LEGACY_MANYLINUX_MAP: dict[_GLibCVersion, str] = {
     # CentOS 7 w/ glibc 2.17 (PEP 599)
-    (2, 17): "manylinux2014",
+    _GLibCVersion(2, 17): "manylinux2014",
     # CentOS 6 w/ glibc 2.12 (PEP 571)
-    (2, 12): "manylinux2010",
+    _GLibCVersion(2, 12): "manylinux2010",
     # CentOS 5 w/ glibc 2.5 (PEP 513)
-    (2, 5): "manylinux1",
+    _GLibCVersion(2, 5): "manylinux1",
 }
 
 

--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -150,7 +150,7 @@ def _glibc_version_string() -> str | None:
     return _glibc_version_string_confstr() or _glibc_version_string_ctypes()
 
 
-def _parse_glibc_version(version_str: str) -> tuple[int, int]:
+def _parse_glibc_version(version_str: str) -> _GLibCVersion:
     """Parse glibc version.
 
     We use a regexp instead of str.split because we want to discard any
@@ -165,15 +165,15 @@ def _parse_glibc_version(version_str: str) -> tuple[int, int]:
             f" got: {version_str}",
             RuntimeWarning,
         )
-        return -1, -1
-    return int(m.group("major")), int(m.group("minor"))
+        return _GLibCVersion(-1, -1)
+    return _GLibCVersion(int(m.group("major")), int(m.group("minor")))
 
 
 @functools.lru_cache()
-def _get_glibc_version() -> tuple[int, int]:
+def _get_glibc_version() -> _GLibCVersion:
     version_str = _glibc_version_string()
     if version_str is None:
-        return (-1, -1)
+        return _GLibCVersion(-1, -1)
     return _parse_glibc_version(version_str)
 
 


### PR DESCRIPTION
## Summary

I get the following type checking errors in the uv-python crate when running mypy:

```console
$ cd crates/uv-python
$ uvx --python 3.13 --with httpx --with types-setuptools --with chevron-blue mypy --ignore-missing-imports .

python/get_interpreter_info.py:549: error: Argument "version" to "_is_compatible" has incompatible type "tuple[int, int]"; expected "_GLibCVersion"  [arg-type]
Found 1 error in 1 file (checked 8 source files)
```

What this PR does:

1. Makes the type annotations more consistent in the uv-python crate in the code that parses the glibc version, addressing this warning. This mirrors the _MuslVersion named tuple in the sibling `_musllinux.py` file
2. Adds an explicit type annotation to the `_LEGACY_MANYLINUX_MAP` dictionary, which also used `tuple[int, int]` instead of `_GLibCVersion`

## Test Plan

Running the same command that got the error before is now all gucci!

```console
$ cd crates/uv-python
$ uvx --python 3.13 --with httpx --with types-setuptools --with chevron-blue mypy --ignore-missing-imports .

Success: no issues found in 8 source files
```
