### PR TITLE
Set base executable when returning virtual environment

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -94,6 +94,7 @@ impl Interpreter {
     pub fn with_virtualenv(self, virtualenv: VirtualEnvironment) -> Self {
         Self {
             scheme: virtualenv.scheme,
+            sys_base_executable: Some(virtualenv.base_executable),
             sys_executable: virtualenv.executable,
             sys_prefix: virtualenv.root,
             target: None,

--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -18,6 +18,9 @@ pub struct VirtualEnvironment {
     /// (Unix, Python 3.11).
     pub executable: PathBuf,
 
+    /// The path to the base executable for the environment, within the `home` directory.
+    pub base_executable: PathBuf,
+
     /// The [`Scheme`] paths for the virtualenv, as returned by (e.g.) `sysconfig.get_paths()`.
     pub scheme: Scheme,
 }

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -400,6 +400,7 @@ pub(crate) fn create(
         },
         root: location,
         executable,
+        base_executable: base_python,
     })
 }
 


### PR DESCRIPTION
## Summary

I'm not sure that this has much of an effect in practice, but currently, when we return a virtual environment, the `sys_base_executable ` of the parent ends up being retained as `sys_base_executable` of the created environment. But these can be, like, subtly different? If you have a symlink to a Python, then for the symlink, `sys_base_executable` will be equal to `sys_executable`. But when you create a virtual environment for that interpreter, we'll set `home` to the resolved symlink, and so `sys_base_executable` will be the resolved symlink too, in general. Anyway, this means that we should now have a consistent value between (1) returning `Virtualenv` from the creation routine and (2) querying the created interpreter.
