### PR TITLE
Use a 'minor' version field (`revision`) in the lockfile

### DIFF
--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -86,8 +87,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -93,8 +94,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -89,8 +90,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -79,8 +80,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },
@@ -149,8 +150,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -79,8 +80,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },
@@ -149,8 +150,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_dynamic.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -54,8 +55,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },
@@ -101,8 +102,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },
@@ -165,8 +166,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -79,8 +80,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },
@@ -149,8 +150,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -63,8 +64,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -61,8 +62,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -56,8 +57,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -5,6 +5,7 @@ expression: result
 Ok(
     Lock {
         version: 1,
+        revision: 0,
         fork_markers: [],
         conflicts: Conflicts(
             [],
@@ -56,8 +57,8 @@ Ok(
                 optional_dependencies: {},
                 dependency_groups: {},
                 metadata: PackageMetadata {
-                    requires_dist: None,
-                    provides_extras: None,
+                    requires_dist: {},
+                    provides_extras: [],
                     dependency_groups: {},
                 },
             },

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -259,8 +259,8 @@ impl<'lock> InstallTarget<'lock> {
             Self::Project { lock, .. }
             | Self::Workspace { lock, .. }
             | Self::NonProjectWorkspace { lock, .. } => {
-                // `provides-extra` was added in Revision 1.
-                if lock.revision() == 0 {
+                // `provides-extra` was added in Version 1 Revision 1.
+                if (lock.version(), lock.revision()) < (1, 1) {
                     return Ok(());
                 }
 

--- a/crates/uv/tests/it/branching_urls.rs
+++ b/crates/uv/tests/it/branching_urls.rs
@@ -203,8 +203,9 @@ fn root_package_splits_transitive_too() -> Result<()> {
     "###
     );
 
-    assert_snapshot!(context.read("uv.lock"), @r#"
+    assert_snapshot!(context.read("uv.lock"), @r###"
     version = 1
+    revision = 1
     requires-python = ">=3.11, <3.13"
     resolution-markers = [
         "python_full_version >= '3.12'",
@@ -225,7 +226,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "anyio", marker = "python_full_version < '3.12'", specifier = "==4.2.0" },
         { name = "anyio", marker = "python_full_version >= '3.12'", specifier = "==4.3.0" },
@@ -274,7 +274,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "b1", marker = "python_full_version < '3.12'", directory = "b1" },
         { name = "b2", marker = "python_full_version >= '3.12'", directory = "b2" },
@@ -289,7 +288,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [{ name = "iniconfig", url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }]
 
     [[package]]
@@ -301,7 +299,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [{ name = "iniconfig", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }]
 
     [[package]]
@@ -324,10 +321,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
         { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3" },
     ]
 
-    [package.metadata]
-    provides-extras = []
-    requires-dist = []
-
     [[package]]
     name = "iniconfig"
     version = "2.0.0"
@@ -339,10 +332,6 @@ fn root_package_splits_transitive_too() -> Result<()> {
         { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
     ]
 
-    [package.metadata]
-    provides-extras = []
-    requires-dist = []
-
     [[package]]
     name = "sniffio"
     version = "1.3.1"
@@ -351,7 +340,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     wheels = [
         { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
     ]
-    "#);
+    "###);
 
     Ok(())
 }
@@ -412,6 +401,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
 
     assert_snapshot!(context.read("uv.lock"), @r#"
     version = 1
+    revision = 1
     requires-python = ">=3.11, <3.13"
     resolution-markers = [
         "python_full_version >= '3.12'",
@@ -433,7 +423,6 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "anyio", marker = "python_full_version < '3.12'", specifier = "==4.2.0" },
         { name = "anyio", marker = "python_full_version >= '3.12'", specifier = "==4.3.0" },
@@ -482,7 +471,6 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [{ name = "iniconfig", specifier = "==1.1.1" }]
 
     [[package]]
@@ -494,7 +482,6 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
 
     [[package]]
@@ -574,8 +561,9 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     );
 
     // We have source dist and wheel for the registry, but only the wheel for the direct URL.
-    assert_snapshot!(context.read("uv.lock"), @r#"
+    assert_snapshot!(context.read("uv.lock"), @r###"
     version = 1
+    revision = 1
     requires-python = ">=3.11, <3.13"
     resolution-markers = [
         "python_full_version >= '3.12'",
@@ -595,7 +583,6 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "iniconfig", marker = "python_full_version < '3.12'", specifier = "==1.1.1" },
         { name = "iniconfig", marker = "python_full_version >= '3.12'", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" },
@@ -623,11 +610,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     wheels = [
         { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
     ]
-
-    [package.metadata]
-    provides-extras = []
-    requires-dist = []
-    "#);
+    "###);
 
     Ok(())
 }
@@ -665,8 +648,9 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     );
 
     // We have source dist and wheel for the registry, but only the wheel for the direct URL.
-    assert_snapshot!(context.read("uv.lock"), @r#"
+    assert_snapshot!(context.read("uv.lock"), @r###"
     version = 1
+    revision = 1
     requires-python = ">=3.11, <3.13"
     resolution-markers = [
         "python_full_version >= '3.12'",
@@ -686,7 +670,6 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "iniconfig", marker = "python_full_version < '3.12'", url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" },
         { name = "iniconfig", marker = "python_full_version >= '3.12'", git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" },
@@ -703,10 +686,6 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
         { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3" },
     ]
 
-    [package.metadata]
-    provides-extras = []
-    requires-dist = []
-
     [[package]]
     name = "iniconfig"
     version = "2.0.0"
@@ -714,7 +693,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     resolution-markers = [
         "python_full_version >= '3.12'",
     ]
-    "#);
+    "###);
 
     Ok(())
 }
@@ -798,8 +777,9 @@ fn dont_pre_visit_url_packages() -> Result<()> {
     "###
     );
 
-    assert_snapshot!(context.read("uv.lock"), @r#"
+    assert_snapshot!(context.read("uv.lock"), @r###"
     version = 1
+    revision = 1
     requires-python = ">=3.11, <3.13"
 
     [options]
@@ -815,7 +795,6 @@ fn dont_pre_visit_url_packages() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [
         { name = "b", directory = "b" },
         { name = "c", specifier = "==0.1.0" },
@@ -830,18 +809,13 @@ fn dont_pre_visit_url_packages() -> Result<()> {
     ]
 
     [package.metadata]
-    provides-extras = []
     requires-dist = [{ name = "c", directory = "c" }]
 
     [[package]]
     name = "c"
     version = "0.1.0"
     source = { directory = "c" }
-
-    [package.metadata]
-    provides-extras = []
-    requires-dist = []
-    "#);
+    "###);
 
     Ok(())
 }

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -75,6 +75,7 @@ fn add_registry() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -111,7 +112,6 @@ fn add_registry() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -243,6 +243,7 @@ fn add_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -280,7 +281,6 @@ fn add_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", specifier = "==3.7.0" },
             { name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" },
@@ -383,6 +383,7 @@ fn add_git_private_source() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -397,7 +398,6 @@ fn add_git_private_source() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
 
         [[package]]
@@ -490,6 +490,7 @@ fn add_git_private_raw() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -504,7 +505,6 @@ fn add_git_private_raw() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
 
         [[package]]
@@ -711,6 +711,7 @@ fn add_git_raw() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -748,7 +749,6 @@ fn add_git_raw() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", specifier = "==3.7.0" },
             { name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.1" },
@@ -976,6 +976,7 @@ fn add_unnamed() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -990,7 +991,6 @@ fn add_unnamed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" }]
 
         [[package]]
@@ -1079,8 +1079,9 @@ fn add_remove_dev() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1119,8 +1120,6 @@ fn add_remove_dev() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = [{ name = "anyio", specifier = "==3.7.0" }]
@@ -1133,7 +1132,7 @@ fn add_remove_dev() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1204,8 +1203,9 @@ fn add_remove_dev() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1217,12 +1217,10 @@ fn add_remove_dev() -> Result<()> {
         source = { editable = "." }
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = []
-        "#
+        "###
         );
     });
 
@@ -1304,8 +1302,9 @@ fn add_remove_optional() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1344,8 +1343,8 @@ fn add_remove_optional() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["io"]
         requires-dist = [{ name = "anyio", marker = "extra == 'io'", specifier = "==3.7.0" }]
+        provides-extras = ["io"]
 
         [[package]]
         name = "sniffio"
@@ -1355,7 +1354,7 @@ fn add_remove_optional() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1427,8 +1426,9 @@ fn add_remove_optional() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1441,8 +1441,7 @@ fn add_remove_optional() -> Result<()> {
 
         [package.metadata]
         provides-extras = ["io"]
-        requires-dist = []
-        "#
+        "###
         );
     });
 
@@ -1670,6 +1669,7 @@ fn add_remove_workspace() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1690,17 +1690,12 @@ fn add_remove_workspace() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child2", editable = "child2" }]
 
         [[package]]
         name = "child2"
         version = "0.1.0"
         source = { editable = "child2" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -1758,6 +1753,7 @@ fn add_remove_workspace() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1774,18 +1770,10 @@ fn add_remove_workspace() -> Result<()> {
         version = "0.1.0"
         source = { editable = "child1" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "child2"
         version = "0.1.0"
         source = { editable = "child2" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -2313,6 +2301,7 @@ fn add_workspace_editable() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2334,7 +2323,6 @@ fn add_workspace_editable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child2", editable = "child2" }]
 
         [[package]]
@@ -2342,18 +2330,10 @@ fn add_workspace_editable() -> Result<()> {
         version = "0.1.0"
         source = { editable = "child2" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "parent"
         version = "0.1.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -2446,6 +2426,7 @@ fn add_workspace_path() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2462,10 +2443,6 @@ fn add_workspace_path() -> Result<()> {
         version = "0.1.0"
         source = { editable = "child" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "parent"
         version = "0.1.0"
@@ -2475,7 +2452,6 @@ fn add_workspace_path() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child", editable = "child" }]
         "#
         );
@@ -2574,6 +2550,7 @@ fn add_path() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2584,10 +2561,6 @@ fn add_path() -> Result<()> {
         version = "0.1.0"
         source = { directory = "packages/child" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "parent"
         version = "0.1.0"
@@ -2597,7 +2570,6 @@ fn add_path() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child", directory = "packages/child" }]
         "#
         );
@@ -2786,6 +2758,7 @@ fn update() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2851,7 +2824,6 @@ fn update() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "requests", extras = ["security"], git = "https://github.com/psf/requests?tag=v2.32.3" },
             { name = "requests", extras = ["socks", "use-chardet-on-py3"], marker = "python_full_version >= '3.8'", git = "https://github.com/psf/requests?tag=v2.32.3" },
@@ -3482,6 +3454,7 @@ fn add_inexact() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3505,7 +3478,6 @@ fn add_inexact() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -3622,6 +3594,7 @@ fn remove_registry() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3631,10 +3604,6 @@ fn remove_registry() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -4307,8 +4276,9 @@ fn add_lower_bound_optional() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -4347,8 +4317,8 @@ fn add_lower_bound_optional() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["io"]
         requires-dist = [{ name = "anyio", marker = "extra == 'io'", specifier = ">=4.3.0" }]
+        provides-extras = ["io"]
 
         [[package]]
         name = "sniffio"
@@ -4358,7 +4328,7 @@ fn add_lower_bound_optional() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -4430,6 +4400,7 @@ fn add_lower_bound_local() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [[package]]
@@ -4450,7 +4421,6 @@ fn add_lower_bound_local() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "local-simple-a", specifier = ">=1.2.3" }]
         "#
         );
@@ -4532,6 +4502,7 @@ fn add_non_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -5491,8 +5462,9 @@ fn add_remove_script_lock() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -5627,7 +5599,7 @@ fn add_remove_script_lock() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d", size = 121067 },
         ]
-        "#
+        "###
         );
     });
 
@@ -5675,6 +5647,7 @@ fn add_remove_script_lock() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -5879,6 +5852,7 @@ fn add_remove_script_lock() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -6850,6 +6824,7 @@ fn add_warn_index_url() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6873,7 +6848,6 @@ fn add_warn_index_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "idna", specifier = ">=3.6" }]
         "#
         );
@@ -6952,6 +6926,7 @@ fn add_no_warn_index_url() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6975,7 +6950,6 @@ fn add_no_warn_index_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2.0.0" }]
         "#
         );
@@ -7045,6 +7019,7 @@ fn add_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7071,7 +7046,6 @@ fn add_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -7131,6 +7105,7 @@ fn add_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7183,7 +7158,6 @@ fn add_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", specifier = "==2.0.0" },
             { name = "jinja2", specifier = ">=3.1.4", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu121" },
@@ -7243,6 +7217,7 @@ fn add_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7300,7 +7275,6 @@ fn add_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", specifier = "==2.0.0" },
             { name = "jinja2", specifier = ">=3.1.4", index = "https://test.pypi.org/simple" },
@@ -7363,6 +7337,7 @@ fn add_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7421,7 +7396,6 @@ fn add_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", specifier = "==2.0.0" },
             { name = "jinja2", specifier = ">=3.1.4", index = "https://test.pypi.org/simple" },
@@ -7492,6 +7466,7 @@ fn add_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7550,7 +7525,6 @@ fn add_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", specifier = "==2.0.0" },
             { name = "jinja2", specifier = ">=3.1.4", index = "https://test.pypi.org/simple" },
@@ -7628,6 +7602,7 @@ fn add_default_index_url() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7651,7 +7626,6 @@ fn add_default_index_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2.0.0" }]
         "#
         );
@@ -7701,6 +7675,7 @@ fn add_default_index_url() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7725,7 +7700,6 @@ fn add_default_index_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", specifier = ">=2.0.0" },
             { name = "typing-extensions", specifier = ">=4.10.0" },
@@ -7802,6 +7776,7 @@ fn add_index_credentials() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7825,7 +7800,6 @@ fn add_index_credentials() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -7898,6 +7872,7 @@ fn existing_index_credentials() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7921,7 +7896,6 @@ fn existing_index_credentials() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -7991,6 +7965,7 @@ fn add_index_with_trailing_slash() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8017,7 +7992,6 @@ fn add_index_with_trailing_slash() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -8087,6 +8061,7 @@ fn add_index_without_trailing_slash() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8113,7 +8088,6 @@ fn add_index_without_trailing_slash() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -8190,8 +8164,9 @@ fn add_group_comment() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -8221,8 +8196,6 @@ fn add_group_comment() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = [
@@ -8248,7 +8221,7 @@ fn add_group_comment() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -8327,6 +8300,7 @@ fn add_index_comments() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8350,7 +8324,6 @@ fn add_index_comments() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0" }]
         "#
         );
@@ -8629,6 +8602,7 @@ fn add_direct_url_subdirectory() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8665,7 +8639,6 @@ fn add_direct_url_subdirectory() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "root", url = "https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz", subdirectory = "packages/root" }]
 
         [[package]]
@@ -8678,7 +8651,6 @@ fn add_direct_url_subdirectory() -> Result<()> {
         sdist = { hash = "sha256:24b55efee28d08ad3cdc58903e359e820601baa6a4a4b3424311541ebcfb09d3" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -8769,6 +8741,7 @@ fn add_direct_url_subdirectory_raw() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8805,7 +8778,6 @@ fn add_direct_url_subdirectory_raw() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "root", url = "https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz", subdirectory = "packages/root" }]
 
         [[package]]
@@ -8818,7 +8790,6 @@ fn add_direct_url_subdirectory_raw() -> Result<()> {
         sdist = { hash = "sha256:24b55efee28d08ad3cdc58903e359e820601baa6a4a4b3424311541ebcfb09d3" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -9482,6 +9453,7 @@ fn repeated_index_cli_environment_variable() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9505,7 +9477,6 @@ fn repeated_index_cli_environment_variable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2.0.0" }]
         "#
         );
@@ -9592,6 +9563,7 @@ fn repeated_index_cli() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9615,7 +9587,6 @@ fn repeated_index_cli() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2.0.0" }]
         "#
         );
@@ -9702,6 +9673,7 @@ fn repeated_index_cli_reversed() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9725,7 +9697,6 @@ fn repeated_index_cli_reversed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2.0.0" }]
         "#
         );

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -520,8 +520,9 @@ fn dependency_conflicting_markers() -> Result<()> {
         },
         {
             insta::assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.12"
             resolution-markers = [
                 "sys_platform == 'darwin'",
@@ -594,7 +595,6 @@ fn dependency_conflicting_markers() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "trio", marker = "sys_platform == 'darwin'", specifier = "==0.25.0" },
                 { name = "trio", marker = "sys_platform == 'win32'", specifier = "==0.10.0" },
@@ -663,7 +663,7 @@ fn dependency_conflicting_markers() -> Result<()> {
             wheels = [
                 { url = "https://files.pythonhosted.org/packages/17/c9/f86f89f14d52f9f2f652ce24cb2f60141a51d087db1563f3fba94ba07346/trio-0.25.0-py3-none-any.whl", hash = "sha256:e6458efe29cc543e557a91e614e2b51710eba2961669329ce9c862d50c6e8e81", size = 467161 },
             ]
-            "#
+            "###
             );
         }
     );
@@ -1218,8 +1218,9 @@ fn non_project_fork() -> Result<()> {
         },
         {
             insta::assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.12"
             resolution-markers = [
                 "sys_platform == 'win32'",
@@ -1281,7 +1282,6 @@ fn non_project_fork() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "anyio", marker = "sys_platform == 'linux'", specifier = "==3.0.0" },
                 { name = "anyio", marker = "sys_platform == 'win32'", specifier = "==2.0.0" },
@@ -1304,7 +1304,7 @@ fn non_project_fork() -> Result<()> {
             wheels = [
                 { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
             ]
-            "#
+            "###
             );
         }
     );
@@ -2115,8 +2115,9 @@ fn script() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
         resolution-markers = [
             "sys_platform == 'win32'",
@@ -2182,7 +2183,7 @@ fn script() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -2233,6 +2234,7 @@ fn script() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
         resolution-markers = [
             "sys_platform == 'win32'",

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -45,6 +45,7 @@ fn lock_wheel_registry() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -81,7 +82,6 @@ fn lock_wheel_registry() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -177,6 +177,7 @@ fn lock_sdist_registry() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -191,7 +192,6 @@ fn lock_sdist_registry() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "source-distribution", specifier = "==0.0.1" }]
 
         [[package]]
@@ -275,6 +275,7 @@ fn lock_sdist_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -289,7 +290,6 @@ fn lock_sdist_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" }]
 
         [[package]]
@@ -365,6 +365,7 @@ fn lock_sdist_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -379,7 +380,6 @@ fn lock_sdist_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }]
 
         [[package]]
@@ -422,6 +422,7 @@ fn lock_sdist_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -436,7 +437,6 @@ fn lock_sdist_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }]
 
         [[package]]
