### PR TITLE
Bump alpine default tag to 3.21

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -176,7 +176,7 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.20,alpine3.20,alpine
+          - alpine:3.21,alpine3.21,alpine
           - debian:bookworm-slim,bookworm-slim,debian-slim
           - buildpack-deps:bookworm,bookworm,debian
           - python:3.13-alpine,python3.13-alpine


### PR DESCRIPTION
## Summary

Alpine 3.21 has been released for a few months and it's now being used officially under `alpine` based [python images](https://hub.docker.com/_/python), hence our python-alpine based images has been using 3.21 since uv 0.5.8 under the hood.

This could arguably be `breaking` as we're dropping alpine3.20 top-level tag, so it could be a good candidate for 0.6.0.

Alternatively, we can keep support for 3.20 and make this non-breaking by simply repointing alpine to now be 3.21 and keeping the 3.20 tag around.
