### PR TITLE
Update bad shell assumptions from "Shell autocompletion" page

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -158,39 +158,77 @@ $ pip install --upgrade uv
 
 ## Shell autocompletion
 
+!!! tip
+
+    You can run `echo $SHELL` to help you determine your shell.
+
 To enable shell autocompletion for uv commands, run one of the following:
 
-=== "Linux and macOS"
+=== "Bash"
 
     ```bash
-    # Determine your shell (e.g., with `echo $SHELL`), then run one of:
     echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
+    ```
+
+=== "Zsh"
+
+    ```bash
     echo 'eval "$(uv generate-shell-completion zsh)"' >> ~/.zshrc
+    ```
+
+=== "fish"
+
+    ```bash
     echo 'uv generate-shell-completion fish | source' >> ~/.config/fish/config.fish
+    ```
+
+=== "Elvish"
+
+    ```bash
     echo 'eval (uv generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
 
-=== "Windows"
+=== "PowerShell / pwsh"
 
     ```powershell
+    if (!(Test-Path -Path $PROFILE)) {
+      New-Item -ItemType File -Path $PROFILE -Force
+    }
     Add-Content -Path $PROFILE -Value '(& uv generate-shell-completion powershell) | Out-String | Invoke-Expression'
     ```
 
 To enable shell autocompletion for uvx, run one of the following:
 
-=== "Linux and macOS"
+=== "Bash"
 
     ```bash
-    # Determine your shell (e.g., with `echo $SHELL`), then run one of:
     echo 'eval "$(uvx --generate-shell-completion bash)"' >> ~/.bashrc
+    ```
+
+=== "Zsh"
+
+    ```bash
     echo 'eval "$(uvx --generate-shell-completion zsh)"' >> ~/.zshrc
+    ```
+
+=== "fish"
+
+    ```bash
     echo 'uvx --generate-shell-completion fish | source' >> ~/.config/fish/config.fish
+    ```
+
+=== "Elvish"
+
+    ```bash
     echo 'eval (uvx --generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
     ```
 
-=== "Windows"
+=== "PowerShell / pwsh"
 
     ```powershell
+    if (!(Test-Path -Path $PROFILE)) {
+      New-Item -ItemType File -Path $PROFILE -Force
+    }
     Add-Content -Path $PROFILE -Value '(& uvx --generate-shell-completion powershell) | Out-String | Invoke-Expression'
     ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

- PowerShell isn't Windows-only
- Bash/Elvish isn't UNIX-only
- PowerShell profile won't necessarily exist
- Extracted the `echo $SHELL` tip to a tip tooltip

The new PowerShell lines are taken directly from https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.5#how-to-create-a-profile

Note that the "Standalone installer" commands are unaffected. Running the Linux one through PowerShell worked just fine.

## Test Plan

Look at the page generated from this PR
<!-- How was it tested? -->
