### PR TITLE
Use consistent 'Registry' prefix for wheel and source distribution logs

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -131,8 +131,7 @@ impl<'a> Planner<'a> {
                         }
                         Some(&entry.dist)
                     }) {
-                        debug!("Requirement already cached: {distribution}");
-                        // STOPSHIP(charlie): If these are mismatched, skip and warn.
+                        debug!("Registry requirement already cached: {distribution}");
                         cached.push(CachedDist::Registry(distribution.clone()));
                         continue;
                     }


### PR DESCRIPTION
## Summary

We say "Registry requirement already cached" for source distributions, but for wheels, it's just "Requirement already cached".