### PR TITLE
Disable CRL checks during Windows test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,12 @@ jobs:
         working-directory: ${{ env.UV_WORKSPACE }}
         run: rustup show
 
+      # There are spurious CRL server offline errors when downloading
+      # `cargo-nextest` with curl below, so we just disable them for now
+      - name: "Disable SChannel CRL checks"
+        run: |
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v EnableCRLCheck /t REG_DWORD /d 0 /f
+
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
@@ -314,6 +320,12 @@ jobs:
         run: |
           rustup target add ${{ matrix.target-arch }}-pc-windows-msvc
           rustup component add rust-src --target ${{ matrix.target-arch }}-pc-windows-msvc
+
+      # There are spurious CRL server offline errors when downloading
+      # `cargo-bloat` with curl below, so we just disable them for now
+      - name: "Disable SChannel CRL checks"
+        run: |
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v EnableCRLCheck /t REG_DWORD /d 0 /f
 
       - name: "Install cargo-bloat"
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
Resolving

```
curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE (0x80092013) 
- The revocation function was unable to check revocation because the revocation server was offline.
```