### PR TITLE
Avoid comparing to system site packages in `--dry-run` mode

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -223,7 +223,7 @@ pub(crate) async fn add(
             AddTarget::Project(project, Box::new(PythonTarget::Interpreter(interpreter)))
         } else {
             // Discover or create the virtual environment.
-            let venv = ProjectEnvironment::get_or_init(
+            let environment = ProjectEnvironment::get_or_init(
                 project.workspace(),
                 python.as_deref().map(PythonRequest::parse),
                 &install_mirrors,
@@ -239,9 +239,9 @@ pub(crate) async fn add(
                 printer,
             )
             .await?
-            .into_environment();
+            .into_environment()?;
 
-            AddTarget::Project(project, Box::new(PythonTarget::Environment(venv)))
+            AddTarget::Project(project, Box::new(PythonTarget::Environment(environment)))
         }
     };
 

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -221,7 +221,7 @@ pub(crate) async fn remove(
                 AddTarget::Project(project, Box::new(PythonTarget::Interpreter(interpreter)))
             } else {
                 // Discover or create the virtual environment.
-                let venv = ProjectEnvironment::get_or_init(
+                let environment = ProjectEnvironment::get_or_init(
                     project.workspace(),
                     python.as_deref().map(PythonRequest::parse),
                     &install_mirrors,
@@ -237,9 +237,9 @@ pub(crate) async fn remove(
                     printer,
                 )
                 .await?
-                .into_environment();
+                .into_environment()?;
 
-                AddTarget::Project(project, Box::new(PythonTarget::Environment(venv)))
+                AddTarget::Project(project, Box::new(PythonTarget::Environment(environment)))
             }
         }
         RemoveTarget::Script(script) => {

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -656,7 +656,7 @@ pub(crate) async fn run(
                     printer,
                 )
                 .await?
-                .into_environment()
+                .into_environment()?
             };
 
             if no_sync {


### PR DESCRIPTION
## Summary

Right now, `uv sync --dry-run` returns the interpreter that _would've_ been used to create the environment; so we end up using _that_ interpreter's `site-packages`, and return changes relative to that interpreter. Instead, we now create a temporary virtual environment and compare against that.

Closes https://github.com/astral-sh/uv/issues/11422.
