### PR TITLE
Use install concurrency for bytecode compilation too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,6 +4928,7 @@ dependencies = [
  "uv-cache",
  "uv-cli",
  "uv-client",
+ "uv-configuration",
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-extract",

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 uv-cache = { workspace = true, features = ["clap"] }
 uv-cli = { workspace = true }
 uv-client = { workspace = true }
+uv-configuration = { workspace = true }
 uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-extract = { workspace = true, optional = true }

--- a/crates/uv-dev/src/compile.rs
+++ b/crates/uv-dev/src/compile.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use tracing::info;
 
 use uv_cache::{Cache, CacheArgs};
+use uv_configuration::Concurrency;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
 #[derive(Parser)]
@@ -33,6 +34,7 @@ pub(crate) async fn compile(args: CompileArgs) -> anyhow::Result<()> {
     let files = uv_installer::compile_tree(
         &fs_err::canonicalize(args.root)?,
         &interpreter,
+        &Concurrency::default(),
         cache.root(),
     )
     .await?;

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -554,7 +554,7 @@ pub(crate) async fn install(
     }
 
     if compile {
-        compile_bytecode(venv, cache, printer).await?;
+        compile_bytecode(venv, &concurrency, cache, printer).await?;
     }
 
     // Construct a summary of the changes made to the environment.


### PR DESCRIPTION
Instead of always using all available threads for bytecode compilation, respect `UV_CONCURRENT_INSTALLS`, so the parallelism is configurable instead of hardcoded. We reuse the install limit since bytecode compilation only runs after install.