### PR TITLE
Set `UV_PYTHON` in Jupyter kernels

### DIFF
--- a/docs/guides/integration/jupyter.md
+++ b/docs/guides/integration/jupyter.md
@@ -51,7 +51,7 @@ $ uv add --dev ipykernel
 Then, you can create the kernel for `project` with:
 
 ```console
-$ uv run ipython kernel install --user --env UV_PYTHON $(pwd)/.venv --name=project
+$ uv run ipython kernel install --user --env VIRTUAL_ENV $(pwd)/.venv --name=project
 ```
 
 From there, start the server with:

--- a/docs/guides/integration/jupyter.md
+++ b/docs/guides/integration/jupyter.md
@@ -51,7 +51,7 @@ $ uv add --dev ipykernel
 Then, you can create the kernel for `project` with:
 
 ```console
-$ uv run ipython kernel install --user --name=project
+$ uv run ipython kernel install --user --env UV_PYTHON $(pwd)/.venv --name=project
 ```
 
 From there, start the server with:


### PR DESCRIPTION
## Summary

It turns out activating the kernel does not change `VIRTUAL_ENV`, so we still install into the environment the Jupyter environment, rather than the project environment.

Unfortunately, after this change, we do still show a warning on `uv add`:

```
warning: `VIRTUAL_ENV=/Users/crmarsh/.cache/uv/archive-v0/3bddKDdYXuX2w57Fu6itL` does not match the project environment path `.venv` and will be ignored
```

`uv pip install` works without warning.

Closes #11154.
