### PR TITLE
Allow `--python <dir>` requests to match existing environments if `sys.executable` is the same file

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1476,8 +1476,12 @@ impl PythonRequest {
                 version_request.matches_interpreter(interpreter)
             }
             PythonRequest::Directory(directory) => {
-                // `sys.prefix` points to the venv root.
+                // `sys.prefix` points to the environment root or `sys.executable` is the same
                 is_same_executable(directory, interpreter.sys_prefix())
+                    || is_same_executable(
+                        virtualenv_python_executable(directory).as_path(),
+                        interpreter.sys_executable(),
+                    )
             }
             PythonRequest::File(file) => {
                 // The interpreter satisfies the request both if it is the venv...


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/11288

I tested the reproduction there manually.

I'm a little uncertain about this behavior, it's not true to the spirit of `--python <dir>` selecting a target environment but this method is only used to see if an existing environment matches for the purpose of invalidation in projects and tools where I think we always force a separate environment anyway?