### PR TITLE
Re-allow HTTP schemes for Git dependencies

### DIFF
--- a/crates/uv-git-types/src/lib.rs
+++ b/crates/uv-git-types/src/lib.rs
@@ -54,7 +54,7 @@ impl GitUrl {
         precise: Option<GitOid>,
     ) -> Result<Self, GitUrlParseError> {
         match repository.scheme() {
-            "https" | "ssh" | "file" => {}
+            "http" | "https" | "ssh" | "file" => {}
             unsupported => {
                 return Err(GitUrlParseError::UnsupportedGitScheme(
                     unsupported.to_string(),


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/11683.
