### PR TITLE
Use an `Arc` for Index URLs

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -17,15 +17,17 @@ use crate::{Index, Verbatim};
 static PYPI_URL: LazyLock<Url> = LazyLock::new(|| Url::parse("https://pypi.org/simple").unwrap());
 
 static DEFAULT_INDEX: LazyLock<Index> = LazyLock::new(|| {
-    Index::from_index_url(IndexUrl::Pypi(VerbatimUrl::from_url(PYPI_URL.clone())))
+    Index::from_index_url(IndexUrl::Pypi(Arc::new(VerbatimUrl::from_url(
+        PYPI_URL.clone(),
+    ))))
 });
 
 /// The URL of an index to use for fetching packages (e.g., PyPI).
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum IndexUrl {
-    Pypi(VerbatimUrl),
-    Url(VerbatimUrl),
-    Path(VerbatimUrl),
+    Pypi(Arc<VerbatimUrl>),
+    Url(Arc<VerbatimUrl>),
+    Path(Arc<VerbatimUrl>),
 }
 
 impl IndexUrl {
@@ -96,9 +98,9 @@ impl IndexUrl {
     /// Convert the index URL into a [`Url`].
     pub fn into_url(self) -> Url {
         match self {
-            Self::Pypi(url) => url.into_url(),
-            Self::Url(url) => url.into_url(),
-            Self::Path(url) => url.into_url(),
+            Self::Pypi(url) => url.to_url(),
+            Self::Url(url) => url.to_url(),
+            Self::Path(url) => url.to_url(),
         }
     }
 
@@ -177,11 +179,11 @@ impl<'de> serde::de::Deserialize<'de> for IndexUrl {
 impl From<VerbatimUrl> for IndexUrl {
     fn from(url: VerbatimUrl) -> Self {
         if url.scheme() == "file" {
-            Self::Path(url)
+            Self::Path(Arc::new(url))
         } else if *url.raw() == *PYPI_URL {
-            Self::Pypi(url)
+            Self::Pypi(Arc::new(url))
         } else {
-            Self::Url(url)
+            Self::Url(Arc::new(url))
         }
     }
 }


### PR DESCRIPTION
## Summary

I realized that we clone this for every distribution. It looks like it's consistently 1-2% faster to use an `Arc` here.