@@ -479,6 +479,7 @@ fn lock_sdist_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -493,7 +494,6 @@ fn lock_sdist_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.2" }]
 
         [[package]]
@@ -541,6 +541,7 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -560,7 +561,6 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "example-pkg-a", git = "https://github.com/pypa/sample-namespace-packages.git?subdirectory=pkg_resources%2Fpkg_a&rev=df7530eeb8fa0cb7dbb8ecb28363e8e36bfa2f45" }]
         "#
         );
@@ -635,6 +635,7 @@ fn lock_sdist_git_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -649,7 +650,6 @@ fn lock_sdist_git_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage.git?rev=0.0.1" }]
 
         [[package]]
@@ -699,6 +699,7 @@ fn lock_sdist_git_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -713,7 +714,6 @@ fn lock_sdist_git_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage.git?rev=0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }]
 
         [[package]]
@@ -753,6 +753,7 @@ fn lock_sdist_git_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -767,7 +768,6 @@ fn lock_sdist_git_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage.git?rev=b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }]
 
         [[package]]
@@ -807,6 +807,7 @@ fn lock_sdist_git_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -821,7 +822,6 @@ fn lock_sdist_git_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage.git?rev=0.0.2" }]
 
         [[package]]
@@ -872,6 +872,7 @@ fn lock_sdist_git_short_rev() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -886,7 +887,6 @@ fn lock_sdist_git_short_rev() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=0dacfd6" }]
 
         [[package]]
@@ -974,8 +974,9 @@ fn lock_wheel_url() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -994,7 +995,6 @@ fn lock_wheel_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["doc", "test", "trio"]
         requires-dist = [
             { name = "anyio", extras = ["trio"], marker = "extra == 'test'" },
             { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
@@ -1015,6 +1015,7 @@ fn lock_wheel_url() -> Result<()> {
             { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1" },
             { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'test'", specifier = ">=0.17" },
         ]
+        provides-extras = ["doc", "test", "trio"]
 
         [[package]]
         name = "idna"
@@ -1034,7 +1035,6 @@ fn lock_wheel_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl" }]
 
         [[package]]
@@ -1045,7 +1045,7 @@ fn lock_wheel_url() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1128,8 +1128,9 @@ fn lock_sdist_url() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1146,7 +1147,6 @@ fn lock_sdist_url() -> Result<()> {
         sdist = { hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" }
 
         [package.metadata]
-        provides-extras = ["doc", "test", "trio"]
         requires-dist = [
             { name = "anyio", extras = ["trio"], marker = "extra == 'test'" },
             { name = "coverage", extras = ["toml"], marker = "extra == 'test'", specifier = ">=7" },
@@ -1167,6 +1167,7 @@ fn lock_sdist_url() -> Result<()> {
             { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1" },
             { name = "uvloop", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'test'", specifier = ">=0.17" },
         ]
+        provides-extras = ["doc", "test", "trio"]
 
         [[package]]
         name = "idna"
@@ -1186,7 +1187,6 @@ fn lock_sdist_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz" }]
 
         [[package]]
@@ -1197,7 +1197,7 @@ fn lock_sdist_url() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1274,6 +1274,7 @@ fn lock_sdist_url_subdirectory() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1310,7 +1311,6 @@ fn lock_sdist_url_subdirectory() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "root", url = "https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz", subdirectory = "packages/root" }]
 
         [[package]]
@@ -1323,7 +1323,6 @@ fn lock_sdist_url_subdirectory() -> Result<()> {
         sdist = { hash = "sha256:24b55efee28d08ad3cdc58903e359e820601baa6a4a4b3424311541ebcfb09d3" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -1409,6 +1408,7 @@ fn lock_sdist_url_subdirectory_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1445,7 +1445,6 @@ fn lock_sdist_url_subdirectory_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "root", url = "https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz", subdirectory = "packages/root" }]
 
         [[package]]
@@ -1458,7 +1457,6 @@ fn lock_sdist_url_subdirectory_pep508() -> Result<()> {
         sdist = { hash = "sha256:24b55efee28d08ad3cdc58903e359e820601baa6a4a4b3424311541ebcfb09d3" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -1545,8 +1543,9 @@ fn lock_project_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1597,11 +1596,11 @@ fn lock_project_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["test"]
         requires-dist = [
             { name = "anyio", specifier = "==3.7.0" },
             { name = "iniconfig", marker = "extra == 'test'" },
         ]
+        provides-extras = ["test"]
 
         [[package]]
         name = "sniffio"
@@ -1611,7 +1610,7 @@ fn lock_project_extra() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1917,6 +1916,7 @@ fn lock_dependency_extra() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2021,7 +2021,6 @@ fn lock_dependency_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "flask", extras = ["dotenv"] }]
 
         [[package]]
@@ -2115,6 +2114,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7"
         resolution-markers = [
             "python_full_version >= '3.10'",
@@ -2250,7 +2250,6 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "requests" },
             { name = "requests", extras = ["socks"], marker = "python_full_version < '3.10'" },
@@ -2413,6 +2412,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2512,7 +2512,6 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "flask", extras = ["foo"] }]
 
         [[package]]
@@ -2594,6 +2593,7 @@ fn lock_upgrade_log() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2624,7 +2624,6 @@ fn lock_upgrade_log() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig" },
             { name = "markupsafe", specifier = "<2" },
@@ -2676,6 +2675,7 @@ fn lock_upgrade_log() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2709,7 +2709,6 @@ fn lock_upgrade_log() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "markupsafe" },
             { name = "typing-extensions" },
@@ -2764,6 +2763,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform != 'win32'",
@@ -2801,7 +2801,6 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "markupsafe", marker = "sys_platform != 'win32'", specifier = "<2" },
             { name = "markupsafe", marker = "sys_platform == 'win32'", specifier = "==2.0.0" },
@@ -2850,6 +2849,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2882,7 +2882,6 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "markupsafe" }]
         "#
         );
@@ -2924,6 +2923,7 @@ fn lock_preference() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2947,7 +2947,6 @@ fn lock_preference() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "<2" }]
         "#
         );
@@ -2984,6 +2983,7 @@ fn lock_preference() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3007,7 +3007,6 @@ fn lock_preference() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -3031,6 +3030,7 @@ fn lock_preference() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3054,7 +3054,6 @@ fn lock_preference() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -3100,6 +3099,7 @@ fn lock_git_plus_prefix() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3114,7 +3114,6 @@ fn lock_git_plus_prefix() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage" }]
 
         [[package]]
@@ -3186,6 +3185,7 @@ fn lock_partial_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
         resolution-markers = [
             "python_full_version >= '3.12'",
@@ -3253,7 +3253,6 @@ fn lock_partial_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", marker = "python_full_version < '3.12'", git = "https://github.com/agronholm/anyio?rev=4.6.2" },
             { name = "anyio", marker = "python_full_version >= '3.12'" },
@@ -3326,6 +3325,7 @@ fn lock_unsupported_tag() -> Result<()> {
     let lock = context.temp_dir.child("uv.lock");
     lock.write_str(r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12.0"
 
         [options]
@@ -3412,6 +3412,7 @@ fn lock_git_sha() -> Result<()> {
     let lock = context.temp_dir.child("uv.lock");
     lock.write_str(r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3476,6 +3477,7 @@ fn lock_git_sha() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3490,7 +3492,6 @@ fn lock_git_sha() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=main" }]
 
         [[package]]
@@ -3576,6 +3577,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7"
         resolution-markers = [
             "python_full_version >= '3.8'",
@@ -3704,7 +3706,6 @@ fn lock_requires_python() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "pygls" }]
 
         [[package]]
@@ -3867,6 +3868,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7.9"
         resolution-markers = [
             "python_full_version >= '3.8'",
@@ -3986,7 +3988,6 @@ fn lock_requires_python() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "pygls" }]
 
         [[package]]
@@ -4087,6 +4088,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -4135,7 +4137,6 @@ fn lock_requires_python() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "pygls" }]
 
         [[package]]
@@ -4221,6 +4222,7 @@ fn lock_requires_python_upper() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
 
         [options]
@@ -4290,7 +4292,6 @@ fn lock_requires_python_upper() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "pydantic" }]
         "#
         );
@@ -4346,6 +4347,7 @@ fn lock_requires_python_exact() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.13"
 
         [options]
@@ -4369,7 +4371,6 @@ fn lock_requires_python_exact() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -4424,6 +4425,7 @@ fn lock_requires_python_fork() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.9"
 
         [options]
@@ -4463,7 +4465,6 @@ fn lock_requires_python_fork() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv", marker = "python_full_version >= '3.8'" }]
         "#
         );
@@ -4519,6 +4520,7 @@ fn lock_requires_python_wheels() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.12.*"
 
         [options]
@@ -4557,7 +4559,6 @@ fn lock_requires_python_wheels() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "frozenlist" }]
         "#
         );
@@ -4603,6 +4604,7 @@ fn lock_requires_python_wheels() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
 
         [options]
@@ -4641,7 +4643,6 @@ fn lock_requires_python_wheels() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "frozenlist" }]
         "#
         );
@@ -4697,6 +4698,7 @@ fn lock_requires_python_star() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
 
         [options]
@@ -4755,7 +4757,6 @@ fn lock_requires_python_star() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "linehaul" }]
 
         [[package]]
@@ -4819,6 +4820,7 @@ fn lock_requires_python_not_equal() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">3.10, !=3.10.9, !=3.10.10, !=3.11.*, <3.13"
 
         [options]
@@ -4842,7 +4844,6 @@ fn lock_requires_python_not_equal() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -4898,6 +4899,7 @@ fn lock_requires_python_pre() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -4956,7 +4958,6 @@ fn lock_requires_python_pre() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "linehaul" }]
 
         [[package]]
@@ -5020,6 +5021,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "<=3.12"
         resolution-markers = [
             "python_full_version >= '3.7'",
@@ -5063,7 +5065,6 @@ fn lock_requires_python_unbounded() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -5161,6 +5162,7 @@ fn lock_requires_python_maximum_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.9'",
@@ -5264,7 +5266,6 @@ fn lock_requires_python_maximum_version() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "numpy" }]
         "#
         );
@@ -5320,6 +5321,7 @@ fn lock_requires_python_fewest_versions() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [options]
@@ -5370,7 +5372,6 @@ fn lock_requires_python_fewest_versions() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "numpy" }]
         "#
         );
@@ -5437,6 +5438,7 @@ fn lock_python_version_marker_complement() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.11'",
@@ -5477,7 +5479,6 @@ fn lock_python_version_marker_complement() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "attrs", marker = "python_full_version < '3.11'" },
             { name = "attrs", marker = "python_full_version >= '3.11'" },
@@ -5548,6 +5549,7 @@ fn lock_dev() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -5576,7 +5578,6 @@ fn lock_dev() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [package.metadata.requires-dev]
@@ -5589,10 +5590,6 @@ fn lock_dev() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d" },
         ]
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -5666,6 +5663,7 @@ fn lock_conditional_unconditional() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -5689,7 +5687,6 @@ fn lock_conditional_unconditional() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig" },
             { name = "iniconfig", marker = "python_full_version < '3.12'" },
