### PR TITLE
Disable wheel testing for `powerpc64le-unknown-linux-gnu`

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -463,21 +463,22 @@ jobs:
                 yum repolist
                 yum install -y gcc-powerpc64-linux-gnu
             fi
-      - uses: uraimo/run-on-arch-action@v2
-        if: matrix.platform.arch != 'ppc64'
-        name: Test wheel
-        with:
-          arch: ${{ matrix.platform.arch }}
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-            ${{ env.MODULE_NAME }} --help
-            uvx --help
+      # TODO(charlie): Re-enable testing for PPC wheels.
+      # - uses: uraimo/run-on-arch-action@v2
+      #   if: matrix.platform.arch != 'ppc64'
+      #   name: Test wheel
+      #   with:
+      #     arch: ${{ matrix.platform.arch }}
+      #     distro: ubuntu20.04
+      #     githubToken: ${{ github.token }}
+      #     install: |
+      #       apt-get update
+      #       apt-get install -y --no-install-recommends python3 python3-pip
+      #       pip3 install -U pip
+      #     run: |
+      #       pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+      #       ${{ env.MODULE_NAME }} --help
+      #       uvx --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

I need to look into this later, but the test step is failing to install Python: https://github.com/astral-sh/uv/actions/runs/13148286589/job/36694160839. We already disable this for the non-`le` variant, so this seems ok to revisit.
