### PR TITLE
Reduce overhead in converting resolutions

### DIFF
--- a/crates/uv-distribution-types/src/dist_error.rs
+++ b/crates/uv-distribution-types/src/dist_error.rs
@@ -100,7 +100,7 @@ impl DerivationChain {
             else {
                 return false;
             };
-            target == dist.as_ref()
+            target == dist.as_ref().into()
         })?;
 
         // Perform a BFS to find the shortest path to the root.

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -220,7 +220,7 @@ impl Edge {
 impl From<&ResolvedDist> for RequirementSource {
     fn from(resolved_dist: &ResolvedDist) -> Self {
         match resolved_dist {
-            ResolvedDist::Installable { dist, .. } => match dist {
+            ResolvedDist::Installable { dist, .. } => match dist.as_ref() {
                 Dist::Built(BuiltDist::Registry(wheels)) => {
                     let wheel = wheels.best_wheel();
                     RequirementSource::Registry {

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -64,15 +64,15 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
     /// Fetch, build, and unzip the distributions in parallel.
     pub fn prepare_stream<'stream>(
         &'stream self,
-        distributions: Vec<Dist>,
+        distributions: Vec<Arc<Dist>>,
         in_flight: &'stream InFlight,
         resolution: &'stream Resolution,
     ) -> impl Stream<Item = Result<CachedDist, Error>> + 'stream {
         distributions
             .into_iter()
-            .map(|dist| async {
+            .map(|dist| async move {
                 let wheel = self
-                    .get_wheel(dist, in_flight, resolution)
+                    .get_wheel((*dist).clone(), in_flight, resolution)
                     .boxed_local()
                     .await?;
                 if let Some(reporter) = self.reporter.as_ref() {
@@ -87,7 +87,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
     #[instrument(skip_all, fields(total = distributions.len()))]
     pub async fn prepare(
         &self,
-        mut distributions: Vec<Dist>,
+        mut distributions: Vec<Arc<Dist>>,
         in_flight: &InFlight,
         resolution: &Resolution,
     ) -> Result<Vec<CachedDist>, Error> {

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::Arc;
 
 use either::Either;
 use itertools::Itertools;
@@ -474,7 +475,10 @@ pub trait Installable<'lock> {
             build_options,
         )?;
         let version = package.version().cloned();
-        let dist = ResolvedDist::Installable { dist, version };
+        let dist = ResolvedDist::Installable {
+            dist: Arc::new(dist),
+            version,
+        };
         let hashes = package.hashes();
         Ok(Node::Dist {
             dist,
@@ -491,7 +495,10 @@ pub trait Installable<'lock> {
             &BuildOptions::default(),
         )?;
         let version = package.version().cloned();
-        let dist = ResolvedDist::Installable { dist, version };
+        let dist = ResolvedDist::Installable {
+            dist: Arc::new(dist),
+            version,
+        };
         let hashes = package.hashes();
         Ok(Node::Dist {
             dist,

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -50,7 +50,7 @@ impl AnnotatedDist {
     pub(crate) fn index(&self) -> Option<&IndexUrl> {
         match &self.dist {
             ResolvedDist::Installed { .. } => None,
-            ResolvedDist::Installable { dist, .. } => match dist {
+            ResolvedDist::Installable { dist, .. } => match dist.as_ref() {
                 Dist::Built(dist) => match dist {
                     BuiltDist::Registry(dist) => Some(&dist.best_wheel().index),
                     BuiltDist::DirectUrl(_) => None,

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use indexmap::IndexSet;
 use petgraph::{
@@ -449,7 +450,7 @@ impl ResolverOutput {
 
             (
                 ResolvedDist::Installable {
-                    dist,
+                    dist: Arc::new(dist),
                     version: Some(version.clone()),
                 },
                 hashes,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -14,7 +14,7 @@ use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::ReceiverStream;
@@ -2370,13 +2370,19 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 .boxed_local()
                                 .await?;
 
-                            Response::Dist { dist, metadata }
+                            Response::Dist {
+                                dist: (*dist).clone(),
+                                metadata,
+                            }
                         }
                         ResolvedDist::Installed { dist } => {
                             let metadata =
                                 provider.get_installed_metadata(&dist).boxed_local().await?;
 
-                            Response::Installed { dist, metadata }
+                            Response::Installed {
+                                dist: (*dist).clone(),
+                                metadata,
+                            }
                         }
                     };
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -728,7 +728,7 @@ fn apply_no_virtual_project(resolution: Resolution) -> Resolution {
             return true;
         };
 
-        let Dist::Source(dist) = dist else {
+        let Dist::Source(dist) = dist.as_ref() else {
             return true;
         };
 
@@ -748,29 +748,28 @@ fn apply_editable_mode(resolution: Resolution, editable: EditableMode) -> Resolu
 
         // Filter out any editable distributions.
         EditableMode::NonEditable => resolution.map(|dist| {
-            let ResolvedDist::Installable {
-                dist:
-                    Dist::Source(SourceDist::Directory(DirectorySourceDist {
-                        name,
-                        install_path,
-                        editable: true,
-                        r#virtual: false,
-                        url,
-                    })),
-                version,
-            } = dist
+            let ResolvedDist::Installable { dist, version } = dist else {
+                return None;
+            };
+            let Dist::Source(SourceDist::Directory(DirectorySourceDist {
+                name,
+                install_path,
+                editable: true,
+                r#virtual: false,
+                url,
+            })) = dist.as_ref()
             else {
                 return None;
             };
 
             Some(ResolvedDist::Installable {
-                dist: Dist::Source(SourceDist::Directory(DirectorySourceDist {
+                dist: Arc::new(Dist::Source(SourceDist::Directory(DirectorySourceDist {
                     name: name.clone(),
                     install_path: install_path.clone(),
                     editable: false,
                     r#virtual: false,
                     url: url.clone(),
-                })),
+                }))),
                 version: version.clone(),
             })
         }),


### PR DESCRIPTION
Solving spent a chunk of its time just converting resolutions, the left two blocks:

![image](https://github.com/user-attachments/assets/6f266440-c6e2-447c-ad7f-f92244f9d09b)

These blocks are `ResolverOutput::from_state` with 1.3% and `ForkState::into_resolution` with 4.1% of resolver thread runtime for apache airflow universal.

We reduce the overhead spent in those functions, to now 1.1% and 2.1% of resolver time spend in those functions by:

Commit 1: Replace the hash set for the edges with a vec in `ForkState::into_resolution`. We deduplicate edges anyway when collecting them, and the hash-and-insert was slow.

Commit 2: Reduce the distribution clonign in `ResolverOutput::from_state` by using an `Arc`.

The same profile excerpt for the resolver with the branch (note that there is now an unrelated block between the two we optimized):

![image](https://github.com/user-attachments/assets/e36c205d-2cf8-4fe6-a2dd-3020c0515922)

Wall times are noisy, but the profiles show those changes as improvements.

```
$ hyperfine --warmup 2 "./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal" "./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal"
Benchmark 1: ./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal
  Time (mean ± σ):      99.1 ms ±   3.8 ms    [User: 111.8 ms, System: 115.5 ms]
  Range (min … max):    93.6 ms … 110.4 ms    29 runs
 
Benchmark 2: ./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal
  Time (mean ± σ):      97.1 ms ±   4.3 ms    [User: 114.8 ms, System: 112.0 ms]
  Range (min … max):    90.9 ms … 112.4 ms    29 runs
 
Summary
  ./uv-branch pip compile --no-progress scripts/requirements/airflow.in --universal ran
    1.02 ± 0.06 times faster than ./uv-main pip compile --no-progress scripts/requirements/airflow.in --universal
```