### PR TITLE
Migrate to published `astral-tokio-tar` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,13 +156,13 @@ dependencies = [
 [[package]]
 name = "astral-tokio-tar"
 version = "0.5.0"
-source = "git+https://github.com/astral-sh/tokio-tar?rev=efeaea927c7a40ee66121de2e1bebfd5d7a4a602#efeaea927c7a40ee66121de2e1bebfd5d7a4a602"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9807072104b1b31db50a77aae7dfdb576a193ff85436c5ded97f601a608f17aa"
 dependencies = [
  "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
- "redox_syscall 0.3.5",
  "rustc-hash",
  "tokio",
  "tokio-stream",
@@ -2893,15 +2893,6 @@ name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ uv-workspace = { path = "crates/uv-workspace" }
 anstream = { version = "0.6.15" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }
-astral-tokio-tar = { git = "https://github.com/astral-sh/tokio-tar", rev = "efeaea927c7a40ee66121de2e1bebfd5d7a4a602" }
+astral-tokio-tar = { version = "0.5.0" }
 async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zstd"] }
 async-trait = { version = "0.1.82" }

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -167,7 +167,7 @@ async fn untar_in(
 
         // Unpack the file into the destination directory.
         #[cfg_attr(not(unix), allow(unused_variables))]
-        let unpacked_at = file.unpack_in_memo(&dst, &mut memo).await?;
+        let unpacked_at = file.unpack_in_raw(&dst, &mut memo).await?;
 
         // Preserve the executable bit.
         #[cfg(unix)]


### PR DESCRIPTION
We now publish this to `crates.io`: https://crates.io/crates/astral-tokio-tar