### PR TITLE
Avoid using `user_display` for workspace locks

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -755,7 +755,7 @@ impl ProjectInterpreter {
                 "uv-{}.lock",
                 cache_digest(workspace.install_path())
             )),
-            workspace.install_path().user_display(),
+            workspace.install_path().simplified_display(),
         )
         .await
     }


### PR DESCRIPTION
## Summary

Right now, the logs are like: "Acquired lock for ``"