@@ -5744,6 +5741,7 @@ fn lock_multiple_markers() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -5767,7 +5765,6 @@ fn lock_multiple_markers() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", marker = "python_full_version < '3.12'" },
             { name = "iniconfig", marker = "implementation_name == 'cpython'" },
@@ -5860,6 +5857,7 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.11, <3.13"
 
         [options]
@@ -5875,7 +5873,6 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "b", directory = "b" },
             { name = "c", directory = "c" },
@@ -5886,18 +5883,10 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
         version = "0.1.0"
         source = { directory = "b" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "c"
         version = "0.1.0"
         source = { directory = "c" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -5948,6 +5937,7 @@ fn lock_cycles() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6013,7 +6003,6 @@ fn lock_cycles() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "fixtures", specifier = "==3.0.0" },
             { name = "testtools", specifier = "==2.3.0" },
@@ -6151,6 +6140,7 @@ fn lock_new_extras() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6207,7 +6197,6 @@ fn lock_new_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "requests", specifier = "==2.31.0" }]
 
         [[package]]
@@ -6276,6 +6265,7 @@ fn lock_new_extras() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6332,7 +6322,6 @@ fn lock_new_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "requests", extras = ["socks"], specifier = "==2.31.0" }]
 
         [[package]]
@@ -6411,6 +6400,7 @@ fn lock_invalid_hash() -> Result<()> {
 
     lock.write_str(r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6523,6 +6513,7 @@ fn lock_resolution_mode() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6559,7 +6550,6 @@ fn lock_resolution_mode() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = ">=3" }]
 
         [[package]]
@@ -6604,6 +6594,7 @@ fn lock_resolution_mode() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6641,7 +6632,6 @@ fn lock_resolution_mode() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = ">=3" }]
 
         [[package]]
@@ -6766,6 +6756,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -6819,7 +6810,6 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -6834,7 +6824,6 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.0.0" }]
 
         [[package]]
@@ -6856,7 +6845,6 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dependency", marker = "sys_platform != 'darwin'", directory = "v2" },
             { name = "dependency", marker = "sys_platform == 'darwin'", directory = "v1" },
@@ -6990,6 +6978,7 @@ fn lock_exclusion() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7004,17 +6993,12 @@ fn lock_exclusion() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "project", virtual = "../" }]
 
         [[package]]
         name = "project"
         version = "0.1.0"
         source = { virtual = "../" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -7095,6 +7079,7 @@ fn lock_relative_lock_deserialization() -> Result<()> {
     child.child("uv.lock").write_str(
         r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7299,6 +7284,7 @@ fn lock_peer_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7315,10 +7301,6 @@ fn lock_peer_member() -> Result<()> {
         version = "0.1.0"
         source = { editable = "../child" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -7328,7 +7310,6 @@ fn lock_peer_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child", editable = "../child" }]
         "#
         );
@@ -7426,6 +7407,7 @@ fn lock_index_workspace_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7446,7 +7428,6 @@ fn lock_index_workspace_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2", index = "https://pypi-proxy.fly.dev/basic-auth/simple" }]
 
         [[package]]
@@ -7467,7 +7448,6 @@ fn lock_index_workspace_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child", editable = "child" }]
         "#
         );
@@ -7574,8 +7554,9 @@ fn lock_dev_transitive() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7598,7 +7579,6 @@ fn lock_dev_transitive() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "baz", editable = "baz" },
             { name = "foo", virtual = "../foo" },
@@ -7616,8 +7596,6 @@ fn lock_dev_transitive() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = [{ name = "typing-extensions", specifier = ">4" }]
@@ -7628,8 +7606,6 @@ fn lock_dev_transitive() -> Result<()> {
         source = { virtual = "../foo" }
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = [{ name = "anyio" }]
@@ -7651,7 +7627,7 @@ fn lock_dev_transitive() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -7713,6 +7689,7 @@ fn lock_redact_https() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7727,7 +7704,6 @@ fn lock_redact_https() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -7901,6 +7877,7 @@ fn lock_redact_git_pep508() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -7915,7 +7892,6 @@ fn lock_redact_git_pep508() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
 
         [[package]]
@@ -7994,6 +7970,7 @@ fn lock_redact_git_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8008,7 +7985,6 @@ fn lock_redact_git_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-private-pypackage", git = "https://github.com/astral-test/uv-private-pypackage" }]
 
         [[package]]
@@ -8085,6 +8061,7 @@ fn lock_redact_git_pep508_non_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8174,6 +8151,7 @@ fn lock_redact_index_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8188,7 +8166,6 @@ fn lock_redact_index_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=2", index = "https://pypi-proxy.fly.dev/basic-auth/simple" }]
 
         [[package]]
@@ -8267,6 +8244,7 @@ fn lock_redact_url_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8281,7 +8259,6 @@ fn lock_redact_url_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", url = "https://public:heron@pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }]
 
         [[package]]
@@ -8291,10 +8268,6 @@ fn lock_redact_url_sources() -> Result<()> {
         wheels = [
             { url = "https://public:heron@pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
         ]
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -8379,6 +8352,7 @@ fn lock_env_credentials() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8393,7 +8367,6 @@ fn lock_env_credentials() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -8540,6 +8513,7 @@ fn lock_relative_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8554,7 +8528,6 @@ fn lock_relative_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -8652,6 +8625,7 @@ fn lock_no_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8666,7 +8640,6 @@ fn lock_no_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -8692,7 +8665,6 @@ fn lock_no_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", directory = "anyio" }]
 
         [package.metadata.requires-dev]
@@ -8742,6 +8714,7 @@ fn lock_no_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8783,7 +8756,6 @@ fn lock_no_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [package.metadata.requires-dev]
@@ -8844,6 +8816,7 @@ fn lock_migrate() -> Result<()> {
     lock.write_str(
         r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8911,6 +8884,7 @@ fn lock_migrate() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -8947,7 +8921,6 @@ fn lock_migrate() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -9010,6 +8983,7 @@ fn lock_upgrade_package() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9047,7 +9021,6 @@ fn lock_upgrade_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", specifier = "<=2" },
             { name = "idna", specifier = "<=3" },
@@ -9106,6 +9079,7 @@ fn lock_upgrade_package() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9143,7 +9117,6 @@ fn lock_upgrade_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio" },
             { name = "idna" },
@@ -9190,6 +9163,7 @@ fn lock_upgrade_package() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9227,7 +9201,6 @@ fn lock_upgrade_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio" },
             { name = "idna" },
@@ -9380,6 +9353,7 @@ fn lock_find_links_local_wheel() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9394,7 +9368,6 @@ fn lock_find_links_local_wheel() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "tqdm", specifier = "==1000.0.0" }]
 
         [[package]]
@@ -9494,6 +9467,7 @@ fn lock_find_links_local_sdist() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9508,7 +9482,6 @@ fn lock_find_links_local_sdist() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "tqdm", specifier = "==999.0.0" }]
 
         [[package]]
@@ -9585,6 +9558,7 @@ fn lock_find_links_http_wheel() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9608,7 +9582,6 @@ fn lock_find_links_http_wheel() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "packaging", specifier = "==23.2" }]
         "#
         );
@@ -9676,6 +9649,7 @@ fn lock_find_links_http_sdist() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9699,7 +9673,6 @@ fn lock_find_links_http_sdist() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "packaging", specifier = "==23.2" }]
         "#
         );
@@ -9807,6 +9780,7 @@ fn lock_local_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [[package]]
@@ -9818,7 +9792,6 @@ fn lock_local_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "tqdm" }]
 
         [[package]]
@@ -9894,6 +9867,7 @@ fn lock_sources_url() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -9930,7 +9904,6 @@ fn lock_sources_url() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "workspace", url = "https://github.com/user-attachments/files/16592193/workspace.zip" }]
 
         [[package]]
@@ -9952,7 +9925,6 @@ fn lock_sources_url() -> Result<()> {
         sdist = { hash = "sha256:ba690a925dc3d1b53e0675201c9ec26ab59eeec72ab271562f53297bf1817263" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
         "#
         );
@@ -10031,6 +10003,7 @@ fn lock_sources_archive() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10067,7 +10040,6 @@ fn lock_sources_archive() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "workspace", path = "workspace.zip" }]
 
         [[package]]
@@ -10089,7 +10061,6 @@ fn lock_sources_archive() -> Result<()> {
         sdist = { hash = "sha256:ba690a925dc3d1b53e0675201c9ec26ab59eeec72ab271562f53297bf1817263" }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
         "#
         );
@@ -10183,6 +10154,7 @@ fn lock_sources_source_tree() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10193,10 +10165,6 @@ fn lock_sources_source_tree() -> Result<()> {
         version = "0.1.0"
         source = { editable = "workspace/anyio" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -10206,7 +10174,6 @@ fn lock_sources_source_tree() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "workspace", directory = "workspace" }]
 
         [[package]]
@@ -10218,7 +10185,6 @@ fn lock_sources_source_tree() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", editable = "workspace/anyio" }]
         "#
         );
@@ -10325,6 +10291,7 @@ fn lock_editable() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10345,17 +10312,12 @@ fn lock_editable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "library", directory = "library" }]
 
         [[package]]
         name = "library"
         version = "0.1.0"
         source = { directory = "library" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "workspace"
@@ -10366,7 +10328,6 @@ fn lock_editable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "library", directory = "library" }]
         "#
         );
@@ -10414,6 +10375,7 @@ fn lock_editable() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10434,17 +10396,12 @@ fn lock_editable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "library", editable = "library" }]
 
         [[package]]
         name = "library"
         version = "0.1.0"
         source = { editable = "library" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "workspace"
@@ -10455,7 +10412,6 @@ fn lock_editable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "library", directory = "library" }]
         "#
         );
@@ -10585,8 +10541,9 @@ fn lock_mixed_extras() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10618,8 +10575,8 @@ fn lock_mixed_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["async"]
         requires-dist = [{ name = "iniconfig", marker = "extra == 'async'", specifier = ">=2" }]
+        provides-extras = ["async"]
 
         [[package]]
         name = "leaf2"
@@ -10627,8 +10584,8 @@ fn lock_mixed_extras() -> Result<()> {
         source = { editable = "../workspace2/packages/leaf2" }
 
         [package.metadata]
-        provides-extras = ["async"]
         requires-dist = [{ name = "packaging", marker = "extra == 'async'", specifier = ">=24" }]
+        provides-extras = ["async"]
 
         [[package]]
         name = "typing-extensions"
@@ -10654,12 +10611,12 @@ fn lock_mixed_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["async"]
         requires-dist = [
             { name = "leaf1", editable = "packages/leaf1" },
             { name = "typing-extensions", marker = "extra == 'async'", specifier = ">=4" },
             { name = "workspace2", directory = "../workspace2" },
         ]
+        provides-extras = ["async"]
 
         [[package]]
         name = "workspace2"
@@ -10670,9 +10627,8 @@ fn lock_mixed_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "leaf2", editable = "../workspace2/packages/leaf2" }]
-        "#
+        "###
         );
     });
 
@@ -10782,8 +10738,9 @@ fn lock_transitive_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10815,8 +10772,8 @@ fn lock_transitive_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["async"]
         requires-dist = [{ name = "iniconfig", marker = "extra == 'async'", specifier = ">=2" }]
+        provides-extras = ["async"]
 
         [[package]]
         name = "typing-extensions"
@@ -10842,13 +10799,13 @@ fn lock_transitive_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["async"]
         requires-dist = [
             { name = "leaf", editable = "packages/leaf" },
             { name = "leaf", extras = ["async"], marker = "extra == 'async'", editable = "packages/leaf" },
             { name = "typing-extensions", marker = "extra == 'async'", specifier = ">=4" },
         ]
-        "#
+        provides-extras = ["async"]
+        "###
         );
     });
 
@@ -10934,6 +10891,7 @@ fn lock_mismatched_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10948,7 +10906,6 @@ fn lock_mismatched_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" }]
 
         [[package]]
@@ -10977,6 +10934,7 @@ fn lock_mismatched_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -10991,7 +10949,6 @@ fn lock_mismatched_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.2" }]
 
         [[package]]
@@ -11045,6 +11002,7 @@ fn lock_mismatched_versions() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11059,7 +11017,6 @@ fn lock_mismatched_versions() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" }]
 
         [[package]]
@@ -11161,6 +11118,7 @@ fn lock_change_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11184,7 +11142,6 @@ fn lock_change_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -11208,6 +11165,7 @@ fn lock_change_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11231,7 +11189,6 @@ fn lock_change_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -11306,6 +11263,7 @@ fn lock_remove_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11348,7 +11306,6 @@ fn lock_remove_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = ">3" }]
 
         [[package]]
@@ -11360,7 +11317,6 @@ fn lock_remove_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "leaf", virtual = "leaf" }]
 
         [[package]]
@@ -11429,6 +11385,7 @@ fn lock_remove_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11438,10 +11395,6 @@ fn lock_remove_member() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -11490,6 +11443,7 @@ fn lock_add_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11499,10 +11453,6 @@ fn lock_add_member() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -11604,6 +11554,7 @@ fn lock_add_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11646,17 +11597,12 @@ fn lock_add_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = ">3" }]
 
         [[package]]
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "sniffio"
@@ -11712,6 +11658,7 @@ fn lock_redundant_add_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11748,7 +11695,6 @@ fn lock_redundant_add_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -11817,6 +11763,7 @@ fn lock_redundant_add_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11854,7 +11801,6 @@ fn lock_redundant_add_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio" },
             { name = "idna" },
@@ -11909,6 +11855,7 @@ fn lock_new_constraints() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -11945,7 +11892,6 @@ fn lock_new_constraints() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -12016,6 +11962,7 @@ fn lock_new_constraints() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12055,7 +12002,6 @@ fn lock_new_constraints() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [[package]]
@@ -12121,6 +12067,7 @@ fn lock_remove_member_non_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12162,7 +12109,6 @@ fn lock_remove_member_non_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = ">3" }]
 
         [[package]]
@@ -12230,6 +12176,7 @@ fn lock_remove_member_non_project() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12276,6 +12223,7 @@ fn lock_rename_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12299,7 +12247,6 @@ fn lock_rename_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -12357,6 +12304,7 @@ fn lock_rename_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12380,7 +12328,6 @@ fn lock_rename_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -12410,6 +12357,7 @@ fn lock_missing_metadata() -> Result<()> {
     // Write a lockfile with a missing `[package.metadata]` section.
     lock.write_str(r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12473,6 +12421,7 @@ fn lock_missing_metadata() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12509,7 +12458,6 @@ fn lock_missing_metadata() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -12554,6 +12502,7 @@ fn lock_dev_dependencies_alias() -> Result<()> {
     // Write a lockfile with `[package.dev-dependencies]`.
     lock.write_str(r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12624,6 +12573,7 @@ fn lock_dev_dependencies_alias() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12652,7 +12602,6 @@ fn lock_dev_dependencies_alias() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "typing-extensions" }]
 
         [package.metadata.requires-dev]
@@ -12707,6 +12656,7 @@ fn lock_reorder() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -12753,7 +12703,6 @@ fn lock_reorder() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio" },
             { name = "iniconfig" },
@@ -12857,6 +12806,7 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7, <4"
         resolution-markers = [
             "python_full_version >= '3.10'",
@@ -12877,7 +12827,6 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -12898,7 +12847,6 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "dependency", marker = "python_full_version >= '3.10'", virtual = "dependency" }]
         "#
         );
