### PR TITLE
Optional schemars dependency

### DIFF
--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 uv-distribution-filename = { workspace = true }
 uv-fs = { workspace = true, features = ["serde"] }
 uv-git = { workspace = true }
-uv-normalize = { workspace = true, features = ["schemars"] }
+uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 
@@ -30,7 +30,7 @@ jiff = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true }
-schemars = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde-untagged = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -41,3 +41,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+
+[features]
+schemars = ["dep:schemars", "uv-normalize/schemars"]

--- a/crates/uv-pypi-types/src/conflicts.rs
+++ b/crates/uv-pypi-types/src/conflicts.rs
@@ -375,9 +375,8 @@ pub enum ConflictError {
 ///
 /// N.B. `Conflicts` is still used for (de)serialization. Specifically, in the
 /// lock file, where the package name is required.
-#[derive(
-    Debug, Default, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SchemaConflicts(Vec<SchemaConflictSet>);
 
 impl SchemaConflicts {
@@ -415,7 +414,8 @@ impl SchemaConflicts {
 /// schema format does not allow specifying the package name (or will make it
 /// optional in the future), where as the in-memory format needs the package
 /// name.
-#[derive(Debug, Default, Clone, Eq, PartialEq, schemars::JsonSchema, serde::Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SchemaConflictSet(Vec<SchemaConflictItem>);
 
 /// Like [`ConflictItem`], but for deserialization in `pyproject.toml`.
@@ -437,6 +437,7 @@ pub struct SchemaConflictItem {
     conflict: ConflictPackage,
 }
 
+#[cfg(feature = "schemars")]
 impl schemars::JsonSchema for SchemaConflictItem {
     fn schema_name() -> String {
         "SchemaConflictItem".to_string()
@@ -474,7 +475,8 @@ impl TryFrom<Vec<SchemaConflictItem>> for SchemaConflictSet {
 ///
 /// Each item is a pair of an (optional) package and a corresponding extra or group name for that
 /// package.
-#[derive(Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 struct ConflictItemWire {
     #[serde(default)]
     package: Option<PackageName>,

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -51,5 +51,8 @@ insta = { version = "1.40.0", features = ["filters", "json", "redactions"] }
 regex = { workspace = true }
 tempfile = { workspace = true }
 
+[features]
+schemars = ["dep:schemars", "uv-pypi-types/schemars"]
+
 [package.metadata.cargo-shear]
 ignored = ["uv-options-metadata"]


### PR DESCRIPTION
In preparation for `uv-build`, make schemars an optional dependency consistently, so it will not be part of the `uv-build` dependency tree.