### PR TITLE
Fix typo "dependency-group" in error message and comments

### DIFF
--- a/crates/uv-configuration/src/dev.rs
+++ b/crates/uv-configuration/src/dev.rs
@@ -46,7 +46,7 @@ impl DevMode {
 
 #[derive(Default, Debug, Clone)]
 pub struct DevGroupsSpecification {
-    /// Legacy option for `dependency-group.dev` and `tool.uv.dev-dependencies`.
+    /// Legacy option for `dependency-groups.dev` and `tool.uv.dev-dependencies`.
     ///
     /// Requested via the `--dev`, `--no-dev`, and `--only-dev` flags.
     dev: Option<DevMode>,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1534,7 +1534,7 @@ pub enum SatisfiesResult<'lock> {
         BTreeSet<Requirement>,
         BTreeSet<Requirement>,
     ),
-    /// A package in the lockfile contains different `dependency-group` metadata than expected.
+    /// A package in the lockfile contains different `dependency-groups` metadata than expected.
     MismatchedPackageDependencyGroups(
         &'lock PackageName,
         Option<&'lock Version>,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -137,16 +137,16 @@ pub(crate) enum ProjectError {
         PathBuf,
     ),
 
-    #[error("Group `{0}` is not defined in the project's `dependency-group` table")]
+    #[error("Group `{0}` is not defined in the project's `dependency-groups` table")]
     MissingGroupProject(GroupName),
 
-    #[error("Group `{0}` is not defined in any project's `dependency-group` table")]
+    #[error("Group `{0}` is not defined in any project's `dependency-groups` table")]
     MissingGroupWorkspace(GroupName),
 
     #[error("PEP 723 scripts do not support dependency groups, but group `{0}` was specified")]
     MissingGroupScript(GroupName),
 
-    #[error("Default group `{0}` (from `tool.uv.default-groups`) is not defined in the project's `dependency-group` table")]
+    #[error("Default group `{0}` (from `tool.uv.default-groups`) is not defined in the project's `dependency-groups` table")]
     MissingDefaultGroup(GroupName),
 
     #[error("Supported environments must be disjoint, but the following markers overlap: `{0}` and `{1}`.\n\n{hint}{colon} replace `{1}` with `{2}`.", hint = "hint".bold().cyan(), colon = ":".bold())]

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1775,7 +1775,7 @@ fn add_remove_workspace() -> Result<()> {
     Ok(())
 }
 
-/// `uv add --dev` should update `dev-dependencies` (rather than `dependency-group.dev`) if a
+/// `uv add --dev` should update `dev-dependencies` (rather than `dependency-groups.dev`) if a
 /// dependency already exists in `dev-dependencies`.
 #[test]
 fn update_existing_dev() -> Result<()> {
@@ -1846,7 +1846,7 @@ fn update_existing_dev() -> Result<()> {
     Ok(())
 }
 
-/// `uv add --dev` should add to `dev-dependencies` (rather than `dependency-group.dev`) if it
+/// `uv add --dev` should add to `dev-dependencies` (rather than `dependency-groups.dev`) if it
 /// exists.
 #[test]
 fn add_existing_dev() -> Result<()> {
@@ -1911,7 +1911,7 @@ fn add_existing_dev() -> Result<()> {
     Ok(())
 }
 
-/// `uv add --group dev` should update `dev-dependencies` (rather than `dependency-group.dev`) if a
+/// `uv add --group dev` should update `dev-dependencies` (rather than `dependency-groups.dev`) if a
 /// dependency already exists.
 #[test]
 fn update_existing_dev_group() -> Result<()> {
@@ -1976,7 +1976,7 @@ fn update_existing_dev_group() -> Result<()> {
     Ok(())
 }
 
-/// `uv add --group dev` should add to `dependency-group` even if `dev-dependencies` exists.
+/// `uv add --group dev` should add to `dependency-groups` even if `dev-dependencies` exists.
 #[test]
 fn add_existing_dev_group() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -2043,7 +2043,7 @@ fn add_existing_dev_group() -> Result<()> {
     Ok(())
 }
 
-/// `uv remove --dev` should remove from both `dev-dependencies` and `dependency-group.dev`.
+/// `uv remove --dev` should remove from both `dev-dependencies` and `dependency-groups.dev`.
 #[test]
 fn remove_both_dev() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -2108,7 +2108,7 @@ fn remove_both_dev() -> Result<()> {
     Ok(())
 }
 
-/// `uv remove --group dev` should remove from both `dev-dependencies` and `dependency-group.dev`.
+/// `uv remove --group dev` should remove from both `dev-dependencies` and `dependency-groups.dev`.
 #[test]
 fn remove_both_dev_group() -> Result<()> {
     let context = TestContext::new("3.12");

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -13728,7 +13728,7 @@ fn lock_non_project_conditional() -> Result<()> {
     Ok(())
 }
 
-/// Lock a (legacy) non-project workspace root with `dependency-group`.
+/// Lock a (legacy) non-project workspace root with `dependency-groups`.
 #[test]
 fn lock_non_project_group() -> Result<()> {
     let context = TestContext::new("3.10");

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -617,7 +617,7 @@ fn sync_legacy_non_project_group() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Group `bop` is not defined in any project's `dependency-group` table
+    error: Group `bop` is not defined in any project's `dependency-groups` table
     "###);
 
     Ok(())
@@ -1754,7 +1754,7 @@ fn sync_non_existent_group() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Group `baz` is not defined in the project's `dependency-group` table
+    error: Group `baz` is not defined in the project's `dependency-groups` table
     "###);
 
     uv_snapshot!(context.filters(), context.sync().arg("--no-group").arg("baz"), @r###"
@@ -1763,7 +1763,7 @@ fn sync_non_existent_group() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Group `baz` is not defined in the project's `dependency-group` table
+    error: Group `baz` is not defined in the project's `dependency-groups` table
     "###);
 
     // Requesting an empty group should succeed.
@@ -1811,7 +1811,7 @@ fn sync_non_existent_default_group() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Default group `bar` (from `tool.uv.default-groups`) is not defined in the project's `dependency-group` table
+    error: Default group `bar` (from `tool.uv.default-groups`) is not defined in the project's `dependency-groups` table
     "###);
 
     Ok(())
@@ -5003,7 +5003,7 @@ fn sync_all_groups() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Group `foo` is not defined in any project's `dependency-group` table
+    error: Group `foo` is not defined in any project's `dependency-groups` table
     "###);
 
     Ok(())


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I got a bit confused when testing `[dependency-groups]` because uv's error message had the same typo I did in my `pyproject.toml`.
I tried to fix it, as well as a few comment I found along the way.


