### PR TITLE
 Add document for specifying Python interpreter in tool installation and upgrade commands.

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -254,6 +254,9 @@ To change the Python version of an existing tool during upgrade:
 $ uv tool upgrade ruff --python=3.10
 ```
 
+For more details on requesting Python versions, see the
+[Requesting a version](../concepts/python-versions.md#requesting-a-version).
+
 ## Next steps
 
 To learn more about managing tools with uv, see the [Tools concept](../concepts/tools.md) page and

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -242,13 +242,13 @@ $ uv tool upgrade --all
 You can specify the Python interpreter to use with the `--python` option when installing or
 upgrading tools.
 
-To install `ruff` with a specific Python version:
+To request a specific Python version for the tool installation:
 
 ```console
 $ uv tool install ruff --python=3.10
 ```
 
-To upgrade `ruff` with a specific Python version:
+To change the Python version of an existing tool during upgrade:
 
 ```console
 $ uv tool upgrade ruff --python=3.10

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -166,6 +166,12 @@ To install `ruff`:
 $ uv tool install ruff
 ```
 
+You can specify the Python interpreter to use with the `--python` option:
+
+```console
+$ uv tool install ruff --python=3.10
+```
+
 When a tool is installed, its executables are placed in a `bin` directory in the `PATH` which allows
 the tool to be run without uv. If it's not on the `PATH`, a warning will be displayed and
 `uv tool update-shell` can be used to add it to the `PATH`.
@@ -219,6 +225,12 @@ To upgrade a tool, use `uv tool upgrade`:
 
 ```console
 $ uv tool upgrade ruff
+```
+
+You can specify the Python interpreter to use with the `--python` option:
+
+```console
+$ uv tool upgrade ruff --python=3.10
 ```
 
 Tool upgrades will respect the version constraints provided when installing the tool. For example,

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -166,12 +166,6 @@ To install `ruff`:
 $ uv tool install ruff
 ```
 
-You can specify the Python interpreter to use with the `--python` option:
-
-```console
-$ uv tool install ruff --python=3.10
-```
-
 When a tool is installed, its executables are placed in a `bin` directory in the `PATH` which allows
 the tool to be run without uv. If it's not on the `PATH`, a warning will be displayed and
 `uv tool update-shell` can be used to add it to the `PATH`.
@@ -227,12 +221,6 @@ To upgrade a tool, use `uv tool upgrade`:
 $ uv tool upgrade ruff
 ```
 
-You can specify the Python interpreter to use with the `--python` option:
-
-```console
-$ uv tool upgrade ruff --python=3.10
-```
-
 Tool upgrades will respect the version constraints provided when installing the tool. For example,
 `uv tool install ruff >=0.3,<0.4` followed by `uv tool upgrade ruff` will upgrade Ruff to the latest
 version in the range `>=0.3,<0.4`.
@@ -247,6 +235,23 @@ To instead upgrade all tools:
 
 ```console
 $ uv tool upgrade --all
+```
+
+## Requesting Python versions
+
+You can specify the Python interpreter to use with the `--python` option when installing or
+upgrading tools.
+
+To install `ruff` with a specific Python version:
+
+```console
+$ uv tool install ruff --python=3.10
+```
+
+To upgrade `ruff` with a specific Python version:
+
+```console
+$ uv tool upgrade ruff --python=3.10
 ```
 
 ## Next steps

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -239,23 +239,30 @@ $ uv tool upgrade --all
 
 ## Requesting Python versions
 
-You can specify the Python interpreter to use with the `--python` option when installing or
-upgrading tools.
+By default, uv will use your default Python interpreter (the first it finds) when when running,
+installing, or upgrading tools. You can specify the Python interpreter to use with the `--python`
+option.
 
-To request a specific Python version for the tool installation:
+For example, to request a specific Python version when running a tool:
 
 ```console
-$ uv tool install ruff --python=3.10
+$ uvx --python 3.10 ruff
 ```
 
-To change the Python version of an existing tool during upgrade:
+Or, when installing a tool:
 
 ```console
-$ uv tool upgrade ruff --python=3.10
+$ uv tool install --python 3.10 ruff
+```
+
+Or, when upgrading a tool:
+
+```console
+$ uv tool upgrade --python 3.10 ruff
 ```
 
 For more details on requesting Python versions, see the
-[Requesting a version](../concepts/python-versions.md#requesting-a-version).
+[Python version](../concepts/python-versions.md#requesting-a-version) concept page..
 
 ## Next steps
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Just to add the section for installing and upgrading uv tool, specifying the Python version, in the document.
Originally, it was planned to add a markdown block (header) for representation, but it was felt to be a bit redundant, so it ended up being like this.

close https://github.com/astral-sh/uv/issues/11536

## Test Plan
Run doc server with strict mode in local. (``mkdocs serve -f mkdocs.public.yml --strict``)
![image](https://github.com/user-attachments/assets/9da66a8b-5423-4937-bc66-ea696ad1ab88)



<!-- How was it tested? -->
