### PR TITLE
Remove `cachedir` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,15 +474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cachedir"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
-dependencies = [
- "tempfile",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,7 +5076,6 @@ name = "uv-fs"
 version = "0.0.1"
 dependencies = [
  "backon",
- "cachedir",
  "dunce",
  "either",
  "encoding_rs_io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ base64 = { version = "0.22.1" }
 bitflags = { version = "2.6.0" }
 boxcar = { version = "0.2.5" }
 bytecheck = { version = "0.8.0" }
-cachedir = { version = "0.3.1" }
 cargo-util = { version = "0.2.14" }
 clap = { version = "4.5.17", features = ["derive", "env", "string", "wrap_help"] }
 clap_complete_command = { version = "0.6.1" }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 workspace = true
 
 [dependencies]
-cachedir = { workspace = true }
 dunce = { workspace = true }
 either = { workspace = true }
 encoding_rs_io = { workspace = true }

--- a/crates/uv-fs/src/cachedir.rs
+++ b/crates/uv-fs/src/cachedir.rs
@@ -3,7 +3,8 @@
 use std::io::Write;
 use std::{io, path};
 
-use cachedir::HEADER;
+/// The `CACHEDIR.TAG` file header as defined by the [specification](https://bford.info/cachedir/).
+const HEADER: &[u8; 43] = b"Signature: 8a477f597d28d172789f06886806bc55";
 
 /// Adds a tag to the specified `directory`.
 ///


### PR DESCRIPTION
## Summary

Vendor the `HEADER` constant too so we can eliminate the dependency on `cachedir`.
