### PR TITLE
Pin to the previous `setup-python` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1720,7 +1720,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.10"
 
@@ -1743,7 +1743,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.10"
           architecture: "x86"
@@ -1767,7 +1767,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.13"
           allow-prereleases: true


### PR DESCRIPTION
The latest release changes the message https://github.com/actions/setup-python/pull/968 but this has been an error for years?

<img width="1409" alt="Screenshot 2025-02-10 at 2 22 01 PM" src="https://github.com/user-attachments/assets/724dfedb-2bc2-4cd4-a1fb-a6fb21116716" />

Debugging #11397 
