### PR TITLE
More consistent `build-binaries.yml`

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,7 +52,7 @@ jobs:
           args: --out dist
       - name: "Test sdist"
         run: |
-          # We can't use find links here, since we need maturin, which means no `--no-index`, and without that option
+          # We can't use `--find-links` here, since we need maturin, which means no `--no-index`, and without that option
           # we run the risk that pip pull uv from PyPI instead.
           pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ${{ env.MODULE_NAME }} --help

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -318,6 +318,8 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
+            # TODO(konsti): figure out why this check is failing.
+            # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
@@ -384,6 +386,8 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
+            # TODO(konsti): figure out why this check is failing.
+            # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
@@ -464,6 +468,8 @@ jobs:
       #     run: |
       #       pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       #       ${{ env.MODULE_NAME }} --help
+      #       # TODO(konsti): figure out why this check is failing.
+      #       # python -m ${{ env.MODULE_NAME }} --helppython -m ${{ env.MODULE_NAME }} --help
       #       uvx --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
@@ -609,6 +615,8 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
+            # TODO(konsti): figure out why this check is failing.
+            # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -52,6 +52,8 @@ jobs:
           args: --out dist
       - name: "Test sdist"
         run: |
+          # We can't use find links here, since we need maturin, which means no `--no-index`, and without that option
+          # we run the risk that pip pull uv from PyPI instead.
           pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ${{ env.MODULE_NAME }} --help
           python -m ${{ env.MODULE_NAME }} --help
@@ -120,7 +122,7 @@ jobs:
           args: --release --locked --out dist --features self-update
       - name: "Test wheel - aarch64"
         run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
           ${{ env.MODULE_NAME }} --help
           python -m ${{ env.MODULE_NAME }} --help
           uvx --help
@@ -177,7 +179,7 @@ jobs:
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
-          python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
           ${{ env.MODULE_NAME }} --help
           python -m ${{ env.MODULE_NAME }} --help
           uvx --help
@@ -241,7 +243,7 @@ jobs:
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
           ${{ env.MODULE_NAME }} --help
           python -m ${{ env.MODULE_NAME }} --help
           uvx --help
@@ -314,7 +316,7 @@ jobs:
             apt-get install -y --no-install-recommends python3 python3-pip
             pip3 install -U pip
           run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
@@ -380,7 +382,7 @@ jobs:
             apt-get install -y --no-install-recommends python3 python3-pip
             pip3 install -U pip
           run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
@@ -460,7 +462,7 @@ jobs:
       #       apt-get install -y --no-install-recommends python3 python3-pip
       #       pip3 install -U pip
       #     run: |
-      #       pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+      #       pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       #       ${{ env.MODULE_NAME }} --help
       #       uvx --help
       - name: "Upload wheels"
@@ -590,7 +592,7 @@ jobs:
             apk add python3
           run: |
             python -m venv .venv
-            .venv/bin/pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            .venv/bin/pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             .venv/bin/${{ env.MODULE_NAME }} --help
             .venv/bin/uvx --help
       - uses: uraimo/run-on-arch-action@v2
@@ -605,7 +607,7 @@ jobs:
             apt-get install -y --no-install-recommends python3 python3-pip
             pip3 install -U pip
           run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -318,7 +318,7 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
-            # TODO(konsti): figure out why this check is failing.
+            # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
             # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
@@ -386,7 +386,7 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
-            # TODO(konsti): figure out why this check is failing.
+            # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
             # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"
@@ -468,7 +468,7 @@ jobs:
       #     run: |
       #       pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       #       ${{ env.MODULE_NAME }} --help
-      #       # TODO(konsti): figure out why this check is failing.
+      #       #(konsti) TODO: Enable this test on all platforms,currently `find_uv_bin` is failingto discover uv here.
       #       # python -m ${{ env.MODULE_NAME }} --helppython -m ${{ env.MODULE_NAME }} --help
       #       uvx --help
       - name: "Upload wheels"
@@ -615,7 +615,7 @@ jobs:
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
-            # TODO(konsti): figure out why this check is failing.
+            # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
             # python -m ${{ env.MODULE_NAME }} --help
             uvx --help
       - name: "Upload wheels"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -40,8 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -69,8 +67,6 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -111,8 +107,6 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -168,8 +162,6 @@ jobs:
             arch: x64 # not relevant here
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -219,8 +211,6 @@ jobs:
           - i686-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -300,8 +290,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -368,8 +356,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -442,8 +428,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -516,8 +500,6 @@ jobs:
           - i686-unknown-linux-musl
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -585,8 +567,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -313,7 +313,7 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
+            apt-get install -y --no-install-recommends python3 python3-pip python-is-python3
             pip3 install -U pip
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
@@ -379,7 +379,7 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
+            apt-get install -y --no-install-recommends python3 python3-pip python-is-python3
             pip3 install -U pip
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
@@ -459,7 +459,7 @@ jobs:
       #     githubToken: ${{ github.token }}
       #     install: |
       #       apt-get update
-      #       apt-get install -y --no-install-recommends python3 python3-pip
+      #       apt-get install -y --no-install-recommends python3 python3-pip python-is-python3
       #       pip3 install -U pip
       #     run: |
       #       pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
@@ -604,7 +604,7 @@ jobs:
           githubToken: ${{ github.token }}
           install: |
             apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
+            apt-get install -y --no-install-recommends python3 python3-pip python-is-python3
             pip3 install -U pip
           run: |
             pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -306,7 +306,7 @@ jobs:
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update
       - uses: uraimo/run-on-arch-action@v2
-        name: Test wheel
+        name: "Test wheel"
         with:
           arch: ${{ matrix.platform.arch == 'arm' && 'armv6' || matrix.platform.arch }}
           distro: ${{ matrix.platform.arch == 'arm' && 'bullseye' || 'ubuntu20.04' }}
@@ -372,7 +372,7 @@ jobs:
           args: --release --locked --out dist --features self-update
       - uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.arch != 'ppc64'
-        name: Test wheel
+        name: "Test wheel"
         with:
           arch: ${{ matrix.platform.arch }}
           distro: ubuntu20.04
@@ -452,7 +452,7 @@ jobs:
       # TODO(charlie): Re-enable testing for PPC wheels.
       # - uses: uraimo/run-on-arch-action@v2
       #   if: matrix.platform.arch != 'ppc64'
-      #   name: Test wheel
+      #   name: "Test wheel"
       #   with:
       #     arch: ${{ matrix.platform.arch }}
       #     distro: ubuntu20.04
@@ -583,7 +583,7 @@ jobs:
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
       - uses: uraimo/run-on-arch-action@v2
-        name: Test wheel
+        name: "Test wheel"
         with:
           arch: ${{ matrix.platform.arch }}
           distro: alpine_latest
@@ -596,7 +596,7 @@ jobs:
             .venv/bin/${{ env.MODULE_NAME }} --help
             .venv/bin/uvx --help
       - uses: uraimo/run-on-arch-action@v2
-        name: Test wheel (manylinux)
+        name: "Test wheel (manylinux)"
         if: matrix.platform.arch == 'aarch64'
         with:
           arch: aarch64


### PR DESCRIPTION
For uv-build, we need to duplicate a lot of the `build-binaries.yml` logic to build another source distribution and wheel. In preparation for that I tried to make the invocations more consistent, to make it easier to review the changes when adding the `uv-build` builds on top.

Split out from #11446