### PR TITLE
Use `SmallString` for filenames and URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4855,6 +4855,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
+ "uv-small-str",
  "uv-static",
  "uv-version",
  "uv-warnings",
@@ -5075,6 +5076,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
+ "uv-small-str",
  "version-ranges",
 ]
 
@@ -5605,6 +5607,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-python",
  "uv-requirements-txt",
+ "uv-small-str",
  "uv-static",
  "uv-types",
  "uv-warnings",

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -23,6 +23,7 @@ uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
+uv-small-str = { workspace = true }
 uv-static = { workspace = true }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -10,6 +10,7 @@ use uv_cache_key::cache_digest;
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{File, FileLocation, IndexUrl, UrlString};
 use uv_pypi_types::HashDigests;
+use uv_small_str::SmallString;
 
 use crate::cached_client::{CacheControl, CachedClientError};
 use crate::html::SimpleHtml;
@@ -186,10 +187,13 @@ impl<'a> FlatIndexClient<'a> {
                 let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;
 
+                // Convert to a reference-counted string.
+                let base = SmallString::from(base.as_str());
+
                 let unarchived: Vec<File> = files
                     .into_iter()
                     .filter_map(|file| {
-                        match File::try_from(file, base.as_url()) {
+                        match File::try_from(file, &base) {
                             Ok(file) => Some(file),
                             Err(err) => {
                                 // Ignore files with unparsable version specifiers.
@@ -270,10 +274,11 @@ impl<'a> FlatIndexClient<'a> {
                 }
             }
 
-            let Ok(filename) = entry.file_name().into_string() else {
+            let filename = entry.file_name();
+            let Some(filename) = filename.to_str() else {
                 warn!(
                     "Skipping non-UTF-8 filename in `--find-links` directory: {}",
-                    entry.file_name().to_string_lossy()
+                    filename.to_string_lossy()
                 );
                 continue;
             };
@@ -283,16 +288,16 @@ impl<'a> FlatIndexClient<'a> {
 
             let file = File {
                 dist_info_metadata: false,
-                filename: filename.to_string(),
+                filename: filename.into(),
                 hashes: HashDigests::empty(),
                 requires_python: None,
                 size: None,
                 upload_time_utc_ms: None,
-                url: FileLocation::AbsoluteUrl(UrlString::from(url)),
+                url: FileLocation::AbsoluteUrl(UrlString::from(&url)),
                 yanked: None,
             };
 
-            let Some(filename) = DistFilename::try_from_normalized_filename(&filename) else {
+            let Some(filename) = DistFilename::try_from_normalized_filename(filename) else {
                 debug!(
                     "Ignoring `--find-links` entry (expected a wheel or source distribution filename): {}",
                     entry.path().display()

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -218,8 +218,8 @@ impl SimpleHtml {
             yanked,
             requires_python,
             hashes,
-            filename: filename.to_string(),
-            url: decoded.to_string(),
+            filename: filename.into(),
+            url: decoded.into(),
             size,
             upload_time,
         }))

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -27,6 +27,7 @@ uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
+uv-small-str = { workspace = true }
 
 arcstr = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/uv-pypi-types/src/base_url.rs
+++ b/crates/uv-pypi-types/src/base_url.rs
@@ -43,6 +43,11 @@ impl BaseUrl {
     pub fn as_url(&self) -> &Url {
         &self.0
     }
+
+    /// Return the underlying [`Url`] as a serialized string.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
 
 impl From<Url> for BaseUrl {

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -40,10 +40,12 @@ fn sorted_simple_json_files<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<File>
 pub struct File {
     // PEP 714-renamed field, followed by PEP 691-compliant field, followed by non-PEP 691-compliant
     // alias used by PyPI.
+    //
+    // TODO(charlie): Use a single value here and move this into the deserializer, to save space.
     pub core_metadata: Option<CoreMetadata>,
     pub dist_info_metadata: Option<CoreMetadata>,
     pub data_dist_info_metadata: Option<CoreMetadata>,
-    pub filename: String,
+    pub filename: SmallString,
     pub hashes: Hashes,
     /// There are a number of invalid specifiers on PyPI, so we first try to parse it into a
     /// [`VersionSpecifiers`] according to spec (PEP 440), then a [`LenientVersionSpecifiers`] with
@@ -53,7 +55,7 @@ pub struct File {
     pub requires_python: Option<Result<VersionSpecifiers, VersionSpecifiersParseError>>,
     pub size: Option<u64>,
     pub upload_time: Option<Timestamp>,
-    pub url: String,
+    pub url: SmallString,
     pub yanked: Option<Box<Yanked>>,
 }
 

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -34,6 +34,7 @@ uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-requirements-txt = { workspace = true }
+uv-small-str = { workspace = true }
 uv-static = { workspace = true }
 uv-types = { workspace = true }
 uv-warnings = { workspace = true }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -43,6 +43,7 @@ use uv_pypi_types::{
     redact_credentials, ConflictPackage, Conflicts, HashDigest, HashDigests, ParsedArchiveUrl,
     ParsedGitUrl, Requirement, RequirementSource,
 };
+use uv_small_str::SmallString;
 use uv_types::{BuildContext, HashStrategy};
 use uv_workspace::WorkspaceMember;
 
@@ -2395,7 +2396,7 @@ impl Package {
                 let ext = SourceDistExtension::from_path(filename.as_ref())?;
                 let file = Box::new(uv_distribution_types::File {
                     dist_info_metadata: false,
-                    filename: filename.to_string(),
+                    filename: SmallString::from(filename),
                     hashes: sdist.hash().map_or(HashDigests::empty(), |hash| {
                         HashDigests::from(hash.0.clone())
                     }),
@@ -2446,7 +2447,7 @@ impl Package {
                 let ext = SourceDistExtension::from_path(filename.as_ref())?;
                 let file = Box::new(uv_distribution_types::File {
                     dist_info_metadata: false,
-                    filename: filename.to_string(),
+                    filename: SmallString::from(filename),
                     hashes: sdist.hash().map_or(HashDigests::empty(), |hash| {
                         HashDigests::from(hash.0.clone())
                     }),
@@ -4027,7 +4028,7 @@ impl Wheel {
                 };
                 let file = Box::new(uv_distribution_types::File {
                     dist_info_metadata: false,
-                    filename: filename.to_string(),
+                    filename: SmallString::from(filename.to_string()),
                     hashes: self.hash.iter().map(|h| h.0.clone()).collect(),
                     requires_python: None,
                     size: self.size,
@@ -4059,7 +4060,7 @@ impl Wheel {
                     .map_err(|()| LockErrorKind::PathToUrl)?;
                 let file = Box::new(uv_distribution_types::File {
                     dist_info_metadata: false,
-                    filename: filename.to_string(),
+                    filename: SmallString::from(filename.to_string()),
                     hashes: self.hash.iter().map(|h| h.0.clone()).collect(),
                     requires_python: None,
                     size: self.size,


### PR DESCRIPTION
## Summary

These are never mutated, so there's no need to store them as `String`.
