### PR TITLE
Update pubgrub to set-based outdated priority tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,8 +2754,8 @@ dependencies = [
 
 [[package]]
 name = "pubgrub"
-version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=648aa343486e5529953153781fc86025c73c4a61#648aa343486e5529953153781fc86025c73c4a61"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4#b70cf707aa43f21b32f3a61b8a0889b15032d5c4"
 dependencies = [
  "indexmap",
  "log",
@@ -5806,7 +5806,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "version-ranges"
 version = "0.1.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=648aa343486e5529953153781fc86025c73c4a61#648aa343486e5529953153781fc86025c73c4a61"
+source = "git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4#b70cf707aa43f21b32f3a61b8a0889b15032d5c4"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ petgraph = { version = "0.7.1" }
 platform-info = { version = "2.0.3" }
 proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.17.0", default-features = false, features = ["flate2"] }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "648aa343486e5529953153781fc86025c73c4a61" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "b70cf707aa43f21b32f3a61b8a0889b15032d5c4" }
 quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }
@@ -177,7 +177,7 @@ tracing-tree = { version = "0.4.0" }
 unicode-width = { version = "0.1.13" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2", features = ["serde"] }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "648aa343486e5529953153781fc86025c73c4a61" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "b70cf707aa43f21b32f3a61b8a0889b15032d5c4" }
 walkdir = { version = "2.5.0" }
 which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.4.0" }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -391,8 +391,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 .map(|(p, v)| format!("{}=={}", state.pubgrub.package_store[p], v))
                                 .join(", ")
                         );
-                        // Choose a package .
-                        let Some(highest_priority_pkg) =
+                        // Choose a package.
+                        // We aren't allowed to use the term intersection as it would extend the
+                        // mutable borrow of `state`.
+                        let Some((highest_priority_pkg, _)) =
                             state.pubgrub.partial_solution.pick_highest_priority_pkg(
                                 |id, _range| state.priorities.get(&state.pubgrub.package_store[id]),
                             )

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -531,17 +531,17 @@ fn excluded_only_compatible_version() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because package-a==1.0.0 depends on package-b==1.0.0 and only the following versions of package-a are available:
+      ╰─▶ Because only the following versions of package-a are available:
               package-a==1.0.0
               package-a==2.0.0
               package-a==3.0.0
-          we can conclude that package-a<2.0.0 depends on package-b==1.0.0.
+          and package-a==1.0.0 depends on package-b==1.0.0, we can conclude that package-a<2.0.0 depends on package-b==1.0.0.
           And because package-a==3.0.0 depends on package-b==3.0.0, we can conclude that all of:
               package-a<2.0.0
               package-a>2.0.0
           depend on one of:
-              package-b<=1.0.0
-              package-b>=3.0.0
+              package-b==1.0.0
+              package-b==3.0.0
 
           And because you require one of:
               package-a<2.0.0


### PR DESCRIPTION
Looks like the set based prioritize tracking from https://github.com/pubgrub-rs/pubgrub/pull/313 is a slight speedup.

I assume the changed derivation tree in the error snapshot is due to out-of-sync virtual package priorities, while the main package priority defining the solution remains stable.

```
$ hyperfine --warmup 2 "./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal" "./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal"
  Benchmark 1: ./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal
    Time (mean ± σ):     115.0 ms ±   4.8 ms    [User: 131.0 ms, System: 113.6 ms]
    Range (min … max):   108.1 ms … 125.8 ms    25 runs

  Benchmark 2: ./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal
    Time (mean ± σ):     105.4 ms ±   2.6 ms    [User: 118.5 ms, System: 113.5 ms]
    Range (min … max):   101.1 ms … 111.9 ms    28 runs

  Summary
    ./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal ran
      1.09 ± 0.05 times faster than ./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal
```