### PR TITLE
Update scripts docs with package indexes

### DIFF
--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -217,6 +217,22 @@ print(Point)
 is not installed — see the documentation on [Python versions](../concepts/python-versions.md) for
 more details.
 
+
+## Using Alternative Package Indexes
+
+If you wish to use an additional [package index](../configuration/indexes.md) to resolve dependencies, you can pass in the index with the `--index` option.
+```console
+$ uv add --index "https://example.com/simple" --script example.py 'requests<3' 'rich'
+```
+
+This will include the package data in the inline metadata:
+```python
+# [[tool.uv.index]]
+# url = "https://example.com/simple"
+```
+
+If you require authentication to access the package index, then please refer to [package index](../configuration/indexes.md).
+
 ## Locking dependencies
 
 uv supports locking dependencies for PEP 723 scripts using the `uv.lock` file format. Unlike with


### PR DESCRIPTION
## Summary

The [current scripts docs page](https://docs.astral.sh/uv/guides/scripts/) doesn't include detail on how to use a custom package index when setting up a script. I believe this might be because it didn't use to work (see #6688 ) but it now does (thanks for that, by the way! 😄) 

Given it's a useful feature, I suggest adding a quick example to the scripts page, with the details of authentication, etc. left to the main `indexes.md` doc.

I'd also suggests that this closes #6688, though it doesn't actually add that feature - that appears to have already been done :) 

## Test Plan

No testing is needed, I think!
