### PR TITLE
Validate dependency groups even when `--frozen` is present

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2622,6 +2622,11 @@ impl Package {
     pub fn provides_extras(&self) -> Option<&Vec<ExtraName>> {
         self.metadata.provides_extras.as_ref()
     }
+
+    /// Returns the dependency groups the package provides, if any.
+    pub fn dependency_groups(&self) -> &BTreeMap<GroupName, BTreeSet<Requirement>> {
+        &self.metadata.dependency_groups
+    }
 }
 
 /// Attempts to construct a `VerbatimUrl` from the given normalized `Path`.

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -1,6 +1,6 @@
 //! Resolve the current [`ProjectWorkspace`] or [`Workspace`].
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use glob::{glob, GlobError, PatternError};
@@ -19,8 +19,7 @@ use uv_warnings::warn_user_once;
 
 use crate::dependency_groups::{DependencyGroupError, FlatDependencyGroups};
 use crate::pyproject::{
-    DependencyGroups, Project, PyProjectToml, PyprojectTomlError, Sources, ToolUvSources,
-    ToolUvWorkspace,
+    Project, PyProjectToml, PyprojectTomlError, Sources, ToolUvSources, ToolUvWorkspace,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -486,44 +485,6 @@ impl Workspace {
             return vec![];
         };
         constraints.clone()
-    }
-
-    /// Returns the set of all dependency group names defined in the workspace.
-    pub fn groups(&self) -> BTreeSet<&GroupName> {
-        self.pyproject_toml
-            .dependency_groups
-            .iter()
-            .flat_map(DependencyGroups::keys)
-            .chain(
-                self.packages
-                    .values()
-                    .filter_map(|member| member.pyproject_toml.dependency_groups.as_ref())
-                    .flat_map(DependencyGroups::keys),
-            )
-            .chain(
-                if self
-                    .pyproject_toml
-                    .tool
-                    .as_ref()
-                    .and_then(|tool| tool.uv.as_ref())
-                    .and_then(|uv| uv.dev_dependencies.as_ref())
-                    .is_some()
-                    || self.packages.values().any(|member| {
-                        member
-                            .pyproject_toml
-                            .tool
-                            .as_ref()
-                            .and_then(|tool| tool.uv.as_ref())
-                            .and_then(|uv| uv.dev_dependencies.as_ref())
-                            .is_some()
-                    })
-                {
-                    Some(&*DEV_DEPENDENCIES)
-                } else {
-                    None
-                },
-            )
-            .collect()
     }
 
     /// The path to the workspace root, the directory containing the top level `pyproject.toml` with

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -23,8 +23,8 @@ use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
-    default_dependency_groups, detect_conflicts, DependencyGroupsTarget, ProjectError,
-    ProjectInterpreter, ScriptInterpreter, UniversalState,
+    default_dependency_groups, detect_conflicts, ProjectError, ProjectInterpreter,
+    ScriptInterpreter, UniversalState,
 };
 use crate::commands::{diagnostics, ExitStatus, OutputWriter};
 use crate::printer::Printer;
@@ -106,24 +106,6 @@ pub(crate) async fn export(
         };
         ExportTarget::Project(project)
     };
-
-    // Validate that any referenced dependency groups are defined in the workspace.
-    if !frozen {
-        let target = match &target {
-            ExportTarget::Project(VirtualProject::Project(project)) => {
-                if all_packages {
-                    DependencyGroupsTarget::Workspace(project.workspace())
-                } else {
-                    DependencyGroupsTarget::Project(project)
-                }
-            }
-            ExportTarget::Project(VirtualProject::NonProject(workspace)) => {
-                DependencyGroupsTarget::Workspace(workspace)
-            }
-            ExportTarget::Script(_) => DependencyGroupsTarget::Script,
-        };
-        target.validate(&dev)?;
-    }
 
     // Determine the default groups to include.
     let defaults = match &target {
@@ -267,6 +249,10 @@ pub(crate) async fn export(
             lock: &lock,
         },
     };
+
+    // Validate that the set of requested extras and development groups are defined in the lockfile.
+    target.validate_extras(&extras)?;
+    target.validate_groups(&dev)?;
 
     // Write the resolved dependencies to the output channel.
     let mut writer = OutputWriter::new(!quiet || output_file.is_none(), output_file.as_deref());

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -24,8 +24,7 @@ use crate::commands::pip::resolution_markers;
 use crate::commands::project::lock::{do_safe_lock, LockMode};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
-    default_dependency_groups, DependencyGroupsTarget, ProjectError, ProjectInterpreter,
-    ScriptInterpreter, UniversalState,
+    default_dependency_groups, ProjectError, ProjectInterpreter, ScriptInterpreter, UniversalState,
 };
 use crate::commands::reporters::LatestVersionReporter;
 use crate::commands::{diagnostics, ExitStatus};
@@ -71,15 +70,6 @@ pub(crate) async fn tree(
         workspace = Workspace::discover(project_dir, &DiscoveryOptions::default()).await?;
         LockTarget::Workspace(&workspace)
     };
-
-    // Validate that any referenced dependency groups are defined in the target.
-    if !frozen {
-        let target = match &target {
-            LockTarget::Workspace(workspace) => DependencyGroupsTarget::Workspace(workspace),
-            LockTarget::Script(..) => DependencyGroupsTarget::Script,
-        };
-        target.validate(&dev)?;
-    }
 
     // Determine the default groups to include.
     let defaults = match target {

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1917,6 +1917,7 @@ fn export_group() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = ["typing-extensions"]
+
         [dependency-groups]
         foo = ["anyio ; sys_platform == 'darwin'"]
         bar = ["iniconfig"]
@@ -2053,6 +2054,16 @@ fn export_group() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
+    "###);
+
+    uv_snapshot!(context.filters(), context.export().arg("--all-groups").arg("--no-group").arg("baz"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    error: Group `baz` is not defined in the project's `dependency-groups` table
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

We now use the same strategy as for extras, validating against the lockfile instead of the `pyproject.toml`.

Closes https://github.com/astral-sh/uv/issues/10882.
