### PR TITLE
Sort dependency group keys when adding new group

### DIFF
--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -4758,11 +4758,7 @@ fn add_group() -> Result<()> {
 
     let pyproject_toml = context.read("pyproject.toml");
 
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject_toml, @r###"
+    assert_snapshot!(pyproject_toml, @r###"
         [project]
         name = "project"
         version = "0.1.0"
@@ -4774,8 +4770,7 @@ fn add_group() -> Result<()> {
             "anyio==3.7.0",
         ]
         "###
-        );
-    });
+    );
 
     uv_snapshot!(context.filters(), context.add().arg("requests").arg("--group").arg("test"), @r###"
     success: true
@@ -4794,11 +4789,7 @@ fn add_group() -> Result<()> {
 
     let pyproject_toml = context.read("pyproject.toml");
 
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject_toml, @r###"
+    assert_snapshot!(pyproject_toml, @r###"
         [project]
         name = "project"
         version = "0.1.0"
@@ -4811,8 +4802,7 @@ fn add_group() -> Result<()> {
             "requests>=2.31.0",
         ]
         "###
-        );
-    });
+    );
 
     uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--group").arg("second"), @r###"
     success: true
@@ -4826,11 +4816,7 @@ fn add_group() -> Result<()> {
 
     let pyproject_toml = context.read("pyproject.toml");
 
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject_toml, @r#"
+    assert_snapshot!(pyproject_toml, @r#"
         [project]
         name = "project"
         version = "0.1.0"
@@ -4846,8 +4832,7 @@ fn add_group() -> Result<()> {
             "requests>=2.31.0",
         ]
         "#
-        );
-    });
+    );
 
     uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--group").arg("alpha"), @r###"
     success: true
@@ -4861,11 +4846,7 @@ fn add_group() -> Result<()> {
 
     let pyproject_toml = context.read("pyproject.toml");
 
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject_toml, @r#"
+    assert_snapshot!(pyproject_toml, @r#"
         [project]
         name = "project"
         version = "0.1.0"
@@ -4884,10 +4865,147 @@ fn add_group() -> Result<()> {
             "requests>=2.31.0",
         ]
         "#
-        );
-    });
+    );
 
     assert!(context.temp_dir.join("uv.lock").exists());
+
+    Ok(())
+}
+
+/// Add a requirement to a dependency group (sorted before the other groups).
+#[test]
+fn add_group_before_commented_groups() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        # This is our dev group
+        dev = [
+            "anyio==3.7.0",
+        ]
+        # This is our test group
+        test = [
+            "anyio==3.7.0",
+            "requests>=2.31.0",
+        ]
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--group").arg("alpha"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==3.7.0
+     + idna==3.6
+     + sniffio==1.3.1
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    assert!(context.temp_dir.join("uv.lock").exists());
+
+    assert_snapshot!(pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        alpha = [
+            "anyio==3.7.0",
+        ]
+        # This is our dev group
+        dev = [
+            "anyio==3.7.0",
+        ]
+        # This is our test group
+        test = [
+            "anyio==3.7.0",
+            "requests>=2.31.0",
+        ]
+        "#
+    );
+
+    Ok(())
+}
+
+/// Add a requirement to dependency group (sorted between the other groups).
+#[test]
+fn add_group_between_commented_groups() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        # This is our dev group
+        dev = [
+            "anyio==3.7.0",
+        ]
+        # This is our test group
+        test = [
+            "anyio==3.7.0",
+            "requests>=2.31.0",
+        ]
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio==3.7.0").arg("--group").arg("eta"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==3.7.0
+     + idna==3.6
+     + sniffio==1.3.1
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    assert!(context.temp_dir.join("uv.lock").exists());
+
+    assert_snapshot!(pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [dependency-groups]
+        # This is our dev group
+        dev = [
+            "anyio==3.7.0",
+        ]
+        eta = [
+            "anyio==3.7.0",
+        ]
+        # This is our test group
+        test = [
+            "anyio==3.7.0",
+            "requests>=2.31.0",
+        ]
+        "#
+    );
 
     Ok(())
 }
@@ -4932,11 +5050,7 @@ fn add_group_to_unsorted() -> Result<()> {
 
     let pyproject_toml = context.read("pyproject.toml");
 
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            pyproject_toml, @r###"
+    assert_snapshot!(pyproject_toml, @r###"
         [project]
         name = "project"
         version = "0.1.0"
@@ -4955,8 +5069,7 @@ fn add_group_to_unsorted() -> Result<()> {
             "anyio==3.7.0",
         ]
         "###
-        );
-    });
+    );
 
     assert!(context.temp_dir.join("uv.lock").exists());
 


### PR DESCRIPTION
This change keeps dependency group keys sorted when adding new ones. 

If earlier dependency group keys were not sorted, we just append the new group key to avoid churn in `pyproject.toml`. See discussion on #11447. I've added a new snapshot test to capture this case.

Closes #11447. 
