### PR TITLE
Catch broken `mac_ver()`

### DIFF
--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -484,6 +484,7 @@ def get_operating_system_and_architecture():
 
         if not version or not architecture:
             print(json.dumps({"result": "error", "kind": "broken_mac_ver"}))
+            sys.exit(0)
 
         # https://github.com/pypa/packaging/blob/cc938f984bbbe43c5734b9656c9837ab3a28191f/src/packaging/tags.py#L356-L363
         is_32bit = struct.calcsize("P") == 4

--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -482,6 +482,9 @@ def get_operating_system_and_architecture():
         # https://github.com/astral-sh/uv/issues/2450
         version, _, architecture = platform.mac_ver()
 
+        if not version or not architecture:
+            print(json.dumps({"result": "error", "kind": "broken_mac_ver"}))
+
         # https://github.com/pypa/packaging/blob/cc938f984bbbe43c5734b9656c9837ab3a28191f/src/packaging/tags.py#L356-L363
         is_32bit = struct.calcsize("P") == 4
         if is_32bit:
@@ -559,7 +562,7 @@ def main() -> None:
     use_sysconfig_scheme = bool(
         getattr(sysconfig, "_PIP_USE_SYSCONFIG", sys.version_info >= (3, 10))
     )
-    
+
     # If we're not using sysconfig, make sure distutils is available.
     if not use_sysconfig_scheme:
         try:
@@ -575,7 +578,7 @@ def main() -> None:
                 __import__("_distutils_hack").remove_shim()
             except (ImportError, AttributeError):
                 pass
-            
+
             import distutils.dist
         except ImportError:
             # We require distutils, but it's not installed; this is fairly

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -698,6 +698,8 @@ enum InterpreterInfoResult {
 pub enum InterpreterInfoError {
     #[error("Could not detect a glibc or a musl libc (while running on Linux)")]
     LibcNotFound,
+    #[error("Broken Python installation, `platform.mac_ver()` returned an empty value, please reinstall Python")]
+    BrokenMacVer,
     #[error("Unknown operating system: `{operating_system}`")]
     UnknownOperatingSystem { operating_system: String },
     #[error("Python {python_version} is not supported. Please use Python 3.8 or newer.")]


### PR DESCRIPTION
A user reported a homebrew Python that would raise an exception in the interpreter probing script because `platform.mac_ver()` returned `('', ('', '', ''), '')` on his installation due to https://github.com/Homebrew/homebrew-core/issues/206778

This is easy enough to catch and show a proper error message instead of the Python backtrace.