### PR TITLE
Disable pip cache in Windows system test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1771,7 +1771,6 @@ jobs:
         with:
           python-version: "3.13"
           allow-prereleases: true
-          cache: pip
 
       - name: "Download binary"
         uses: actions/download-artifact@v4


### PR DESCRIPTION
I have no idea why we'd want the cache enabled here anyway?

Closes https://github.com/astral-sh/uv/issues/11397