### PR TITLE
Upgrade Rust toolchain to 1.85

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -247,7 +247,7 @@ impl Cache {
             Refresh::None(_) => return Ok(Freshness::Fresh),
             Refresh::All(timestamp) => timestamp,
             Refresh::Packages(packages, timestamp) => {
-                if package.map_or(true, |package| packages.contains(package)) {
+                if package.is_none_or(|package| packages.contains(package)) {
                     timestamp
                 } else {
                     return Ok(Freshness::Fresh);

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -1,6 +1,5 @@
 use uv_cache::Refresh;
 use uv_configuration::ConfigSettings;
-use uv_distribution_types::{PipExtraIndex, PipFindLinks, PipIndex};
 use uv_resolver::PrereleaseMode;
 use uv_settings::{Combine, PipOptions, ResolverInstallerOptions, ResolverOptions};
 
@@ -203,12 +202,11 @@ impl From<IndexArgs> for PipOptions {
                 .combine(
                     index.map(|index| index.into_iter().filter_map(Maybe::into_option).collect()),
                 ),
-            index_url: index_url.and_then(Maybe::into_option).map(PipIndex::from),
+            index_url: index_url.and_then(Maybe::into_option),
             extra_index_url: extra_index_url.map(|extra_index_urls| {
                 extra_index_urls
                     .into_iter()
                     .filter_map(Maybe::into_option)
-                    .map(PipExtraIndex::from)
                     .collect()
             }),
             no_index: if no_index { Some(true) } else { None },
@@ -216,7 +214,6 @@ impl From<IndexArgs> for PipOptions {
                 find_links
                     .into_iter()
                     .filter_map(Maybe::into_option)
-                    .map(PipFindLinks::from)
                     .collect()
             }),
             ..PipOptions::default()

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -707,7 +707,7 @@ impl RegistryClient {
         };
 
         // Attempt to fetch via a range request.
-        if index.map_or(true, |index| capabilities.supports_range_requests(index)) {
+        if index.is_none_or(|index| capabilities.supports_range_requests(index)) {
             let req = self
                 .uncached_client(url)
                 .head(url.clone())

--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -27,7 +27,7 @@ impl HashPolicy<'_> {
         match self {
             HashPolicy::Generate(HashGeneration::Url) => dist.file().is_none(),
             HashPolicy::Generate(HashGeneration::All) => {
-                dist.file().map_or(true, |file| file.hashes.is_empty())
+                dist.file().is_none_or(|file| file.hashes.is_empty())
             }
             HashPolicy::Validate(_) => false,
             HashPolicy::None => false,

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -267,7 +267,7 @@ impl<'a> IndexLocations {
             let mut seen = FxHashSet::default();
             self.indexes
                 .iter()
-                .filter(move |index| index.name.as_ref().map_or(true, |name| seen.insert(name)))
+                .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
                 .find(|index| index.default)
                 .or_else(|| Some(&DEFAULT_INDEX))
         }
@@ -284,7 +284,7 @@ impl<'a> IndexLocations {
             Either::Right(
                 self.indexes
                     .iter()
-                    .filter(move |index| index.name.as_ref().map_or(true, |name| seen.insert(name)))
+                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
                     .filter(|index| !index.default && !index.explicit),
             )
         }
@@ -313,9 +313,9 @@ impl<'a> IndexLocations {
         } else {
             let mut seen = FxHashSet::default();
             Either::Right(
-                self.indexes.iter().filter(move |index| {
-                    index.name.as_ref().map_or(true, |name| seen.insert(name))
-                }),
+                self.indexes
+                    .iter()
+                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name))),
             )
         }
     }
@@ -356,7 +356,7 @@ impl<'a> IndexLocations {
                 self.indexes
                     .iter()
                     .chain(self.flat_index.iter())
