### PR TITLE
Use a stable directory for (local) script virtual environments

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -109,6 +109,11 @@ impl CacheShard {
         fs_err::create_dir_all(self.as_ref())?;
         LockedFile::acquire(self.join(".lock"), self.display()).await
     }
+
+    /// Return the [`CacheShard`] as a [`PathBuf`].
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
 }
 
 impl AsRef<Path> for CacheShard {

--- a/crates/uv-resolver/src/redirect.rs
+++ b/crates/uv-resolver/src/redirect.rs
@@ -16,7 +16,7 @@ pub(crate) fn url_to_precise(url: VerbatimParsedUrl, git: &GitResolver) -> Verba
 
     let Some(new_git_url) = git.precise(git_url.clone()) else {
         if cfg!(debug_assertions) {
-            panic!("Unresolved Git URL: {}, {git_url:?}", url.verbatim,);
+            panic!("Unresolved Git URL: {}, {git_url:?}", url.verbatim);
         } else {
             return url;
         }

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -65,7 +65,7 @@ impl Pep723Item {
 }
 
 /// A reference to a PEP 723 item.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum Pep723ItemRef<'item> {
     /// A PEP 723 script read from disk.
     Script(&'item Pep723Script),

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -3,16 +3,12 @@ use tracing::debug;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::{cache_digest, hash_digest};
 use uv_client::Connectivity;
-use uv_configuration::{
-    Concurrency, DevGroupsManifest, ExtrasSpecification, InstallOptions, PreviewMode, TrustedHost,
-};
+use uv_configuration::{Concurrency, PreviewMode, TrustedHost};
 use uv_distribution_types::{Name, Resolution};
 use uv_python::{Interpreter, PythonEnvironment};
-use uv_resolver::Installable;
 
 use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::pip::operations::Modifications;
-use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::{
     resolve_environment, sync_environment, EnvironmentSpecification, PlatformState, ProjectError,
 };
@@ -68,93 +64,6 @@ impl CachedEnvironment {
             .await?,
         );
 
-        Self::from_resolution(
-            resolution,
-            interpreter,
-            settings,
-            state,
-            install,
-            installer_metadata,
-            connectivity,
-            concurrency,
-            native_tls,
-            allow_insecure_host,
-            cache,
-            printer,
-            preview,
-        )
-        .await
-    }
-
-    /// Get or create an [`CachedEnvironment`] based on a given [`InstallTarget`].
-    pub(crate) async fn from_lock(
-        target: InstallTarget<'_>,
-        extras: &ExtrasSpecification,
-        dev: &DevGroupsManifest,
-        install_options: InstallOptions,
-        settings: &ResolverInstallerSettings,
-        interpreter: &Interpreter,
-        state: &PlatformState,
-        install: Box<dyn InstallLogger>,
-        installer_metadata: bool,
-        connectivity: Connectivity,
-        concurrency: Concurrency,
-        native_tls: bool,
-        allow_insecure_host: &[TrustedHost],
-        cache: &Cache,
-        printer: Printer,
-        preview: PreviewMode,
-    ) -> Result<Self, ProjectError> {
-        let interpreter = Self::base_interpreter(interpreter, cache)?;
-
-        // Determine the tags, markers, and interpreter to use for resolution.
-        let tags = interpreter.tags()?;
-        let marker_env = interpreter.resolver_marker_environment();
-
-        // Read the lockfile.
-        let resolution = target.to_resolution(
-            &marker_env,
-            tags,
-            extras,
-            dev,
-            &settings.build_options,
-            &install_options,
-        )?;
-
-        Self::from_resolution(
-            resolution,
-            interpreter,
-            settings,
-            state,
-            install,
-            installer_metadata,
-            connectivity,
-            concurrency,
-            native_tls,
-            allow_insecure_host,
-            cache,
-            printer,
-            preview,
-        )
-        .await
-    }
-
-    /// Get or create an [`CachedEnvironment`] based on a given [`Resolution`].
-    pub(crate) async fn from_resolution(
-        resolution: Resolution,
-        interpreter: Interpreter,
-        settings: &ResolverInstallerSettings,
-        state: &PlatformState,
-        install: Box<dyn InstallLogger>,
-        installer_metadata: bool,
-        connectivity: Connectivity,
-        concurrency: Concurrency,
-        native_tls: bool,
-        allow_insecure_host: &[TrustedHost],
-        cache: &Cache,
-        printer: Printer,
-        preview: PreviewMode,
-    ) -> Result<Self, ProjectError> {
         // Hash the resolution by hashing the generated lockfile.
         // TODO(charlie): If the resolution contains any mutable metadata (like a path or URL
         // dependency), skip this step.

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -319,7 +319,6 @@ fn run_pep723_script() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
     "###);
 
     // But neither invocation should create a lockfile.
@@ -847,8 +846,7 @@ fn run_pep723_script_lock() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + iniconfig==2.0.0
+    Audited 1 package in [TIME]
     "###);
 
     // With a lockfile, running with `--locked` should not warn.
@@ -860,6 +858,7 @@ fn run_pep723_script_lock() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Audited 1 package in [TIME]
     "###);
 
     // Modify the metadata.
@@ -895,6 +894,7 @@ fn run_pep723_script_lock() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Audited 1 package in [TIME]
     Traceback (most recent call last):
       File "[TEMP_DIR]/main.py", line 8, in <module>
         import anyio
@@ -3276,8 +3276,6 @@ fn run_gui_script_explicit_windows() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved in [TIME]
-    Audited in [TIME]
     Using executable: pythonw.exe
     "###);
 
@@ -3341,9 +3339,7 @@ fn run_gui_script_explicit_unix() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved in [TIME]
-    Audited in [TIME]
-    Using executable: python3
+    Using executable: python
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

Today, scripts use `CachedEnvironment`, which results in a different virtual environment path every time the interpreter changes _or_ the project requirements change. This makes it impossible to provide users with a stable path to the script that they can use for (e.g.) directing their editor.

This PR modifies `uv run` to use a stable path for local scripts (we continue to use `CachedEnvironment` for remote scripts and scripts from `stdin`). The logic now looks a lot more like it does for projects: we `get_or_init` an environment, etc.

For now, the path to the script is like: `environments-v1/4485801245a4732f`, where `4485801245a4732f` is a SHA of the absolute path to the script. But I'm not picky on that :)
