### PR TITLE
Mark `sync::sync_dry_run` test as requiring `python-managed`

### DIFF
--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -6556,6 +6556,7 @@ fn find_links_relative_in_config_works_from_subdir() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
 fn sync_dry_run() -> Result<()> {
     let context = TestContext::new_with_versions(&["3.8", "3.12"]);
 


### PR DESCRIPTION
## Summary

Mark `sync::sync_dry_run` as requiring `python-managed`, as it fails with system Python executables due to extraneous Python packages being installed:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot: sync_dry_run
Source: crates/uv/tests/it/sync.rs:6574
────────────────────────────────────────────────────────────────────────────────
Expression: snapshot
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
    5     5 │ Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
    6     6 │ Would create virtual environment at: .venv
    7     7 │ Resolved 2 packages in [TIME]
    8     8 │ Would create lockfile at: uv.lock
    9       │-Would download 1 package
   10       │-Would install 1 package
   11       │- + iniconfig==2.0.0
          9 │+Would uninstall 1310 packages
         10 │+ - a2wsgi==1.10.8
[…]
```

## Test Plan

```
cargo test --no-default-features --features=python,pypi,git
```