### PR TITLE
Bring parity to `uvx` and `uv tool install` requests

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -30,7 +30,7 @@ use crate::commands::project::{
     EnvironmentSpecification, PlatformState, ProjectError,
 };
 use crate::commands::tool::common::{install_executables, refine_interpreter, remove_entrypoints};
-use crate::commands::tool::Target;
+use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::ExitStatus;
 use crate::commands::{diagnostics, reporters::PythonDownloadReporter};
 use crate::printer::Printer;
@@ -95,105 +95,40 @@ pub(crate) async fn install(
         .allow_insecure_host(allow_insecure_host.to_vec());
 
     // Parse the input requirement.
-    let target = Target::parse(&package, from.as_deref());
+    let request = ToolRequest::parse(&package, from.as_deref());
 
     // If the user passed, e.g., `ruff@latest`, refresh the cache.
-    let cache = if target.is_latest() {
+    let cache = if request.is_latest() {
         cache.with_refresh(Refresh::All(Timestamp::now()))
     } else {
         cache
     };
 
     // Resolve the `--from` requirement.
-    let from = match target {
+    let from = match &request.target {
         // Ex) `ruff`
-        Target::Unspecified(name) => {
+        Target::Unspecified(from) => {
             let source = if editable {
-                RequirementsSource::Editable(name.to_string())
+                RequirementsSource::Editable((*from).to_string())
             } else {
-                RequirementsSource::Package(name.to_string())
+                RequirementsSource::Package((*from).to_string())
             };
-            let requirements = RequirementsSpecification::from_source(&source, &client_builder)
-                .await?
-                .requirements;
-            resolve_names(
-                requirements,
-                &interpreter,
-                &settings,
-                &state,
-                connectivity,
-                concurrency,
-                native_tls,
-                allow_insecure_host,
-                &cache,
-                printer,
-                preview,
-            )
-            .await?
-            .pop()
-            .unwrap()
-        }
-        // Ex) `ruff@0.6.0`
-        Target::Version(name, ref extras, ref version)
-        | Target::FromVersion(_, name, ref extras, ref version) => {
-            if editable {
-                bail!("`--editable` is only supported for local packages");
-            }
-
-            Requirement {
-                name: PackageName::from_str(name)?,
-                extras: extras.clone(),
-                groups: vec![],
-                marker: MarkerTree::default(),
-                source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(
-                        version.clone(),
-                    )),
-                    index: None,
-                    conflict: None,
-                },
-                origin: None,
-            }
-        }
-        // Ex) `ruff@latest`
-        Target::Latest(name, ref extras) | Target::FromLatest(_, name, ref extras) => {
-            if editable {
-                bail!("`--editable` is only supported for local packages");
-            }
-
-            Requirement {
-                name: PackageName::from_str(name)?,
-                extras: extras.clone(),
-                groups: vec![],
-                marker: MarkerTree::default(),
-                source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::empty(),
-                    index: None,
-                    conflict: None,
-                },
-                origin: None,
-            }
-        }
-        // Ex) `ruff>=0.6.0`
-        Target::From(package, from) => {
-            // Parse the positional name. If the user provided more than a package name, it's an error
-            // (e.g., `uv install foo==1.0 --from foo`).
-            let Ok(package) = PackageName::from_str(package) else {
-                bail!("Package requirement (`{from}`) provided with `--from` conflicts with install request (`{package}`)", from = from.cyan(), package = package.cyan())
-            };
-
-            let source = if editable {
-                RequirementsSource::Editable(from.to_string())
-            } else {
-                RequirementsSource::Package(from.to_string())
-            };
-            let requirements = RequirementsSpecification::from_source(&source, &client_builder)
+            let requirement = RequirementsSpecification::from_source(&source, &client_builder)
                 .await?
                 .requirements;
 
-            // Parse the `--from` requirement.
-            let from_requirement = resolve_names(
-                requirements,
+            // If the user provided an executable name, verify that it matches the `--from` requirement.
+            let executable = if let Some(executable) = request.executable {
+                let Ok(executable) = PackageName::from_str(executable) else {
+                    bail!("Package requirement (`{from}`) provided with `--from` conflicts with install request (`{executable}`)", from = from.cyan(), executable = executable.cyan())
+                };
+                Some(executable)
+            } else {
+                None
+            };
+
+            let requirement = resolve_names(
+                requirement,
                 &interpreter,
                 &settings,
                 &state,
@@ -209,17 +144,58 @@ pub(crate) async fn install(
             .pop()
             .unwrap();
 
-            // Check if the positional name conflicts with `--from`.
-            if from_requirement.name != package {
-                // Determine if it's an entirely different package (e.g., `uv install foo --from bar`).
-                bail!(
-                    "Package name (`{}`) provided with `--from` does not match install request (`{}`)",
-                    from_requirement.name.cyan(),
-                    package.cyan()
-                );
+            // Determine if it's an entirely different package (e.g., `uv install foo --from bar`).
+            if let Some(executable) = executable {
+                if requirement.name != executable {
+                    bail!(
+                        "Package name (`{}`) provided with `--from` does not match install request (`{}`)",
+                        requirement.name.cyan(),
+                        executable.cyan()
+                    );
+                }
             }
 
-            from_requirement
+            requirement
+        }
+        // Ex) `ruff@0.6.0`
+        Target::Version(.., name, ref extras, ref version) => {
+            if editable {
+                bail!("`--editable` is only supported for local packages");
+            }
+
+            Requirement {
+                name: name.clone(),
+                extras: extras.clone(),
+                groups: vec![],
+                marker: MarkerTree::default(),
+                source: RequirementSource::Registry {
+                    specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(
+                        version.clone(),
+                    )),
+                    index: None,
+                    conflict: None,
+                },
+                origin: None,
+            }
+        }
+        // Ex) `ruff@latest`
+        Target::Latest(.., name, ref extras) => {
+            if editable {
+                bail!("`--editable` is only supported for local packages");
+            }
+
+            Requirement {
+                name: name.clone(),
+                extras: extras.clone(),
+                groups: vec![],
+                marker: MarkerTree::default(),
+                source: RequirementSource::Registry {
+                    specifier: VersionSpecifiers::empty(),
+                    index: None,
+                    conflict: None,
+                },
+                origin: None,
+            }
         }
     };
 
@@ -232,7 +208,7 @@ pub(crate) async fn install(
     }
 
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.
-    let settings = if target.is_latest() {
+    let settings = if request.is_latest() {
         ResolverInstallerSettings {
             upgrade: settings
                 .upgrade
@@ -368,7 +344,7 @@ pub(crate) async fn install(
         .as_ref()
         .filter(|_| {
             // And the user didn't request a reinstall or upgrade...
-            !target.is_latest() && settings.reinstall.is_none() && settings.upgrade.is_none()
+            !request.is_latest() && settings.reinstall.is_none() && settings.upgrade.is_none()
         })
         .is_some()
     {

--- a/crates/uv/src/commands/tool/mod.rs
+++ b/crates/uv/src/commands/tool/mod.rs
@@ -14,84 +14,62 @@ pub(crate) mod uninstall;
 pub(crate) mod update_shell;
 pub(crate) mod upgrade;
 
+/// A request to run or install a tool (e.g., `uvx ruff@latest`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolRequest<'a> {
+    /// The executable name (e.g., `ruff`), if specified explicitly.
+    pub(crate) executable: Option<&'a str>,
+    /// The target to install or run (e.g., `ruff@latest` or `ruff==0.6.0`).
+    pub(crate) target: Target<'a>,
+}
+
+impl<'a> ToolRequest<'a> {
+    /// Parse a tool request into an executable name and a target.
+    pub(crate) fn parse(command: &'a str, from: Option<&'a str>) -> Self {
+        if let Some(from) = from {
+            let target = Target::parse(from);
+            Self {
+                executable: Some(command),
+                target,
+            }
+        } else {
+            let target = Target::parse(command);
+            Self {
+                executable: None,
+                target,
+            }
+        }
+    }
+
+    /// Returns whether the target package is Python.
+    pub(crate) fn is_python(&self) -> bool {
+        let name = match self.target {
+            Target::Unspecified(name) => name,
+            Target::Version(name, ..) => name,
+            Target::Latest(name, ..) => name,
+        };
+        name.eq_ignore_ascii_case("python") || cfg!(windows) && name.eq_ignore_ascii_case("pythonw")
+    }
+
+    /// Returns `true` if the target is `latest`.
+    pub(crate) fn is_latest(&self) -> bool {
+        matches!(self.target, Target::Latest(..))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Target<'a> {
     /// e.g., `ruff`
     Unspecified(&'a str),
     /// e.g., `ruff[extra]@0.6.0`
-    Version(&'a str, Vec<ExtraName>, Version),
+    Version(&'a str, PackageName, Vec<ExtraName>, Version),
     /// e.g., `ruff[extra]@latest`
-    Latest(&'a str, Vec<ExtraName>),
-    /// e.g., `ruff --from ruff[extra]>=0.6.0`
-    From(&'a str, &'a str),
-    /// e.g., `ruff --from ruff[extra]@0.6.0`
-    FromVersion(&'a str, &'a str, Vec<ExtraName>, Version),
-    /// e.g., `ruff --from ruff[extra]@latest`
-    FromLatest(&'a str, &'a str, Vec<ExtraName>),
+    Latest(&'a str, PackageName, Vec<ExtraName>),
 }
 
 impl<'a> Target<'a> {
     /// Parse a target into a command name and a requirement.
-    pub(crate) fn parse(target: &'a str, from: Option<&'a str>) -> Self {
-        if let Some(from) = from {
-            // e.g. `--from ruff`, no special handling
-            let Some((name, version)) = from.split_once('@') else {
-                return Self::From(target, from);
-            };
-
-            // e.g. `--from ruff@`, warn and treat the whole thing as the command
-            if version.is_empty() {
-                debug!("Ignoring empty version request in `--from`");
-                return Self::From(target, from);
-            }
-
-            // Split into name and extras (e.g., `flask[dotenv]`).
-            let (name, extras) = match name.split_once('[') {
-                Some((name, extras)) => {
-                    let Some(extras) = extras.strip_suffix(']') else {
-                        // e.g., ignore `flask[dotenv`.
-                        debug!("Ignoring invalid extras in `--from`");
-                        return Self::From(target, from);
-                    };
-                    (name, extras)
-                }
-                None => (name, ""),
-            };
-
-            // e.g., ignore `git+https://github.com/astral-sh/ruff.git@main`
-            if PackageName::from_str(name).is_err() {
-                debug!("Ignoring non-package name `{name}` in `--from`");
-                return Self::From(target, from);
-            }
-
-            // e.g., ignore `ruff[1.0.0]` or any other invalid extra.
-            let Ok(extras) = extras
-                .split(',')
-                .map(str::trim)
-                .filter(|extra| !extra.is_empty())
-                .map(ExtraName::from_str)
-                .collect::<Result<Vec<_>, _>>()
-            else {
-                debug!("Ignoring invalid extras `{extras}` in `--from`");
-                return Self::From(target, from);
-            };
-
-            match version {
-                // e.g., `ruff@latest`
-                "latest" => return Self::FromLatest(target, name, extras),
-                // e.g., `ruff@0.6.0`
-                version => {
-                    if let Ok(version) = Version::from_str(version) {
-                        return Self::FromVersion(target, name, extras, version);
-                    }
-                }
-            };
-
-            // e.g. `--from ruff@invalid`, warn and treat the whole thing as the command
-            debug!("Ignoring invalid version request `{version}` in `--from`");
-            return Self::From(target, from);
-        }
-
+    pub(crate) fn parse(target: &'a str) -> Self {
         // e.g. `ruff`, no special handling
         let Some((name, version)) = target.split_once('@') else {
             return Self::Unspecified(target);
@@ -104,22 +82,22 @@ impl<'a> Target<'a> {
         }
 
         // Split into name and extras (e.g., `flask[dotenv]`).
-        let (name, extras) = match name.split_once('[') {
-            Some((name, extras)) => {
+        let (executable, extras) = match name.split_once('[') {
+            Some((executable, extras)) => {
                 let Some(extras) = extras.strip_suffix(']') else {
                     // e.g., ignore `flask[dotenv`.
-                    return Self::Unspecified(name);
+                    return Self::Unspecified(target);
                 };
-                (name, extras)
+                (executable, extras)
             }
             None => (name, ""),
         };
 
         // e.g., ignore `git+https://github.com/astral-sh/ruff.git@main`
-        if PackageName::from_str(name).is_err() {
+        let Ok(name) = PackageName::from_str(executable) else {
             debug!("Ignoring non-package name `{name}` in command");
             return Self::Unspecified(target);
-        }
+        };
 
         // e.g., ignore `ruff[1.0.0]` or any other invalid extra.
         let Ok(extras) = extras
@@ -135,64 +113,18 @@ impl<'a> Target<'a> {
 
         match version {
             // e.g., `ruff@latest`
-            "latest" => return Self::Latest(name, extras),
+            "latest" => Self::Latest(executable, name, extras),
             // e.g., `ruff@0.6.0`
             version => {
                 if let Ok(version) = Version::from_str(version) {
-                    return Self::Version(name, extras, version);
+                    Self::Version(executable, name, extras, version)
+                } else {
+                    // e.g. `ruff@invalid`, warn and treat the whole thing as the command
+                    debug!("Ignoring invalid version request `{version}` in command");
+                    Self::Unspecified(target)
                 }
             }
-        };
-
-        // e.g. `ruff@invalid`, warn and treat the whole thing as the command
-        debug!("Ignoring invalid version request `{version}` in command");
-        Self::Unspecified(target)
-    }
-
-    /// Returns the name of the executable.
-    pub(crate) fn executable(&self) -> &str {
-        match self {
-            Self::Unspecified(name) => {
-                // Identify the package name from the PEP 508 specifier.
-                //
-                // For example, given `ruff>=0.6.0`, extract `ruff`, to use as the executable name.
-                let index = name
-                    .find(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.'))
-                    .unwrap_or(name.len());
-                &name[..index]
-            }
-            Self::Version(name, _, _) => name,
-            Self::Latest(name, _) => name,
-            Self::FromVersion(name, _, _, _) => name,
-            Self::FromLatest(name, _, _) => name,
-            Self::From(name, _) => name,
         }
-    }
-
-    /// Returns whether the target package is Python.
-    pub(crate) fn is_python(&self) -> bool {
-        let name = match self {
-            Self::Unspecified(name) => {
-                // Identify the package name from the PEP 508 specifier.
-                //
-                // For example, given `ruff>=0.6.0`, extract `ruff`, to use as the executable name.
-                let index = name
-                    .find(|c| !matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.'))
-                    .unwrap_or(name.len());
-                &name[..index]
-            }
-            Self::Version(name, _, _) => name,
-            Self::Latest(name, _) => name,
-            Self::FromVersion(_, name, _, _) => name,
-            Self::FromLatest(_, name, _) => name,
-            Self::From(_, name) => name,
-        };
-        name.eq_ignore_ascii_case("python") || cfg!(windows) && name.eq_ignore_ascii_case("pythonw")
-    }
-
-    /// Returns `true` if the target is `latest`.
-    fn is_latest(&self) -> bool {
-        matches!(self, Self::Latest(..) | Self::FromLatest(..))
     }
 }
 
@@ -202,41 +134,56 @@ mod tests {
 
     #[test]
     fn parse_target() {
-        let target = Target::parse("flask", None);
+        let target = Target::parse("flask");
         let expected = Target::Unspecified("flask");
         assert_eq!(target, expected);
 
-        let target = Target::parse("flask@3.0.0", None);
-        let expected = Target::Version("flask", vec![], Version::new([3, 0, 0]));
-        assert_eq!(target, expected);
-
-        let target = Target::parse("flask@3.0.0", None);
-        let expected = Target::Version("flask", vec![], Version::new([3, 0, 0]));
-        assert_eq!(target, expected);
-
-        let target = Target::parse("flask@latest", None);
-        let expected = Target::Latest("flask", vec![]);
-        assert_eq!(target, expected);
-
-        let target = Target::parse("flask[dotenv]@3.0.0", None);
+        let target = Target::parse("flask@3.0.0");
         let expected = Target::Version(
             "flask",
+            PackageName::from_str("flask").unwrap(),
+            vec![],
+            Version::new([3, 0, 0]),
+        );
+        assert_eq!(target, expected);
+
+        let target = Target::parse("flask@3.0.0");
+        let expected = Target::Version(
+            "flask",
+            PackageName::from_str("flask").unwrap(),
+            vec![],
+            Version::new([3, 0, 0]),
+        );
+        assert_eq!(target, expected);
+
+        let target = Target::parse("flask@latest");
+        let expected = Target::Latest("flask", PackageName::from_str("flask").unwrap(), vec![]);
+        assert_eq!(target, expected);
+
+        let target = Target::parse("flask[dotenv]@3.0.0");
+        let expected = Target::Version(
+            "flask",
+            PackageName::from_str("flask").unwrap(),
             vec![ExtraName::from_str("dotenv").unwrap()],
             Version::new([3, 0, 0]),
         );
         assert_eq!(target, expected);
 
-        let target = Target::parse("flask[dotenv]@latest", None);
-        let expected = Target::Latest("flask", vec![ExtraName::from_str("dotenv").unwrap()]);
+        let target = Target::parse("flask[dotenv]@latest");
+        let expected = Target::Latest(
+            "flask",
+            PackageName::from_str("flask").unwrap(),
+            vec![ExtraName::from_str("dotenv").unwrap()],
+        );
         assert_eq!(target, expected);
 
         // Missing a closing `]`.
-        let target = Target::parse("flask[dotenv", None);
+        let target = Target::parse("flask[dotenv");
         let expected = Target::Unspecified("flask[dotenv");
         assert_eq!(target, expected);
 
         // Too many `]`.
-        let target = Target::parse("flask[dotenv]]", None);
+        let target = Target::parse("flask[dotenv]]");
         let expected = Target::Unspecified("flask[dotenv]]");
         assert_eq!(target, expected);
     }

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -3351,3 +3351,57 @@ fn tool_install_python() {
     error: Cannot install Python with `uv tool install`. Did you mean to use `uv python install`?
     "###);
 }
+
+#[test]
+fn tool_install_mismatched_name() {
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--from")
+        .arg("https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Package name (`flask`) provided with `--from` does not match install request (`black`)
+    "###);
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--from")
+        .arg("flask @ https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Package name (`flask`) provided with `--from` does not match install request (`black`)
+    "###);
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("flask")
+        .arg("--from")
+        .arg("black @ https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Package name (`black`) provided with `--from` does not match install request (`flask`)
+    "###);
+}

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -655,6 +655,56 @@ fn tool_run_url() {
      + markupsafe==2.1.5
      + werkzeug==3.0.1
     "###);
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg("https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl")
+        .arg("flask")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 3.0.3
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    "###);
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("flask @ https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 3.0.3
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    "###);
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 3.0.3
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    "###);
 }
 
 /// Read requirements from a `requirements.txt` file.


### PR DESCRIPTION
## Summary

This PR refactors the whole `Target` abstraction, mostly to remove all the repeated `From*` variants and logic in favor of a higher-level struct that captures those details separately.

In doing so, it also adds support to `uvx` for unnamed requirements, for parity with `uv tool install`. So, e.g., the following will show the `flask` version:

```
uvx git+https://github.com/pallets/flask --version
```

I think this makes sense conceptually since we already support arbitrary named requirements there.
