### PR TITLE
Add MACOSX_DEPLOYMENT_TARGET hint for macos platform wheels

### DIFF
--- a/crates/uv-platform-tags/src/platform_tag.rs
+++ b/crates/uv-platform-tags/src/platform_tag.rs
@@ -229,6 +229,28 @@ impl PlatformTag {
             } | Self::Win32
         )
     }
+
+    /// Return the major and minor fields if set for the [`PlatformTag`] variant.
+    pub fn major_minor(&self) -> Option<(u16, u16)> {
+        match self {
+            Self::Manylinux {
+                major,
+                minor,
+                arch: _,
+            }
+            | Self::Musllinux {
+                major,
+                minor,
+                arch: _,
+            }
+            | Self::Macos {
+                major,
+                minor,
+                binary_format: _,
+            } => Some((*major, *minor)),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for PlatformTag {

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -1666,7 +1666,7 @@ impl std::fmt::Display for PubGrubHint {
                         ":".bold(),
                         "MACOSX_DEPLOYMENT_TARGET".cyan(),
                     ))
-                    .unwrap_or(String::from(""));
+                    .unwrap_or(String::new());
                 let formatted_tags = tags
                     .iter()
                     .map(|tag| format!("`{}`", tag.cyan()))

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -8,15 +8,6 @@ use owo_colors::OwoColorize;
 use pubgrub::{DerivationTree, Derived, External, Map, Range, ReportFormatter, Term};
 use rustc_hash::FxHashMap;
 
-use uv_configuration::{IndexStrategy, NoBinary, NoBuild};
-use uv_distribution_types::{
-    IncompatibleDist, IncompatibleSource, IncompatibleWheel, Index, IndexCapabilities,
-    IndexLocations, IndexUrl,
-};
-use uv_normalize::PackageName;
-use uv_pep440::{Version, VersionSpecifiers};
-use uv_platform_tags::{AbiTag, IncompatibleTag, LanguageTag, PlatformTag, Tags};
-
 use crate::candidate_selector::CandidateSelector;
 use crate::error::ErrorTree;
 use crate::fork_indexes::ForkIndexes;
@@ -30,6 +21,16 @@ use crate::resolver::{
 use crate::{
     Flexibility, InMemoryIndex, Options, RequiresPython, ResolverEnvironment, VersionsResponse,
 };
+use uv_configuration::{macos_deployment_target, IndexStrategy, NoBinary, NoBuild, TargetTriple};
+use uv_distribution_types::{
+    IncompatibleDist, IncompatibleSource, IncompatibleWheel, Index, IndexCapabilities,
+    IndexLocations, IndexUrl,
+};
+use uv_normalize::PackageName;
+use uv_pep440::{Version, VersionSpecifiers};
+use uv_pep508::CanonicalMarkerValueString;
+use uv_platform_tags::{AbiTag, IncompatibleTag, LanguageTag, PlatformTag, Tags};
+use uv_static::EnvVars;
 
 #[derive(Debug)]
 pub(crate) struct PubGrubReportFormatter<'a> {
@@ -584,7 +585,7 @@ impl PubGrubReportFormatter<'_> {
                             }
                             // Check for unavailable versions due to incompatible tags.
                             IncompatibleDist::Wheel(IncompatibleWheel::Tag(tag)) => {
-                                if let Some(hint) = self.tag_hint(
+                                if let Some(hints) = self.tag_hints(
                                     name,
                                     set,
                                     *tag,
@@ -594,7 +595,9 @@ impl PubGrubReportFormatter<'_> {
                                     env,
                                     tags,
                                 ) {
-                                    output_hints.insert(hint);
+                                    for hint in hints {
+                                        output_hints.insert(hint);
+                                    }
                                 }
                             }
                             _ => {}
@@ -714,9 +717,9 @@ impl PubGrubReportFormatter<'_> {
         };
     }
 
-    /// Generate a [`PubGrubHint`] for a package that doesn't have any wheels matching the current
+    /// Generate [`PubGrubHints`] for a package that doesn't have any wheels matching the current
     /// Python version, ABI, or platform.
-    fn tag_hint(
+    fn tag_hints(
         &self,
         name: &PackageName,
         set: &Range<Version>,
@@ -726,7 +729,7 @@ impl PubGrubReportFormatter<'_> {
         fork_indexes: &ForkIndexes,
         env: &ResolverEnvironment,
         tags: Option<&Tags>,
-    ) -> Option<PubGrubHint> {
+    ) -> Option<PubGrubHints> {
         let response = if let Some(url) = fork_indexes.get(name) {
             index.explicit().get(&(name.clone(), url.clone()))
         } else {
@@ -749,12 +752,12 @@ impl PubGrubReportFormatter<'_> {
                 if tags.is_empty() {
                     None
                 } else {
-                    Some(PubGrubHint::LanguageTags {
+                    Some(vec![PubGrubHint::LanguageTags {
                         package: name.clone(),
                         version: candidate.version().clone(),
                         tags,
                         best,
-                    })
+                    }])
                 }
             }
             IncompatibleTag::Abi | IncompatibleTag::AbiPythonVersion => {
@@ -774,12 +777,12 @@ impl PubGrubReportFormatter<'_> {
                 if tags.is_empty() {
                     None
                 } else {
-                    Some(PubGrubHint::AbiTags {
+                    Some(vec![PubGrubHint::AbiTags {
                         package: name.clone(),
                         version: candidate.version().clone(),
                         tags,
                         best,
-                    })
+                    }])
                 }
             }
             IncompatibleTag::Platform => {
@@ -800,11 +803,25 @@ impl PubGrubReportFormatter<'_> {
                 if tags.is_empty() {
                     None
                 } else {
-                    Some(PubGrubHint::PlatformTags {
+                    let mut hints = Vec::new();
+                    hints.push(PubGrubHint::PlatformTags {
                         package: name.clone(),
                         version: candidate.version().clone(),
-                        tags,
-                    })
+                        tags: tags.clone(),
+                    });
+                    // If the platform target is macOS, and we have an available macOS wheel,
+                    // include an additional hint to override the minimum deployment target.
+                    if env.marker_environment().is_some_and(|marker| {
+                        marker.get_string(CanonicalMarkerValueString::SysPlatform)
+                            == TargetTriple::Macos.sys_platform()
+                    }) {
+                        if let Some(tag) = tags.iter().find(|tag| tag.is_macos()) {
+                            hints.push(PubGrubHint::PlatformMacosDeploymentTarget {
+                                tag: tag.clone(),
+                            });
+                        };
+                    }
+                    Some(hints)
                 }
             }
         }
@@ -983,6 +1000,8 @@ impl PubGrubReportFormatter<'_> {
     }
 }
 
