### PR TITLE
Allow source distributions to produce wheels with +local suffixes

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -2576,7 +2576,7 @@ fn validate_metadata(
     }
 
     if let Some(version) = source.version() {
-        if metadata.version != *version {
+        if *version != metadata.version && *version != metadata.version.clone().without_local() {
             return Err(Error::WheelMetadataVersionMismatch {
                 metadata: metadata.version.clone(),
                 given: version.clone(),

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -192,7 +192,9 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                         return Err(Error::from_dist(dist, err, resolution));
                     }
                     if let Some(version) = dist.version() {
-                        if *version != cached.filename().version {
+                        if *version != cached.filename().version
+                            && *version != cached.filename().version.clone().without_local()
+                        {
                             let err = uv_distribution::Error::WheelMetadataVersionMismatch {
                                 given: version.clone(),
                                 metadata: cached.filename().version.clone(),


### PR DESCRIPTION
## Summary

We currently enforce that if you do `uv pip install ./dist/iniconfig-1.0.0.tar.gz`, the build _must_ produce a wheel like `iniconfig-1.0.0-py3-none-any.whl` (i.e., the name and version must match). It turns out some packages produce a wheel that has a local suffix on it, like `vllm`. This PR makes the check a little more permissive in that we now accept `1.0.0` or that version with a local suffix (e.g., `1.0.0+cpu`). I don't love this practice, but we already relaxed this check when _installing_ a wheel, so this seems reasonable:

https://github.com/astral-sh/uv/blob/5e15881dccc9201c10696cfcaf3a3e1ad8081f31/crates/uv-install-wheel/src/install.rs#L50-L52

Note that this is _still_ stricter than pip. pip seems to only require that the package name is the same (i.e., `iniconfig` matches `iniconfig`; but they'll happily install a wheel like `iniconfig-2.0.0-py3-none-any.whl` given `./dist/iniconfig-1.0.0.tar.gz`).

Closes https://github.com/astral-sh/uv/issues/11038.
