### PR TITLE
Clear ephemeral overlays when running tools

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -176,6 +176,12 @@ pub(crate) enum ProjectError {
     #[error("Failed to parse PEP 723 script metadata")]
     Pep723ScriptTomlParse(#[source] toml::de::Error),
 
+    #[error("Failed to remove ephemeral overlay")]
+    OverlayRemoval(#[source] std::io::Error),
+
+    #[error("Failed to find `site-packages` directory for environment")]
+    NoSitePackages,
+
     #[error(transparent)]
     DependencyGroup(#[from] DependencyGroupError),
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -766,5 +766,8 @@ async fn get_or_create_environment(
         },
     };
 
+    // Clear any existing overlay.
+    environment.clear_overlay()?;
+
     Ok((from, environment.into()))
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -3928,11 +3928,86 @@ fn run_repeated() -> Result<()> {
     uv_snapshot!(
         context.filters(),
         context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+        import typing_extensions; import iniconfig
+                                  ^^^^^^^^^^^^^^^^
+    ModuleNotFoundError: No module named 'iniconfig'
+    "###);
+
+    Ok(())
+}
+
+/// See: <https://github.com/astral-sh/uv/issues/11117>
+#[test]
+fn run_without_overlay() -> Result<()> {
+    let context = TestContext::new_with_versions(&["3.13"]);
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11, <4"
+        dependencies = ["iniconfig"]
+        "#
+    })?;
+
+    // Import `iniconfig` in the context of the project.
+    uv_snapshot!(
+        context.filters(),
+        context.run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    Using CPython 3.13.[X] interpreter at: [PYTHON-3.13]
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + typing-extensions==4.10.0
+    "###);
+
+    // Import `iniconfig` in the context of a `tool run` command, which should fail.
+    uv_snapshot!(
+        context.filters(),
+        context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+        import typing_extensions; import iniconfig
+                                  ^^^^^^^^^^^^^^^^
+    ModuleNotFoundError: No module named 'iniconfig'
+    "###);
+
+    // Re-running in the context of the project should reset the overlay.
+    uv_snapshot!(
+        context.filters(),
+        context.run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Audited 1 package in [TIME]
     Resolved 1 package in [TIME]
     "###);
 


### PR DESCRIPTION
## Summary

This PR removes the ephemeral `.pth` overlay when using a cached environment. This solution isn't _completely_ safe, since we could remove the `.pth` file just as another process is starting the environment... But that risk already exists today, since we could _overwrite_ the `.pth` file just as another process is starting the environment, so I think what I've added here is a strict improvement.

Ideally, we wouldn't write this file at all, and we'd instead somehow (e.g.) pass a file to the interpreter to run at startup? Or find some other solution that doesn't require poisoning the cache like this.

Closes https://github.com/astral-sh/uv/issues/11117.

# Test Plan

Ran through the great reproduction steps from the linked issue.

Before:

![Screenshot 2025-01-31 at 2 11 31 PM](https://github.com/user-attachments/assets/d36e1db5-27b1-483a-9ced-bec67bd7081d)

After:

![Screenshot 2025-01-31 at 2 11 39 PM](https://github.com/user-attachments/assets/1f963ce0-7903-4acd-9fd6-753374c31705)
