### PR TITLE
Fallback to `GET` on HTTP 400 when attempting to use range requests for wheel download

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -98,6 +98,12 @@ impl Error {
                     if status == reqwest::StatusCode::FORBIDDEN {
                         return true;
                     }
+
+                    // In some cases, registries (like Alibaba Cloud) return a 400 for HEAD requests
+                    // when they're not supported. Again, it's better to be lenient here.
+                    if status == reqwest::StatusCode::BAD_REQUEST {
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/11501