### PR TITLE
Add Discord to PyPI project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ Repository = "https://github.com/astral-sh/uv"
 Documentation = "https://docs.astral.sh/uv"
 Changelog = "https://github.com/astral-sh/uv/blob/main/CHANGELOG.md"
 Releases = "https://github.com/astral-sh/uv/releases"
+Discord = "https://discord.gg/astral-sh"
 
 [tool.maturin]
 bindings = "bin"


### PR DESCRIPTION
Referencing https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet

https://github.com/pypi/warehouse/blob/70eac9796fa1eae24741525688a112586eab9010/warehouse/templates/packaging/detail.html#L38-L39