### PR TITLE
chore: Update the default starting file when using `uv init example-app`

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -30,7 +30,7 @@ $ tree example-app
 example-app
 ├── .python-version
 ├── README.md
-├── main.py
+├── hello.py
 └── pyproject.toml
 ```
 
@@ -49,7 +49,7 @@ dependencies = []
 
 The sample file defines a `main` function with some standard boilerplate:
 
-```python title="main.py"
+```python title="hello.py"
 def main():
     print("Hello from example-app!")
 
@@ -61,7 +61,7 @@ if __name__ == "__main__":
 Python files can be executed with `uv run`:
 
 ```console
-$ uv run main.py
+$ uv run hello.py
 Hello from example-project!
 ```
 


### PR DESCRIPTION
Update the default starting file name.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Update the default starting file when using `uv init example-app`. I am using version uv 0.5.26.

## Test Plan

<!-- How was it tested? -->
