### PR TITLE
Require the command in `uvx <name>` to be available in the Python environment

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -514,11 +514,7 @@ impl<'a> ExecutableProviderHints<'a> {
 
     /// If the executable is not provided by any package.
     fn not_from_any(&self) -> bool {
-        match self.from {
-            // Nothing to do for Python
-            ToolRequirement::Python => return false,
-            ToolRequirement::Package { .. } => self.packages.is_empty(),
-        }
+        self.packages.is_empty()
     }
 }
 

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -139,15 +139,10 @@ fn tool_run_at_version() {
         .arg("pytest@8.0.0")
         .arg("--version")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `pytest@8.0.0` was not found.
-    The following executables are provided by `pytest`:
-    - py.test
-    - pytest
-    Consider using `uv tool run --from pytest <EXECUTABLE_NAME>` instead.
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
@@ -157,8 +152,11 @@ fn tool_run_at_version() {
      + packaging==24.0
      + pluggy==1.4.0
      + pytest==8.1.1
-    warning: An executable named `pytest@8.0.0` is not provided by package `pytest`.
-    "###);
+    An executable named `pytest@8.0.0` is not provided by package `pytest`.
+    The following executables are available:
+    - py.test
+    - pytest
+    ");
 }
 
 #[test]
@@ -265,15 +263,10 @@ fn tool_run_suggest_valid_commands() {
     .arg("black")
     .arg("orange")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `orange` was not found.
-    The following executables are provided by `black`:
-    - black
-    - blackd
-    Consider using `uv tool run --from black <EXECUTABLE_NAME>` instead.
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
@@ -285,17 +278,19 @@ fn tool_run_suggest_valid_commands() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
-    warning: An executable named `orange` is not provided by package `black`.
-    "###);
+    An executable named `orange` is not provided by package `black`.
+    The following executables are available:
+    - black
+    - blackd
+    ");
 
     uv_snapshot!(context.filters(), context.tool_run()
     .arg("fastapi-cli")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `fastapi-cli` was not found.
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -304,8 +299,8 @@ fn tool_run_suggest_valid_commands() {
      + fastapi-cli==0.0.1
      + importlib-metadata==1.7.0
      + zipp==3.18.1
-    warning: Package `fastapi-cli` does not provide any executables.
-    "###);
+    Package `fastapi-cli` does not provide any executables.
+    ");
 }
 
 #[test]
@@ -327,7 +322,7 @@ fn tool_run_warn_executable_not_in_from() {
         .arg("fastapi")
         .arg("fastapi")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -371,7 +366,7 @@ fn tool_run_warn_executable_not_in_from() {
      + watchfiles==0.21.0
      + websockets==12.0
     warning: An executable named `fastapi` is not provided by package `fastapi` but is available via the dependency `fastapi-cli`. Consider using `uv tool run --from fastapi-cli fastapi` instead.
-    "###);
+    ");
 }
 
 #[test]
@@ -1540,11 +1535,10 @@ fn warn_no_executables_found() {
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("requests")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `requests` was not found.
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
@@ -1555,8 +1549,8 @@ fn warn_no_executables_found() {
      + idna==3.6
      + requests==2.31.0
      + urllib3==2.2.1
-    warning: Package `requests` does not provide any executables.
-    "###);
+    Package `requests` does not provide any executables.
+    ");
 }
 
 /// Warn when a user passes `--upgrade` to `uv tool run`.
@@ -2198,19 +2192,19 @@ fn tool_run_verbatim_name() {
         .arg("change-wheel-version")
         .arg("--help")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
-        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `change-wheel-version` was not found.
-    The following executables are provided by `change-wheel-version`:
-    - change_wheel_version
-    Consider using `uv tool run --from change-wheel-version <EXECUTABLE_NAME>` instead.
 
     ----- stderr -----
     Resolved [N] packages in [TIME]
-    warning: An executable named `change-wheel-version` is not provided by package `change-wheel-version`.
-    "###);
+    An executable named `change-wheel-version` is not provided by package `change-wheel-version`.
+    The following executables are available:
+    - change_wheel_version
+
+    Use `uv tool run --from change-wheel-version change_wheel_version` instead.
+    ");
 
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("--from")

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2506,16 +2506,14 @@ fn tool_run_windows_runnable_types() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    The executable `does_not_exist` was not found.
-    The following executables are provided by `foo`:
+
+    ----- stderr -----
+    An executable named `does_not_exist` is not provided by package `foo`.
+    The following executables are available:
     - custom_pydoc.exe
     - custom_pydoc.bat
     - custom_pydoc.cmd
     - custom_pydoc.ps1
-    Consider using `uv tool run --from foo <EXECUTABLE_NAME>` instead.
-
-    ----- stderr -----
-    warning: An executable named `does_not_exist` is not provided by package `foo`.
     "###);
 
     // Test with explicit .bat extension


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/7804

Includes a few small minor changes to the messaging, but the primary change is that in, e.g., `uvx foo`, if the `foo` package does not provide the `foo` executable we will no longer execute an arbitrary `foo` executable if present on the `PATH`. This prevents confusing and surprising behavior, such as the user reported where they did `uv tool install foobar` (which provides `foo`) then `uvx foo` (which does not provide `foo`) later falls back to the executable provided by `foobar` since it's on the `PATH`. We don't enforce this for `--from`, so things like `uvx --from foo bash -c "..."` are still totally valid. We also still allow `uvx foo` where the `foo` executable is provided by a _dependency_ of `foo` instead of `foo` itself.

Most of the diff here is consolidating the logic of the `hint_on_not_found` and `warn_executable_not_provided_by_package ` utilities.