+type PubGrubHints = Vec<PubGrubHint>;
+
 #[derive(Debug, Clone)]
 pub(crate) enum PubGrubHint {
     /// There are pre-release versions available for a package, but pre-releases weren't enabled
@@ -1135,6 +1154,10 @@ pub(crate) enum PubGrubHint {
         // excluded from `PartialEq` and `Hash`
         tags: BTreeSet<PlatformTag>,
     },
+    PlatformMacosDeploymentTarget {
+        // excluded from `PartialEq` and `Hash`
+        tag: PlatformTag,
+    },
 }
 
 /// This private enum mirrors [`PubGrubHint`] but only includes fields that should be
@@ -1205,6 +1228,7 @@ enum PubGrubHintCore {
     PlatformTags {
         package: PackageName,
     },
+    PlatformMacosDeploymentTarget,
 }
 
 impl From<PubGrubHint> for PubGrubHintCore {
@@ -1265,6 +1289,9 @@ impl From<PubGrubHint> for PubGrubHintCore {
             PubGrubHint::LanguageTags { package, .. } => Self::LanguageTags { package },
             PubGrubHint::AbiTags { package, .. } => Self::AbiTags { package },
             PubGrubHint::PlatformTags { package, .. } => Self::PlatformTags { package },
+            PubGrubHint::PlatformMacosDeploymentTarget { .. } => {
+                Self::PlatformMacosDeploymentTarget
+            }
         }
     }
 }
