### PR TITLE
Run uv-dev tests

### DIFF
--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -57,6 +57,9 @@ uv-performance-flate2-backend = { path = "../uv-performance-flate2-backend", opt
 uv-performance-memory-allocator = { path = "../uv-performance-memory-allocator", optional = true }
 walkdir = { workspace = true }
 
+[lib]
+name = "uv_dev"
+
 [[bin]]
 name = "uv-dev"
 # We don't want to build the dev CLI by default, so we skip it by requiring an off-by-default feature

--- a/crates/uv-dev/src/lib.rs
+++ b/crates/uv-dev/src/lib.rs
@@ -1,0 +1,69 @@
+use std::env;
+
+use anyhow::Result;
+use clap::Parser;
+use tracing::instrument;
+
+use crate::clear_compile::ClearCompileArgs;
+use crate::compile::CompileArgs;
+use crate::generate_all::Args as GenerateAllArgs;
+use crate::generate_cli_reference::Args as GenerateCliReferenceArgs;
+use crate::generate_env_vars_reference::Args as GenerateEnvVarsReferenceArgs;
+use crate::generate_json_schema::Args as GenerateJsonSchemaArgs;
+use crate::generate_options_reference::Args as GenerateOptionsReferenceArgs;
+#[cfg(feature = "render")]
+use crate::render_benchmarks::RenderBenchmarksArgs;
+use crate::wheel_metadata::WheelMetadataArgs;
+
+mod clear_compile;
+mod compile;
+mod generate_all;
+mod generate_cli_reference;
+mod generate_env_vars_reference;
+mod generate_json_schema;
+mod generate_options_reference;
+mod render_benchmarks;
+mod wheel_metadata;
+
+const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
+
+#[derive(Parser)]
+enum Cli {
+    /// Display the metadata for a `.whl` at a given URL.
+    WheelMetadata(WheelMetadataArgs),
+    /// Compile all `.py` to `.pyc` files in the tree.
+    Compile(CompileArgs),
+    /// Remove all `.pyc` in the tree.
+    ClearCompile(ClearCompileArgs),
+    /// Run all code and documentation generation steps.
+    GenerateAll(GenerateAllArgs),
+    /// Generate JSON schema for the TOML configuration file.
+    GenerateJSONSchema(GenerateJsonSchemaArgs),
+    /// Generate the options reference for the documentation.
+    GenerateOptionsReference(GenerateOptionsReferenceArgs),
+    /// Generate the CLI reference for the documentation.
+    GenerateCliReference(GenerateCliReferenceArgs),
+    /// Generate the environment variables reference for the documentation.
+    GenerateEnvVarsReference(GenerateEnvVarsReferenceArgs),
+    #[cfg(feature = "render")]
+    /// Render the benchmarks.
+    RenderBenchmarks(RenderBenchmarksArgs),
+}
+
+#[instrument] // Anchor span to check for overhead
+pub async fn run() -> Result<()> {
+    let cli = Cli::parse();
+    match cli {
+        Cli::WheelMetadata(args) => wheel_metadata::wheel_metadata(args).await?,
+        Cli::Compile(args) => compile::compile(args).await?,
+        Cli::ClearCompile(args) => clear_compile::clear_compile(&args)?,
+        Cli::GenerateAll(args) => generate_all::main(&args)?,
+        Cli::GenerateJSONSchema(args) => generate_json_schema::main(&args)?,
+        Cli::GenerateOptionsReference(args) => generate_options_reference::main(&args)?,
+        Cli::GenerateCliReference(args) => generate_cli_reference::main(&args)?,
+        Cli::GenerateEnvVarsReference(args) => generate_env_vars_reference::main(&args)?,
+        #[cfg(feature = "render")]
+        Cli::RenderBenchmarks(args) => render_benchmarks::render_benchmarks(&args)?,
+    }
+    Ok(())
+}

--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -5,10 +5,8 @@ use std::str::FromStr;
 use std::time::Instant;
 
 use anstream::eprintln;
-use anyhow::Result;
-use clap::Parser;
 use owo_colors::OwoColorize;
-use tracing::{debug, instrument};
+use tracing::debug;
 use tracing_durations_export::plot::PlotConfig;
 use tracing_durations_export::DurationsLayerBuilder;
 use tracing_subscriber::filter::Directive;
@@ -16,70 +14,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-use crate::clear_compile::ClearCompileArgs;
-use crate::compile::CompileArgs;
-use crate::generate_all::Args as GenerateAllArgs;
-use crate::generate_cli_reference::Args as GenerateCliReferenceArgs;
-use crate::generate_env_vars_reference::Args as GenerateEnvVarsReferenceArgs;
-use crate::generate_json_schema::Args as GenerateJsonSchemaArgs;
-use crate::generate_options_reference::Args as GenerateOptionsReferenceArgs;
-#[cfg(feature = "render")]
-use crate::render_benchmarks::RenderBenchmarksArgs;
-use crate::wheel_metadata::WheelMetadataArgs;
-use uv_static::EnvVars;
-
-mod clear_compile;
-mod compile;
-mod generate_all;
-mod generate_cli_reference;
-mod generate_env_vars_reference;
-mod generate_json_schema;
-mod generate_options_reference;
-mod render_benchmarks;
-mod wheel_metadata;
-
-const ROOT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../");
-
-#[derive(Parser)]
-enum Cli {
-    /// Display the metadata for a `.whl` at a given URL.
-    WheelMetadata(WheelMetadataArgs),
-    /// Compile all `.py` to `.pyc` files in the tree.
-    Compile(CompileArgs),
-    /// Remove all `.pyc` in the tree.
-    ClearCompile(ClearCompileArgs),
-    /// Run all code and documentation generation steps.
-    GenerateAll(GenerateAllArgs),
-    /// Generate JSON schema for the TOML configuration file.
-    GenerateJSONSchema(GenerateJsonSchemaArgs),
-    /// Generate the options reference for the documentation.
-    GenerateOptionsReference(GenerateOptionsReferenceArgs),
-    /// Generate the CLI reference for the documentation.
-    GenerateCliReference(GenerateCliReferenceArgs),
-    /// Generate the environment variables reference for the documentation.
-    GenerateEnvVarsReference(GenerateEnvVarsReferenceArgs),
-    #[cfg(feature = "render")]
-    /// Render the benchmarks.
-    RenderBenchmarks(RenderBenchmarksArgs),
-}
-
-#[instrument] // Anchor span to check for overhead
-async fn run() -> Result<()> {
-    let cli = Cli::parse();
-    match cli {
-        Cli::WheelMetadata(args) => wheel_metadata::wheel_metadata(args).await?,
-        Cli::Compile(args) => compile::compile(args).await?,
-        Cli::ClearCompile(args) => clear_compile::clear_compile(&args)?,
-        Cli::GenerateAll(args) => generate_all::main(&args)?,
-        Cli::GenerateJSONSchema(args) => generate_json_schema::main(&args)?,
-        Cli::GenerateOptionsReference(args) => generate_options_reference::main(&args)?,
-        Cli::GenerateCliReference(args) => generate_cli_reference::main(&args)?,
-        Cli::GenerateEnvVarsReference(args) => generate_env_vars_reference::main(&args)?,
-        #[cfg(feature = "render")]
-        Cli::RenderBenchmarks(args) => render_benchmarks::render_benchmarks(&args)?,
-    }
-    Ok(())
-}
+use uv_dev::run;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {

--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
 use uv_dev::run;
+use uv_static::EnvVars;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {


### PR DESCRIPTION
In #6827, we switched the uv-dev binary to not being built by default. As an unintended side effect, we were also stopping to run the tests that ensured the schema was up-to-date.

To fix this, we split uv-dev into an unconditional library, with only the binary being a conditional build. This way, `cargo test` and `cargo nextest` pick those tests up again.

An alternative would be running tests with the `dev` feature, with the side effect of always building the uv-dev binary, too.
