### PR TITLE
fix an issue where conflict markers could instigate a very large lock file

### DIFF
--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1153,6 +1153,49 @@ impl MarkerTree {
         MarkerTree(INTERNER.lock().only_extras(self.0))
     }
 
+    /// Calls the provided function on every `extra` in this tree.
+    ///
+    /// The operator provided to the function is guaranteed to be
+    /// `MarkerOperator::Equal` or `MarkerOperator::NotEqual`.
+    pub fn visit_extras(self, mut f: impl FnMut(MarkerOperator, &ExtraName)) {
+        fn imp(tree: MarkerTree, f: &mut impl FnMut(MarkerOperator, &ExtraName)) {
+            match tree.kind() {
+                MarkerTreeKind::True | MarkerTreeKind::False => {}
+                MarkerTreeKind::Version(kind) => {
+                    for (tree, _) in simplify::collect_edges(kind.edges()) {
+                        imp(tree, f);
+                    }
+                }
+                MarkerTreeKind::String(kind) => {
+                    for (tree, _) in simplify::collect_edges(kind.children()) {
+                        imp(tree, f);
+                    }
+                }
+                MarkerTreeKind::In(kind) => {
+                    for (_, tree) in kind.children() {
+                        imp(tree, f);
+                    }
+                }
+                MarkerTreeKind::Contains(kind) => {
+                    for (_, tree) in kind.children() {
+                        imp(tree, f);
+                    }
+                }
+                MarkerTreeKind::Extra(kind) => {
+                    if kind.low.is_false() {
+                        f(MarkerOperator::Equal, kind.name().extra());
+                    } else {
+                        f(MarkerOperator::NotEqual, kind.name().extra());
+                    }
+                    for (_, tree) in kind.children() {
+                        imp(tree, f);
+                    }
+                }
+            }
+        }
+        imp(self, &mut f);
+    }
+
     fn simplify_extras_with_impl(self, is_extra: &impl Fn(&ExtraName) -> bool) -> MarkerTree {
         MarkerTree(INTERNER.lock().restrict(self.0, &|var| match var {
             Variable::Extra(name) => is_extra(name.extra()).then_some(true),
@@ -3200,6 +3243,52 @@ mod test {
                 or (os_name == 'nt' and sys_platform == 'win32')")
             .only_extras(),
             m("os_name == 'Linux' or os_name != 'Linux'"),
+        );
+    }
+
+    #[test]
+    fn visit_extras() {
+        let collect = |m: MarkerTree| -> Vec<(&'static str, String)> {
+            let mut collected = vec![];
+            m.visit_extras(|op, extra| {
+                let op = match op {
+                    MarkerOperator::Equal => "==",
+                    MarkerOperator::NotEqual => "!=",
+                    _ => unreachable!(),
+                };
+                collected.push((op, extra.as_str().to_string()));
+            });
+            collected
+        };
+        assert_eq!(collect(m("os_name == 'Linux'")), vec![]);
+        assert_eq!(
+            collect(m("extra == 'foo'")),
+            vec![("==", "foo".to_string())]
+        );
+        assert_eq!(
+            collect(m("extra == 'Linux' and extra == 'foo'")),
+            vec![("==", "foo".to_string()), ("==", "linux".to_string())]
+        );
+        assert_eq!(
+            collect(m("os_name == 'Linux' and extra == 'foo'")),
+            vec![("==", "foo".to_string())]
+        );
+
+        let marker = "
+            python_full_version >= '3.12'
+            and sys_platform == 'darwin'
+            and extra == 'extra-27-resolution-markers-for-days-cpu'
+            and extra != 'extra-27-resolution-markers-for-days-cu124'
+        ";
+        assert_eq!(
+            collect(m(marker)),
+            vec![
+                ("==", "extra-27-resolution-markers-for-days-cpu".to_string()),
+                (
+                    "!=",
+                    "extra-27-resolution-markers-for-days-cu124".to_string()
+                ),
+            ]
         );
     }
 }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -12,7 +12,7 @@ use tracing::trace;
 use uv_distribution_types::{
     DerivationChain, DistErrorKind, IndexCapabilities, IndexLocations, IndexUrl, RequestedDist,
 };
-use uv_normalize::PackageName;
+use uv_normalize::{ExtraName, InvalidNameError, PackageName};
 use uv_pep440::{LocalVersionSlice, Version};
 use uv_platform_tags::Tags;
 use uv_static::EnvVars;
@@ -112,6 +112,19 @@ pub enum ResolveError {
 
     #[error("Package `{0}` is unavailable")]
     PackageUnavailable(PackageName),
+
+    #[error("Invalid extra value in conflict marker: {reason}: {raw_extra}")]
+    InvalidExtraInConflictMarker {
+        reason: String,
+        raw_extra: ExtraName,
+    },
+
+    #[error("Invalid {kind} value in conflict marker: {name_error}")]
+    InvalidValueInConflictMarker {
+        kind: &'static str,
+        #[source]
+        name_error: InvalidNameError,
+    },
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -8,7 +8,7 @@ use crate::pubgrub::{PubGrubDependency, PubGrubPackage};
 use crate::requires_python::RequiresPythonRange;
 use crate::resolver::ForkState;
 use crate::universal_marker::{ConflictMarker, UniversalMarker};
-use crate::{PythonRequirement, RequiresPython};
+use crate::{PythonRequirement, RequiresPython, ResolveError};
 
 /// Represents one or more marker environments for a resolution.
 ///
@@ -303,7 +303,10 @@ impl ResolverEnvironment {
     /// with an initial set of forked resolver states (e.g., those present in
     /// a lock file), then this creates the initial set of forks from that
     /// configuration.
-    pub(crate) fn initial_forked_states(&self, init: ForkState) -> Vec<ForkState> {
+    pub(crate) fn initial_forked_states(
+        &self,
+        init: ForkState,
+    ) -> Result<Vec<ForkState>, ResolveError> {
         let Kind::Universal {
             ref initial_forks,
             markers: ref _markers,
@@ -311,17 +314,28 @@ impl ResolverEnvironment {
             exclude: ref _exclude,
         } = self.kind
         else {
-            return vec![init];
+            return Ok(vec![init]);
         };
         if initial_forks.is_empty() {
-            return vec![init];
+            return Ok(vec![init]);
         }
         initial_forks
             .iter()
             .rev()
-            .map(|initial_fork| {
-                init.clone()
-                    .with_env(self.narrow_environment(*initial_fork))
+            .filter_map(|&initial_fork| {
+                let combined = UniversalMarker::from_combined(initial_fork);
+                let (include, exclude) = match combined.conflict().filter_rules() {
+                    Ok(rules) => rules,
+                    Err(err) => return Some(Err(err)),
+                };
+                let mut env = self.filter_by_group(
+                    include
+                        .into_iter()
+                        .map(Ok)
+                        .chain(exclude.into_iter().map(Err)),
+                )?;
+                env = env.narrow_environment(combined.pep508());
+                Some(Ok(init.clone().with_env(env)))
             })
             .collect()
     }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -325,7 +325,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             prefetcher,
         );
         let mut preferences = self.preferences.clone();
-        let mut forked_states = self.env.initial_forked_states(state);
+        let mut forked_states = self.env.initial_forked_states(state)?;
         let mut resolutions = vec![];
 
         'FORK: while let Some(mut state) = forked_states.pop() {

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -8447,18 +8447,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
         requires-python = ">=3.12"
         resolution-markers = [
             "extra != 'extra-27-resolution-markers-for-days-cpu' and extra == 'extra-27-resolution-markers-for-days-cu124'",
-            "python_version < '0'",
-            "python_version < '0'",
-            "python_version < '0'",
-            "python_version < '0'",
             "sys_platform != 'darwin' and extra == 'extra-27-resolution-markers-for-days-cpu' and extra != 'extra-27-resolution-markers-for-days-cu124'",
-            "python_version < '0'",
-            "python_version < '0'",
             "sys_platform == 'darwin' and extra == 'extra-27-resolution-markers-for-days-cpu' and extra != 'extra-27-resolution-markers-for-days-cu124'",
-            "python_version < '0'",
-            "python_version < '0'",
-            "python_version < '0'",
-            "python_version < '0'",
             "extra != 'extra-27-resolution-markers-for-days-cpu' and extra != 'extra-27-resolution-markers-for-days-cu124'",
         ]
         conflicts = [[
@@ -8749,8 +8739,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "fsspec", marker = "sys_platform == 'darwin'" },
             { name = "jinja2", marker = "sys_platform == 'darwin'" },
             { name = "networkx", marker = "sys_platform == 'darwin'" },
-            { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
-            { name = "sympy", marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+            { name = "setuptools", marker = "sys_platform == 'darwin'" },
+            { name = "sympy", marker = "sys_platform == 'darwin'" },
             { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
         ]
         wheels = [
@@ -8770,8 +8760,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "fsspec", marker = "sys_platform != 'darwin'" },
             { name = "jinja2", marker = "sys_platform != 'darwin'" },
             { name = "networkx", marker = "sys_platform != 'darwin'" },
-            { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
-            { name = "sympy", marker = "python_full_version >= '3.12' and sys_platform != 'darwin'" },
+            { name = "setuptools", marker = "sys_platform != 'darwin'" },
+            { name = "sympy", marker = "sys_platform != 'darwin'" },
             { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
         ]
         wheels = [
@@ -8807,8 +8797,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
             { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
             { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-            { name = "setuptools", marker = "python_full_version >= '3.12'" },
-            { name = "sympy", marker = "python_full_version >= '3.12'" },
+            { name = "setuptools" },
+            { name = "sympy" },
             { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
             { name = "typing-extensions" },
         ]


### PR DESCRIPTION
This PR fixes a problem where re-running `uv lock` could, in some
cases, exponentially expand the contents of a lock file with more and
more resolution markers. This can only happen when conflict markers are
enabled.

The problem here is a bit in the weeds, but basically, during
resolution, we only use conflict _exclusions_. That's because, during
resolution, we don't really have state that tells us whether a
particular extra (or group) is enabled at this point in the graph (and
I'm not sure such a thing is possible). Instead, we simply do _not_
follow edges corresponding to a package and an extra/group that have
been marked as an exclusion for the current fork. However, we do keep
track of inclusion rules as we go.

Once resolution completes, we translate our inclusion and exclusion
rules for each fork into our "universal" marker that combines standard
PEP 508 markers with conflict markers (the result is still purpotedly
valid PEP 508, but somewhat of a bastardization).

Now, if you then change your `pyproject.toml` in a way that causes
resolution to run again, we read the markers serialized in the lock
file as input to resolution. This helps retain stability (which is
not a concern specific to conflict markers). However, this caused
resolution to work with both inclusion and exclusion rules inside the
marker itself. Which... kinda works, but it's inconsistent with only
respecting exclusion rules. The end result is that we end up producing
extra forks that aren't technically possible, but this isn't known
until all of the constraints are combined at the end of resolution. In
reality, we should never create these forks in the first place.

The conflict forking logic does take impossible forks into account, but
because of how conflict markers were filtering back into resolution,
this wasn't working properly.

So in this PR, we fix the problem by deserializing the conflict marker
back into conflicting inclusion/exclusion rules. Resolution then starts
with these rules in the first place and our logic for not visiting
impossible forks (which were manifesting as `python_version < '0'` in
the lock file) applies.

Fixes #9735