@@ -1657,30 +1684,48 @@ impl std::fmt::Display for PubGrubHint {
                 tags,
             } => {
                 let s = if tags.len() == 1 { "" } else { "s" };
-                let macos_env_hint = tags
-                    .iter()
-                    .any(|tag| matches!(*tag, PlatformTag::Macos { .. }))
-                    .then_some(format!(
-                        "\n\n{}{} Use `{}` to set the deployment target on macos platform",
-                        "hint".bold().cyan(),
-                        ":".bold(),
-                        "MACOSX_DEPLOYMENT_TARGET".cyan(),
-                    ))
-                    .unwrap_or(String::new());
-                let formatted_tags = tags
-                    .iter()
-                    .map(|tag| format!("`{}`", tag.cyan()))
-                    .join(", ");
                 write!(
                     f,
-                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}{}",
+                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
                     "hint".bold().cyan(),
                     ":".bold(),
                     package.cyan(),
                     format!("v{version}").cyan(),
-                    formatted_tags,
-                    macos_env_hint,
+                    tags.iter()
+                        .map(|tag| format!("`{}`", tag.cyan()))
+                        .join(", "),
                 )
+            }
+            Self::PlatformMacosDeploymentTarget { tag } => {
+                let current_version = {
+                    let (major, minor) = macos_deployment_target();
+                    format!("{major}.{minor}")
+                };
+                // We should always return an example as the current caller passes macOS tag with
+                // major/minor fields, however if that changes we will skip the example portion.
+                let example_version = tag
+                    .is_macos()
+                    .then(|| {
+                        tag.major_minor().map_or(String::new(), |(major, minor)| {
+                            format!(
+                                "(e.g. {}={}{}{})",
+                                EnvVars::MACOSX_DEPLOYMENT_TARGET.cyan(),
+                                major.cyan(),
+                                ".".cyan(),
+                                minor.cyan()
+                            )
+                        })
+                    })
+                    .unwrap_or_default();
+                write!(
+                    f,
+                    "{}{} The current minimum macOS deployment target is {}, set environment variable {} to change the minimum deployment target {}",
+                    "hint".bold().cyan(),
+                    ":".bold(),
+                    current_version.cyan(),
+                    EnvVars::MACOSX_DEPLOYMENT_TARGET.cyan(),
+                    example_version,
+            )
             }
         }
     }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -1657,16 +1657,29 @@ impl std::fmt::Display for PubGrubHint {
                 tags,
             } => {
                 let s = if tags.len() == 1 { "" } else { "s" };
+                let macos_env_hint = tags
+                    .iter()
+                    .any(|tag| matches!(*tag, PlatformTag::Macos { .. }))
+                    .then_some(format!(
+                        "\n\n{}{} Use `{}` to set the deployment target on macos platform",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        "MACOSX_DEPLOYMENT_TARGET".cyan(),
+                    ))
+                    .unwrap_or(String::from(""));
+                let formatted_tags = tags
+                    .iter()
+                    .map(|tag| format!("`{}`", tag.cyan()))
+                    .join(", ");
                 write!(
                     f,
-                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
+                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}{}",
                     "hint".bold().cyan(),
                     ":".bold(),
                     package.cyan(),
                     format!("v{version}").cyan(),
-                    tags.iter()
-                        .map(|tag| format!("`{}`", tag.cyan()))
-                        .join(", "),
+                    formatted_tags,
+                    macos_env_hint,
                 )
             }
         }

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -14778,7 +14778,7 @@ fn invalid_platform() -> Result<()> {
         .pip_compile()
         .arg("--python-platform")
         .arg("linux")
-        .arg("requirements.in"), @r###"
+        .arg("requirements.in"), @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -14791,7 +14791,9 @@ fn invalid_platform() -> Result<()> {
           hint: You require CPython 3.10 (`cp310`), but we only found wheels for `open3d` (v0.15.2) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
           hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `win_amd64`
-    "###);
+
+          hint: Use `MACOSX_DEPLOYMENT_TARGET` to set the deployment target on macos platform
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2084,7 +2084,7 @@ fn install_git_private_https_pat_not_authorized() {
     // and hang the test
     uv_snapshot!(filters, context.pip_install()
         .arg(format!("uv-private-pypackage @ git+https://git:{token}@github.com/astral-test/uv-private-pypackage"))
-        , @r###"
+        , @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -2095,9 +2095,10 @@ fn install_git_private_https_pat_not_authorized() {
       ├─▶ failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
       ╰─▶ process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
           --- stderr
-          remote: Invalid username or password.
+          remote: Support for password authentication was removed on August 13, 2021.
+          remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
           fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
-    "###);
+    ");
 }
 
 /// Install a package from a private GitHub repository using a PAT

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4135,8 +4135,6 @@ fn no_sdist_no_wheels_with_matching_platform() {
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
           hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
-
-          hint: Use `MACOSX_DEPLOYMENT_TARGET` to set the deployment target on macos platform
     ");
 
     assert_not_installed(

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4124,7 +4124,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
     uv_snapshot!(filters, command(&context)
         .arg("--python-platform=x86_64-manylinux2014")
         .arg("no-sdist-no-wheels-with-matching-platform-a")
-        , @r###"
+        , @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -4135,7 +4135,9 @@ fn no_sdist_no_wheels_with_matching_platform() {
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
           hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
-    "###);
+
+          hint: Use `MACOSX_DEPLOYMENT_TARGET` to set the deployment target on macos platform
+    ");
 
     assert_not_installed(
         &context.venv,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Addresses: https://github.com/astral-sh/uv/issues/10699

Adds a hint that the user may utilize `MACOSX_DEPLOYMENT_TARGET` to change the deployment target for macos platform wheels.

## Test Plan

<!-- How was it tested? -->
```shell
uv git:(issue-10699) echo "mlx" | cargo run -- pip compile - -p 3.12 --python-platform=macos
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of mlx are available:
          mlx==0.0.2
          mlx==0.0.3
          mlx==0.0.4
          mlx==0.0.5
          mlx==0.0.6
          mlx==0.0.7
          mlx==0.0.9
          mlx==0.0.10
          mlx==0.0.11
          mlx==0.1.0
          mlx==0.2.0
          mlx==0.3.0
          mlx==0.4.0
          mlx==0.5.1
          mlx==0.6.0
          mlx==0.7.0
          mlx==0.8.1
          mlx==0.9.1
          mlx==0.10.0
          mlx==0.11.1
          mlx==0.12.2
          mlx==0.13.0
          mlx==0.13.1
          mlx==0.14.0
          mlx==0.14.1
          mlx==0.15.0
          mlx==0.15.1
          mlx==0.15.2
          mlx==0.16.0
          mlx==0.16.1
          mlx==0.16.2
          mlx==0.16.3
          mlx==0.17.1
          mlx==0.17.2
          mlx==0.17.3
          mlx==0.18.0
          mlx==0.18.1
          mlx==0.19.0
          mlx==0.19.3
          mlx==0.20.0
          mlx==0.21.0
          mlx==0.21.1
          mlx==0.22.0
          mlx==0.22.1
          mlx==0.23.1
      and mlx<=0.0.3 has no wheels with a matching Python ABI tag (e.g., `cp312`), we can conclude that mlx<=0.0.3 cannot be used.
      And because mlx>=0.0.4 has no wheels with a matching platform tag (e.g., `macosx_12_0_arm64`) and you require mlx, we can conclude that your requirements are unsatisfiable.

      hint: You require CPython 3.12 (`cp312`), but we only found wheels for `mlx` (v0.0.3) with the following Python ABI tags: `cp38`, `cp39`, `cp310`, `cp311`

      hint: Wheels are available for `mlx` (v0.23.1) on the following platforms: `manylinux_2_31_x86_64`, `macosx_13_0_arm64`, `macosx_14_0_arm64`

      hint: Use `MACOSX_DEPLOYMENT_TARGET` to set the deployment target on macos platform
``` 