@@ -12969,6 +12917,7 @@ fn lock_narrowed_python_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7"
         resolution-markers = [
             "python_full_version >= '3.11'",
@@ -12988,7 +12937,6 @@ fn lock_narrowed_python_version() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -13009,7 +12957,6 @@ fn lock_narrowed_python_version() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dependency", marker = "python_full_version < '3.9'", directory = "dependency" },
             { name = "dependency", marker = "python_full_version >= '3.11'", directory = "dependency" },
@@ -13070,6 +13017,7 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -13101,7 +13049,6 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", marker = "python_full_version >= '3.11'" },
             { name = "anyio", marker = "sys_platform == 'darwin'" },
@@ -13178,6 +13125,7 @@ fn lock_constrained_environment() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform != 'win32'",
@@ -13262,7 +13210,6 @@ fn lock_constrained_environment() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "black" }]
         "#
         );
@@ -13356,6 +13303,7 @@ fn lock_constrained_environment() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -13447,7 +13395,6 @@ fn lock_constrained_environment() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "black" }]
         "#
         );
@@ -13502,6 +13449,7 @@ fn lock_constrained_environment_legacy() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform != 'win32'",
@@ -13546,7 +13494,6 @@ fn lock_constrained_environment_legacy() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "black" }]
 
         [[package]]
@@ -13691,6 +13638,7 @@ fn lock_non_project_fork() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
         resolution-markers = [
             "python_full_version >= '3.11'",
@@ -13883,6 +13831,7 @@ fn lock_non_project_conditional() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -13991,6 +13940,7 @@ fn lock_non_project_group() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
 
         [options]
@@ -14131,6 +14081,7 @@ fn lock_non_project_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14148,10 +14099,6 @@ fn lock_non_project_sources() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/d7/77/ff688d1504cdc4db2a938e2b7b9adee5dd52e34efbd2431051efc9984de9/idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a" },
         ]
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -14215,8 +14162,9 @@ fn lock_dropped_dev_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14251,12 +14199,10 @@ fn lock_dropped_dev_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         dev = [{ name = "coverage", extras = ["toml"] }]
-        "#
+        "###
         );
     });
 
@@ -14332,6 +14278,7 @@ fn lock_empty_dev_dependencies() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14355,7 +14302,6 @@ fn lock_empty_dev_dependencies() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [package.metadata.requires-dev]
@@ -14436,6 +14382,7 @@ fn lock_empty_dependency_group() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14459,7 +14406,6 @@ fn lock_empty_dependency_group() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [package.metadata.requires-dev]
@@ -14540,6 +14486,7 @@ fn lock_trailing_slash() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14576,7 +14523,6 @@ fn lock_trailing_slash() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -14716,6 +14662,7 @@ fn lock_explicit_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14762,7 +14709,6 @@ fn lock_explicit_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", specifier = "==3.7.0" },
             { name = "iniconfig", specifier = "==2.0.0", index = "https://test.pypi.org/simple" },
@@ -14824,6 +14770,7 @@ fn lock_explicit_default_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14847,7 +14794,6 @@ fn lock_explicit_default_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0", index = "https://test.pypi.org/simple" }]
         "#
         );
@@ -14911,6 +14857,7 @@ fn lock_explicit_default_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -14934,7 +14881,6 @@ fn lock_explicit_default_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = "==2.0.0", index = "https://test.pypi.org/simple" }]
         "#
         );
@@ -14988,6 +14934,7 @@ fn lock_named_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15002,7 +14949,6 @@ fn lock_named_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "typing-extensions" }]
 
         [[package]]
@@ -15057,6 +15003,7 @@ fn lock_default_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15080,7 +15027,6 @@ fn lock_default_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -15120,6 +15066,7 @@ fn lock_default_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15143,7 +15090,6 @@ fn lock_default_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -15200,6 +15146,7 @@ fn lock_named_index_cli() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15233,7 +15180,6 @@ fn lock_named_index_cli() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "jinja2", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu121" }]
         "#
         );
@@ -15288,6 +15234,7 @@ fn lock_repeat_named_index() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15311,7 +15258,6 @@ fn lock_repeat_named_index() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -15362,6 +15308,7 @@ fn lock_repeat_named_index_cli() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15404,7 +15351,6 @@ fn lock_repeat_named_index_cli() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "jinja2", specifier = "==3.1.2" }]
         "#
         );
@@ -15429,6 +15375,7 @@ fn lock_repeat_named_index_cli() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15476,7 +15423,6 @@ fn lock_repeat_named_index_cli() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "jinja2", specifier = "==3.1.2" }]
         "#
         );
@@ -15528,6 +15474,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15646,7 +15593,6 @@ fn lock_explicit_virtual_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "black" }]
 
         [package.metadata.requires-dev]
@@ -15746,6 +15692,7 @@ fn lock_implicit_virtual_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -15864,7 +15811,6 @@ fn lock_implicit_virtual_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "black" }]
 
         [package.metadata.requires-dev]
@@ -15974,6 +15920,7 @@ fn lock_implicit_virtual_path() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -16001,7 +15948,6 @@ fn lock_implicit_virtual_path() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">1" }]
 
         [[package]]
@@ -16032,7 +15978,6 @@ fn lock_implicit_virtual_path() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", specifier = ">3" },
             { name = "child", virtual = "child" },
@@ -16158,6 +16103,7 @@ fn lock_split_python_environment() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.7"
         resolution-markers = [
             "python_full_version < '3.8'",
@@ -16180,7 +16126,6 @@ fn lock_split_python_environment() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "uv", marker = "python_full_version >= '3.8'" }]
 
         [[package]]
@@ -16269,6 +16214,7 @@ fn lock_python_upper_bound() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.9' and python_full_version < '3.13'",
@@ -16503,7 +16449,6 @@ fn lock_python_upper_bound() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "magika", marker = "python_full_version < '3.13'" }]
 
         [[package]]
@@ -16641,6 +16586,7 @@ fn lock_simplified_environments() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -16672,7 +16618,6 @@ fn lock_simplified_environments() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
         "#
         );
@@ -16751,6 +16696,7 @@ fn lock_dependency_metadata() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -16793,7 +16739,6 @@ fn lock_dependency_metadata() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
         "#
         );
@@ -16957,6 +16902,7 @@ fn lock_dependency_metadata_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -16995,7 +16941,6 @@ fn lock_dependency_metadata_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", git = "https://github.com/agronholm/anyio?tag=4.6.2" }]
         "#
         );
@@ -17070,6 +17015,7 @@ fn lock_strip_fragment() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -17083,10 +17029,6 @@ fn lock_strip_fragment() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
         ]
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -17096,7 +17038,6 @@ fn lock_strip_fragment() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }]
         "#
         );
@@ -17474,6 +17415,7 @@ fn lock_change_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "python_full_version >= '3.13'",
@@ -17534,7 +17476,6 @@ fn lock_change_requires_python() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", marker = "python_full_version == '3.12.*'", specifier = "<3" },
             { name = "anyio", marker = "python_full_version >= '3.13'", specifier = ">3,<4" },
@@ -17584,6 +17525,7 @@ fn lock_change_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
         resolution-markers = [
             "python_full_version >= '3.13'",
@@ -17645,7 +17587,6 @@ fn lock_change_requires_python() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "anyio", marker = "python_full_version == '3.12.*'", specifier = "<3" },
             { name = "anyio", marker = "python_full_version >= '3.13'", specifier = ">3" },
@@ -17729,6 +17670,7 @@ fn lock_keyring_credentials() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -17743,7 +17685,6 @@ fn lock_keyring_credentials() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -17799,6 +17740,7 @@ fn lock_multiple_sources() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform != 'win32'",
@@ -17817,10 +17759,6 @@ fn lock_multiple_sources() -> Result<()> {
         ]
         sdist = { hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "iniconfig"
         version = "2.0.0"
@@ -17832,10 +17770,6 @@ fn lock_multiple_sources() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
         ]
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -17846,7 +17780,6 @@ fn lock_multiple_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", marker = "sys_platform != 'win32'", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" },
             { name = "iniconfig", marker = "sys_platform == 'win32'", url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz" },
@@ -17995,6 +17928,7 @@ fn lock_multiple_sources_index_disjoint_markers() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'win32'",
@@ -18059,7 +17993,6 @@ fn lock_multiple_sources_index_disjoint_markers() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "jinja2", marker = "sys_platform != 'win32'", specifier = ">=3,<3.1.4", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124" },
             { name = "jinja2", marker = "sys_platform == 'win32'", specifier = ">=3,<3.1.4", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118" },
@@ -18124,8 +18057,9 @@ fn lock_multiple_sources_index_mixed() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'win32'",
@@ -18167,11 +18101,11 @@ fn lock_multiple_sources_index_mixed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["i18n"]
         requires-dist = [
             { name = "babel", marker = "extra == 'i18n'", specifier = ">=2.7" },
             { name = "markupsafe", specifier = ">=2.0" },
         ]
+        provides-extras = ["i18n"]
 
         [[package]]
         name = "markupsafe"
@@ -18197,12 +18131,11 @@ fn lock_multiple_sources_index_mixed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "jinja2", marker = "sys_platform != 'win32'", url = "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl" },
             { name = "jinja2", marker = "sys_platform == 'win32'", specifier = ">=3,<3.1.4", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118" },
         ]
-        "#
+        "###
         );
     });
 
@@ -18298,6 +18231,7 @@ fn lock_multiple_sources_index_explicit() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'win32'",
@@ -18385,7 +18319,6 @@ fn lock_multiple_sources_index_explicit() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "jinja2", marker = "sys_platform != 'win32'", specifier = ">=3" },
             { name = "jinja2", marker = "sys_platform == 'win32'", specifier = ">=3", index = "https://test.pypi.org/simple" },
@@ -18444,6 +18377,7 @@ fn lock_multiple_sources_non_total() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -18476,10 +18410,6 @@ fn lock_multiple_sources_non_total() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
         ]
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -18490,7 +18420,6 @@ fn lock_multiple_sources_non_total() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "iniconfig", marker = "sys_platform != 'darwin'" },
             { name = "iniconfig", marker = "sys_platform == 'darwin'", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" },
@@ -18549,6 +18478,7 @@ fn lock_multiple_sources_respect_marker() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -18572,7 +18502,6 @@ fn lock_multiple_sources_respect_marker() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", marker = "sys_platform == 'win32'" }]
         "#
         );
@@ -18629,8 +18558,9 @@ fn lock_multiple_sources_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -18644,10 +18574,6 @@ fn lock_multiple_sources_extra() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
         ]
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "project"
         version = "0.1.0"
@@ -18659,12 +18585,12 @@ fn lock_multiple_sources_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cpu"]
         requires-dist = [
             { name = "iniconfig", marker = "extra == 'cpu'", url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" },
             { name = "iniconfig", marker = "extra != 'cpu'" },
         ]
-        "#
+        provides-extras = ["cpu"]
+        "###
         );
     });
 
@@ -19063,6 +18989,7 @@ fn lock_group_include() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -19142,7 +19069,6 @@ fn lock_group_include() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "typing-extensions" }]
 
         [package.metadata.requires-dev]
@@ -19592,6 +19518,7 @@ fn lock_group_workspace() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -19633,7 +19560,6 @@ fn lock_group_workspace() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">1" }]
 
         [package.metadata.requires-dev]
@@ -19702,7 +19628,6 @@ fn lock_group_workspace() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "child", editable = "child" }]
 
         [package.metadata.requires-dev]
@@ -19784,6 +19709,7 @@ fn lock_transitive_git() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -19798,7 +19724,6 @@ fn lock_transitive_git() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "c", git = "https://github.com/astral-sh/workspace-virtual-root-test?subdirectory=packages%2Fc&rev=fac39c8d4c5d0ef32744e2bb309bbe34a759fd46" }]
 
         [[package]]
@@ -19947,6 +19872,7 @@ fn lock_dynamic_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -19955,10 +19881,6 @@ fn lock_dynamic_version() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -19989,6 +19911,7 @@ fn lock_dynamic_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -19997,10 +19920,6 @@ fn lock_dynamic_version() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -20063,6 +19982,7 @@ fn lock_dynamic_version_dependencies() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20071,10 +19991,6 @@ fn lock_dynamic_version_dependencies() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "###
         );
     });
@@ -20105,6 +20021,7 @@ fn lock_dynamic_version_dependencies() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20113,10 +20030,6 @@ fn lock_dynamic_version_dependencies() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "###
         );
     });
@@ -20167,6 +20080,7 @@ fn lock_dynamic_version_no_build() -> Result<()> {
     context.temp_dir.child("uv.lock").write_str(indoc::indoc! {
     r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20264,6 +20178,7 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20278,10 +20193,6 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         [[package]]
         name = "dynamic"
         source = { editable = "dynamic" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "iniconfig"
@@ -20302,7 +20213,6 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dynamic", editable = "dynamic" },
             { name = "iniconfig", specifier = ">=2" },
@@ -20338,6 +20248,7 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20352,10 +20263,6 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         [[package]]
         name = "dynamic"
         source = { editable = "dynamic" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "iniconfig"
@@ -20376,7 +20283,6 @@ fn lock_dynamic_version_workspace_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dynamic", editable = "dynamic" },
             { name = "iniconfig", specifier = ">=2" },
@@ -20460,6 +20366,7 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20468,10 +20375,6 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         [[package]]
         name = "dynamic"
         source = { directory = "dynamic" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "iniconfig"
@@ -20492,7 +20395,6 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dynamic", directory = "dynamic" },
             { name = "iniconfig", specifier = ">=2" },
@@ -20528,6 +20430,7 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20536,10 +20439,6 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         [[package]]
         name = "dynamic"
         source = { directory = "dynamic" }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [[package]]
         name = "iniconfig"
@@ -20560,7 +20459,6 @@ fn lock_dynamic_version_path_dependency() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "dynamic", directory = "dynamic" },
             { name = "iniconfig", specifier = ">=2" },
@@ -20630,8 +20528,9 @@ fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20673,11 +20572,11 @@ fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["all", "async"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'all'" },
             { name = "anyio", marker = "extra == 'async'" },
         ]
+        provides-extras = ["all", "async"]
 
         [[package]]
         name = "sniffio"
@@ -20696,7 +20595,7 @@ fn lock_dynamic_version_self_extra_hatchling() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
         ]
-        "#
+        "###
         );
     });
 
@@ -20789,8 +20688,9 @@ fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20832,11 +20732,11 @@ fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["all", "async"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'async'" },
             { name = "project", extras = ["async"], marker = "extra == 'all'" },
         ]
+        provides-extras = ["all", "async"]
 
         [[package]]
         name = "sniffio"
@@ -20855,7 +20755,7 @@ fn lock_dynamic_version_self_extra_setuptools() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
         ]
