### PR TITLE
fix: make -p flag in  an alias for --python

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1087,7 +1087,14 @@ pub struct PipCompileArgs {
     ///
     /// See `uv help python` for details on Python discovery and supported
     /// request formats.
-    #[arg(long, verbatim_doc_comment, help_heading = "Python options", value_parser = parse_maybe_string)]
+    #[arg(
+        long = "python",
+        short = 'p',
+        env = EnvVars::UV_PYTHON,
+        verbatim_doc_comment,
+        help_heading = "Python options",
+        value_parser = parse_maybe_string
+    )]
     pub python: Option<Maybe<String>>,
 
     /// Install packages into the system Python environment.
@@ -1170,7 +1177,7 @@ pub struct PipCompileArgs {
     ///
     /// If a patch version is omitted, the minimum patch version is assumed. For
     /// example, `3.8` is mapped to `3.8.0`.
-    #[arg(long, short, help_heading = "Python options")]
+    #[arg(long = "python-version", help_heading = "Python options")]
     pub python_version: Option<PythonVersion>,
 
     /// The platform for which requirements should be resolved.
@@ -1340,13 +1347,11 @@ pub struct PipSyncArgs {
     /// be used with caution, as it can modify the system Python installation.
     ///
     /// See `uv help python` for details on Python discovery and supported request formats.
-    #[arg(
-        long,
-        short,
-        env = EnvVars::UV_PYTHON,
+    #[arg(long,
+        short = 'p',
         verbatim_doc_comment,
         help_heading = "Python options",
-        value_parser = parse_maybe_string,
+        value_parser = parse_maybe_string
     )]
     pub python: Option<Maybe<String>>,
 
@@ -1458,7 +1463,7 @@ pub struct PipSyncArgs {
     ///
     /// If a patch version is omitted, the minimum patch version is assumed. For example, `3.7` is
     /// mapped to `3.7.0`.
-    #[arg(long)]
+    #[arg(long, help_heading = "Python options")]
     pub python_version: Option<PythonVersion>,
 
     /// The platform for which requirements should be installed.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1347,11 +1347,13 @@ pub struct PipSyncArgs {
     /// be used with caution, as it can modify the system Python installation.
     ///
     /// See `uv help python` for details on Python discovery and supported request formats.
-    #[arg(long,
-        short = 'p',
+    #[arg(
+        long,
+        short,
+        env = EnvVars::UV_PYTHON,
         verbatim_doc_comment,
         help_heading = "Python options",
-        value_parser = parse_maybe_string
+        value_parser = parse_maybe_string,
     )]
     pub python: Option<Maybe<String>>,
 
@@ -1463,7 +1465,7 @@ pub struct PipSyncArgs {
     ///
     /// If a patch version is omitted, the minimum patch version is assumed. For example, `3.7` is
     /// mapped to `3.7.0`.
-    #[arg(long, help_heading = "Python options")]
+    #[arg(long)]
     pub python_version: Option<PythonVersion>,
 
     /// The platform for which requirements should be installed.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5824,7 +5824,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>This setting has no effect when used in the <code>uv pip</code> interface.</p>
 
-</dd><dt><code>--python</code> <i>python</i></dt><dd><p>The Python interpreter to use during resolution.</p>
+</dd><dt><code>--python</code>, <code>-p</code> <i>python</i></dt><dd><p>The Python interpreter to use during resolution.</p>
 
 <p>A Python interpreter is required for building source distributions to determine package metadata when there are not wheels.</p>
 
@@ -5832,6 +5832,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 
+<p>May also be set with the <code>UV_PYTHON</code> environment variable.</p>
 </dd><dt><code>--python-platform</code> <i>python-platform</i></dt><dd><p>The platform for which requirements should be resolved.</p>
 
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
@@ -5931,7 +5932,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <li><code>only-system</code>:  Only use system Python installations; never use managed Python installations</li>
 </ul>
-</dd><dt><code>--python-version</code>, <code>-p</code> <i>python-version</i></dt><dd><p>The Python version to use for resolution.</p>
+</dd><dt><code>--python-version</code> <i>python-version</i></dt><dd><p>The Python version to use for resolution.</p>
 
 <p>For example, <code>3.8</code> or <code>3.8.17</code>.</p>
 


### PR DESCRIPTION
closes #11285 

## Changes
- Modified the argument parsing in `PipCompileArgs` to make `-p` alias to `--python`
- Removed short form from `--python-version` option
- Added explicit long and short form specifications to avoid ambiguity