### PR TITLE
Fix relative paths in bytecode compilation

### DIFF
--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -75,7 +75,8 @@ pub async fn compile_tree(
 ) -> Result<usize, CompileError> {
     debug_assert!(
         dir.is_absolute(),
-        "compileall doesn't work with relative paths"
+        "compileall doesn't work with relative paths: `{}`",
+        dir.display()
     );
     let worker_count = std::thread::available_parallelism().unwrap_or_else(|err| {
         warn_user!("Couldn't determine number of cores, compiling with a single thread: {err}");

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use tool::update_shell::update_shell as tool_update_shell;
 pub(crate) use tool::upgrade::upgrade as tool_upgrade;
 use uv_cache::Cache;
 use uv_distribution_types::InstalledMetadata;
-use uv_fs::Simplified;
+use uv_fs::{Simplified, CWD};
 use uv_installer::compile_tree;
 use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
@@ -153,6 +153,7 @@ pub(super) async fn compile_bytecode(
     let start = std::time::Instant::now();
     let mut files = 0;
     for site_packages in venv.site_packages() {
+        let site_packages = CWD.join(site_packages);
         files += compile_tree(&site_packages, venv.python_executable(), cache.root())
             .await
             .with_context(|| {


### PR DESCRIPTION
Bytecode compilation would panic with a relative path such as `--target target`.