### PR TITLE
Respect concurrency limits in parallel index fetch

### DIFF
--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -155,7 +155,9 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
         let result = self
             .fetcher
             .client()
-            .managed(|client| client.simple(package_name, index, self.capabilities))
+            .manual(|client, semaphore| {
+                client.simple(package_name, index, self.capabilities, semaphore)
+            })
             .await;
 
         match result {

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -1,3 +1,4 @@
+use tokio::sync::Semaphore;
 use tracing::debug;
 use uv_client::{RegistryClient, VersionFiles};
 use uv_distribution_filename::DistFilename;
@@ -27,10 +28,15 @@ impl LatestClient<'_> {
         &self,
         package: &PackageName,
         index: Option<&IndexUrl>,
+        download_concurrency: &Semaphore,
     ) -> anyhow::Result<Option<DistFilename>, uv_client::Error> {
         debug!("Fetching latest version of: `{package}`");
 
-        let archives = match self.client.simple(package, index, self.capabilities).await {
+        let archives = match self
+            .client
+            .simple(package, index, self.capabilities, download_concurrency)
+            .await
+        {
             Ok(archives) => archives,
             Err(err) => {
                 return match err.into_kind() {


### PR DESCRIPTION
With the parallel simple index fetching, we would only acquire one download concurrency token, meaning that we could in the worst case make times the number of indexes more requests than the user requested limit. We fix this by passing the semaphore down to the simple API method.