-                    .filter(move |index| index.name.as_ref().map_or(true, |name| seen.insert(name)))
+                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
             } {
                 if index.default {
                     if default {
@@ -406,7 +406,7 @@ impl<'a> IndexUrls {
             let mut seen = FxHashSet::default();
             self.indexes
                 .iter()
-                .filter(move |index| index.name.as_ref().map_or(true, |name| seen.insert(name)))
+                .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
                 .find(|index| index.default)
                 .or_else(|| Some(&DEFAULT_INDEX))
         }
@@ -423,7 +423,7 @@ impl<'a> IndexUrls {
             Either::Right(
                 self.indexes
                     .iter()
-                    .filter(move |index| index.name.as_ref().map_or(true, |name| seen.insert(name)))
+                    .filter(move |index| index.name.as_ref().is_none_or(|name| seen.insert(name)))
                     .filter(|index| !index.default && !index.explicit),
             )
         }
@@ -462,7 +462,7 @@ impl<'a> IndexUrls {
                     self.indexes
                         .iter()
                         .filter(move |index| {
-                            index.name.as_ref().map_or(true, |name| seen.insert(name))
+                            index.name.as_ref().is_none_or(|name| seen.insert(name))
                         })
                         .filter(|index| !index.default)
                 }
@@ -471,7 +471,7 @@ impl<'a> IndexUrls {
                     self.indexes
                         .iter()
                         .filter(move |index| {
-                            index.name.as_ref().map_or(true, |name| seen.insert(name))
+                            index.name.as_ref().is_none_or(|name| seen.insert(name))
                         })
                         .find(|index| index.default)
                         .into_iter()

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -356,7 +356,7 @@ impl LoweredRequirement {
         let source = source
             .iter()
             .filter(|source| {
-                source.extra().map_or(true, |target| {
+                source.extra().is_none_or(|target| {
                     requirement
                         .marker
                         .top_level_extra_name()
@@ -613,7 +613,7 @@ fn url_source(
     let verbatim_url = VerbatimUrl::from_url(verbatim_url);
     Ok(RequirementSource::Url {
         location: url,
-        subdirectory: subdirectory.map(PathBuf::from),
+        subdirectory,
         ext,
         url: verbatim_url,
     })

--- a/crates/uv-distribution/src/source/built_wheel_metadata.rs
+++ b/crates/uv-distribution/src/source/built_wheel_metadata.rs
@@ -61,8 +61,8 @@ impl BuiltWheelMetadata {
 
     /// Returns `true` if the wheel matches the given package name and version.
     pub(crate) fn matches(&self, name: Option<&PackageName>, version: Option<&Version>) -> bool {
-        name.map_or(true, |name| self.filename.name == *name)
-            && version.map_or(true, |version| self.filename.version == *version)
+        name.is_none_or(|name| self.filename.name == *name)
+            && version.is_none_or(|version| self.filename.version == *version)
     }
 }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -2765,8 +2765,8 @@ impl CachedMetadata {
 
     /// Returns `true` if the metadata matches the given package name and version.
     fn matches(&self, name: Option<&PackageName>, version: Option<&Version>) -> bool {
-        name.map_or(true, |name| self.0.name == *name)
-            && version.map_or(true, |version| self.0.version == *version)
+        name.is_none_or(|name| self.0.name == *name)
+            && version.is_none_or(|version| self.0.version == *version)
     }
 }
 

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -12,7 +12,7 @@ use tracing::{debug, instrument};
 use url::Url;
 
 use uv_cache_key::{cache_digest, RepositoryUrl};
-use uv_git_types::{GitOid, GitUrl};
+use uv_git_types::GitUrl;
 
 use crate::git::GitRemote;
 use crate::GIT_STORE;
@@ -107,7 +107,7 @@ impl GitSource {
                     &db_path,
                     db,
                     self.git.reference(),
-                    locked_rev.map(GitOid::from),
+                    locked_rev,
                     &self.client,
                     self.disable_ssl,
                 )?;

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -435,7 +435,7 @@ pub fn looks_like_git_repository(url: &Url) -> bool {
         Some("github.com" | "gitlab.com" | "bitbucket.org")
     ) && Path::new(url.path())
         .extension()
-        .map_or(true, |ext| ext.eq_ignore_ascii_case("git"))
+        .is_none_or(|ext| ext.eq_ignore_ascii_case("git"))
         && url
             .path_segments()
             .is_some_and(|segments| segments.count() == 2)

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1037,7 +1037,7 @@ pub(crate) fn find_python_installation(
     let mut first_error = None;
     for result in installations {
         // Iterate until the first critical error or happy result
-        if !result.as_ref().err().map_or(true, Error::is_critical) {
+        if !result.as_ref().err().is_none_or(Error::is_critical) {
             // Track the first non-critical error
             if first_error.is_none() {
                 if let Err(err) = result {
@@ -2214,7 +2214,7 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(self_major, self_minor, self_prerelease, _) => {
                 // Pre-releases of Python versions are always for the zero patch version
                 (*self_major, *self_minor, 0) == (major, minor, patch)
-                    && prerelease.map_or(true, |pre| *self_prerelease == pre)
+                    && prerelease.is_none_or(|pre| *self_prerelease == pre)
             }
         }
     }

--- a/crates/uv-requirements/src/extras.rs
+++ b/crates/uv-requirements/src/extras.rs
@@ -56,9 +56,7 @@ impl<'a, Context: BuildContext> ExtrasResolver<'a, Context> {
         } = self;
         requirements
             .map(|requirement| async {
-                Self::resolve_requirement(requirement, hasher, index, &database)
-                    .await
-                    .map(Requirement::from)
+                Self::resolve_requirement(requirement, hasher, index, &database).await
             })
             .collect::<FuturesOrdered<_>>()
             .try_collect()

--- a/crates/uv-resolver/src/resolver/indexes.rs
+++ b/crates/uv-resolver/src/resolver/indexes.rs
@@ -68,7 +68,7 @@ impl Indexes {
                 entry
                     .conflict
                     .as_ref()
-                    .map_or(true, |conflict| env.included_by_group(conflict.as_ref()))
+                    .is_none_or(|conflict| env.included_by_group(conflict.as_ref()))
             })
             .map(|entry| &entry.index)
             .collect()

--- a/crates/uv-trampoline/README.md
+++ b/crates/uv-trampoline/README.md
@@ -13,19 +13,19 @@ LLD and add the `rustup` targets:
 ```shell
 sudo apt install llvm clang lld
 cargo install cargo-xwin
-rustup toolchain install nightly-2025-01-03
-rustup component add rust-src --toolchain nightly-2025-01-03-x86_64-unknown-linux-gnu
-rustup target add --toolchain nightly-2025-01-03 i686-pc-windows-msvc
-rustup target add --toolchain nightly-2025-01-03 x86_64-pc-windows-msvc
-rustup target add --toolchain nightly-2025-01-03 aarch64-pc-windows-msvc
+rustup toolchain install nightly-2025-02-16
+rustup component add rust-src --toolchain nightly-2025-02-16-x86_64-unknown-linux-gnu
+rustup target add --toolchain nightly-2025-02-16 i686-pc-windows-msvc
+rustup target add --toolchain nightly-2025-02-16 x86_64-pc-windows-msvc
+rustup target add --toolchain nightly-2025-02-16 aarch64-pc-windows-msvc
 ```
 
 Then, build the trampolines for all supported architectures:
 
 ```shell
-cargo +nightly-2025-01-03 xwin build --xwin-arch x86 --release --target i686-pc-windows-msvc
-cargo +nightly-2025-01-03 xwin build --release --target x86_64-pc-windows-msvc
-cargo +nightly-2025-01-03 xwin build --release --target aarch64-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --xwin-arch x86 --release --target i686-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --release --target x86_64-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --release --target aarch64-pc-windows-msvc
 ```
 
 ### Cross-compiling from macOS
@@ -36,19 +36,19 @@ LLVM and add the `rustup` targets:
 ```shell
 brew install llvm
 cargo install cargo-xwin
-rustup toolchain install nightly-2025-01-03
-rustup component add rust-src --toolchain nightly-2025-01-03-aarch64-apple-darwin
-rustup target add --toolchain nightly-2025-01-03 i686-pc-windows-msvc
-rustup target add --toolchain nightly-2025-01-03 x86_64-pc-windows-msvc
-rustup target add --toolchain nightly-2025-01-03 aarch64-pc-windows-msvc
+rustup toolchain install nightly-2025-02-16
+rustup component add rust-src --toolchain nightly-2025-02-16-aarch64-apple-darwin
+rustup target add --toolchain nightly-2025-02-16 i686-pc-windows-msvc
+rustup target add --toolchain nightly-2025-02-16 x86_64-pc-windows-msvc
+rustup target add --toolchain nightly-2025-02-16 aarch64-pc-windows-msvc
 ```
 
 Then, build the trampolines for all supported architectures:
 
 ```shell
-cargo +nightly-2025-01-03 xwin build --release --target i686-pc-windows-msvc
-cargo +nightly-2025-01-03 xwin build --release --target x86_64-pc-windows-msvc
-cargo +nightly-2025-01-03 xwin build --release --target aarch64-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --release --target i686-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --release --target x86_64-pc-windows-msvc
+cargo +nightly-2025-02-16 xwin build --release --target aarch64-pc-windows-msvc
 ```
 
 ### Updating the prebuilt executables

--- a/crates/uv-trampoline/rust-toolchain.toml
+++ b/crates/uv-trampoline/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-01-03"
+channel = "nightly-2025-02-16"

--- a/crates/uv-types/src/builds.rs
+++ b/crates/uv-types/src/builds.rs
@@ -17,7 +17,7 @@ impl BuildIsolation<'_> {
             Self::Isolated => true,
             Self::Shared(_) => false,
             Self::SharedPackage(_, packages) => {
-                package.map_or(true, |package| !packages.iter().any(|p| p == package))
+                package.is_none_or(|package| !packages.iter().any(|p| p == package))
             }
         }
     }

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1187,7 +1187,7 @@ fn find_dependencies(
     let mut to_replace = Vec::new();
     for (i, dep) in deps.iter().enumerate() {
         if let Some(req) = dep.as_str().and_then(try_parse_requirement) {
-            if marker.map_or(true, |m| *m == req.marker) && *name == req.name {
+            if marker.is_none_or(|m| *m == req.marker) && *name == req.name {
                 to_replace.push((i, req));
             }
         }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -654,7 +654,7 @@ impl ScriptInterpreter {
 
         match PythonEnvironment::from_root(&root, cache) {
             Ok(venv) => {
-                if python_request.as_ref().map_or(true, |request| {
+                if python_request.as_ref().is_none_or(|request| {
                     if request.satisfied(venv.interpreter(), cache) {
                         debug!(
                             "The script environment's Python version satisfies `{}`",
@@ -796,7 +796,7 @@ impl ProjectInterpreter {
         let venv = workspace.venv(active);
         match PythonEnvironment::from_root(&venv, cache) {
             Ok(venv) => {
-                if python_request.as_ref().map_or(true, |request| {
+                if python_request.as_ref().is_none_or(|request| {
                     if request.satisfied(venv.interpreter(), cache) {
                         debug!(
                             "The virtual environment's Python version satisfies `{}`",

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -119,7 +119,7 @@ pub(crate) async fn list(
                 result
                     .as_ref()
                     .err()
-                    .map_or(true, DiscoveryError::is_critical)
+                    .is_none_or(DiscoveryError::is_critical)
             })
             .collect::<Result<Vec<Result<PythonInstallation, PythonNotFound>>, DiscoveryError>>()?
             .into_iter()

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -681,7 +681,7 @@ async fn get_or_create_environment(
             let existing_environment = installed_tools
                 .get_environment(&requirement.name, cache)?
                 .filter(|environment| {
-                    python_request.as_ref().map_or(true, |python_request| {
+                    python_request.as_ref().is_none_or(|python_request| {
                         python_request.satisfied(environment.interpreter(), cache)
                     })
                 });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"


### PR DESCRIPTION
## Summary

* Upgrade the rust toolchain to 1.85.0. This does not increase the MSRV.
* Update windows trampoline to 1.86 nightly beta (previously in 1.85 nightly beta).

## Test Plan

Existing tests
