### PR TITLE
Fix macro typo

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1405,11 +1405,6 @@ async fn run_project(
                 return Ok(ExitStatus::Success);
             }
         };
-        ($arg:expr, false) => {
-            if globals.show_settings {#
-                writeln!(printer.stdout(), "{:#?}", $arg)?;
-            }
-        };
     }
 
     match *project_command {


### PR DESCRIPTION
This typo wasn't caught because the `($arg:expr, false)` macro branch was never exercised.

For example, prior to this change, if you add
```
show_settings!(globals, false);
```
below, you'll get a compiler error.
