### PR TITLE
Add experimental direct src layout

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -81,6 +81,8 @@ pub enum Error {
     InvalidDataRoot { name: String, path: PathBuf },
     #[error("Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: {}", _0.user_display())]
     VenvInSourceTree(PathBuf),
+    #[error("Expected a direct src directory with `__init__.py` at: {}", _0.user_display())]
+    MissingDirectSrcModule(PathBuf),
     #[error("Inconsistent metadata between prepare and build step: {0}")]
     InconsistentSteps(&'static str),
     #[error("Failed to write to {}", _0.user_display())]

--- a/crates/uv-build-backend/src/settings.rs
+++ b/crates/uv-build-backend/src/settings.rs
@@ -23,6 +23,18 @@ pub struct BuildBackendSettings {
     )]
     pub(crate) module_root: PathBuf,
 
+    /// Use `module-root` itself as the package instead of nesting the module name below it.
+    ///
+    /// The direct src layout is a custom uv extension for a `src/__init__.py` layout. It avoids
+    /// nesting the package name below `src`, but always requires installation because Python would
+    /// otherwise import the package as `src` rather than by the project name.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"direct-src = true"#
+    )]
+    pub(crate) direct_src: bool,
+
     /// The name of the module directory inside `module-root`.
     ///
     /// The default module name is the package name with dots and dashes replaced by underscores.
