### PR TITLE
Use `SmallString` on `Hashes`

### DIFF
--- a/crates/uv-extract/src/hash.rs
+++ b/crates/uv-extract/src/hash.rs
@@ -41,19 +41,19 @@ impl From<Hasher> for HashDigest {
         match hasher {
             Hasher::Md5(hasher) => HashDigest {
                 algorithm: HashAlgorithm::Md5,
-                digest: format!("{:x}", hasher.finalize()).into_boxed_str(),
+                digest: format!("{:x}", hasher.finalize()).into(),
             },
             Hasher::Sha256(hasher) => HashDigest {
                 algorithm: HashAlgorithm::Sha256,
-                digest: format!("{:x}", hasher.finalize()).into_boxed_str(),
+                digest: format!("{:x}", hasher.finalize()).into(),
             },
             Hasher::Sha384(hasher) => HashDigest {
                 algorithm: HashAlgorithm::Sha384,
-                digest: format!("{:x}", hasher.finalize()).into_boxed_str(),
+                digest: format!("{:x}", hasher.finalize()).into(),
             },
             Hasher::Sha512(hasher) => HashDigest {
                 algorithm: HashAlgorithm::Sha512,
-                digest: format!("{:x}", hasher.finalize()).into_boxed_str(),
+                digest: format!("{:x}", hasher.finalize()).into(),
             },
         }
     }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -68,8 +68,8 @@ pub enum PublishError {
     HashMismatch {
         filename: Box<DistFilename>,
         hash_algorithm: HashAlgorithm,
-        local: Box<str>,
-        remote: Box<str>,
+        local: String,
+        remote: String,
     },
     #[error("Hash is missing in index for {0}")]
     MissingHash(Box<DistFilename>),
@@ -547,8 +547,8 @@ pub async fn check_url(
             Err(PublishError::HashMismatch {
                 filename: Box::new(filename.clone()),
                 hash_algorithm: remote_hash.algorithm,
-                local: local_hash.digest,
-                remote: remote_hash.digest.clone(),
+                local: local_hash.digest.to_string(),
+                remote: remote_hash.digest.to_string(),
             })
         }
     } else {

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -138,10 +138,10 @@ impl Default for Yanked {
 /// PEP 691 says multiple hashes can be included and the interpretation is left to the client.
 #[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize)]
 pub struct Hashes {
-    pub md5: Option<Box<str>>,
-    pub sha256: Option<Box<str>>,
-    pub sha384: Option<Box<str>>,
-    pub sha512: Option<Box<str>>,
+    pub md5: Option<SmallString>,
+    pub sha256: Option<SmallString>,
+    pub sha384: Option<SmallString>,
+    pub sha512: Option<SmallString>,
 }
 
 impl Hashes {
@@ -163,42 +163,30 @@ impl Hashes {
         }
 
         match name {
-            "md5" => {
-                let md5 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: Some(md5),
-                    sha256: None,
-                    sha384: None,
-                    sha512: None,
-                })
-            }
-            "sha256" => {
-                let sha256 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: Some(sha256),
-                    sha384: None,
-                    sha512: None,
-                })
-            }
-            "sha384" => {
-                let sha384 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: None,
-                    sha384: Some(sha384),
-                    sha512: None,
-                })
-            }
-            "sha512" => {
-                let sha512 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: None,
-                    sha384: None,
-                    sha512: Some(sha512),
-                })
-            }
+            "md5" => Ok(Hashes {
+                md5: Some(SmallString::from(value)),
+                sha256: None,
+                sha384: None,
+                sha512: None,
+            }),
+            "sha256" => Ok(Hashes {
+                md5: None,
+                sha256: Some(SmallString::from(value)),
+                sha384: None,
+                sha512: None,
+            }),
+            "sha384" => Ok(Hashes {
+                md5: None,
+                sha256: None,
+                sha384: Some(SmallString::from(value)),
+                sha512: None,
+            }),
+            "sha512" => Ok(Hashes {
+                md5: None,
+                sha256: None,
+                sha384: None,
+                sha512: Some(SmallString::from(value)),
+            }),
             _ => Err(HashError::UnsupportedHashAlgorithm(fragment.to_string())),
         }
     }
@@ -224,42 +212,30 @@ impl FromStr for Hashes {
         }
 
         match name {
-            "md5" => {
-                let md5 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: Some(md5),
-                    sha256: None,
-                    sha384: None,
-                    sha512: None,
-                })
-            }
-            "sha256" => {
-                let sha256 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: Some(sha256),
-                    sha384: None,
-                    sha512: None,
-                })
-            }
-            "sha384" => {
-                let sha384 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: None,
-                    sha384: Some(sha384),
-                    sha512: None,
-                })
-            }
-            "sha512" => {
-                let sha512 = value.to_owned().into_boxed_str();
-                Ok(Hashes {
-                    md5: None,
-                    sha256: None,
-                    sha384: None,
-                    sha512: Some(sha512),
-                })
-            }
+            "md5" => Ok(Hashes {
+                md5: Some(SmallString::from(value)),
+                sha256: None,
+                sha384: None,
+                sha512: None,
+            }),
+            "sha256" => Ok(Hashes {
+                md5: None,
+                sha256: Some(SmallString::from(value)),
+                sha384: None,
+                sha512: None,
+            }),
+            "sha384" => Ok(Hashes {
+                md5: None,
+                sha256: None,
+                sha384: Some(SmallString::from(value)),
+                sha512: None,
+            }),
+            "sha512" => Ok(Hashes {
+                md5: None,
+                sha256: None,
+                sha384: None,
+                sha512: Some(SmallString::from(value)),
+            }),
             _ => Err(HashError::UnsupportedHashAlgorithm(s.to_string())),
         }
     }
@@ -331,7 +307,7 @@ impl std::fmt::Display for HashAlgorithm {
 #[rkyv(derive(Debug))]
 pub struct HashDigest {
     pub algorithm: HashAlgorithm,
-    pub digest: Box<str>,
+    pub digest: SmallString,
 }
 
 impl HashDigest {
@@ -367,11 +343,9 @@ impl FromStr for HashDigest {
         }
 
         let algorithm = HashAlgorithm::from_str(name)?;
+        let digest = SmallString::from(value);
 
-        Ok(HashDigest {
-            algorithm,
-            digest: value.to_owned().into_boxed_str(),
-        })
+        Ok(Self { algorithm, digest })
     }
 }
 

--- a/crates/uv-small-str/src/lib.rs
+++ b/crates/uv-small-str/src/lib.rs
@@ -83,6 +83,31 @@ impl serde::Serialize for SmallString {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for SmallString {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = deserializer.deserialize_str(SmallStringVisitor)?;
+        Ok(s)
+    }
+}
+
+struct SmallStringVisitor;
+
+impl serde::de::Visitor<'_> for SmallStringVisitor {
+    type Value = SmallString;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a string")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(v.into())
+    }
+
+    fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+        Ok(v.into())
+    }
+}
+
 /// An [`rkyv`] implementation for [`SmallString`].
 impl rkyv::Archive for SmallString {
     type Archived = rkyv::string::ArchivedString;


### PR DESCRIPTION
## Summary

We should use this consistently over `Box<str>`.
