### PR TITLE
Short name for "--group" option

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3281,7 +3281,7 @@ pub struct AddArgs {
     /// Add the requirements to the specified dependency group.
     ///
     /// These requirements will not be included in the published metadata for the project.
-    #[arg(long, conflicts_with("dev"), conflicts_with("optional"))]
+    #[arg(long, short = 'G', conflicts_with("dev"), conflicts_with("optional"))]
     pub group: Option<GroupName>,
 
     /// Add the requirements as editable.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add short name `-G` for `--group` option in `uv add` command.

The `uv add --group` command is used quite often. Having short alternative form `uv add -G` will let user type less.
The `-G` short name also exists in Poetry and PDM.

## Test Plan

```console
$ uv help add

...

Options:
  -G, --group <GROUP>
          Add the requirements to the specified dependency group.
```