### PR TITLE
Remove warnings for missing lower bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,7 +4999,6 @@ dependencies = [
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-types",
- "uv-warnings",
  "uv-workspace",
  "walkdir",
  "zip",

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -86,8 +86,8 @@ mod resolver {
     use uv_cache::Cache;
     use uv_client::RegistryClient;
     use uv_configuration::{
-        BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, LowerBound,
-        PreviewMode, SourceStrategy,
+        BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, PreviewMode,
+        SourceStrategy,
     };
     use uv_dispatch::{BuildDispatch, SharedState};
     use uv_distribution::DistributionDatabase;
@@ -187,7 +187,6 @@ mod resolver {
             &build_options,
             &hashes,
             exclude_newer,
-            LowerBound::default(),
             sources,
             concurrency,
             PreviewMode::Enabled,

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -26,7 +26,7 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{debug, info_span, instrument, Instrument};
 
-use uv_configuration::{BuildKind, BuildOutput, ConfigSettings, LowerBound, SourceStrategy};
+use uv_configuration::{BuildKind, BuildOutput, ConfigSettings, SourceStrategy};
 use uv_distribution::BuildRequires;
 use uv_distribution_types::{IndexLocations, Resolution};
 use uv_fs::{PythonExt, Simplified};
@@ -480,7 +480,6 @@ impl SourceBuild {
                                     install_path,
                                     locations,
                                     source_strategy,
-                                    LowerBound::Allow,
                                 )
                                 .await
                                 .map_err(Error::Lowering)?;
@@ -910,7 +909,6 @@ async fn create_pep517_build_environment(
                 install_path,
                 locations,
                 source_strategy,
-                LowerBound::Allow,
             )
             .await
             .map_err(Error::Lowering)?;

--- a/crates/uv-configuration/src/bounds.rs
+++ b/crates/uv-configuration/src/bounds.rs
@@ -1,8 +1,0 @@
-#[derive(Debug, Default, Copy, Clone)]
-pub enum LowerBound {
-    /// Allow missing lower bounds.
-    #[default]
-    Allow,
-    /// Warn about missing lower bounds.
-    Warn,
-}

--- a/crates/uv-configuration/src/lib.rs
+++ b/crates/uv-configuration/src/lib.rs
@@ -1,5 +1,4 @@
 pub use authentication::*;
-pub use bounds::*;
 pub use build_options::*;
 pub use concurrency::*;
 pub use config_settings::*;
@@ -24,7 +23,6 @@ pub use trusted_publishing::*;
 pub use vcs::*;
 
 mod authentication;
-mod bounds;
 mod build_options;
 mod concurrency;
 mod config_settings;

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -16,8 +16,8 @@ use uv_build_frontend::{SourceBuild, SourceBuildContext};
 use uv_cache::Cache;
 use uv_client::RegistryClient;
 use uv_configuration::{
-    BuildKind, BuildOptions, ConfigSettings, Constraints, IndexStrategy, LowerBound, PreviewMode,
-    Reinstall, SourceStrategy,
+    BuildKind, BuildOptions, ConfigSettings, Constraints, IndexStrategy, PreviewMode, Reinstall,
+    SourceStrategy,
 };
 use uv_configuration::{BuildOutput, Concurrency};
 use uv_distribution::DistributionDatabase;
@@ -93,7 +93,7 @@ pub struct BuildDispatch<'a> {
     exclude_newer: Option<ExcludeNewer>,
     source_build_context: SourceBuildContext,
     build_extra_env_vars: FxHashMap<OsString, OsString>,
-    bounds: LowerBound,
+
     sources: SourceStrategy,
     concurrency: Concurrency,
     preview: PreviewMode,
@@ -116,7 +116,6 @@ impl<'a> BuildDispatch<'a> {
         build_options: &'a BuildOptions,
         hasher: &'a HashStrategy,
         exclude_newer: Option<ExcludeNewer>,
-        bounds: LowerBound,
         sources: SourceStrategy,
         concurrency: Concurrency,
         preview: PreviewMode,
@@ -139,7 +138,7 @@ impl<'a> BuildDispatch<'a> {
             exclude_newer,
             source_build_context: SourceBuildContext::default(),
             build_extra_env_vars: FxHashMap::default(),
-            bounds,
+
             sources,
             concurrency,
             preview,
@@ -192,10 +191,6 @@ impl BuildContext for BuildDispatch<'_> {
 
     fn config_settings(&self) -> &ConfigSettings {
         self.config_settings
-    }
-
-    fn bounds(&self) -> LowerBound {
-        self.bounds
     }
 
     fn sources(&self) -> SourceStrategy {

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -33,7 +33,6 @@ uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-types = { workspace = true }
-uv-warnings = { workspace = true }
 uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/uv-distribution/src/metadata/build_requires.rs
+++ b/crates/uv-distribution/src/metadata/build_requires.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use uv_configuration::{LowerBound, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_distribution_types::IndexLocations;
 use uv_normalize::PackageName;
 use uv_workspace::pyproject::ToolUvSources;
@@ -37,7 +37,6 @@ impl BuildRequires {
         install_path: &Path,
         locations: &IndexLocations,
         sources: SourceStrategy,
-        lower_bound: LowerBound,
     ) -> Result<Self, MetadataError> {
         let discovery = match sources {
             SourceStrategy::Enabled => DiscoveryOptions::default(),
@@ -54,13 +53,7 @@ impl BuildRequires {
             return Ok(Self::from_metadata23(metadata));
         };
 
-        Self::from_project_workspace(
-            metadata,
-            &project_workspace,
-            locations,
-            sources,
-            lower_bound,
-        )
+        Self::from_project_workspace(metadata, &project_workspace, locations, sources)
     }
 
     /// Lower the `build-system.requires` field from a `pyproject.toml` file.
@@ -69,7 +62,6 @@ impl BuildRequires {
         project_workspace: &ProjectWorkspace,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
-        lower_bound: LowerBound,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -118,7 +110,6 @@ impl BuildRequires {
                         group,
                         locations,
                         project_workspace.workspace(),
-                        lower_bound,
                         None,
                     )
                     .map(move |requirement| match requirement {
@@ -148,7 +139,6 @@ impl BuildRequires {
         workspace: &Workspace,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
-        lower_bound: LowerBound,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -195,7 +185,6 @@ impl BuildRequires {
                         group,
                         locations,
                         workspace,
-                        lower_bound,
                         None,
                     )
                     .map(move |requirement| match requirement {

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use uv_configuration::{LowerBound, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_distribution_types::{GitSourceUrl, IndexLocations};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
@@ -80,7 +80,6 @@ impl Metadata {
         git_source: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         sources: SourceStrategy,
-        bounds: LowerBound,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let requires_dist = uv_pypi_types::RequiresDist {
@@ -101,7 +100,6 @@ impl Metadata {
             git_source,
             locations,
             sources,
-            bounds,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -4,7 +4,7 @@ use std::slice;
 
 use rustc_hash::FxHashSet;
 
-use uv_configuration::{LowerBound, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_distribution_types::IndexLocations;
 use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_pep508::MarkerTree;
@@ -49,7 +49,6 @@ impl RequiresDist {
         git_member: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         sources: SourceStrategy,
-        lower_bound: LowerBound,
     ) -> Result<Self, MetadataError> {
         // TODO(konsti): Cache workspace discovery.
         let discovery_options = DiscoveryOptions {
@@ -70,14 +69,7 @@ impl RequiresDist {
             return Ok(Self::from_metadata23(metadata));
         };
 
-        Self::from_project_workspace(
-            metadata,
-            &project_workspace,
-            git_member,
-            locations,
-            sources,
-            lower_bound,
-        )
+        Self::from_project_workspace(metadata, &project_workspace, git_member, locations, sources)
     }
 
     fn from_project_workspace(
@@ -86,7 +78,6 @@ impl RequiresDist {
         git_member: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
-        lower_bound: LowerBound,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -178,7 +169,6 @@ impl RequiresDist {
                                 Some(&group),
                                 locations,
                                 project_workspace.workspace(),
-                                lower_bound,
                                 git_member,
                             )
                             .map(
@@ -223,7 +213,6 @@ impl RequiresDist {
                         group,
                         locations,
                         project_workspace.workspace(),
-                        lower_bound,
                         git_member,
                     )
                     .map(move |requirement| match requirement {
@@ -474,7 +463,7 @@ mod test {
     use indoc::indoc;
     use insta::assert_snapshot;
 
-    use uv_configuration::{LowerBound, SourceStrategy};
+    use uv_configuration::SourceStrategy;
     use uv_distribution_types::IndexLocations;
     use uv_normalize::PackageName;
     use uv_pep508::Requirement;
@@ -507,7 +496,6 @@ mod test {
             None,
             &IndexLocations::default(),
             SourceStrategy::default(),
-            LowerBound::default(),
         )?)
     }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1163,7 +1163,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         None,
                         self.build_context.locations(),
                         self.build_context.sources(),
-                        self.build_context.bounds(),
                     )
                     .await?,
                 ));
@@ -1216,7 +1215,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             None,
                             self.build_context.locations(),
                             self.build_context.sources(),
-                            self.build_context.bounds(),
                         )
                         .await?,
                     ));
@@ -1265,7 +1263,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     None,
                     self.build_context.locations(),
                     self.build_context.sources(),
-                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1323,7 +1320,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 None,
                 self.build_context.locations(),
                 self.build_context.sources(),
-                self.build_context.bounds(),
             )
             .await?,
         ))
@@ -1391,7 +1387,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     None,
                     self.build_context.locations(),
                     self.build_context.sources(),
-                    self.build_context.bounds(),
                 )
                 .await?;
                 Ok(Some(requires_dist))
@@ -1637,7 +1632,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             Some(&git_member),
                             self.build_context.locations(),
                             self.build_context.sources(),
-                            self.build_context.bounds(),
                         )
                         .await?,
                     ));
@@ -1670,7 +1664,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                                 Some(&git_member),
                                 self.build_context.locations(),
                                 self.build_context.sources(),
-                                self.build_context.bounds(),
                             )
                             .await?,
                         ));
@@ -1722,7 +1715,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     Some(&git_member),
                     self.build_context.locations(),
                     self.build_context.sources(),
-                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1780,7 +1772,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 Some(&git_member),
                 self.build_context.locations(),
                 self.build_context.sources(),
-                self.build_context.bounds(),
             )
             .await?,
         ))

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 
 use uv_cache::Cache;
-use uv_configuration::{
-    BuildKind, BuildOptions, BuildOutput, ConfigSettings, LowerBound, SourceStrategy,
-};
+use uv_configuration::{BuildKind, BuildOptions, BuildOutput, ConfigSettings, SourceStrategy};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     CachedDist, DependencyMetadata, DistributionId, IndexCapabilities, IndexLocations,
@@ -83,9 +81,6 @@ pub trait BuildContext {
 
     /// The [`ConfigSettings`] used to build distributions.
     fn config_settings(&self) -> &ConfigSettings;
-
-    /// Whether to warn on missing lower bounds.
-    fn bounds(&self) -> LowerBound;
 
     /// Whether to incorporate `tool.uv.sources` when resolving requirements.
     fn sources(&self) -> SourceStrategy;

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -22,8 +22,7 @@ use uv_cache::{Cache, CacheBucket};
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildKind, BuildOptions, BuildOutput, Concurrency, ConfigSettings, Constraints,
-    HashCheckingMode, IndexStrategy, KeyringProviderType, LowerBound, PreviewMode, SourceStrategy,
-    TrustedHost,
+    HashCheckingMode, IndexStrategy, KeyringProviderType, PreviewMode, SourceStrategy, TrustedHost,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_filename::{
@@ -580,7 +579,6 @@ async fn build_package(
         build_options,
         &hasher,
         exclude_newer,
-        LowerBound::Allow,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -13,8 +13,8 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, DevGroupsSpecification,
-    ExtrasSpecification, IndexStrategy, LowerBound, NoBinary, NoBuild, PreviewMode, Reinstall,
-    SourceStrategy, TrustedHost, Upgrade,
+    ExtrasSpecification, IndexStrategy, NoBinary, NoBuild, PreviewMode, Reinstall, SourceStrategy,
+    TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
@@ -361,7 +361,6 @@ pub(crate) async fn pip_compile(
         &build_options,
         &build_hashes,
         exclude_newer,
-        LowerBound::Warn,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -10,8 +10,8 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, DevGroupsSpecification,
-    ExtrasSpecification, HashCheckingMode, IndexStrategy, LowerBound, PreviewMode, Reinstall,
-    SourceStrategy, TrustedHost, Upgrade,
+    ExtrasSpecification, HashCheckingMode, IndexStrategy, PreviewMode, Reinstall, SourceStrategy,
+    TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
@@ -390,7 +390,6 @@ pub(crate) async fn pip_install(
         &build_options,
         &build_hasher,
         exclude_newer,
-        LowerBound::Warn,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -10,8 +10,8 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, DevGroupsSpecification,
-    ExtrasSpecification, HashCheckingMode, IndexStrategy, LowerBound, PreviewMode, Reinstall,
-    SourceStrategy, TrustedHost, Upgrade,
+    ExtrasSpecification, HashCheckingMode, IndexStrategy, PreviewMode, Reinstall, SourceStrategy,
+    TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
@@ -333,7 +333,6 @@ pub(crate) async fn pip_sync(
         &build_options,
         &build_hasher,
         exclude_newer,
-        LowerBound::Warn,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -17,8 +17,8 @@ use uv_cache_key::RepositoryUrl;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DevGroupsManifest, DevGroupsSpecification, DevMode, EditableMode,
-    ExtrasSpecification, GroupsSpecification, InstallOptions, LowerBound, PreviewMode,
-    SourceStrategy, TrustedHost,
+    ExtrasSpecification, GroupsSpecification, InstallOptions, PreviewMode, SourceStrategy,
+    TrustedHost,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -340,7 +340,6 @@ pub(crate) async fn add(
                 &settings.build_options,
                 &build_hasher,
                 settings.exclude_newer,
-                LowerBound::default(),
                 sources,
                 concurrency,
                 preview,
@@ -680,7 +679,6 @@ async fn lock_and_sync(
         },
         (&target).into(),
         settings.into(),
-        LowerBound::default(),
         &lock_state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -801,7 +799,6 @@ async fn lock_and_sync(
                 },
                 (&target).into(),
                 settings.into(),
-                LowerBound::default(),
                 &lock_state,
                 Box::new(SummaryResolveLogger),
                 connectivity,

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -10,7 +10,7 @@ use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::{
     Concurrency, DevGroupsSpecification, EditableMode, ExportFormat, ExtrasSpecification,
-    InstallOptions, LowerBound, PreviewMode, TrustedHost,
+    InstallOptions, PreviewMode, TrustedHost,
 };
 use uv_normalize::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
@@ -193,7 +193,6 @@ pub(crate) async fn export(
         mode,
         (&target).into(),
         settings.as_ref(),
-        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -12,8 +12,8 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DevGroupsSpecification, ExtrasSpecification, LowerBound, PreviewMode,
-    Reinstall, TrustedHost, Upgrade,
+    Concurrency, Constraints, DevGroupsSpecification, ExtrasSpecification, PreviewMode, Reinstall,
+    TrustedHost, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -160,7 +160,6 @@ pub(crate) async fn lock(
         mode,
         target,
         settings.as_ref(),
-        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -222,7 +221,7 @@ pub(super) async fn do_safe_lock(
     mode: LockMode<'_>,
     target: LockTarget<'_>,
     settings: ResolverSettingsRef<'_>,
-    bounds: LowerBound,
+
     state: &UniversalState,
     logger: Box<dyn ResolveLogger>,
     connectivity: Connectivity,
@@ -255,7 +254,6 @@ pub(super) async fn do_safe_lock(
                 interpreter,
                 Some(existing),
                 settings,
-                bounds,
                 state,
                 logger,
                 connectivity,
@@ -295,7 +293,6 @@ pub(super) async fn do_safe_lock(
                 interpreter,
                 existing,
                 settings,
-                bounds,
                 state,
                 logger,
                 connectivity,
@@ -326,7 +323,7 @@ async fn do_lock(
     interpreter: &Interpreter,
     existing_lock: Option<Lock>,
     settings: ResolverSettingsRef<'_>,
-    bounds: LowerBound,
+
     state: &UniversalState,
     logger: Box<dyn ResolveLogger>,
     connectivity: Connectivity,
@@ -551,7 +548,6 @@ async fn do_lock(
         build_options,
         &build_hasher,
         exclude_newer,
-        bounds,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use itertools::Either;
 
-use uv_configuration::{LowerBound, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_distribution::LoweredRequirement;
 use uv_distribution_types::{Index, IndexLocations};
 use uv_normalize::{GroupName, PackageName};
@@ -304,7 +304,6 @@ impl<'lock> LockTarget<'lock> {
                     workspace,
                     locations,
                     sources,
-                    LowerBound::Warn,
                 )?;
 
                 Ok(metadata
@@ -350,7 +349,6 @@ impl<'lock> LockTarget<'lock> {
                             sources,
                             indexes,
                             locations,
-                            LowerBound::Allow,
                         )
                         .map(move |requirement| match requirement {
                             Ok(requirement) => Ok(requirement.into_inner()),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -11,7 +11,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DevGroupsManifest, DevGroupsSpecification, ExtrasSpecification,
-    GroupsSpecification, LowerBound, PreviewMode, Reinstall, TrustedHost, Upgrade,
+    GroupsSpecification, PreviewMode, Reinstall, TrustedHost, Upgrade,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::DistributionDatabase;
@@ -1134,7 +1134,6 @@ pub(crate) async fn resolve_names(
         build_options,
         &build_hasher,
         *exclude_newer,
-        LowerBound::Allow,
         *sources,
         concurrency,
         preview,
@@ -1325,7 +1324,6 @@ pub(crate) async fn resolve_environment(
         build_options,
         &build_hasher,
         exclude_newer,
-        LowerBound::Allow,
         sources,
         concurrency,
         preview,
@@ -1465,7 +1463,6 @@ pub(crate) async fn sync_environment(
         build_options,
         &build_hasher,
         exclude_newer,
-        LowerBound::Allow,
         sources,
         concurrency,
         preview,
@@ -1680,7 +1677,6 @@ pub(crate) async fn update_environment(
         build_options,
         &build_hasher,
         *exclude_newer,
-        LowerBound::Allow,
         *sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -10,8 +10,8 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::{
-    Concurrency, DevGroupsManifest, EditableMode, ExtrasSpecification, InstallOptions, LowerBound,
-    PreviewMode, TrustedHost,
+    Concurrency, DevGroupsManifest, EditableMode, ExtrasSpecification, InstallOptions, PreviewMode,
+    TrustedHost,
 };
 use uv_fs::Simplified;
 use uv_normalize::DEV_DEPENDENCIES;
@@ -272,7 +272,6 @@ pub(crate) async fn remove(
         mode,
         (&target).into(),
         settings.as_ref().into(),
-        LowerBound::Allow,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -18,7 +18,7 @@ use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{
     Concurrency, DevGroupsManifest, DevGroupsSpecification, EditableMode, ExtrasSpecification,
-    GroupsSpecification, InstallOptions, LowerBound, PreviewMode, SourceStrategy, TrustedHost,
+    GroupsSpecification, InstallOptions, PreviewMode, SourceStrategy, TrustedHost,
 };
 use uv_distribution::LoweredRequirement;
 use uv_fs::which::is_executable;
@@ -228,7 +228,6 @@ pub(crate) async fn run(
                 mode,
                 target,
                 settings.as_ref().into(),
-                LowerBound::Allow,
                 &lock_state,
                 if show_resolution {
                     Box::new(DefaultResolveLogger)
@@ -345,7 +344,6 @@ pub(crate) async fn run(
                             script_sources,
                             script_indexes,
                             &settings.index_locations,
-                            LowerBound::Allow,
                         )
                         .map_ok(LoweredRequirement::into_inner)
                     })
@@ -365,7 +363,6 @@ pub(crate) async fn run(
                             script_sources,
                             script_indexes,
                             &settings.index_locations,
-                            LowerBound::Allow,
                         )
                         .map_ok(LoweredRequirement::into_inner)
                     })
@@ -385,7 +382,6 @@ pub(crate) async fn run(
                             script_sources,
                             script_indexes,
                             &settings.index_locations,
-                            LowerBound::Allow,
                         )
                         .map_ok(LoweredRequirement::into_inner)
                     })
@@ -717,7 +713,6 @@ pub(crate) async fn run(
                     mode,
                     project.workspace().into(),
                     settings.as_ref().into(),
-                    LowerBound::Allow,
                     &lock_state,
                     if show_resolution {
                         Box::new(DefaultResolveLogger)

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -8,7 +8,7 @@ use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DevGroupsManifest, DevGroupsSpecification, EditableMode,
-    ExtrasSpecification, HashCheckingMode, InstallOptions, LowerBound, PreviewMode, TrustedHost,
+    ExtrasSpecification, HashCheckingMode, InstallOptions, PreviewMode, TrustedHost,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution_types::{
@@ -146,7 +146,6 @@ pub(crate) async fn sync(
         mode,
         project.workspace().into(),
         settings.as_ref().into(),
-        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -387,7 +386,6 @@ pub(super) async fn do_sync(
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.
-    let bounds = LowerBound::default();
     let build_constraints = Constraints::default();
     let build_hasher = HashStrategy::default();
     let dry_run = false;
@@ -421,7 +419,6 @@ pub(super) async fn do_sync(
         build_options,
         &build_hasher,
         exclude_newer,
-        bounds,
         sources,
         concurrency,
         preview,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -8,7 +8,7 @@ use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
 use uv_client::{Connectivity, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, DevGroupsSpecification, LowerBound, PreviewMode, TargetTriple, TrustedHost,
+    Concurrency, DevGroupsSpecification, PreviewMode, TargetTriple, TrustedHost,
 };
 use uv_distribution_types::IndexCapabilities;
 use uv_pep508::PackageName;
@@ -146,7 +146,6 @@ pub(crate) async fn tree(
         mode,
         target,
         settings.as_ref(),
-        LowerBound::Allow,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,7 +14,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, KeyringProviderType,
-    LowerBound, NoBinary, NoBuild, PreviewMode, SourceStrategy, TrustedHost,
+    NoBinary, NoBuild, PreviewMode, SourceStrategy, TrustedHost,
 };
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution_types::{DependencyMetadata, Index, IndexLocations};
@@ -350,7 +350,6 @@ async fn venv_impl(
             &build_options,
             &build_hasher,
             exclude_newer,
-            LowerBound::Allow,
             sources,
             concurrency,
             preview,

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -8352,8 +8352,6 @@ fn lock_multiple_indexes_same_realm_different_credentials() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Missing version constraint (e.g., a lower bound) for `iniconfig`
-    warning: Missing version constraint (e.g., a lower bound) for `anyio`
     Resolved 5 packages in [TIME]
     "###);
 

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -12712,7 +12712,6 @@ fn warn_missing_constraint() -> Result<()> {
         # via foo (pyproject.toml)
 
     ----- stderr -----
-    warning: Missing version constraint (e.g., a lower bound) for `tqdm`
     Resolved 4 packages in [TIME]
     "###);
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -5496,7 +5496,6 @@ fn sync_git_repeated_member_dynamic_metadata() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Missing version constraint (e.g., a lower bound) for `typing-extensions`
     Resolved 5 packages in [TIME]
     "###);
 


### PR DESCRIPTION
These are noisy relative to the effect they have on the user. It seems better to prioritize hints on poor resolutions. Notably, it seems hard to make these "not noisy" ref #11091.

Does not include the "lowest" resolution mode, in which lower bounds are critical.
