### PR TITLE
add pip install setuptools in flash-attn docs

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -319,7 +319,7 @@ You could run the following sequence of commands to sync `flash-attn`:
 
 ```console
 $ uv venv
-$ uv pip install torch
+$ uv pip install torch setuptools
 $ uv sync
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I followed the docs to install flash-attn with uv and got the following issue 
```uv sync
Resolved 27 packages in 12ms
  × Failed to build `flash-attn==2.7.4.post1`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 8, in <module>
      ModuleNotFoundError: No module named 'setuptools'

      hint: This usually indicates a problem with the package or the build environment.
```

installing setuptools before running uv sync as done with torch helps fix it.
## Test Plan

I tested locally before it failed to install, after it worked