### PR TITLE
Allow PEP 508 requirements in tool requests

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -518,18 +518,28 @@ async fn get_or_create_environment(
     } else {
         ToolRequirement::Package(match target {
             // Ex) `ruff`
-            Target::Unspecified(name) => Requirement {
-                name: PackageName::from_str(name)?,
-                extras: vec![],
-                groups: vec![],
-                marker: MarkerTree::default(),
-                source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::empty(),
-                    index: None,
-                    conflict: None,
-                },
-                origin: None,
-            },
+            Target::Unspecified(name) => {
+                let source = RequirementsSource::Package((*name).to_string());
+                let requirements = RequirementsSpecification::from_source(&source, &client_builder)
+                    .await?
+                    .requirements;
+                resolve_names(
+                    requirements,
+                    &interpreter,
+                    settings,
+                    &state,
+                    connectivity,
+                    concurrency,
+                    native_tls,
+                    allow_insecure_host,
+                    cache,
+                    printer,
+                    preview,
+                )
+                .await?
+                .pop()
+                .unwrap()
+            }
             // Ex) `ruff@0.6.0`
             Target::Version(name, extras, version)
             | Target::FromVersion(_, name, extras, version) => Requirement {

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -100,7 +100,10 @@ fn tool_run_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Not a valid package or extra name: "pytest@". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+    error: Failed to parse: `pytest@`
+      Caused by: Expected URL
+    pytest@
+           ^
     "###);
 
     // Invalid versions are just treated as package and command names
@@ -110,11 +113,12 @@ fn tool_run_at_version() {
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Not a valid package or extra name: "pytest@invalid". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+      × Failed to resolve tool requirement
+      ╰─▶ Distribution not found at: file://[TEMP_DIR]/invalid
     "###);
 
     let filters = context
@@ -1453,6 +1457,71 @@ fn tool_run_latest_extra() {
      + jinja2==3.1.3
      + markupsafe==2.1.5
      + python-dotenv==1.0.1
+     + werkzeug==3.0.1
+    "###);
+}
+
+#[test]
+fn tool_run_extra() {
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("flask[dotenv]")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 3.0.2
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
+    Installed 8 packages in [TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==3.0.2
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
+     + python-dotenv==1.0.1
+     + werkzeug==3.0.1
+    "###);
+}
+
+#[test]
+fn tool_run_specifier() {
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("flask<3.0.0")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 2.3.3
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
+    Installed 7 packages in [TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==2.3.3
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
      + werkzeug==3.0.1
     "###);
 }


### PR DESCRIPTION
## Summary

This allows previously-unsupported patterns like:

- `uvx ruff>=0.5.0`
- `uvx flask[dotenv]`

Closes https://github.com/astral-sh/uv/issues/6296.
