### PR TITLE
Set `COLUMNS` during tests 

### DIFF
--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -644,4 +644,9 @@ impl EnvVars {
     /// error.
     #[attr_hidden]
     pub const UV_RUN_MAX_RECURSION_DEPTH: &'static str = "UV_RUN_MAX_RECURSION_DEPTH";
+
+    /// Overrides terminal width used for wrapping.
+    ///
+    /// This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
+    pub const COLUMNS: &'static str = "COLUMNS";
 }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -646,7 +646,7 @@ impl EnvVars {
     pub const UV_RUN_MAX_RECURSION_DEPTH: &'static str = "UV_RUN_MAX_RECURSION_DEPTH";
 
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
-    /// 
+    ///
     /// This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
     pub const COLUMNS: &'static str = "COLUMNS";
 }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -645,8 +645,8 @@ impl EnvVars {
     #[attr_hidden]
     pub const UV_RUN_MAX_RECURSION_DEPTH: &'static str = "UV_RUN_MAX_RECURSION_DEPTH";
 
-    /// Overrides terminal width used for wrapping.
-    ///
+    /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
+    /// 
     /// This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
     pub const COLUMNS: &'static str = "COLUMNS";
 }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -563,6 +563,10 @@ impl TestContext {
             // When running the tests in a venv, ignore that venv, otherwise we'll capture warnings.
             .env_remove(EnvVars::VIRTUAL_ENV)
             .env(EnvVars::UV_NO_WRAP, "1")
+            // While we disable wrapping in UV above, other tools may still wrap their output.
+            // Set a fixed COLUMNS value to ensure they wrap consistently, independently of
+            // terminal width.
+            .env(EnvVars::COLUMNS, "100")
             .env(EnvVars::PATH, path)
             .env(EnvVars::HOME, self.home_dir.as_os_str())
             .env(EnvVars::UV_PYTHON_INSTALL_DIR, "")

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -562,10 +562,10 @@ impl TestContext {
         command
             // When running the tests in a venv, ignore that venv, otherwise we'll capture warnings.
             .env_remove(EnvVars::VIRTUAL_ENV)
+            // Disable wrapping of uv output for readability / determinism in snapshots.
             .env(EnvVars::UV_NO_WRAP, "1")
-            // While we disable wrapping in UV above, other tools may still wrap their output.
-            // Set a fixed COLUMNS value to ensure they wrap consistently, independently of
-            // terminal width.
+            // While we disable wrapping in uv above, invoked tools may still wrap their output so
+            // we set a fixed `COLUMNS` value for isolation from terminal width.
             .env(EnvVars::COLUMNS, "100")
             .env(EnvVars::PATH, path)
             .env(EnvVars::HOME, self.home_dir.as_os_str())

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1824,13 +1824,12 @@ fn tool_run_verbatim_name() {
         .arg("change_wheel_version")
         .arg("--help")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: true
     exit_code: 0
     ----- stdout -----
-    usage: change_wheel_version [-h] [--local-version LOCAL_VERSION]
-                                [--version VERSION] [--delete-old-wheel]
-                                [--allow-same-version]
+    usage: change_wheel_version [-h] [--local-version LOCAL_VERSION] [--version VERSION]
+                                [--delete-old-wheel] [--allow-same-version]
                                 wheel
 
     positional arguments:
@@ -1851,7 +1850,7 @@ fn tool_run_verbatim_name() {
      + installer==0.7.0
      + packaging==24.0
      + wheel==0.43.0
-    "###);
+    ");
 
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("change-wheel-version")
@@ -1877,13 +1876,12 @@ fn tool_run_verbatim_name() {
         .arg("change_wheel_version")
         .arg("--help")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: true
     exit_code: 0
     ----- stdout -----
-    usage: change_wheel_version [-h] [--local-version LOCAL_VERSION]
-                                [--version VERSION] [--delete-old-wheel]
-                                [--allow-same-version]
+    usage: change_wheel_version [-h] [--local-version LOCAL_VERSION] [--version VERSION]
+                                [--delete-old-wheel] [--allow-same-version]
                                 wheel
 
     positional arguments:
@@ -1898,5 +1896,5 @@ fn tool_run_verbatim_name() {
 
     ----- stderr -----
     Resolved [N] packages in [TIME]
-    "###);
+    ");
 }

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -399,6 +399,12 @@ Used to detect Bash shell usage.
 
 Use to control color via `anstyle`.
 
+### `COLUMNS`
+
+Overrides terminal width used for wrapping. This variable is not read by uv directly.
+
+This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
+
 ### `CONDA_DEFAULT_ENV`
 
 Used to determine if an active Conda environment is the base environment or not.


### PR DESCRIPTION
## Summary

When tests are run downstream, the `COLUMNS` environment variable is used to force fixed output width and avoid test failures due to different terminal widths.  However, this occasionally causes test regressions when other tests rely on different output width. Use the same `COLUMNS` value in CI to ensure consistent output and catch any regressions.

## Test Plan

It wasn't, it's supposed to be tested by the CI :-).
