### PR TITLE
Initialize PEP 723 script in `uv lock --script`

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -152,6 +152,19 @@ impl TestContext {
         self
     }
 
+    /// Add extra standard filtering for Windows-compatible missing file errors.
+    pub fn with_filtered_missing_file_error(mut self) -> Self {
+        self.filters.push((
+            regex::escape("The system cannot find the file specified. (os error 2)"),
+            "[OS ERROR 2]".to_string(),
+        ));
+        self.filters.push((
+            regex::escape("No such file or directory (os error 2)"),
+            "[OS ERROR 2]".to_string(),
+        ));
+        self
+    }
+
     /// Add extra standard filtering for executable suffixes on the current platform e.g.
     /// drops `.exe` on Windows.
     #[must_use]

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -23622,26 +23622,16 @@ fn lock_script_path() -> Result<()> {
 /// `uv lock --script` should add a PEP 723 tag, if it doesn't exist already.
 #[test]
 fn lock_script_initialize() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_missing_file_error();
 
-    let error = regex::escape("The system cannot find the path specified. (os error 2)");
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain(std::iter::once((
-            error.as_str(),
-            "No such file or directory (os error 2)",
-        )))
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, context.lock().arg("--script").arg("script.py"), @r###"
+    uv_snapshot!(context.filters(), context.lock().arg("--script").arg("script.py"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    error: failed to read from file `script.py`: No such file or directory (os error 2)
-    "###);
+    error: failed to read from file `script.py`: [OS ERROR 2]
+    ");
 
     let script = context.temp_dir.child("script.py");
     script.write_str(indoc! { r"


### PR DESCRIPTION
## Summary

Like `uv add --script`, `uv lock --script` will now initialize a PEP 723 script tag if it doesn't already exist.
