### PR TITLE
Disable SSL in Git commands for `--allow-insecure-host`

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -387,15 +387,18 @@ enum Security {
 impl BaseClient {
     /// Selects the appropriate client based on the host's trustworthiness.
     pub fn for_host(&self, url: &Url) -> &ClientWithMiddleware {
-        if self
-            .allow_insecure_host
-            .iter()
-            .any(|allow_insecure_host| allow_insecure_host.matches(url))
-        {
+        if self.disable_ssl(url) {
             &self.dangerous_client
         } else {
             &self.client
         }
+    }
+
+    /// Returns `true` if the host is trusted to use the insecure client.
+    pub fn disable_ssl(&self, url: &Url) -> bool {
+        self.allow_insecure_host
+            .iter()
+            .any(|allow_insecure_host| allow_insecure_host.matches(url))
     }
 
     /// The configured client timeout, in seconds.

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -215,6 +215,11 @@ impl RegistryClient {
         self.client.uncached().for_host(url)
     }
 
+    /// Returns `true` if SSL verification is disabled for the given URL.
+    pub fn disable_ssl(&self, url: &Url) -> bool {
+        self.client.uncached().disable_ssl(url)
+    }
+
     /// Return the [`Connectivity`] mode used by this client.
     pub fn connectivity(&self) -> Connectivity {
         self.connectivity

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1430,7 +1430,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .git()
             .fetch(
                 resource.git,
-                client.unmanaged.uncached_client(resource.url).clone(),
+                client
+                    .unmanaged
+                    .uncached_client(resource.git.repository())
+                    .clone(),
+                client.unmanaged.disable_ssl(resource.git.repository()),
                 self.build_context.cache().bucket(CacheBucket::Git),
                 self.reporter
                     .clone()
@@ -1530,7 +1534,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .git()
             .github_fast_path(
                 resource.git,
-                client.unmanaged.uncached_client(resource.url).clone(),
+                client
+                    .unmanaged
+                    .uncached_client(resource.git.repository())
+                    .clone(),
             )
             .await
         {
@@ -1582,7 +1589,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .git()
             .fetch(
                 resource.git,
-                client.unmanaged.uncached_client(resource.url).clone(),
+                client
+                    .unmanaged
+                    .uncached_client(resource.git.repository())
+                    .clone(),
+                client.unmanaged.disable_ssl(resource.git.repository()),
                 self.build_context.cache().bucket(CacheBucket::Git),
                 self.reporter
                     .clone()
@@ -1812,6 +1823,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .fetch(
                 git,
                 client.unmanaged.uncached_client(git.repository()).clone(),
+                client.unmanaged.disable_ssl(git.repository()),
                 self.build_context.cache().bucket(CacheBucket::Git),
                 self.reporter
                     .clone()

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -106,6 +106,7 @@ impl GitResolver {
         &self,
         url: &GitUrl,
         client: ClientWithMiddleware,
+        disable_ssl: bool,
         cache: PathBuf,
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<Fetch, GitResolverError> {
@@ -139,6 +140,14 @@ impl GitResolver {
         } else {
             GitSource::new(url.as_ref().clone(), client, cache)
         };
+
+        // If necessary, disable SSL.
+        let source = if disable_ssl {
+            source.dangerous()
+        } else {
+            source
+        };
+
         let fetch = tokio::task::spawn_blocking(move || source.fetch())
             .await?
             .map_err(GitResolverError::Git)?;

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -22,6 +22,8 @@ pub struct GitSource {
     git: GitUrl,
     /// The HTTP client to use for fetching.
     client: ClientWithMiddleware,
+    /// Whether to disable SSL verification.
+    disable_ssl: bool,
     /// The path to the Git source database.
     cache: PathBuf,
     /// The reporter to use for this source.
@@ -37,9 +39,19 @@ impl GitSource {
     ) -> Self {
         Self {
             git,
+            disable_ssl: false,
             client: client.into(),
             cache: cache.into(),
             reporter: None,
+        }
+    }
+
+    /// Disable SSL verification for this [`GitSource`].
+    #[must_use]
+    pub fn dangerous(self) -> Self {
+        Self {
+            disable_ssl: true,
+            ..self
         }
     }
 
@@ -96,6 +108,7 @@ impl GitSource {
                     &self.git.reference,
                     locked_rev.map(GitOid::from),
                     &self.client,
+                    self.disable_ssl,
                 )?;
 
                 (db, actual_rev, task)

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -449,6 +449,10 @@ impl EnvVars {
     #[attr_hidden]
     pub const GIT_ALTERNATE_OBJECT_DIRECTORIES: &'static str = "GIT_ALTERNATE_OBJECT_DIRECTORIES";
 
+    /// Disables SSL verification for git operations.
+    #[attr_hidden]
+    pub const GIT_SSL_NO_VERIFY: &'static str = "GIT_SSL_NO_VERIFY";
+
     /// Used in tests for better git isolation.
     ///
     /// For example, we run some tests in ~/.local/share/uv/tests.


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/11176.

## Test Plan

- Created a self-signed certificate.
- Ran `openssl s_server -cert cert.pem -key key.pem -WWW -port 8443`.
- Verified that `cargo run pip install git+https://localhost:8443/repo.git` failed with:

```
error: Git operation failed
  Caused by: failed to fetch into: /Users/crmarsh/.cache/uv/git-v0/db/0773914b3ec4a56e
  Caused by: process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://localhost:8443/repo.git' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
--- stderr
fatal: unable to access 'https://localhost:8443/repo.git/': SSL certificate problem: self signed certificate
```

- Verified that `cargo run pip install git+https://localhost:8443/repo.git --allow-insecure-host https://localhost:8443` continued further.
