### PR TITLE
Avoid using owned `String` for package name constructors

### DIFF
--- a/crates/uv-configuration/src/extras.rs
+++ b/crates/uv-configuration/src/extras.rs
@@ -95,7 +95,7 @@ mod tests {
             Vec::new()
         );
         ($($x:expr),+ $(,)?) => (
-            vec![$(ExtraName::new($x.into()).unwrap()),+]
+            vec![$(ExtraName::from_owned($x.into()).unwrap()),+]
         )
     }
 

--- a/crates/uv-normalize/src/extra_name.rs
+++ b/crates/uv-normalize/src/extra_name.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use uv_small_str::SmallString;
 
-use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNameError};
+use crate::{validate_and_normalize_ref, InvalidNameError};
 
 /// The normalized name of an extra dependency.
 ///
@@ -22,8 +22,11 @@ pub struct ExtraName(SmallString);
 
 impl ExtraName {
     /// Create a validated, normalized extra name.
-    pub fn new(name: String) -> Result<Self, InvalidNameError> {
-        validate_and_normalize_owned(name).map(Self)
+    ///
+    /// At present, this is no more efficient than calling [`ExtraName::from_str`].
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn from_owned(name: String) -> Result<Self, InvalidNameError> {
+        validate_and_normalize_ref(&name).map(Self)
     }
 
     /// Return the underlying extra name as a string.

--- a/crates/uv-normalize/src/group_name.rs
+++ b/crates/uv-normalize/src/group_name.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use uv_small_str::SmallString;
 
-use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNameError};
+use crate::{validate_and_normalize_ref, InvalidNameError};
 
 /// The normalized name of a dependency group.
 ///
@@ -20,8 +20,11 @@ pub struct GroupName(SmallString);
 
 impl GroupName {
     /// Create a validated, normalized group name.
-    pub fn new(name: String) -> Result<Self, InvalidNameError> {
-        validate_and_normalize_owned(name).map(Self)
+    ///
+    /// At present, this is no more efficient than calling [`GroupName::from_str`].
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn from_owned(name: String) -> Result<Self, InvalidNameError> {
+        validate_and_normalize_ref(&name).map(Self)
     }
 }
 
@@ -69,4 +72,4 @@ impl AsRef<str> for GroupName {
 /// Internally, we model dependency groups as a generic concept; but externally, we only expose the
 /// `dev-dependencies` group.
 pub static DEV_DEPENDENCIES: LazyLock<GroupName> =
-    LazyLock::new(|| GroupName::new("dev".to_string()).unwrap());
+    LazyLock::new(|| GroupName::from_str("dev").unwrap());

--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -13,15 +13,6 @@ mod extra_name;
 mod group_name;
 mod package_name;
 
-/// Validate and normalize an owned package or extra name.
-pub(crate) fn validate_and_normalize_owned(name: String) -> Result<SmallString, InvalidNameError> {
-    if is_normalized(&name)? {
-        Ok(SmallString::from(name))
-    } else {
-        Ok(SmallString::from(normalize(&name)?))
-    }
-}
-
 /// Validate and normalize an unowned package or extra name.
 pub(crate) fn validate_and_normalize_ref(
     name: impl AsRef<str>,
@@ -151,12 +142,6 @@ mod tests {
                 validate_and_normalize_ref(input).unwrap().as_ref(),
                 "friendly-bard"
             );
-            assert_eq!(
-                validate_and_normalize_owned(input.to_string())
-                    .unwrap()
-                    .as_ref(),
-                "friendly-bard"
-            );
         }
     }
 
@@ -186,12 +171,6 @@ mod tests {
         let unchanged = ["friendly-bard", "1okay", "okay2"];
         for input in unchanged {
             assert_eq!(validate_and_normalize_ref(input).unwrap().as_ref(), input);
-            assert_eq!(
-                validate_and_normalize_owned(input.to_string())
-                    .unwrap()
-                    .as_ref(),
-                input
-            );
             assert!(is_normalized(input).unwrap());
         }
     }
@@ -209,7 +188,6 @@ mod tests {
         ];
         for input in failures {
             assert!(validate_and_normalize_ref(input).is_err());
-            assert!(validate_and_normalize_owned(input.to_string()).is_err());
             assert!(is_normalized(input).is_err());
         }
     }

--- a/crates/uv-normalize/src/package_name.rs
+++ b/crates/uv-normalize/src/package_name.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use uv_small_str::SmallString;
 
-use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNameError};
+use crate::{validate_and_normalize_ref, InvalidNameError};
 
 /// The normalized name of a package.
 ///
