### PR TITLE
rework log verbosity (`-vvv`)

### DIFF
--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -548,6 +548,9 @@ impl EnvVars {
     /// for more.
     pub const RUST_LOG: &'static str = "RUST_LOG";
 
+    /// Give log messages more detailed context
+    pub const UV_LOG_CONTEXT: &'static str = "UV_LOG_CONTEXT";
+
     /// Use to set the stack size used by uv.
     ///
     /// The value is in bytes, and the default is typically 2MB (2097152).

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -548,7 +548,9 @@ impl EnvVars {
     /// for more.
     pub const RUST_LOG: &'static str = "RUST_LOG";
 
-    /// Give log messages more detailed context
+    /// Add additional context and structure to log messages.
+    ///
+    /// If logging is not enabled, e.g., with `RUST_LOG` or `-v`, this has no effect.
     pub const UV_LOG_CONTEXT: &'static str = "UV_LOG_CONTEXT";
 
     /// Use to set the stack size used by uv.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -279,9 +279,10 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     let duration_layer = None::<tracing_subscriber::layer::Identity>;
     logging::setup_logging(
         match globals.verbose {
-            0 => logging::Level::Default,
-            1 => logging::Level::Verbose,
-            2.. => logging::Level::ExtraVerbose,
+            0 => logging::Level::Off,
+            1 => logging::Level::DebugUv,
+            2 => logging::Level::TraceUv,
+            3.. => logging::Level::TraceAll,
         },
         duration_layer,
         globals.color,

--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -126,15 +126,15 @@ pub(crate) fn setup_logging(
             tracing::level_filters::LevelFilter::OFF.into()
         }
         Level::DebugUv => {
-            // Show `DEBUG` messages from the CLI crate
+            // Show `DEBUG` messages from the CLI crate (and ERROR/WARN/INFO)
             Directive::from_str("uv=debug").unwrap()
         }
         Level::TraceUv => {
-            // Show `TRACE` messages from the CLI crate, but allow `RUST_LOG` to override.
+            // Show `TRACE` messages from the CLI crate (and ERROR/WARN/INFO/DEBUG)
             Directive::from_str("uv=trace").unwrap()
         }
         Level::TraceAll => {
-            // Show `TRACE` messages from the CLI crate, but allow `RUST_LOG` to override.
+            // Show all `TRACE` messages (and ERROR/WARN/INFO/DEBUG)
             Directive::from_str("trace").unwrap()
         }
     };

--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -21,8 +21,6 @@ use tracing_tree::HierarchicalLayer;
 
 use uv_cli::ColorChoice;
 use uv_static::EnvVars;
-#[cfg(feature = "tracing-durations-export")]
-use uv_static::EnvVars;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Level {

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -173,6 +173,10 @@ a link mode.
 Equivalent to the `--locked` command-line argument. If set, uv will assert that the
 `uv.lock` remains unchanged.
 
+### `UV_LOG_CONTEXT`
+
+Give log messages more detailed context
+
 ### `UV_NATIVE_TLS`
 
 Equivalent to the `--native-tls` command-line argument. If set to `true`, uv will

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -175,7 +175,9 @@ Equivalent to the `--locked` command-line argument. If set, uv will assert that 
 
 ### `UV_LOG_CONTEXT`
 
-Give log messages more detailed context
+Add additional context and structure to log messages.
+
+If logging is not enabled, e.g., with `RUST_LOG` or `-v`, this has no effect.
 
 ### `UV_NATIVE_TLS`
 


### PR DESCRIPTION
Reworks how log verbosity flags work.

* `<no argument>` is the same, equivalent to `RUST_LOG=off`
* `-v` is the same, equivalent to `RUST_LOG=uv=debug`
* `-vv` is now equivalent to `RUST_LOG=uv=trace` (previously it only enabled more log message context)
* `-vvv` is now equivalent to `RUST_LOG=trace` (previously it was equivalent to `-vv`)

The "more context" that `-vv` had has been moved to an orthogonal setting via an environment variable. Setting  `UV_LOG_CONTEXT=1` will add the extra context that `-vv` did.

In the future we may make these more granular as we try to use `info!/warn!` more.

Fixes #1569 