### PR TITLE
Display path separators as backslashes on Windows

### DIFF
--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -6,7 +7,7 @@ use toml_edit::Table;
 use toml_edit::Value;
 use toml_edit::{Array, Item};
 
-use uv_fs::PortablePath;
+use uv_fs::{PortablePath, Simplified};
 use uv_pypi_types::{Requirement, VerbatimParsedUrl};
 use uv_settings::ToolOptions;
 
@@ -96,6 +97,32 @@ impl TryFrom<ToolWire> for Tool {
 pub struct ToolEntrypoint {
     pub name: String,
     pub install_path: PathBuf,
+}
+
+impl Display for ToolEntrypoint {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        #[cfg(windows)]
+        {
+            write!(
+                f,
+                "{} ({})",
+                self.name,
+                self.install_path
+                    .simplified_display()
+                    .to_string()
+                    .replace('/', "\\")
+            )
+        }
+        #[cfg(unix)]
+        {
+            write!(
+                f,
+                "{} ({})",
+                self.name,
+                self.install_path.simplified_display()
+            )
+        }
+    }
 }
 
 /// Format an array so that each element is on its own line and has a trailing comma.

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -98,29 +98,7 @@ pub(crate) async fn list(
         // Output tool entrypoints
         for entrypoint in tool.entrypoints() {
             if show_paths {
-                #[cfg(windows)]
-                {
-                    writeln!(
-                        printer.stdout(),
-                        "- {} ({})",
-                        entrypoint.name,
-                        entrypoint
-                            .install_path
-                            .simplified_display()
-                            .to_string()
-                            .replace('/', "\\")
-                            .cyan()
-                    )?;
-                }
-                #[cfg(unix)]
-                {
-                    writeln!(
-                        printer.stdout(),
-                        "- {} ({})",
-                        entrypoint.name,
-                        entrypoint.install_path.display().cyan()
-                    )?;
-                }
+                writeln!(printer.stdout(), "- {}", entrypoint.to_string().cyan())?;
             } else {
                 writeln!(printer.stdout(), "- {}", entrypoint.name)?;
             }

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -98,12 +98,29 @@ pub(crate) async fn list(
         // Output tool entrypoints
         for entrypoint in tool.entrypoints() {
             if show_paths {
-                writeln!(
-                    printer.stdout(),
-                    "- {} ({})",
-                    entrypoint.name,
-                    entrypoint.install_path.simplified_display().cyan()
-                )?;
+                #[cfg(windows)]
+                {
+                    writeln!(
+                        printer.stdout(),
+                        "- {} ({})",
+                        entrypoint.name,
+                        entrypoint
+                            .install_path
+                            .simplified_display()
+                            .to_string()
+                            .replace('/', "\\")
+                            .cyan()
+                    )?;
+                }
+                #[cfg(unix)]
+                {
+                    writeln!(
+                        printer.stdout(),
+                        "- {} ({})",
+                        entrypoint.name,
+                        entrypoint.install_path.display().cyan()
+                    )?;
+                }
             } else {
                 writeln!(printer.stdout(), "- {}", entrypoint.name)?;
             }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -250,6 +250,19 @@ impl TestContext {
         self
     }
 
+    /// Add a filter that ignores temporary directory in path.
+    pub fn with_filtered_windows_temp_dir(mut self) -> Self {
+        let pattern = regex::escape(
+            &self
+                .temp_dir
+                .simplified_display()
+                .to_string()
+                .replace('/', "\\"),
+        );
+        self.filters.push((pattern, "[TEMP_DIR]".to_string()));
+        self
+    }
+
     /// Add extra directories and configuration for managed Python installations.
     #[must_use]
     pub fn with_managed_python_dirs(mut self) -> Self {
@@ -264,6 +277,12 @@ impl TestContext {
         self.extra_env
             .push((EnvVars::UV_PYTHON_DOWNLOADS.into(), "automatic".into()));
 
+        self
+    }
+
+    /// Clear filters on `TestContext`.
+    pub fn clear_filters(mut self) -> Self {
+        self.filters.clear();
         self
     }
 
@@ -985,6 +1004,14 @@ impl TestContext {
             .iter()
             .map(|(p, r)| (p.as_str(), r.as_str()))
             .chain(INSTA_FILTERS.iter().copied())
+            .collect()
+    }
+
+    /// Only the filters added to this test context.
+    pub fn filters_without_standard_filters(&self) -> Vec<(&str, &str)> {
+        self.filters
+            .iter()
+            .map(|(p, r)| (p.as_str(), r.as_str()))
             .collect()
     }
 

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -64,6 +64,36 @@ fn tool_list_paths() {
     "###);
 }
 
+#[cfg(windows)]
+#[test]
+fn tool_list_paths_windows() {
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_list().arg("--show-paths")
+    .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+    .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black v24.2.0 ([TEMP_DIR]\tools\black)
+    - black ([TEMP_DIR]\bin\black)
+    - blackd ([TEMP_DIR]\bin\blackd)
+
+    ----- stderr -----
+    "###);
+}
+
 #[test]
 fn tool_list_empty() {
     let context = TestContext::new("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -67,7 +67,9 @@ fn tool_list_paths() {
 #[cfg(windows)]
 #[test]
 fn tool_list_paths_windows() {
-    let context = TestContext::new("3.12").with_filtered_exe_suffix();
+    let context = TestContext::new("3.12")
+        .clear_filters()
+        .with_filtered_windows_temp_dir();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -80,15 +82,15 @@ fn tool_list_paths_windows() {
         .assert()
         .success();
 
-    uv_snapshot!(context.filters(), context.tool_list().arg("--show-paths")
+    uv_snapshot!(context.filters_without_standard_filters(), context.tool_list().arg("--show-paths")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
     .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     black v24.2.0 ([TEMP_DIR]\tools\black)
-    - black ([TEMP_DIR]\bin\black)
-    - blackd ([TEMP_DIR]\bin\blackd)
+    - black.exe ([TEMP_DIR]\bin\black.exe)
+    - blackd.exe ([TEMP_DIR]\bin\blackd.exe)
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
Currently, `uv tool list --show-paths` will show backslashes as path separators for packages but not entrypoints. This PR changes this to be consistent.

Closes #10426.