@@ -33,8 +33,11 @@ pub struct PackageName(SmallString);
 
 impl PackageName {
     /// Create a validated, normalized package name.
-    pub fn new(name: String) -> Result<Self, InvalidNameError> {
-        validate_and_normalize_owned(name).map(Self)
+    ///
+    /// At present, this is no more efficient than calling [`PackageName::from_str`].
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn from_owned(name: String) -> Result<Self, InvalidNameError> {
+        validate_and_normalize_ref(&name).map(Self)
     }
 
     /// Escape this name with underscores (`_`) instead of dashes (`-`)

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -625,7 +625,8 @@ fn parse_extras_cursor<T: Pep508Url>(
 
         // Add the parsed extra
         extras.push(
-            ExtraName::new(buffer).expect("`ExtraName` validation should match PEP 508 parsing"),
+            ExtraName::from_str(&buffer)
+                .expect("`ExtraName` validation should match PEP 508 parsing"),
         );
         is_first_iteration = false;
     }

--- a/crates/uv-pypi-types/src/metadata/metadata10.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata10.rs
@@ -20,7 +20,7 @@ impl Metadata10 {
     /// Parse the [`Metadata10`] from a `PKG-INFO` file, as included in a source distribution.
     pub fn parse_pkg_info(content: &[u8]) -> Result<Self, MetadataError> {
         let headers = Headers::parse(content)?;
-        let name = PackageName::new(
+        let name = PackageName::from_owned(
             headers
                 .get_first_value("Name")
                 .ok_or(MetadataError::FieldNotFound("Name"))?,

--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -40,7 +40,7 @@ impl ResolutionMetadata {
     pub fn parse_metadata(content: &[u8]) -> Result<Self, MetadataError> {
         let headers = Headers::parse(content)?;
 
-        let name = PackageName::new(
+        let name = PackageName::from_owned(
             headers
                 .get_first_value("Name")
                 .ok_or(MetadataError::FieldNotFound("Name"))?,
@@ -63,13 +63,15 @@ impl ResolutionMetadata {
             .map(VersionSpecifiers::from);
         let provides_extras = headers
             .get_all_values("Provides-Extra")
-            .filter_map(|provides_extra| match ExtraName::new(provides_extra) {
-                Ok(extra_name) => Some(extra_name),
-                Err(err) => {
-                    warn!("Ignoring invalid extra: {err}");
-                    None
-                }
-            })
+            .filter_map(
+                |provides_extra| match ExtraName::from_owned(provides_extra) {
+                    Ok(extra_name) => Some(extra_name),
+                    Err(err) => {
+                        warn!("Ignoring invalid extra: {err}");
+                        None
+                    }
+                },
+            )
             .collect::<Vec<_>>();
         let dynamic = headers
             .get_all_values("Dynamic")
@@ -116,7 +118,7 @@ impl ResolutionMetadata {
         }
 
         // The `Name` and `Version` fields are required, and can't be dynamic.
-        let name = PackageName::new(
+        let name = PackageName::from_owned(
             headers
                 .get_first_value("Name")
                 .ok_or(MetadataError::FieldNotFound("Name"))?,
@@ -141,13 +143,15 @@ impl ResolutionMetadata {
             .map(VersionSpecifiers::from);
         let provides_extras = headers
             .get_all_values("Provides-Extra")
-            .filter_map(|provides_extra| match ExtraName::new(provides_extra) {
-                Ok(extra_name) => Some(extra_name),
-                Err(err) => {
-                    warn!("Ignoring invalid extra: {err}");
-                    None
-                }
-            })
+            .filter_map(
+                |provides_extra| match ExtraName::from_owned(provides_extra) {
+                    Ok(extra_name) => Some(extra_name),
+                    Err(err) => {
+                        warn!("Ignoring invalid extra: {err}");
+                        None
+                    }
+                },
+            )
             .collect::<Vec<_>>();
 
         Ok(Self {

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -865,7 +865,7 @@ impl PyProjectTomlMut {
                     let Some(dependencies) = dependencies.as_array() else {
                         continue;
                     };
-                    let Ok(extra) = ExtraName::new(extra.to_string()) else {
+                    let Ok(extra) = ExtraName::from_str(extra) else {
                         continue;
                     };
 
@@ -882,7 +882,7 @@ impl PyProjectTomlMut {
                 let Some(dependencies) = dependencies.as_array() else {
                     continue;
                 };
-                let Ok(group) = GroupName::new(group.to_string()) else {
+                let Ok(group) = GroupName::from_str(group) else {
                     continue;
                 };
 

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -126,7 +126,7 @@ pub(crate) async fn init(
                     // Pre-normalize the package name by removing any leading or trailing
                     // whitespace, and replacing any internal whitespace with hyphens.
                     let name = name.trim().replace(' ', "-");
-                    PackageName::new(name)?
+                    PackageName::from_owned(name)?
                 }
             };
 


### PR DESCRIPTION
## Summary

Since we use `SmallString` internally, there's no benefit to passing an owned string to the `PackageName` constructor (same goes for `ExtraName`, etc.). I've kept them for now (maybe that will change in the future, so it's useful to have clients passed own values if they _can_), but removed a bunch of usages where we were casting from `&str` to `String` needlessly to use the constructor.