@@ -177,6 +189,7 @@ impl Default for BuildBackendSettings {
     fn default() -> Self {
         Self {
             module_root: PathBuf::from("src"),
+            direct_src: false,
             module_name: None,
             source_include: Vec::new(),
             default_excludes: true,

--- a/crates/uv-build-backend/src/uv_direct_src_finder.py
+++ b/crates/uv-build-backend/src/uv_direct_src_finder.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+from importlib.abc import MetaPathFinder
+from importlib.machinery import PathFinder
+from importlib.metadata import DistributionFinder
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from importlib.metadata import Distribution
+    from importlib.machinery import ModuleSpec
+    from typing import Iterable, Sequence
+    from types import ModuleType
+
+
+class UvDirectSrcFinder(PathFinder, MetaPathFinder):
+    """A meta path finder to add support for `src/__init__.py` layouts.
+
+    By default, Python requires that a module is either defined in a file with its
+    name (e.g. `foo.abi3.so`, `foo.py`) or there is a directory with the name, e.g.
+    `foo/__init__.py`. We want to support `src/__init__.py`, to avoid duplicating the
+    project name and ending up with structures such as `foo/src/foo/__init__.py`, where
+    `foo/pyproject.toml` also exists."""
+
+    name: str
+    """The name of the module."""
+    project_dir: str
+    """The directory containing the `pyproject.toml` and the `src` folder."""
+
+    def __init__(self, name: str, project_dir: str):
+        self.name = name
+        self.project_dir = project_dir
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        from pathlib import Path
+        from importlib.util import spec_from_file_location
+
+        if fullname == self.name:
+            init_py = Path(self.project_dir).joinpath("__init__.py")
+            if not init_py.is_file():
+                print(
+                    f"Missing source editable `{self.name}` at `{self.project_dir}`, "
+                    f"please run uv to refresh",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            return spec_from_file_location(fullname, init_py)
+
+    def find_distributions(
+        self, context: DistributionFinder.Context = DistributionFinder.Context()
+    ) -> Iterable[Distribution]:
+        """https://docs.python.org/3/library/importlib.metadata.html#extending-the-search-algorithm
+
+        The context has a name and a path attribute and we need to return an
+        iterator with our Distribution object."""
+        from importlib.metadata import PathDistribution
+        from pathlib import Path
+
+        if context.name is None or context.name == self.name:
+            return iter([PathDistribution(Path(self.project_dir))])
+        else:
+            return iter([])

--- a/crates/uv-build-backend/src/uv_direct_src_finder.py
+++ b/crates/uv-build-backend/src/uv_direct_src_finder.py
@@ -7,10 +7,10 @@ from importlib.metadata import DistributionFinder
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
-    from importlib.metadata import Distribution
     from importlib.machinery import ModuleSpec
-    from typing import Iterable, Sequence
+    from importlib.metadata import Distribution
     from types import ModuleType
+    from typing import Iterable, Sequence
 
 
 class UvDirectSrcFinder(PathFinder, MetaPathFinder):
@@ -37,8 +37,8 @@ class UvDirectSrcFinder(PathFinder, MetaPathFinder):
         path: Sequence[str] | None = None,
         target: ModuleType | None = None,
     ) -> ModuleSpec | None:
-        from pathlib import Path
         from importlib.util import spec_from_file_location
+        from pathlib import Path
 
         if fullname == self.name:
             init_py = Path(self.project_dir).joinpath("__init__.py")
@@ -52,7 +52,7 @@ class UvDirectSrcFinder(PathFinder, MetaPathFinder):
             return spec_from_file_location(fullname, init_py)
 
     def find_distributions(
-        self, context: DistributionFinder.Context = DistributionFinder.Context()
+        self, context: DistributionFinder.Context | None = None
     ) -> Iterable[Distribution]:
         """https://docs.python.org/3/library/importlib.metadata.html#extending-the-search-algorithm
 
@@ -60,6 +60,9 @@ class UvDirectSrcFinder(PathFinder, MetaPathFinder):
         iterator with our Distribution object."""
         from importlib.metadata import PathDistribution
         from pathlib import Path
+
+        if context is None:
+            context = DistributionFinder.Context()
 
         if context.name is None or context.name == self.name:
             return iter([PathDistribution(Path(self.project_dir))])

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace};
 use walkdir::WalkDir;
 
 use uv_distribution_filename::WheelFilename;
-use uv_fs::Simplified;
+use uv_fs::{Simplified, normalize_path};
 use uv_globfilter::{GlobDirFilter, PortableGlobParser};
 use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag};
 use uv_preview::PreviewFeature;
@@ -38,6 +38,9 @@ const WHOLE_FILE_ZIP_ENTRY_LIMIT: u64 = 16 * 1024 * 1024;
 // down read/write loop overhead compared to the 8 KiB default while remaining a
 // small fixed allocation for entries that are too large for `write_entry_whole`.
 const ZIP_STREAM_BUFFER_SIZE: usize = 128 * 1024;
+
+/// A meta path finder to add support for `src/__init__.py` layouts, which we copy into the venv.
+static UV_DIRECT_SRC_FINDER: &str = include_str!("uv_direct_src_finder.py");
 
 /// Build a wheel from the source tree and place it in the output directory.
 pub fn build_wheel(
@@ -269,6 +272,7 @@ pub fn build_editable(
     metadata_directory: Option<&Path>,
     uv_version: &str,
     show_warnings: bool,
+    preview: bool,
 ) -> Result<WheelFilename, Error> {
     let pyproject_toml = PyProjectToml::parse(&source_tree.join("pyproject.toml"))?;
     for warning in pyproject_toml.check_build_system(uv_version) {
@@ -302,21 +306,72 @@ pub fn build_editable(
     let temp_file = uv_fs::tempfile_in(wheel_dir)?;
     let mut wheel_writer = ZipDirectoryWriter::new_wheel(temp_file.as_file());
 
-    debug!("Adding pth file to {}", wheel_path.user_display());
-    // Check that a module root exists in the directory we're linking from the `.pth` file
-    let (src_root, _module_relative) = find_roots(
-        source_tree,
-        &pyproject_toml,
-        &settings.module_root,
-        settings.module_name.as_ref(),
-        settings.namespace,
-        show_warnings,
-    )?;
+    if settings.direct_src {
+        let relative_module_root = normalize_path(&settings.module_root);
+        let src_root = source_tree.join(&relative_module_root);
+        if !normalize_path(&src_root).starts_with(normalize_path(source_tree)) {
+            return Err(Error::InvalidModuleRoot(relative_module_root.to_path_buf()));
+        }
+        if !preview {
+            warn_user_once!(
+                "The direct src layout is experimental and may be removed without warning"
+            );
+        }
+        debug!(
+            "Adding direct src pth file to {}",
+            wheel_path.user_display()
+        );
+        if !src_root.join("__init__.py").is_file() {
+            return Err(Error::MissingDirectSrcModule(src_root));
+        }
 
-    wheel_writer.write_bytes(
-        &format!("{}.pth", pyproject_toml.name().as_dist_info_name()),
-        src_root.as_os_str().as_encoded_bytes(),
-    )?;
+        // Lines in pth files starting with `import ` are executed, so we have to cram all our code
+        // into the same line. Example unfolded code:
+        // ```python
+        // import sys
+        // from _foo_bar_direct_src_support import UvFlatEditableFinder
+        // sys.meta_path.append(UvFlatEditableFinder("foo_bar", "/home/ferris/projects/foo_bar/src"))
+        // ```
+        let load_finder = [
+            "import sys",
+            &format!(
+                "from _{}_direct_src_support import UvDirectSrcFinder",
+                pyproject_toml.name().as_dist_info_name()
+            ),
+            &format!(
+                r#"sys.meta_path.insert(0, UvDirectSrcFinder("{}", "{}"))"#,
+                pyproject_toml.name().as_dist_info_name(),
+                src_root.display()
+            ),
+        ]
+        .join("; ");
+        wheel_writer.write_bytes(
+            &format!("{}.pth", pyproject_toml.name().as_dist_info_name()),
+            load_finder.as_bytes(),
+        )?;
+        wheel_writer.write_bytes(
+            &format!(
+                "_{}_direct_src_support.py",
+                pyproject_toml.name().as_dist_info_name()
+            ),
+            UV_DIRECT_SRC_FINDER.as_bytes(),
+        )?;
+    } else {
+        debug!("Adding pth file to {}", wheel_path.user_display());
+        // Check that a module root exists in the directory we're linking from the `.pth` file.
+        let (src_root, _module_relative) = find_roots(
+            source_tree,
+            &pyproject_toml,
+            &settings.module_root,
+            settings.module_name.as_ref(),
+            settings.namespace,
+            show_warnings,
+        )?;
+        wheel_writer.write_bytes(
+            &format!("{}.pth", pyproject_toml.name().as_dist_info_name()),
+            src_root.as_os_str().as_encoded_bytes(),
+        )?;
+    }
 
     write_data_files(
         source_tree,

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace};
 use walkdir::WalkDir;
 
 use uv_distribution_filename::WheelFilename;
-use uv_fs::{Simplified, normalize_path};
+use uv_fs::{PythonExt, Simplified, normalize_path};
 use uv_globfilter::{GlobDirFilter, PortableGlobParser};
 use uv_platform_tags::{AbiTag, LanguageTag, PlatformTag};
 use uv_preview::PreviewFeature;
@@ -341,7 +341,7 @@ pub fn build_editable(
             &format!(
                 r#"sys.meta_path.insert(0, UvDirectSrcFinder("{}", "{}"))"#,
                 pyproject_toml.name().as_dist_info_name(),
-                src_root.display()
+                src_root.escape_for_python()
             ),
         ]
         .join("; ");

--- a/crates/uv-build/src/main.rs
+++ b/crates/uv-build/src/main.rs
@@ -102,6 +102,7 @@ fn main() -> Result<()> {
                 metadata_directory.as_deref(),
                 uv_version::version(),
                 false,
+                preview.all_enabled(),
             )?;
             // Tell the build frontend about the name of the artifact we built
             writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -603,6 +603,7 @@ impl BuildContext for BuildDispatch<'_> {
         debug!("Performing direct build for {identifier}");
 
         let output_dir = output_dir.to_path_buf();
+        let preview = self.preview;
         let filename = tokio::task::spawn_blocking(move || -> Result<_> {
             let filename = match build_kind {
                 BuildKind::Wheel => {
@@ -631,6 +632,7 @@ impl BuildContext for BuildDispatch<'_> {
                         None,
                         uv_version::version(),
                         sources.is_none(),
+                        preview.all_enabled(),
                     )?;
                     DistFilename::WheelFilename(wheel)
                 }

--- a/crates/uv/src/commands/build_backend.rs
+++ b/crates/uv/src/commands/build_backend.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use std::env;
 use std::io::Write;
 use std::path::Path;
+use uv_preview::Preview;
 
 /// PEP 517 hook to build a source distribution.
 pub(crate) fn build_sdist(sdist_directory: &Path) -> Result<ExitStatus> {
@@ -38,6 +39,7 @@ pub(crate) fn build_wheel(
 pub(crate) fn build_editable(
     wheel_directory: &Path,
     metadata_directory: Option<&Path>,
+    preview: Preview,
 ) -> Result<ExitStatus> {
     let filename = uv_build_backend::build_editable(
         &env::current_dir()?,
@@ -45,6 +47,7 @@ pub(crate) fn build_editable(
         metadata_directory,
         uv_version::version(),
         false,
+        preview.all_enabled(),
     )?;
     // Tell the build frontend about the name of the artifact we built
     writeln!(&mut std::io::stdout(), "{filename}").context("stdout is closed")?;

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2021,6 +2021,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             } => commands::build_backend::build_editable(
                 &wheel_directory,
                 metadata_directory.as_deref(),
+                globals.preview,
             ),
             BuildBackendCommand::GetRequiresForBuildSdist => {
                 commands::build_backend::get_requires_for_build_sdist()

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -17541,3 +17541,57 @@ fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn direct_src_editable() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+            [project]
+            name = "flat"
+            version = "0.1.0"
+            requires-python = ">=3.12"
+
+            [tool.uv.build-backend]
+            direct-src = true
+
+            [build-system]
+            requires = ["uv_build>=0.7,<10000"]
+            build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src/__init__.py")
+        .write_str(indoc! {r#"
+            def say_hi():
+                print("🐊")
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.sync().arg("--preview"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + flat==0.1.0 (from file://[TEMP_DIR]/)
+    "###);
+
+    uv_snapshot!(context.run().arg("python").arg("-c").arg("import flat; flat.say_hi()"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    🐊
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked 1 package in [TIME]
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
Currently, there are two main options for a project layout, as described in https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/.

`<package_name>/__init__.py`: The project is importable even when not installed. The community seems to be migrating to the `src` layout https://hynek.me/articles/testing-packaging/.

`src/<package_name>/__init__.py`: We add an extra layer of directory only to repeat the package name. This makes the library layout feel higher overhead than needed, making adoption especially in small projects harder, where the alternative is just having some Python files in a directory without any packaging.

As an alternative, we introduce `src/__init__.py`, a layout familiar from other programming languages. It is low overhead (no extra indirection, docs are "put your python files in `src`, `uv sync` and `import <package_name>`") and it enforces isolation through (editable) installation (you can't `import <package_name>` directly).

Python does not support this natively it always want the module name in the directory or filename. We hack around this by using a custom meta finder that we insert at the top import priority. This code runs at every python startup. Imports are lazy where possible to reduce overhead. Since we're hacking the Python import system to achieve this, it's experimental. I like `src/__init__.py` a lot, but everything that runs code through `.pth` in implicit, pre-main life is to be regarded with some suspicion.

This PR only adds editable support (the harder part), proper `build_{sdist,wheel}` will be added in an upstack PR.