-        "#
+        "###
         );
     });
 
@@ -20942,6 +20842,7 @@ fn lock_dynamic_built_cache() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -20950,10 +20851,6 @@ fn lock_dynamic_built_cache() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -20992,6 +20889,7 @@ fn lock_dynamic_built_cache() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21000,10 +20898,6 @@ fn lock_dynamic_built_cache() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21070,6 +20964,7 @@ fn lock_shared_build_dependency() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.9'",
@@ -21192,7 +21087,6 @@ fn lock_shared_build_dependency() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "libcst", specifier = ">=1.1.0" }]
 
         [[package]]
@@ -21349,6 +21243,7 @@ fn lock_dynamic_to_static() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21357,10 +21252,6 @@ fn lock_dynamic_to_static() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21409,6 +21300,7 @@ fn lock_dynamic_to_static() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21418,10 +21310,6 @@ fn lock_dynamic_to_static() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21466,6 +21354,7 @@ fn lock_static_to_dynamic() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21475,10 +21364,6 @@ fn lock_static_to_dynamic() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21546,6 +21431,7 @@ fn lock_static_to_dynamic() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21554,10 +21440,6 @@ fn lock_static_to_dynamic() -> Result<()> {
         [[package]]
         name = "project"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21597,6 +21479,7 @@ fn lock_bump_static_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21606,10 +21489,6 @@ fn lock_bump_static_version() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -21654,6 +21533,7 @@ fn lock_bump_static_version() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -21663,10 +21543,6 @@ fn lock_bump_static_version() -> Result<()> {
         name = "project"
         version = "0.2.0"
         source = { virtual = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
         "#
         );
     });
@@ -22003,6 +21879,7 @@ fn lock_relative_project() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22017,7 +21894,6 @@ fn lock_relative_project() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "typing-extensions" }]
 
         [[package]]
@@ -22103,8 +21979,9 @@ fn lock_recursive_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22142,7 +22019,6 @@ fn lock_recursive_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo", "bar", "baz", "bop", "qux"]
         requires-dist = [
             { name = "iniconfig", marker = "extra == 'foo'" },
             { name = "project", extras = ["bar"], marker = "sys_platform == 'darwin' and extra == 'bop'" },
@@ -22150,7 +22026,8 @@ fn lock_recursive_extra() -> Result<()> {
             { name = "project", extras = ["bop"], marker = "python_full_version == '3.12.*' and extra == 'qux'" },
             { name = "project", extras = ["foo"], marker = "extra == 'bar'" },
         ]
-        "#
+        provides-extras = ["foo", "bar", "baz", "bop", "qux"]
+        "###
         );
     });
 
@@ -22243,6 +22120,7 @@ fn lock_no_build_static_metadata() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22257,7 +22135,6 @@ fn lock_no_build_static_metadata() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -22366,6 +22243,7 @@ fn lock_self_compatible() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22380,7 +22258,6 @@ fn lock_self_compatible() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "project" },
             { name = "typing-extensions" },
@@ -22466,6 +22343,7 @@ fn lock_self_exact() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22480,7 +22358,6 @@ fn lock_self_exact() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "project", specifier = "==0.1.0" },
             { name = "typing-extensions" },
@@ -22597,8 +22474,9 @@ fn lock_self_extra_to_extra_compatible() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22613,11 +22491,11 @@ fn lock_self_extra_to_extra_compatible() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo"]
         requires-dist = [
             { name = "project", extras = ["foo"], marker = "extra == 'foo'" },
             { name = "typing-extensions" },
         ]
+        provides-extras = ["foo"]
 
         [[package]]
         name = "typing-extensions"
@@ -22627,7 +22505,7 @@ fn lock_self_extra_to_extra_compatible() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -22767,8 +22645,9 @@ fn lock_self_extra_compatible() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22783,11 +22662,11 @@ fn lock_self_extra_compatible() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo"]
         requires-dist = [
             { name = "project", marker = "extra == 'foo'" },
             { name = "typing-extensions" },
         ]
+        provides-extras = ["foo"]
 
         [[package]]
         name = "typing-extensions"
@@ -22797,7 +22676,7 @@ fn lock_self_extra_compatible() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -22902,6 +22781,7 @@ fn lock_self_marker_compatible() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -22916,7 +22796,6 @@ fn lock_self_marker_compatible() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "project", marker = "sys_platform == 'win32'" },
             { name = "typing-extensions" },
@@ -23034,6 +22913,7 @@ fn lock_split_on_windows() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -23048,7 +22928,6 @@ fn lock_split_on_windows() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "pyqt5-qt5" }]
 
         [[package]]
@@ -23134,6 +23013,7 @@ fn lock_arm() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "platform_machine == 'arm64'",
@@ -23165,7 +23045,6 @@ fn lock_arm() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "numpy" }]
         "#
         );
@@ -23209,6 +23088,7 @@ fn lock_x86_64() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "platform_machine == 'x86_64'",
@@ -23241,7 +23121,6 @@ fn lock_x86_64() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "numpy" }]
         "#
         );
@@ -23285,6 +23164,7 @@ fn lock_x86() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "platform_machine == 'i686'",
@@ -23314,7 +23194,6 @@ fn lock_x86() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "numpy" }]
         "#
         );
@@ -23357,6 +23236,7 @@ fn lock_script() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -23493,6 +23373,7 @@ fn lock_script_path() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -23526,7 +23407,6 @@ fn lock_script_path() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
 
         [[package]]
@@ -23697,8 +23577,9 @@ fn lock_pytorch_cpu() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12.[X]"
         resolution-markers = [
             "(platform_machine != 'aarch64' and extra != 'extra-7-project-cpu' and extra == 'extra-7-project-cu124') or (sys_platform != 'linux' and extra != 'extra-7-project-cpu' and extra == 'extra-7-project-cu124')",
@@ -24060,7 +23941,6 @@ fn lock_pytorch_cpu() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cpu", "cu124"]
         requires-dist = [
             { name = "jinja2", specifier = "<=3.1.4" },
             { name = "numpy", specifier = "<=2.2.0" },
@@ -24069,6 +23949,7 @@ fn lock_pytorch_cpu() -> Result<()> {
             { name = "torchvision", marker = "extra == 'cpu'", specifier = ">=0.20.1,<0.20.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cpu", conflict = { package = "project", extra = "cpu" } },
             { name = "torchvision", marker = "extra == 'cu124'", specifier = ">=0.20.1,<0.20.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
+        provides-extras = ["cpu", "cu124"]
 
         [[package]]
         name = "setuptools"
@@ -24275,7 +24156,7 @@ fn lock_pytorch_cpu() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
         ]
-        "#
+        "###
         );
     });
 
@@ -24349,8 +24230,9 @@ fn lock_pytorch_preferences() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10.0"
         resolution-markers = [
             "sys_platform != 'darwin' and extra != 'extra-7-project-cpu' and extra == 'extra-7-project-cu118'",
@@ -24612,13 +24494,13 @@ fn lock_pytorch_preferences() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cpu", "cu118"]
         requires-dist = [
             { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = "==2.2.2" },
             { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cu118'", specifier = "==2.2.2" },
             { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cpu'", specifier = "==2.2.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cpu", conflict = { package = "project", extra = "cpu" } },
             { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cu118'", specifier = "==2.2.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
         ]
+        provides-extras = ["cpu", "cu118"]
 
         [[package]]
         name = "sympy"
@@ -24773,7 +24655,7 @@ fn lock_pytorch_preferences() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
         ]
-        "#
+        "###
         );
     });
 

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -89,8 +89,9 @@ fn extra_basic() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "extra1" },
@@ -114,11 +115,11 @@ fn extra_basic() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["extra1", "extra2"]
         requires-dist = [
             { name = "sortedcontainers", marker = "extra == 'extra1'", specifier = "==2.3.0" },
             { name = "sortedcontainers", marker = "extra == 'extra2'", specifier = "==2.4.0" },
         ]
+        provides-extras = ["extra1", "extra2"]
 
         [[package]]
         name = "sortedcontainers"
@@ -137,7 +138,7 @@ fn extra_basic() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -282,8 +283,9 @@ fn extra_basic_three_extras() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "extra1" },
@@ -311,12 +313,12 @@ fn extra_basic_three_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["extra1", "extra2", "project3"]
         requires-dist = [
             { name = "sortedcontainers", marker = "extra == 'extra1'", specifier = "==2.2.0" },
             { name = "sortedcontainers", marker = "extra == 'extra2'", specifier = "==2.3.0" },
             { name = "sortedcontainers", marker = "extra == 'project3'", specifier = "==2.4.0" },
         ]
+        provides-extras = ["extra1", "extra2", "project3"]
 
         [[package]]
         name = "sortedcontainers"
@@ -344,7 +346,7 @@ fn extra_basic_three_extras() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -756,8 +758,9 @@ fn extra_multiple_independent() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "extra1" },
@@ -825,13 +828,13 @@ fn extra_multiple_independent() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["extra1", "extra2", "project3", "project4"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'project3'", specifier = "==4.1.0" },
             { name = "anyio", marker = "extra == 'project4'", specifier = "==4.2.0" },
             { name = "sortedcontainers", marker = "extra == 'extra1'", specifier = "==2.3.0" },
             { name = "sortedcontainers", marker = "extra == 'extra2'", specifier = "==2.4.0" },
         ]
+        provides-extras = ["extra1", "extra2", "project3", "project4"]
 
         [[package]]
         name = "sniffio"
@@ -859,7 +862,7 @@ fn extra_multiple_independent() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -905,8 +908,9 @@ fn extra_config_change_ignore_lockfile() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "extra1" },
@@ -930,11 +934,11 @@ fn extra_config_change_ignore_lockfile() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["extra1", "extra2"]
         requires-dist = [
             { name = "sortedcontainers", marker = "extra == 'extra1'", specifier = "==2.3.0" },
             { name = "sortedcontainers", marker = "extra == 'extra2'", specifier = "==2.4.0" },
         ]
+        provides-extras = ["extra1", "extra2"]
 
         [[package]]
         name = "sortedcontainers"
@@ -953,7 +957,7 @@ fn extra_config_change_ignore_lockfile() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1719,8 +1723,9 @@ fn group_basic() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "group1" },
@@ -1744,8 +1749,6 @@ fn group_basic() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         group1 = [{ name = "sortedcontainers", specifier = "==2.3.0" }]
@@ -1768,7 +1771,7 @@ fn group_basic() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -1875,8 +1878,9 @@ fn group_default() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "group1" },
@@ -1900,8 +1904,6 @@ fn group_default() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         group1 = [{ name = "sortedcontainers", specifier = "==2.3.0" }]
@@ -1924,7 +1926,7 @@ fn group_default() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -2088,8 +2090,9 @@ fn mixed() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "group1" },
@@ -2115,8 +2118,8 @@ fn mixed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["extra1"]
         requires-dist = [{ name = "sortedcontainers", marker = "extra == 'extra1'", specifier = "==2.4.0" }]
+        provides-extras = ["extra1"]
 
         [package.metadata.requires-dev]
         group1 = [{ name = "sortedcontainers", specifier = "==2.3.0" }]
@@ -2138,7 +2141,7 @@ fn mixed() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -2257,8 +2260,9 @@ fn multiple_sources_index_disjoint_extras() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "cu118" },
@@ -2325,12 +2329,12 @@ fn multiple_sources_index_disjoint_extras() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cu118", "cu124"]
         requires-dist = [
             { name = "jinja2", marker = "extra == 'cu118'", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
             { name = "jinja2", marker = "extra == 'cu124'", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
-        "#
+        provides-extras = ["cu118", "cu124"]
+        "###
         );
     });
 
@@ -2406,8 +2410,9 @@ fn multiple_sources_index_disjoint_groups() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "cu118" },
@@ -2474,13 +2479,11 @@ fn multiple_sources_index_disjoint_groups() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         cu118 = [{ name = "jinja2", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", group = "cu118" } }]
         cu124 = [{ name = "jinja2", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", group = "cu124" } }]
-        "#
+        "###
         );
     });
 
@@ -2556,8 +2559,9 @@ fn multiple_sources_index_disjoint_extras_with_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "cu118" },
@@ -2643,12 +2647,12 @@ fn multiple_sources_index_disjoint_extras_with_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cu118", "cu124"]
         requires-dist = [
             { name = "jinja2", extras = ["i18n"], marker = "extra == 'cu118'", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
             { name = "jinja2", extras = ["i18n"], marker = "extra == 'cu124'", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
-        "#
+        provides-extras = ["cu118", "cu124"]
+        "###
         );
     });
 
@@ -2724,8 +2728,9 @@ fn multiple_sources_index_disjoint_extras_with_marker() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "extra != 'extra-7-project-cu118' and extra == 'extra-7-project-cu124'",
@@ -2817,13 +2822,13 @@ fn multiple_sources_index_disjoint_extras_with_marker() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cu118", "cu124"]
         requires-dist = [
             { name = "jinja2", marker = "sys_platform == 'darwin' and extra == 'cu118'", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
             { name = "jinja2", marker = "sys_platform != 'darwin' and extra == 'cu118'", specifier = "==3.1.2" },
             { name = "jinja2", marker = "extra == 'cu124'", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
-        "#
+        provides-extras = ["cu118", "cu124"]
+        "###
         );
     });
 
@@ -3049,8 +3054,9 @@ fn shared_optional_dependency_extra1() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -3109,12 +3115,12 @@ fn shared_optional_dependency_extra1() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo", "bar", "baz"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'baz'" },
             { name = "idna", marker = "extra == 'bar'", specifier = "==3.6" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
         ]
+        provides-extras = ["foo", "bar", "baz"]
 
         [[package]]
         name = "sniffio"
@@ -3124,7 +3130,7 @@ fn shared_optional_dependency_extra1() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3188,8 +3194,9 @@ fn shared_optional_dependency_group1() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "foo" },
@@ -3248,8 +3255,6 @@ fn shared_optional_dependency_group1() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         bar = [{ name = "idna", specifier = "==3.6" }]
@@ -3264,7 +3269,7 @@ fn shared_optional_dependency_group1() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3330,8 +3335,9 @@ fn shared_optional_dependency_mixed1() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -3392,8 +3398,8 @@ fn shared_optional_dependency_mixed1() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo"]
         requires-dist = [{ name = "idna", marker = "extra == 'foo'", specifier = "==3.5" }]
+        provides-extras = ["foo"]
 
         [package.metadata.requires-dev]
         bar = [{ name = "idna", specifier = "==3.6" }]
@@ -3407,7 +3413,7 @@ fn shared_optional_dependency_mixed1() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3474,8 +3480,9 @@ fn shared_optional_dependency_extra2() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -3533,13 +3540,13 @@ fn shared_optional_dependency_extra2() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo", "bar"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'bar'" },
             { name = "anyio", marker = "extra == 'foo'" },
             { name = "idna", marker = "extra == 'bar'", specifier = "==3.6" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
         ]
