### PR TITLE
Revert "Temporarily disable cloudsmith test"

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -148,11 +148,11 @@ local_targets: dict[str, TargetConfiguration] = {
         "https://codeberg.org/api/packages/astral-test-user/pypi",
         "https://codeberg.org/api/packages/astral-test-user/pypi/simple/",
     ),
-    # "cloudsmith": TargetConfiguration(
-    #    "astral-test-token",
-    #    "https://python.cloudsmith.io/astral-test/astral-test-1/",
-    #    "https://dl.cloudsmith.io/public/astral-test/astral-test-1/python/simple/",
-    # ),
+    "cloudsmith": TargetConfiguration(
+        "astral-test-token",
+        "https://python.cloudsmith.io/astral-test/astral-test-1/",
+        "https://dl.cloudsmith.io/public/astral-test/astral-test-1/python/simple/",
+    ),
 }
 all_targets: dict[str, TargetConfiguration] = local_targets | {
     "pypi-trusted-publishing": TargetConfiguration(


### PR DESCRIPTION
Cloudsmith increased our limit, we can test on cloudsmith again.

This reverts commit f675c119dd3b3a1b7c5ff060c01c0127cfff7ac0.
