### PR TITLE
Respect `no-build` label in Docker image builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   docker-build:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     name: Build Docker image (ghcr.io/astral-sh/uv) for ${{ matrix.platform }}
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
e.g., https://github.com/astral-sh/uv/pull/11329 is runner Docker image builds but should not