+        provides-extras = ["foo", "bar"]
 
         [[package]]
         name = "sniffio"
@@ -3549,7 +3556,7 @@ fn shared_optional_dependency_extra2() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3614,8 +3621,9 @@ fn shared_optional_dependency_group2() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
         conflicts = [[
             { package = "project", group = "foo" },
@@ -3673,8 +3681,6 @@ fn shared_optional_dependency_group2() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
-        requires-dist = []
 
         [package.metadata.requires-dev]
         bar = [
@@ -3694,7 +3700,7 @@ fn shared_optional_dependency_group2() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3761,8 +3767,9 @@ fn shared_optional_dependency_mixed2() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -3822,11 +3829,11 @@ fn shared_optional_dependency_mixed2() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo"]
         requires-dist = [
             { name = "anyio", marker = "extra == 'foo'" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
         ]
+        provides-extras = ["foo"]
 
         [package.metadata.requires-dev]
         bar = [
@@ -3842,7 +3849,7 @@ fn shared_optional_dependency_mixed2() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3904,8 +3911,9 @@ fn shared_dependency_extra() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -3964,12 +3972,12 @@ fn shared_dependency_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo", "bar"]
         requires-dist = [
             { name = "anyio" },
             { name = "idna", marker = "extra == 'bar'", specifier = "==3.6" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
         ]
+        provides-extras = ["foo", "bar"]
 
         [[package]]
         name = "sniffio"
@@ -3979,7 +3987,7 @@ fn shared_dependency_extra() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -4078,8 +4086,9 @@ fn shared_dependency_group() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", group = "foo" },
@@ -4138,7 +4147,6 @@ fn shared_dependency_group() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio" }]
 
         [package.metadata.requires-dev]
@@ -4153,7 +4161,7 @@ fn shared_dependency_group() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -4254,8 +4262,9 @@ fn shared_dependency_mixed() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "foo" },
@@ -4316,11 +4325,11 @@ fn shared_dependency_mixed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo"]
         requires-dist = [
             { name = "anyio" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
         ]
+        provides-extras = ["foo"]
 
         [package.metadata.requires-dev]
         bar = [{ name = "idna", specifier = "==3.6" }]
@@ -4333,7 +4342,7 @@ fn shared_dependency_mixed() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -4470,8 +4479,9 @@ conflicts = [
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = "==3.11.*"
         conflicts = [[
             { package = "project", extra = "x1" },
@@ -4545,12 +4555,12 @@ conflicts = [
         ]
 
         [package.metadata]
-        provides-extras = ["x1"]
         requires-dist = [
             { name = "anyio", specifier = ">=4" },
             { name = "idna", marker = "extra == 'x1'", specifier = "==3.6" },
             { name = "proxy1", virtual = "proxy1" },
         ]
+        provides-extras = ["x1"]
 
         [[package]]
         name = "proxy1"
@@ -4566,11 +4576,11 @@ conflicts = [
         ]
 
         [package.metadata]
-        provides-extras = ["x2", "x3"]
         requires-dist = [
             { name = "idna", marker = "extra == 'x2'", specifier = "==3.4" },
             { name = "idna", marker = "extra == 'x3'", specifier = "==3.5" },
         ]
+        provides-extras = ["x2", "x3"]
 
         [[package]]
         name = "sniffio"
@@ -4580,7 +4590,7 @@ conflicts = [
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#
+        "###
         );
     });
 
@@ -4655,8 +4665,9 @@ fn jinja_no_conflict_markers1() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "project", extra = "cu118" },
@@ -4742,12 +4753,12 @@ fn jinja_no_conflict_markers1() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cu118", "cu124"]
         requires-dist = [
             { name = "jinja2", extras = ["i18n"], marker = "extra == 'cu118'", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
             { name = "jinja2", extras = ["i18n"], marker = "extra == 'cu124'", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
-        "#
+        provides-extras = ["cu118", "cu124"]
+        "###
         );
     });
 
@@ -4816,8 +4827,9 @@ fn jinja_no_conflict_markers2() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "extra != 'extra-7-project-cu118' and extra == 'extra-7-project-cu124'",
@@ -4909,13 +4921,13 @@ fn jinja_no_conflict_markers2() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cu118", "cu124"]
         requires-dist = [
             { name = "jinja2", marker = "sys_platform == 'darwin' and extra == 'cu118'", specifier = "==3.1.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu118", conflict = { package = "project", extra = "cu118" } },
             { name = "jinja2", marker = "sys_platform != 'darwin' and extra == 'cu118'", specifier = "==3.1.2" },
             { name = "jinja2", marker = "extra == 'cu124'", specifier = "==3.1.3", index = "https://astral-sh.github.io/pytorch-mirror/whl/cu124", conflict = { package = "project", extra = "cu124" } },
         ]
-        "#
+        provides-extras = ["cu118", "cu124"]
+        "###
         );
     });
 
@@ -4976,8 +4988,9 @@ fn collision_extra() -> Result<()> {
     }, {
         assert_snapshot!(
             lock,
-            @r#"
+            @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "pkg", extra = "foo" },
@@ -5039,13 +5052,13 @@ fn collision_extra() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["foo", "bar", "extra-3-pkg-foo"]
         requires-dist = [
             { name = "anyio" },
             { name = "idna", marker = "extra == 'bar'", specifier = "==3.6" },
             { name = "idna", marker = "extra == 'foo'", specifier = "==3.5" },
             { name = "sortedcontainers", marker = "extra == 'extra-3-pkg-foo'", specifier = ">=2" },
         ]
+        provides-extras = ["foo", "bar", "extra-3-pkg-foo"]
 
         [[package]]
         name = "sniffio"
@@ -5064,7 +5077,7 @@ fn collision_extra() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
         ]
-        "#
+        "###
         );
     });
 
@@ -5204,8 +5217,9 @@ fn extra_inferences() -> Result<()> {
     }, {
         assert_snapshot!(
             lock,
-            @r#"
+            @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         conflicts = [[
             { package = "pkg", extra = "x1" },
@@ -6576,12 +6590,12 @@ fn extra_inferences() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["x1", "x2"]
         requires-dist = [
             { name = "apache-airflow", marker = "extra == 'x1'", specifier = "==2.5.0" },
             { name = "apache-airflow", marker = "extra == 'x2'", specifier = "==2.6.0" },
             { name = "quickpath-airflow-operator", specifier = "==1.0.2" },
         ]
+        provides-extras = ["x1", "x2"]
 
         [[package]]
         name = "pluggy"
@@ -7166,7 +7180,7 @@ fn extra_inferences() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/c5/f4/2fdc5a11503bc61818243653d836061c9ce0370e2dd9ac5917258a007675/yarl-1.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984", size = 76397 },
             { url = "https://files.pythonhosted.org/packages/4d/05/4d79198ae568a92159de0f89e710a8d19e3fa267b719a236582eee921f4a/yarl-1.9.4-py3-none-any.whl", hash = "sha256:928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad", size = 31638 },
         ]
-        "#
+        "###
         );
     });
 
@@ -7239,8 +7253,9 @@ fn deduplicate_resolution_markers() -> Result<()> {
     }, {
         assert_snapshot!(
             lock,
-            @r#"
+            @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
         resolution-markers = [
             "sys_platform != 'linux' and extra != 'extra-3-pkg-x1' and extra == 'extra-3-pkg-x2'",
@@ -7315,14 +7330,14 @@ fn deduplicate_resolution_markers() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["x1", "x2"]
         requires-dist = [
             { name = "idna", marker = "sys_platform == 'linux' and extra == 'x1'", specifier = "==3.6" },
             { name = "idna", marker = "sys_platform != 'linux' and extra == 'x1'", specifier = "==3.5" },
             { name = "markupsafe", marker = "sys_platform == 'linux' and extra == 'x2'", specifier = "==2.1.0" },
             { name = "markupsafe", marker = "sys_platform != 'linux' and extra == 'x2'", specifier = "==2.0.0" },
         ]
-        "#
+        provides-extras = ["x1", "x2"]
+        "###
         );
     });
 
@@ -7392,8 +7407,9 @@ fn incorrect_extra_simplification_leads_to_multiple_torch_packages() -> Result<(
     }, {
         assert_snapshot!(
             lock,
-            @r#"
+            @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
         resolution-markers = [
             "python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-4-test-chgnet' and extra == 'extra-4-test-m3gnet'",
@@ -9734,7 +9750,6 @@ fn incorrect_extra_simplification_leads_to_multiple_torch_packages() -> Result<(
         ]
 
         [package.metadata]
-        provides-extras = ["chgnet", "m3gnet"]
         requires-dist = [
             { name = "chgnet", marker = "extra == 'chgnet'", specifier = "==0.4.0" },
             { name = "mace-torch", specifier = "==0.3.9" },
@@ -9742,6 +9757,7 @@ fn incorrect_extra_simplification_leads_to_multiple_torch_packages() -> Result<(
             { name = "torch", marker = "extra == 'm3gnet'", specifier = "==2.2.1" },
             { name = "torchdata", marker = "extra == 'm3gnet'", specifier = "==0.7.1" },
         ]
+        provides-extras = ["chgnet", "m3gnet"]
 
         [[package]]
         name = "torch"
@@ -10068,7 +10084,7 @@ fn incorrect_extra_simplification_leads_to_multiple_torch_packages() -> Result<(
             { url = "https://files.pythonhosted.org/packages/f5/d5/688db678e987c3e0fb17867970700b92603cadf36c56e5fb08f23e822a0c/yarl-1.18.3-cp313-cp313-win_amd64.whl", hash = "sha256:578e281c393af575879990861823ef19d66e2b1d0098414855dd367e234f5b3c", size = 315723 },
             { url = "https://files.pythonhosted.org/packages/f5/4b/a06e0ec3d155924f77835ed2d167ebd3b211a7b0853da1cf8d8414d784ef/yarl-1.18.3-py3-none-any.whl", hash = "sha256:b57f4f58099328dfb26c6a771d09fb20dbbae81d20cfb66141251ea063bd101b", size = 45109 },
         ]
-        "#
+        "###
         );
     });
 
@@ -10133,8 +10149,9 @@ fn overlapping_resolution_markers() -> Result<()> {
     }, {
         assert_snapshot!(
             lock,
-            @r#"
+            @r###"
         version = 1
+        revision = 1
         requires-python = "==3.10.*"
         resolution-markers = [
             "sys_platform == 'linux' and extra != 'extra-14-ads-mega-model-cpu' and extra == 'extra-14-ads-mega-model-cu118'",
@@ -10173,13 +10190,13 @@ fn overlapping_resolution_markers() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["cpu", "cu118"]
         requires-dist = [
             { name = "torch", marker = "sys_platform == 'darwin' and extra == 'cpu'", specifier = "==2.2.2" },
             { name = "torch", marker = "sys_platform != 'darwin' and extra == 'cpu'", specifier = "==2.2.2", index = "https://astral-sh.github.io/pytorch-mirror/whl/cpu", conflict = { package = "ads-mega-model", extra = "cpu" } },
             { name = "torch", marker = "extra == 'cu118'", specifier = "==2.2.2" },
             { name = "wandb", specifier = "==0.17.6" },
         ]
+        provides-extras = ["cpu", "cu118"]
 
         [[package]]
         name = "certifi"
@@ -10743,7 +10760,7 @@ fn overlapping_resolution_markers() -> Result<()> {
             { url = "https://files.pythonhosted.org/packages/df/b9/1d26752a7c9ff5b255c921e13a9c5176e21a0b77e53d3febf892d90c86a5/wandb-0.17.6-py3-none-win32.whl", hash = "sha256:247b1c9677fd633a460201f421d4fd4f370e7243d06257fab0ad1bb728ddcc1c", size = 6504208 },
             { url = "https://files.pythonhosted.org/packages/fc/2c/280b8891362967e54de2267454ac6033568b8412ec31225f00ecc11db7a6/wandb-0.17.6-py3-none-win_amd64.whl", hash = "sha256:51954f993b372c20812616838302183f0e3abf137614f05d80c7c17c307bfff9", size = 6504213 },
         ]
-        "#
+        "###
         );
     });
 

--- a/crates/uv/tests/it/lock_scenarios.rs
+++ b/crates/uv/tests/it/lock_scenarios.rs
@@ -121,8 +121,9 @@ fn wrong_backtracking_basic() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -135,7 +136,6 @@ fn wrong_backtracking_basic() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a" },
             { name = "package-b" },
@@ -161,7 +161,7 @@ fn wrong_backtracking_basic() -> Result<()> {
         wheels = [
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/wrong_backtracking_basic_b-2.0.9-py3-none-any.whl", hash = "sha256:bf96af1a69f8c1d1d9c2687cd5d6f023cda56dd77d3f37f3cdd422e2a410541f" },
         ]
-        "#
+        "###
         );
     });
 
@@ -245,8 +245,9 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -272,12 +273,11 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=1" },
         ]
-        "#
+        "###
         );
     });
 
@@ -363,8 +363,9 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -385,12 +386,11 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", specifier = "<2" },
             { name = "package-a", specifier = ">=1" },
         ]
-        "#
+        "###
         );
     });
 
@@ -463,8 +463,9 @@ fn fork_basic() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -506,12 +507,11 @@ fn fork_basic() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -749,8 +749,9 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'linux'",
@@ -842,14 +843,13 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "==4.3.0" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = "==4.4.0" },
             { name = "package-b", marker = "sys_platform == 'linux'", specifier = "==1.0.0" },
             { name = "package-c", marker = "sys_platform == 'darwin'", specifier = "==1.0.0" },
         ]
-        "#
+        "###
         );
     });
 
@@ -928,8 +928,9 @@ fn fork_upgrade() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -962,9 +963,8 @@ fn fork_upgrade() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-foo" }]
-        "#
+        "###
         );
     });
 
@@ -1049,8 +1049,9 @@ fn fork_incomplete_markers() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.11'",
@@ -1114,13 +1115,12 @@ fn fork_incomplete_markers() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "python_full_version < '3.10'", specifier = "==1" },
             { name = "package-a", marker = "python_full_version >= '3.11'", specifier = "==2" },
             { name = "package-b" },
         ]
-        "#
+        "###
         );
     });
 
@@ -1203,8 +1203,9 @@ fn fork_marker_accrue() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -1250,12 +1251,11 @@ fn fork_marker_accrue() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "implementation_name == 'cpython'", specifier = "==1.0.0" },
             { name = "package-b", marker = "implementation_name == 'pypy'", specifier = "==1.0.0" },
         ]
-        "#
+        "###
         );
     });
 
