### PR TITLE
uv-python tests: Use #!/bin/sh instead of #!/bin/bash

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -1090,7 +1090,7 @@ mod tests {
         fs::write(
             &mocked_interpreter,
             formatdoc! {r"
-        #!/bin/bash
+        #!/bin/sh
         echo '{json}'
         "},
         )
@@ -1109,7 +1109,7 @@ mod tests {
         fs::write(
             &mocked_interpreter,
             formatdoc! {r"
-        #!/bin/bash
+        #!/bin/sh
         echo '{}'
         ", json.replace("3.12", "3.13")},
         )

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
             fs_err::write(
                 path,
                 formatdoc! {r"
-                #!/bin/bash
+                #!/bin/sh
                 echo '{json}'
                 "},
             )?;
@@ -314,7 +314,7 @@ mod tests {
             fs_err::write(
                 path,
                 formatdoc! {r"
-                #!/bin/bash
+                #!/bin/sh
                 echo '{output}' 1>&2
                 "},
             )?;
@@ -535,7 +535,7 @@ mod tests {
         fs_err::write(
             children[0].join(format!("python{}", env::consts::EXE_SUFFIX)),
             formatdoc! {r"
-        #!/bin/bash
+        #!/bin/sh
         echo 'foo'
         "},
         )?;


### PR DESCRIPTION
NixOS has (and POSIX mandates) a /bin/sh but not a /bin/bash, so this fixes tests on NixOS.
