### PR TITLE
Improve performance of uv-python crate's manylinux submodule

### DIFF
--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -232,7 +232,7 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
     if set(archs) & {"x86_64", "i686"}:
         # On x86/i686 also oldest glibc to be supported is (2, 5).
         too_old_glibc2 = _GLibCVersion(2, 4)
-    current_glibc = _GLibCVersion(*_get_glibc_version())
+    current_glibc = _get_glibc_version()
     glibc_max_list = [current_glibc]
     # We can assume compatibility across glibc major versions.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=24636

--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -252,11 +252,8 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                 min_minor = -1
             for glibc_minor in range(glibc_max.minor, min_minor, -1):
                 glibc_version = _GLibCVersion(glibc_max.major, glibc_minor)
-                tag = "manylinux_{}_{}".format(*glibc_version)
                 if _is_compatible(arch, glibc_version):
-                    yield f"{tag}_{arch}"
-                # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
-                if glibc_version in _LEGACY_MANYLINUX_MAP:
-                    legacy_tag = _LEGACY_MANYLINUX_MAP[glibc_version]
-                    if _is_compatible(arch, glibc_version):
+                    yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
+                    # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
+                    if legacy_tag := _LEGACY_MANYLINUX_MAP.get(glibc_version):
                         yield f"{legacy_tag}_{arch}"


### PR DESCRIPTION
## Summary

This PR makes a few performance improvements:

1. Reduces the need to unpack and repack a `_GLibCVersion` tuple
2. Reduces the doubled call to `_is_compatible(arch, glibc_version)`
3. Moves the assignment of the `tag` variable directly into the yield, reducing memory allocation in case this is never used when `_is_compatible(arch, glibc_version)` is false
4. Combines the check of the `glibc_version` being in `_LEGACY_MANYLINUX_MAP` and the assignment to the variable together. I'm not sure if this is actually better, but using the assignment expression reduces this from 4 lines to 2

## Test Plan

I'm not quite sure how this is module tested, but I'm pretty confident these changes won't affect anything. If someone can point me towards a place to write some unit tests, I'm happy to do so
