### PR TITLE
Remove build backend parking breaks

### DIFF
--- a/python/uv/__init__.py
+++ b/python/uv/__init__.py
@@ -1,48 +1,24 @@
 from __future__ import annotations
 
-import os
-
-if os.environ.get("UV_PREVIEW"):
-    from ._build_backend import *
+from ._build_backend import *
 from ._find_uv import find_uv_bin
 
-if os.environ.get("UV_PREVIEW"):
-    __all__ = [
-        "find_uv_bin",
-        # PEP 517 hook `build_sdist`.
-        "build_sdist",
-        # PEP 517 hook `build_wheel`.
-        "build_wheel",
-        # PEP 660 hook `build_editable`.
-        "build_editable",
-        # PEP 517 hook `get_requires_for_build_sdist`.
-        "get_requires_for_build_sdist",
-        # PEP 517 hook `get_requires_for_build_wheel`.
-        "get_requires_for_build_wheel",
-        # PEP 517 hook `prepare_metadata_for_build_wheel`.
-        "prepare_metadata_for_build_wheel",
-        # PEP 660 hook `get_requires_for_build_editable`.
-        "get_requires_for_build_editable",
-        # PEP 660 hook `prepare_metadata_for_build_editable`.
-        "prepare_metadata_for_build_editable",
-    ]
-else:
-    __all__ = ["find_uv_bin"]
-
-
-def __getattr__(attr_name: str) -> object:
-    if attr_name in {
-        "build_sdist",
-        "build_wheel",
-        "build_editable",
-        "get_requires_for_build_sdist",
-        "get_requires_for_build_wheel",
-        "prepare_metadata_for_build_wheel",
-        "get_requires_for_build_editable",
-        "prepare_metadata_for_build_editable",
-    }:
-        err = f"Using `uv.{attr_name}` is not allowed. The uv build backend requires preview mode to be enabled, e.g., via the `UV_PREVIEW=1` environment variable."
-        raise AttributeError(err)
-
-    err = f"module 'uv' has no attribute '{attr_name}'"
-    raise AttributeError(err)
+__all__ = [
+    "find_uv_bin",
+    # PEP 517 hook `build_sdist`.
+    "build_sdist",
+    # PEP 517 hook `build_wheel`.
+    "build_wheel",
+    # PEP 660 hook `build_editable`.
+    "build_editable",
+    # PEP 517 hook `get_requires_for_build_sdist`.
+    "get_requires_for_build_sdist",
+    # PEP 517 hook `get_requires_for_build_wheel`.
+    "get_requires_for_build_wheel",
+    # PEP 517 hook `prepare_metadata_for_build_wheel`.
+    "prepare_metadata_for_build_wheel",
+    # PEP 660 hook `get_requires_for_build_editable`.
+    "get_requires_for_build_editable",
+    # PEP 660 hook `prepare_metadata_for_build_editable`.
+    "prepare_metadata_for_build_editable",
+]

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -23,7 +23,15 @@ if TYPE_CHECKING:
 
 
 def warn_config_settings(config_settings: "Mapping[Any, Any] | None" = None) -> None:
+    import os
     import sys
+
+    if not os.environ.get("UV_PREVIEW"):
+        print(
+            "Warning: The uv build backend is in preview. "
+            "Set the `UV_PREVIEW` environment variable to `1` to acknowledge.",
+            file=sys.stderr,
+        )
 
     if config_settings:
         print("Warning: Config settings are not supported", file=sys.stderr)


### PR DESCRIPTION
We want to make it easier for users to try the build backend, so we allow using the build backend without requiring `UV_PREVIEW=1`. Instead, we only print a note about the preview status of the build backend. This improves using packages with the uv build backend with other PEP 517 frontends that don't have uv's `--preview` flag.

Closes #11819