### PR TITLE
Use a `SmallString` for the Yanked enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5431,6 +5431,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
+ "uv-small-str",
 ]
 
 [[package]]

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -184,7 +184,7 @@ impl SimpleHtml {
         let yanked = if let Some(yanked) = link.attributes().get("data-yanked").flatten() {
             let yanked = std::str::from_utf8(yanked.as_bytes())?;
             let yanked = html_escape::decode_html_entities(yanked);
-            Some(Yanked::Reason(yanked.to_string()))
+            Some(Yanked::Reason(yanked.into()))
         } else {
             None
         };

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -22,6 +22,7 @@ uv-git-types = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
+uv-small-str = { workspace = true }
 
 hashbrown = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 
 use jiff::Timestamp;
 use serde::{Deserialize, Deserializer, Serialize};
+
 use uv_pep440::{VersionSpecifiers, VersionSpecifiersParseError};
+use uv_small_str::SmallString;
 
 use crate::lenient_requirement::LenientVersionSpecifiers;
 
@@ -101,7 +103,7 @@ impl CoreMetadata {
 #[rkyv(derive(Debug))]
 pub enum Yanked {
     Bool(bool),
-    Reason(String),
+    Reason(SmallString),
 }
 
 impl<'de> Deserialize<'de> for Yanked {
@@ -111,7 +113,7 @@ impl<'de> Deserialize<'de> for Yanked {
     {
         serde_untagged::UntaggedEnumVisitor::new()
             .bool(|bool| Ok(Yanked::Bool(bool)))
-            .string(|string| Ok(Yanked::Reason(string.to_owned())))
+            .string(|string| Ok(Yanked::Reason(SmallString::from(string))))
             .deserialize(deserializer)
     }
 }

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -476,7 +476,7 @@ impl ResolverOutput {
                 Some(Yanked::Reason(reason)) => {
                     diagnostics.push(ResolutionDiagnostic::YankedVersion {
                         dist: dist.clone(),
-                        reason: Some(reason.clone()),
+                        reason: Some(reason.to_string()),
                     });
                 }
             }

--- a/crates/uv-small-str/src/lib.rs
+++ b/crates/uv-small-str/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::PartialEq;
 use std::ops::Deref;
 
@@ -23,6 +24,15 @@ impl From<String> for SmallString {
     #[inline]
     fn from(s: String) -> Self {
         Self(s.into())
+    }
+}
+
+impl From<Cow<'_, str>> for SmallString {
+    fn from(s: Cow<'_, str>) -> Self {
+        match s {
+            Cow::Borrowed(s) => Self::from(s),
+            Cow::Owned(s) => Self::from(s),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This is stored on `File`, which we create extensively. Easy way to reduce size.
