### PR TITLE
Reuse refined interpreter to create tool environment

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -454,8 +454,8 @@ pub(crate) async fn install(
         .await;
 
         // If the resolution failed, retry with the inferred `requires-python` constraint.
-        let resolution = match resolution {
-            Ok(resolution) => resolution,
+        let (resolution, interpreter) = match resolution {
+            Ok(resolution) => (resolution, interpreter),
             Err(err) => match err {
                 ProjectError::Operation(err) => {
                     // If the resolution failed due to the discovered interpreter not satisfying the
@@ -505,7 +505,7 @@ pub(crate) async fn install(
                     )
                     .await
                     {
-                        Ok(resolution) => resolution,
+                        Ok(resolution) => (resolution, interpreter),
                         Err(ProjectError::Operation(err)) => {
                             return diagnostics::OperationDiagnostic::native_tls(native_tls)
                                 .report(err)


### PR DESCRIPTION
## Summary

As-is, we used the refined interpreter to _resolve_, but we then created the tool environment with the "old" interpreter. So we risked running (e.g.) code that requires Python 3.12 in a Python 3.10 environment. We need to propagate the updated interpreter.

This is fairly hard to test, because it requires an environment in which we're able to download new interpreters.

Closes https://github.com/astral-sh/uv/issues/11678#issuecomment-2672659074.
