### PR TITLE
Create a `.git` directory in the test context root

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -332,6 +332,11 @@ impl TestContext {
 
         let root = tempfile::TempDir::new_in(bucket).expect("Failed to create test root directory");
 
+        // Create a `.git` directory to isolate tests that search for git boundaries from the state
+        // of the file system
+        fs_err::create_dir_all(root.path().join(".git"))
+            .expect("Failed to create `.git` placeholder in test root directory");
+
         let temp_dir = ChildPath::new(root.path()).child("temp");
         fs_err::create_dir_all(&temp_dir).expect("Failed to create test working directory");
 


### PR DESCRIPTION
This fixes errors in the test suite when, e.g., `~`, is a Git repository.