@@ -1407,8 +1407,9 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
@@ -1494,12 +1495,11 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -1588,8 +1588,9 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
@@ -1663,12 +1664,11 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -1758,8 +1758,9 @@ fn fork_marker_inherit_combined() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
@@ -1833,12 +1834,11 @@ fn fork_marker_inherit_combined() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -1921,8 +1921,9 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -1976,12 +1977,11 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2070,8 +2070,9 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -2137,12 +2138,11 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2227,8 +2227,9 @@ fn fork_marker_inherit() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -2270,12 +2271,11 @@ fn fork_marker_inherit() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2366,8 +2366,9 @@ fn fork_marker_limited_inherit() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -2431,13 +2432,12 @@ fn fork_marker_limited_inherit() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'linux'", specifier = ">=2" },
             { name = "package-b" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2522,8 +2522,9 @@ fn fork_marker_selection() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -2575,13 +2576,12 @@ fn fork_marker_selection() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a" },
             { name = "package-b", marker = "sys_platform == 'darwin'", specifier = "<2" },
             { name = "package-b", marker = "sys_platform == 'linux'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2678,8 +2678,9 @@ fn fork_marker_track() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'darwin'",
@@ -2743,13 +2744,12 @@ fn fork_marker_track() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a" },
             { name = "package-b", marker = "sys_platform == 'darwin'", specifier = "<2.8" },
             { name = "package-b", marker = "sys_platform == 'linux'", specifier = ">=2.8" },
         ]
-        "#
+        "###
         );
     });
 
@@ -2831,8 +2831,9 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -2878,12 +2879,11 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", specifier = "==1.0.0" },
             { name = "package-b", specifier = "==1.0.0" },
         ]
-        "#
+        "###
         );
     });
 
@@ -3131,8 +3131,9 @@ fn fork_overlapping_markers_basic() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "python_full_version >= '3.11'",
@@ -3158,13 +3159,12 @@ fn fork_overlapping_markers_basic() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "python_full_version < '3.10'", specifier = ">=1.0.0" },
             { name = "package-a", marker = "python_full_version >= '3.10'", specifier = ">=1.1.0" },
             { name = "package-a", marker = "python_full_version >= '3.11'", specifier = ">=1.2.0" },
         ]
-        "#
+        "###
         );
     });
 
@@ -3299,8 +3299,9 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'linux'",
@@ -3403,9 +3404,8 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-cleaver" }]
-        "#
+        "###
         );
     });
 
@@ -3678,8 +3678,9 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'linux'",
@@ -3826,13 +3827,12 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-bar" },
             { name = "package-cleaver" },
             { name = "package-foo" },
         ]
-        "#
+        "###
         );
     });
 
@@ -3962,8 +3962,9 @@ fn preferences_dependent_forking() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "sys_platform == 'linux'",
@@ -4028,13 +4029,12 @@ fn preferences_dependent_forking() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-bar" },
             { name = "package-cleaver" },
             { name = "package-foo" },
         ]
-        "#
+        "###
         );
     });
 
@@ -4137,8 +4137,9 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
         resolution-markers = [
             "os_name == 'darwin' and sys_platform == 'illumos'",
@@ -4212,12 +4213,11 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'illumos'", specifier = "<2" },
             { name = "package-a", marker = "sys_platform == 'windows'", specifier = ">=2" },
         ]
-        "#
+        "###
         );
     });
 
@@ -4292,6 +4292,7 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
 
         [[package]]
@@ -4300,7 +4301,6 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
         source = { virtual = "." }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9'", specifier = "==1.0.0" }]
         "###
         );
@@ -4377,6 +4377,7 @@ fn fork_requires_python_full() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
 
         [[package]]
@@ -4385,7 +4386,6 @@ fn fork_requires_python_full() -> Result<()> {
         source = { virtual = "." }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9'", specifier = "==1.0.0" }]
         "###
         );
@@ -4464,8 +4464,9 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10.1"
 
         [[package]]
@@ -4486,9 +4487,8 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.10.*'", specifier = "==1.0.0" }]
-        "#
+        "###
         );
     });
 
@@ -4560,6 +4560,7 @@ fn fork_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
 
         [[package]]
@@ -4568,7 +4569,6 @@ fn fork_requires_python() -> Result<()> {
         source = { virtual = "." }
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9.*'", specifier = "==1.0.0" }]
         "###
         );
@@ -4639,8 +4639,9 @@ fn requires_python_wheels() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.10"
 
         [[package]]
@@ -4652,7 +4653,6 @@ fn requires_python_wheels() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", specifier = "==1.0.0" }]
 
         [[package]]
@@ -4664,7 +4664,7 @@ fn requires_python_wheels() -> Result<()> {
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/requires_python_wheels_a-1.0.0-cp310-cp310-any.whl", hash = "sha256:b979494a0d7dc825b84d6c516ac407143915f6d2840d229ee2a36b3d06deb61d" },
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/requires_python_wheels_a-1.0.0-cp311-cp311-any.whl", hash = "sha256:b979494a0d7dc825b84d6c516ac407143915f6d2840d229ee2a36b3d06deb61d" },
         ]
-        "#
+        "###
         );
     });
 
@@ -4736,8 +4736,9 @@ fn unreachable_package() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -4749,7 +4750,6 @@ fn unreachable_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a", marker = "sys_platform == 'win32'", specifier = "==1.0.0" }]
 
         [[package]]
@@ -4760,7 +4760,7 @@ fn unreachable_package() -> Result<()> {
         wheels = [
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/unreachable_package_a-1.0.0-py3-none-any.whl", hash = "sha256:cc472ded9f3b260e6cda0e633fa407a13607e190422cb455f02beebd32d6751f" },
         ]
-        "#
+        "###
         );
     });
 
@@ -4838,8 +4838,9 @@ fn unreachable_wheels() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -4853,7 +4854,6 @@ fn unreachable_wheels() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [
             { name = "package-a", marker = "sys_platform == 'win32'", specifier = "==1.0.0" },
             { name = "package-b", marker = "sys_platform == 'linux'", specifier = "==1.0.0" },
@@ -4887,7 +4887,7 @@ fn unreachable_wheels() -> Result<()> {
         wheels = [
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/unreachable_wheels_c-1.0.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:4b846c5b1646b04828a2bef6c9d180ff7cfd725866013dcec8933de7fb5f9e8d" },
         ]
-        "#
+        "###
         );
     });
 
@@ -4967,8 +4967,9 @@ fn specific_architecture() -> Result<()> {
         filters => filters,
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.8"
 
         [[package]]
@@ -4980,7 +4981,6 @@ fn specific_architecture() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "package-a" }]
 
         [[package]]
@@ -5028,7 +5028,7 @@ fn specific_architecture() -> Result<()> {
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/specific_architecture_d-1.0.0-cp313-cp313-freebsd_13_x86_64.whl", hash = "sha256:842864c1348694fab33199eb05921602c2abfc77844a81085a55db02edd30da4" },
             { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/specific_architecture_d-1.0.0-cp313-cp313-manylinux2010_i686.whl", hash = "sha256:842864c1348694fab33199eb05921602c2abfc77844a81085a55db02edd30da4" },
         ]
-        "#
+        "###
         );
     });
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -815,8 +815,9 @@ fn run_pep723_script_lock() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -833,7 +834,7 @@ fn run_pep723_script_lock() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
         ]
-        "#
+        "###
         );
     });
 
@@ -925,6 +926,7 @@ fn run_pep723_script_lock() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -1728,8 +1730,9 @@ fn run_locked() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            existing, @r#"
+            existing, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1766,7 +1769,6 @@ fn run_locked() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]
@@ -1777,7 +1779,7 @@ fn run_locked() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
         ]
-        "#);
+        "###);
         }
     );
 

--- a/crates/uv/tests/it/snapshots/it__ecosystem__black-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__black-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.10' and implementation_name == 'pypy' and sys_platform == 'win32'",
@@ -208,7 +209,6 @@ uvloop = [
 ]
 
 [package.metadata]
-provides-extras = ["colorama", "d", "jupyter", "uvloop"]
 requires-dist = [
     { name = "aiohttp", marker = "implementation_name == 'pypy' and sys_platform == 'win32' and extra == 'd'", specifier = ">=3.7.4,!=3.9.0" },
     { name = "aiohttp", marker = "(implementation_name != 'pypy' and extra == 'd') or (sys_platform != 'win32' and extra == 'd')", specifier = ">=3.7.4" },
@@ -224,6 +224,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.1" },
     { name = "uvloop", marker = "extra == 'uvloop'", specifier = ">=0.15.2" },
 ]
+provides-extras = ["colorama", "d", "jupyter", "uvloop"]
 
 [[package]]
 name = "click"

