### PR TITLE
Fix broken anchors in readme and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ An extremely fast Python package and project manager, written in Rust.
 - 🛠️ [Runs and installs](#tools) tools published as Python packages.
 - 🔩 Includes a [pip-compatible interface](#the-pip-interface) for a performance boost with a
   familiar CLI.
-- 🏢 Supports Cargo-style [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces)
-  for scalable projects.
+- 🏢 Supports Cargo-style [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces) for
+  scalable projects.
 - 💾 Disk-space efficient, with a [global cache](https://docs.astral.sh/uv/concepts/cache) for
   dependency deduplication.
 - ⏬ Installable without Rust or Python via `curl` or `pip`.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ An extremely fast Python package and project manager, written in Rust.
 - 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `twine`, `virtualenv`,
   and more.
 - ⚡️ [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than `pip`.
-- 🗂️ Provides [comprehensive project management](#project), with a
-  [universal lockfile](https://docs.astral.sh/uv/concepts/projects/layout.md#the-lockfile).
-- ❇️ [Runs scripts](#script-support), with support for
-  [inline dependency metadata](https://docs.astral.sh/uv/guides/scripts.md#declaring-script-dependencies).
+- 🗂️ Provides [comprehensive project management](#projects), with a
+  [universal lockfile](https://docs.astral.sh/uv/concepts/projects/layout#the-lockfile).
+- ❇️ [Runs scripts](#scripts), with support for
+  [inline dependency metadata](https://docs.astral.sh/uv/guides/scripts#declaring-script-dependencies).
 - 🐍 [Installs and manages](#python-versions) Python versions.
-- 🛠️ [Runs and installs](#tool) tools published as Python packages.
+- 🛠️ [Runs and installs](#tools) tools published as Python packages.
 - 🔩 Includes a [pip-compatible interface](#the-pip-interface) for a performance boost with a
   familiar CLI.
-- 🏢 Supports Cargo-style [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces.md)
+- 🏢 Supports Cargo-style [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces)
   for scalable projects.
-- 💾 Disk-space efficient, with a [global cache](https://docs.astral.sh/uv/concepts/cache.md) for
+- 💾 Disk-space efficient, with a [global cache](https://docs.astral.sh/uv/concepts/cache) for
   dependency deduplication.
 - ⏬ Installable without Rust or Python via `curl` or `pip`.
 - 🖥️ Supports macOS, Linux, and Windows.
@@ -227,7 +227,7 @@ Pinned `.python-version` to `3.11`
 See the [Python installation documentation](https://docs.astral.sh/uv/guides/install-python/) to get
 started.
 
-### A pip-compatible interface
+### The pip interface
 
 uv provides a drop-in replacement for common `pip`, `pip-tools`, and `virtualenv` commands.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,12 @@ An extremely fast Python package and project manager, written in Rust.
 - 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `twine`, `virtualenv`,
   and more.
 - ⚡️ [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than `pip`.
-- 🗂️ Provides [comprehensive project management](#project), with a
+- 🗂️ Provides [comprehensive project management](#projects), with a
   [universal lockfile](./concepts/projects/layout.md#the-lockfile).
-- ❇️ [Runs scripts](#script-support), with support for
+- ❇️ [Runs scripts](#scripts), with support for
   [inline dependency metadata](./guides/scripts.md#declaring-script-dependencies).
 - 🐍 [Installs and manages](#python-versions) Python versions.
-- 🛠️ [Runs and installs](#tool) tools published as Python packages.
+- 🛠️ [Runs and installs](#tools) tools published as Python packages.
 - 🔩 Includes a [pip-compatible interface](#the-pip-interface) for a performance boost with a
   familiar CLI.
 - 🏢 Supports Cargo-style [workspaces](./concepts/projects/workspaces.md) for scalable projects.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I've just fixed some broken anchors after browing ux doc site.

## Test Plan

- `index.md`: based on `mkdocs serve` log
- `readme.md`: manual check

## Aside

Do you manually keep `readme.md` and `index.md` partially sync? I've tried
checking pre-commit and other scripts but found no way to port my edits from one
to the other.

<!-- How was it tested? -->
