### PR TITLE
Use stable environments for remote and stdin scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5604,6 +5604,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.11",
  "toml",
+ "url",
  "uv-pep440",
  "uv-pep508",
  "uv-pypi-types",

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -1,10 +1,12 @@
-use owo_colors::OwoColorize;
 use std::borrow::Cow;
 use std::env;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+use owo_colors::OwoColorize;
 use tracing::debug;
+
 use uv_cache::Cache;
 use uv_cache_key::cache_digest;
 use uv_fs::{LockedFile, Simplified};

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -23,3 +23,4 @@ memchr = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 toml = { workspace = true }
+url = { workspace = true }

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::LazyLock;
 use memchr::memmem::Finder;
 use serde::Deserialize;
 use thiserror::Error;
+use url::Url;
 
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::PackageName;
@@ -24,7 +25,7 @@ pub enum Pep723Item {
     /// A PEP 723 script provided via `stdin`.
     Stdin(Pep723Metadata),
     /// A PEP 723 script provided via a remote URL.
-    Remote(Pep723Metadata),
+    Remote(Pep723Metadata, Url),
 }
 
 impl Pep723Item {
@@ -33,7 +34,7 @@ impl Pep723Item {
         match self {
             Self::Script(script) => &script.metadata,
             Self::Stdin(metadata) => metadata,
-            Self::Remote(metadata) => metadata,
+            Self::Remote(metadata, ..) => metadata,
         }
     }
 
@@ -42,7 +43,7 @@ impl Pep723Item {
         match self {
             Self::Script(script) => script.metadata,
             Self::Stdin(metadata) => metadata,
-            Self::Remote(metadata) => metadata,
+            Self::Remote(metadata, ..) => metadata,
         }
     }
 
@@ -50,8 +51,8 @@ impl Pep723Item {
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Script(script) => Some(&script.path),
-            Self::Stdin(_) => None,
-            Self::Remote(_) => None,
+            Self::Stdin(..) => None,
+            Self::Remote(..) => None,
         }
     }
 
@@ -72,7 +73,7 @@ pub enum Pep723ItemRef<'item> {
     /// A PEP 723 script provided via `stdin`.
     Stdin(&'item Pep723Metadata),
     /// A PEP 723 script provided via a remote URL.
-    Remote(&'item Pep723Metadata),
+    Remote(&'item Pep723Metadata, &'item Url),
 }
 
 impl Pep723ItemRef<'_> {
@@ -81,7 +82,7 @@ impl Pep723ItemRef<'_> {
         match self {
             Self::Script(script) => &script.metadata,
             Self::Stdin(metadata) => metadata,
-            Self::Remote(metadata) => metadata,
+            Self::Remote(metadata, ..) => metadata,
         }
     }
 
@@ -89,8 +90,8 @@ impl Pep723ItemRef<'_> {
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Script(script) => Some(&script.path),
-            Self::Stdin(_) => None,
-            Self::Remote(_) => None,
+            Self::Stdin(..) => None,
+            Self::Remote(..) => None,
         }
     }
 }
@@ -100,7 +101,7 @@ impl<'item> From<&'item Pep723Item> for Pep723ItemRef<'item> {
         match item {
             Pep723Item::Script(script) => Self::Script(script),
             Pep723Item::Stdin(metadata) => Self::Stdin(metadata),
-            Pep723Item::Remote(metadata) => Self::Remote(metadata),
+            Pep723Item::Remote(metadata, url) => Self::Remote(metadata, url),
         }
     }
 }

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -157,11 +157,6 @@ impl CachedEnvironment {
         Ok(())
     }
 
-    /// Convert the [`CachedEnvironment`] into an [`Interpreter`].
-    pub(crate) fn into_interpreter(self) -> Interpreter {
-        self.0.into_interpreter()
-    }
-
     /// Return the [`Interpreter`] to use for the cached environment, based on a given
     /// [`Interpreter`].
     ///

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -178,9 +178,9 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     Err(Pep723Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => None,
                     Err(err) => return Err(err.into()),
                 },
-                Some(RunCommand::PythonRemote(script, _)) => {
+                Some(RunCommand::PythonRemote(url, script, _)) => {
                     match Pep723Metadata::read(&script).await {
-                        Ok(Some(metadata)) => Some(Pep723Item::Remote(metadata)),
+                        Ok(Some(metadata)) => Some(Pep723Item::Remote(metadata, url.clone())),
                         Ok(None) => None,
                         Err(Pep723Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
                             None
@@ -1571,8 +1571,8 @@ async fn run_project(
             // Unwrap the script.
             let script = script.map(|script| match script {
                 Pep723Item::Script(script) => script,
-                Pep723Item::Stdin(_) => unreachable!("`uv lock` does not support stdin"),
-                Pep723Item::Remote(_) => unreachable!("`uv lock` does not support remote files"),
+                Pep723Item::Stdin(..) => unreachable!("`uv lock` does not support stdin"),
+                Pep723Item::Remote(..) => unreachable!("`uv lock` does not support remote files"),
             });
 
             Box::pin(commands::lock(
@@ -1669,8 +1669,8 @@ async fn run_project(
             // Unwrap the script.
             let script = script.map(|script| match script {
                 Pep723Item::Script(script) => script,
-                Pep723Item::Stdin(_) => unreachable!("`uv remove` does not support stdin"),
-                Pep723Item::Remote(_) => unreachable!("`uv remove` does not support remote files"),
+                Pep723Item::Stdin(..) => unreachable!("`uv remove` does not support stdin"),
+                Pep723Item::Remote(..) => unreachable!("`uv remove` does not support remote files"),
             });
 
             Box::pin(commands::remove(
@@ -1711,8 +1711,8 @@ async fn run_project(
             // Unwrap the script.
             let script = script.map(|script| match script {
                 Pep723Item::Script(script) => script,
-                Pep723Item::Stdin(_) => unreachable!("`uv tree` does not support stdin"),
-                Pep723Item::Remote(_) => unreachable!("`uv tree` does not support remote files"),
+                Pep723Item::Stdin(..) => unreachable!("`uv tree` does not support stdin"),
+                Pep723Item::Remote(..) => unreachable!("`uv tree` does not support remote files"),
             });
 
             Box::pin(commands::tree(
@@ -1757,8 +1757,8 @@ async fn run_project(
             // Unwrap the script.
             let script = script.map(|script| match script {
                 Pep723Item::Script(script) => script,
-                Pep723Item::Stdin(_) => unreachable!("`uv export` does not support stdin"),
-                Pep723Item::Remote(_) => unreachable!("`uv export` does not support remote files"),
+                Pep723Item::Stdin(..) => unreachable!("`uv export` does not support stdin"),
+                Pep723Item::Remote(..) => unreachable!("`uv export` does not support remote files"),
             });
 
             commands::export(


### PR DESCRIPTION
## Summary

This is a follow-on to #11347 to use a stable directory for remote and stdin scripts. The annoying piece here was figuring out what to use as the cache key. For remote scripts, I'm using the URL; for stdin scripts, there isn't any identifying information, so I'm just using a hash of the metadata.