--- a/crates/uv/tests/it/snapshots/it__ecosystem__github-wikidata-bot-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__github-wikidata-bot-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -126,7 +127,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = []
 requires-dist = [
     { name = "cachecontrol", extras = ["filecache"], specifier = ">=0.14,<0.15" },
     { name = "mwparserfromhell", specifier = ">=0.6.4,<0.7" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__home-assistant-core-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__home-assistant-core-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12.[X]"
 
 [options]
@@ -663,7 +664,6 @@ dependencies = [
 ]
 
 [package.metadata]
-provides-extras = []
 requires-dist = [
     { name = "aiodns", specifier = "==3.2.0" },
     { name = "aiohttp", specifier = "==3.9.5" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__packse-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__packse-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [options]
@@ -340,7 +341,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["index", "serve"]
 requires-dist = [
     { name = "chevron-blue", specifier = ">=0.2.1" },
     { name = "hatchling", specifier = ">=1.20.0" },
@@ -352,6 +352,7 @@ requires-dist = [
     { name = "twine", specifier = ">=4.0.2" },
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
+provides-extras = ["index", "serve"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/snapshots/it__ecosystem__saleor-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__saleor-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [options]
@@ -1864,7 +1865,6 @@ dependencies = [
 ]
 
 [package.metadata]
-provides-extras = []
 requires-dist = [
     { name = "adyen", specifier = ">=4.0.0,<5.0.0" },
     { name = "aniso8601", specifier = ">=7.0.0,<8.0.0" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__transformers-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__transformers-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.9.0"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
@@ -5874,7 +5875,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["ja", "sklearn", "tf", "tf-cpu", "torch", "accelerate", "retrieval", "flax", "tokenizers", "ftfy", "onnxruntime", "onnx", "modelcreation", "sagemaker", "deepspeed", "optuna", "ray", "sigopt", "integrations", "serving", "audio", "speech", "torch-speech", "tf-speech", "flax-speech", "vision", "timm", "torch-vision", "codecarbon", "video", "sentencepiece", "deepspeed-testing", "quality", "all", "docs-specific", "docs", "torchhub", "agents"]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'accelerate'", specifier = ">=0.21.0" },
     { name = "accelerate", marker = "extra == 'agents'", specifier = ">=0.21.0" },
@@ -6077,6 +6077,7 @@ requires-dist = [
     { name = "urllib3", marker = "extra == 'quality'", specifier = "<2.0.0" },
     { name = "uvicorn", marker = "extra == 'serving'" },
 ]
+provides-extras = ["ja", "sklearn", "tf", "tf-cpu", "torch", "accelerate", "retrieval", "flax", "tokenizers", "ftfy", "onnxruntime", "onnx", "modelcreation", "sagemaker", "deepspeed", "optuna", "ray", "sigopt", "integrations", "serving", "audio", "speech", "torch-speech", "tf-speech", "flax-speech", "vision", "timm", "torch-vision", "codecarbon", "video", "sentencepiece", "deepspeed-testing", "quality", "all", "docs-specific", "docs", "torchhub", "agents"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/ecosystem.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = "==3.11.*"
 
 [options]
@@ -3957,7 +3958,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["deploy"]
 requires-dist = [
     { name = "alembic", specifier = ">=0.7.0" },
     { name = "alembic-postgresql-enum" },
@@ -4039,6 +4039,7 @@ requires-dist = [
     { name = "zope-sqlalchemy" },
     { name = "zxcvbn" },
 ]
+provides-extras = ["deploy"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/snapshots/it__workflow__jax_instability-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__jax_instability-2.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/workflow.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.9.0"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -168,7 +169,6 @@ dependencies = [
 ]
 
 [package.metadata]
-provides-extras = []
 requires-dist = [{ name = "jax", specifier = "==0.4.17" }]
 
 [[package]]

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_existing_package_noop-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_existing_package_noop-2.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/workflow.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [options]
@@ -336,7 +337,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["index", "serve"]
 requires-dist = [
     { name = "chevron-blue", specifier = ">=0.2.1" },
     { name = "hatchling", specifier = ">=1.20.0" },
@@ -348,6 +348,7 @@ requires-dist = [
     { name = "twine", specifier = ">=4.0.2" },
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
+provides-extras = ["index", "serve"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_one_package-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_one_package-2.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/workflow.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [options]
@@ -336,7 +337,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["index", "serve"]
 requires-dist = [
     { name = "chevron-blue", specifier = ">=0.2.1" },
     { name = "hatchling", specifier = ">=1.20.0" },
@@ -348,6 +348,7 @@ requires-dist = [
     { name = "twine", specifier = ">=4.0.2" },
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
+provides-extras = ["index", "serve"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_promote_transitive_to_direct_then_remove-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_promote_transitive_to_direct_then_remove-2.snap
@@ -3,6 +3,7 @@ source: crates/uv/tests/it/workflow.rs
 expression: lock
 ---
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [options]
@@ -336,7 +337,6 @@ dev = [
 ]
 
 [package.metadata]
-provides-extras = ["index", "serve"]
 requires-dist = [
     { name = "chevron-blue", specifier = ">=0.2.1" },
     { name = "hatchling", specifier = ">=1.20.0" },
@@ -348,6 +348,7 @@ requires-dist = [
     { name = "twine", specifier = ">=4.0.2" },
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
+provides-extras = ["index", "serve"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -1073,8 +1073,9 @@ fn sync_relative_wheel() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.12"
 
             [options]
@@ -1088,10 +1089,6 @@ fn sync_relative_wheel() -> Result<()> {
                 { filename = "ok-1.0.0-py3-none-any.whl", hash = "sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f" },
             ]
 
-            [package.metadata]
-            provides-extras = []
-            requires-dist = []
-
             [[package]]
             name = "relative-wheel"
             version = "0.1.0"
@@ -1101,9 +1098,8 @@ fn sync_relative_wheel() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [{ name = "ok", path = "wheels/ok-1.0.0-py3-none-any.whl" }]
-            "#
+            "###
             );
         }
     );
@@ -2411,8 +2407,9 @@ fn sync_group_legacy_non_project_member() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2438,7 +2435,6 @@ fn sync_group_legacy_non_project_member() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig", specifier = ">=1" }]
 
         [[package]]
@@ -2458,7 +2454,7 @@ fn sync_group_legacy_non_project_member() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -2522,8 +2518,9 @@ fn sync_group_self() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -2570,11 +2567,11 @@ fn sync_group_self() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = ["test"]
         requires-dist = [
             { name = "idna", marker = "extra == 'test'", specifier = ">=3" },
             { name = "iniconfig", specifier = ">=2" },
         ]
+        provides-extras = ["test"]
 
         [package.metadata.requires-dev]
         bar = [{ name = "project", extras = ["test"] }]
@@ -2591,7 +2588,7 @@ fn sync_group_self() -> Result<()> {
         wheels = [
             { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
         ]
-        "#
+        "###
         );
     });
 
@@ -3308,8 +3305,9 @@ fn convert_to_virtual() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3333,9 +3331,8 @@ fn convert_to_virtual() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
-        "#
+        "###
         );
     });
 
@@ -3368,8 +3365,9 @@ fn convert_to_virtual() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3393,9 +3391,8 @@ fn convert_to_virtual() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
-        "#
+        "###
         );
     });
 
@@ -3437,8 +3434,9 @@ fn convert_to_package() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3462,9 +3460,8 @@ fn convert_to_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
-        "#
+        "###
         );
     });
 
@@ -3502,8 +3499,9 @@ fn convert_to_package() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -3527,9 +3525,8 @@ fn convert_to_package() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "iniconfig" }]
-        "#
+        "###
         );
     });
 
@@ -4920,8 +4917,9 @@ fn sync_dynamic_extra() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.12"
 
             [options]
@@ -4950,11 +4948,11 @@ fn sync_dynamic_extra() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = ["dev"]
             requires-dist = [
                 { name = "iniconfig" },
                 { name = "typing-extensions", marker = "extra == 'dev'" },
             ]
+            provides-extras = ["dev"]
 
             [[package]]
             name = "typing-extensions"
@@ -4964,7 +4962,7 @@ fn sync_dynamic_extra() -> Result<()> {
             wheels = [
                 { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6249,8 +6247,9 @@ fn sync_stale_egg_info() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.13"
 
             [options]
@@ -6266,7 +6265,6 @@ fn sync_stale_egg_info() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "member", git = "https://github.com/astral-sh/uv-stale-egg-info-test.git?subdirectory=member" },
                 { name = "root", git = "https://github.com/astral-sh/uv-stale-egg-info-test.git" },
@@ -6296,7 +6294,7 @@ fn sync_stale_egg_info() -> Result<()> {
             wheels = [
                 { url = "https://files.pythonhosted.org/packages/92/e1/1c8bb3420105e70bdf357d57dd5567202b4ef8d27f810e98bb962d950834/setuptools-69.2.0-py3-none-any.whl", hash = "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c", size = 821485 },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6356,8 +6354,9 @@ fn sync_git_repeated_member_static_metadata() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.13"
 
             [options]
@@ -6373,7 +6372,6 @@ fn sync_git_repeated_member_static_metadata() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "uv-git-workspace-in-root", git = "https://github.com/astral-sh/workspace-in-root-test.git" },
                 { name = "workspace-member-in-subdir", git = "https://github.com/astral-sh/workspace-in-root-test.git?subdirectory=workspace-member-in-subdir" },
@@ -6391,7 +6389,7 @@ fn sync_git_repeated_member_static_metadata() -> Result<()> {
             dependencies = [
                 { name = "uv-git-workspace-in-root" },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6450,8 +6448,9 @@ fn sync_git_repeated_member_dynamic_metadata() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.13"
 
             [options]
@@ -6475,7 +6474,6 @@ fn sync_git_repeated_member_dynamic_metadata() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "dependency", git = "https://github.com/astral-sh/uv-dynamic-metadata-test.git?subdirectory=dependency" },
                 { name = "package", git = "https://github.com/astral-sh/uv-dynamic-metadata-test.git" },
@@ -6507,7 +6505,7 @@ fn sync_git_repeated_member_dynamic_metadata() -> Result<()> {
             wheels = [
                 { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6568,8 +6566,9 @@ fn sync_git_repeated_member_backwards_path() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.13"
 
             [options]
@@ -6590,7 +6589,6 @@ fn sync_git_repeated_member_backwards_path() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [
                 { name = "dependency", git = "https://github.com/astral-sh/uv-backwards-path-test?subdirectory=dependency" },
                 { name = "package", git = "https://github.com/astral-sh/uv-backwards-path-test?subdirectory=root" },
@@ -6603,7 +6601,7 @@ fn sync_git_repeated_member_backwards_path() -> Result<()> {
             dependencies = [
                 { name = "dependency" },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6750,8 +6748,9 @@ fn sync_git_path_dependency() -> Result<()> {
         },
         {
             assert_snapshot!(
-                lock, @r#"
+                lock, @r###"
             version = 1
+            revision = 1
             requires-python = ">=3.13"
 
             [options]
@@ -6766,7 +6765,6 @@ fn sync_git_path_dependency() -> Result<()> {
             ]
 
             [package.metadata]
-            provides-extras = []
             requires-dist = [{ name = "package2", git = "https://github.com/astral-sh/uv-path-dependency-test.git?subdirectory=package2" }]
 
             [[package]]
@@ -6781,7 +6779,7 @@ fn sync_git_path_dependency() -> Result<()> {
             dependencies = [
                 { name = "package1" },
             ]
-            "#
+            "###
             );
         }
     );
@@ -6858,8 +6856,9 @@ fn sync_build_tag() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -6884,9 +6883,8 @@ fn sync_build_tag() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "build-tag" }]
-        "#
+        "###
         );
     });
 
@@ -7411,6 +7409,7 @@ fn sync_locked_script() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -7515,6 +7514,7 @@ fn sync_locked_script() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]

--- a/crates/uv/tests/it/tree.rs
+++ b/crates/uv/tests/it/tree.rs
@@ -1248,6 +1248,7 @@ fn script() -> Result<()> {
         assert_snapshot!(
             lock, @r#"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]
@@ -1433,6 +1434,7 @@ fn script() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.11"
 
         [options]

--- a/crates/uv/tests/it/workflow.rs
+++ b/crates/uv/tests/it/workflow.rs
@@ -35,7 +35,7 @@ fn packse_add_remove_one_package() {
         assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -306,20 +306,21 @@
+        @@ -307,20 +307,21 @@
          name = "packse"
          version = "0.0.0"
          source = { editable = "." }
@@ -58,7 +58,7 @@ fn packse_add_remove_one_package() {
              { name = "watchfiles" },
          ]
         @@ -335,20 +336,21 @@
-         provides-extras = ["index", "serve"]
+         [package.metadata]
          requires-dist = [
              { name = "chevron-blue", specifier = ">=0.2.1" },
              { name = "hatchling", specifier = ">=1.20.0" },
@@ -71,6 +71,7 @@ fn packse_add_remove_one_package() {
         +    { name = "tzdata", specifier = ">=2024.1" },
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
+         provides-extras = ["index", "serve"]
 
          [package.metadata.requires-dev]
          dev = [
@@ -78,8 +79,7 @@ fn packse_add_remove_one_package() {
              { name = "pytest", specifier = ">=7.4.3" },
              { name = "syrupy", specifier = ">=4.6.0" },
          ]
-
-        @@ -600,20 +602,29 @@
+        @@ -601,20 +603,29 @@
              { name = "rfc3986" },
              { name = "rich" },
              { name = "urllib3" },
@@ -123,7 +123,7 @@ fn packse_add_remove_one_package() {
         assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -306,21 +306,20 @@
+        @@ -307,21 +307,20 @@
          name = "packse"
          version = "0.0.0"
          source = { editable = "." }
@@ -146,7 +146,7 @@ fn packse_add_remove_one_package() {
              { name = "watchfiles" },
          ]
         @@ -336,21 +335,20 @@
-         provides-extras = ["index", "serve"]
+         [package.metadata]
          requires-dist = [
              { name = "chevron-blue", specifier = ">=0.2.1" },
              { name = "hatchling", specifier = ">=1.20.0" },
@@ -159,6 +159,7 @@ fn packse_add_remove_one_package() {
         -    { name = "tzdata", specifier = ">=2024.1" },
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
+         provides-extras = ["index", "serve"]
 
          [package.metadata.requires-dev]
          dev = [
@@ -166,8 +167,7 @@ fn packse_add_remove_one_package() {
              { name = "pytest", specifier = ">=7.4.3" },
              { name = "syrupy", specifier = ">=4.6.0" },
          ]
-
-        @@ -599,29 +597,20 @@
+        @@ -600,29 +598,20 @@
              { name = "readme-renderer" },
              { name = "requests" },
              { name = "requests-toolbelt" },
@@ -277,7 +277,7 @@ fn packse_promote_transitive_to_direct_then_remove() {
         assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -305,20 +305,21 @@
+        @@ -306,20 +306,21 @@
          [[package]]
          name = "packse"
          version = "0.0.0"
@@ -300,8 +300,8 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "pypiserver" },
              { name = "watchfiles" },
         @@ -334,20 +335,21 @@
+
          [package.metadata]
-         provides-extras = ["index", "serve"]
          requires-dist = [
              { name = "chevron-blue", specifier = ">=0.2.1" },
              { name = "hatchling", specifier = ">=1.20.0" },
@@ -314,13 +314,13 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "twine", specifier = ">=4.0.2" },
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
+         provides-extras = ["index", "serve"]
 
          [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },
              { name = "syrupy", specifier = ">=4.6.0" },
-         ]
         "###);
     });
 
@@ -335,7 +335,7 @@ fn packse_promote_transitive_to_direct_then_remove() {
         assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -305,21 +305,20 @@
+        @@ -306,21 +306,20 @@
          [[package]]
          name = "packse"
          version = "0.0.0"
@@ -358,8 +358,8 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "pypiserver" },
              { name = "watchfiles" },
         @@ -335,21 +334,20 @@
+
          [package.metadata]
-         provides-extras = ["index", "serve"]
          requires-dist = [
              { name = "chevron-blue", specifier = ">=0.2.1" },
              { name = "hatchling", specifier = ">=1.20.0" },
@@ -372,13 +372,13 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "twine", specifier = ">=4.0.2" },
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
+         provides-extras = ["index", "serve"]
 
          [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },
              { name = "syrupy", specifier = ">=4.6.0" },
-         ]
         "###);
     });
 
@@ -431,10 +431,10 @@ fn jax_instability() -> Result<()> {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(diff, @r#"
+        assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -8,21 +8,21 @@
+        @@ -9,21 +9,21 @@
          ]
 
          [options]
@@ -457,7 +457,7 @@ fn jax_instability() -> Result<()> {
          name = "jax"
          version = "0.4.17"
          source = { registry = "https://pypi.org/simple" }
-        @@ -149,29 +149,42 @@
+        @@ -150,28 +150,41 @@
              { url = "https://files.pythonhosted.org/packages/f3/31/91a2a3c5eb85d2bfa86d7c98f2df5d77dcdefb3d80ca9f9037ad04393acf/scipy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e646d8571804a304e1da01040d21577685ce8e2db08ac58e543eaca063453e1c", size = 45816713 },
              { url = "https://files.pythonhosted.org/packages/ed/be/49a3f999dc91f1a653847f38c34763dcdeaa8a327f3665bdfe9bf5555109/scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35", size = 38929252 },
              { url = "https://files.pythonhosted.org/packages/32/48/f605bad3e610efe05a51b56698578f7a98f900513a4bad2c9f12df845cd6/scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067", size = 31356374 },
@@ -486,7 +486,6 @@ fn jax_instability() -> Result<()> {
          ]
 
          [package.metadata]
-         provides-extras = []
         -requires-dist = [{ name = "jax", specifier = "==0.4.17" }]
         +requires-dist = [
         +    { name = "jax", specifier = "==0.4.17" },
@@ -501,7 +500,7 @@ fn jax_instability() -> Result<()> {
          wheels = [
              { url = "https://files.pythonhosted.org/packages/c2/0a/ba9d0ee9536d3ef73a3448e931776e658b36f128d344e175bc32b092a8bf/zipp-3.18.1-py3-none-any.whl", hash = "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b", size = 8247 },
          ]
-        "#);
+        "###);
     });
 
     let diff = context.diff_lock(|context| {
@@ -512,10 +511,10 @@ fn jax_instability() -> Result<()> {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(diff, @r#"
+        assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -149,42 +149,29 @@
+        @@ -150,41 +150,28 @@
              { url = "https://files.pythonhosted.org/packages/f3/31/91a2a3c5eb85d2bfa86d7c98f2df5d77dcdefb3d80ca9f9037ad04393acf/scipy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e646d8571804a304e1da01040d21577685ce8e2db08ac58e543eaca063453e1c", size = 45816713 },
              { url = "https://files.pythonhosted.org/packages/ed/be/49a3f999dc91f1a653847f38c34763dcdeaa8a327f3665bdfe9bf5555109/scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35", size = 38929252 },
              { url = "https://files.pythonhosted.org/packages/32/48/f605bad3e610efe05a51b56698578f7a98f900513a4bad2c9f12df845cd6/scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067", size = 31356374 },
@@ -544,7 +543,6 @@ fn jax_instability() -> Result<()> {
          ]
 
          [package.metadata]
-         provides-extras = []
         -requires-dist = [
         -    { name = "jax", specifier = "==0.4.17" },
         -    { name = "tzdata", specifier = ">=2024.1" },
@@ -559,7 +557,7 @@ fn jax_instability() -> Result<()> {
          wheels = [
              { url = "https://files.pythonhosted.org/packages/c2/0a/ba9d0ee9536d3ef73a3448e931776e658b36f128d344e175bc32b092a8bf/zipp-3.18.1-py3-none-any.whl", hash = "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b", size = 8247 },
          ]
-        "#);
+        "###);
     });
 
     // Back to where we started.
@@ -577,7 +575,7 @@ fn jax_instability() -> Result<()> {
         assert_snapshot!(diff, @r###"
         --- old
         +++ new
-        @@ -8,21 +8,21 @@
+        @@ -9,21 +9,21 @@
          ]
 
          [options]

--- a/crates/uv/tests/it/workspace.rs
+++ b/crates/uv/tests/it/workspace.rs
@@ -1199,8 +1199,9 @@ fn workspace_inherit_sources() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            lock, @r#"
+            lock, @r###"
         version = 1
+        revision = 1
         requires-python = ">=3.12"
 
         [options]
@@ -1221,7 +1222,6 @@ fn workspace_inherit_sources() -> Result<()> {
         ]
 
         [package.metadata]
-        provides-extras = []
         requires-dist = [{ name = "library", editable = "../library" }]
 
         [[package]]
@@ -1229,19 +1229,11 @@ fn workspace_inherit_sources() -> Result<()> {
         version = "0.1.0"
         source = { editable = "../library" }
 
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-
         [[package]]
         name = "workspace"
         version = "0.1.0"
         source = { editable = "." }
-
-        [package.metadata]
-        provides-extras = []
-        requires-dist = []
-        "#
+        "###
         );
     });
 


### PR DESCRIPTION
## Summary

This is an alternative to the approach we took in #11063 whereby we always included `provides-extra` and `requires-dist`, since we needed some way to differentiate between "no extras" and "lockfile was generated by a uv version that didn't include extras".

Instead, this PR adds a minor version (called a "revision") to the lockfile that we can use to indicate support for this feature. While lockfile version bumps are backwards-incompatible, older uv versions _can_ read lockfiles with a later revision -- they just won't understand all the data.

In a future major version bump, we could simplify things and change the schema to use a (major, minor) format instead of these two separate fields. But this is the only way to do it that's backwards-compatible with existing uv versions.
