### PR TITLE
Handle nested .git directories in `uv init`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1219,7 +1219,11 @@ fn init_vcs(path: &Path, vcs: Option<VersionControlSystem>) -> Result<()> {
         (Some(vcs), None) => vcs,
         // If a version control system was specified, but a VCS was detected, then the user is
         // asking for a specific vcs, so we use it
-        (Some(vcs), Some(_existing)) => vcs,
+        (Some(vcs), Some(existing)) => {
+            debug!("Requested version control system ({vcs}) conflicts with existing version system ({existing})");
+            debug!("Initializing requested version control system: {vcs}");
+            vcs
+        }
     };
 
     // Attempt to initialize the VCS.

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1217,16 +1217,9 @@ fn init_vcs(path: &Path, vcs: Option<VersionControlSystem>) -> Result<()> {
         (Some(VersionControlSystem::None), _) => VersionControlSystem::None,
         // If a version control system was specified, use it.
         (Some(vcs), None) => vcs,
-        // If a version control system was specified, but a VCS was detected...
-        (Some(vcs), Some(existing)) => {
-            // If they differ, raise an error.
-            if vcs != existing {
-                anyhow::bail!("The project is already in a version control system (`{existing}`); cannot initialize with `--vcs {vcs}`");
-            }
-
-            // Otherwise, ignore the specified VCS, since it's already in use.
-            VersionControlSystem::None
-        }
+        // If a version control system was specified, but a VCS was detected, then the user is
+        // asking for a specific vcs, so we use it
+        (Some(vcs), Some(_existing)) => vcs,
     };
 
     // Attempt to initialize the VCS.

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -332,6 +332,9 @@ impl TestContext {
 
         let root = tempfile::TempDir::new_in(bucket).expect("Failed to create test root directory");
 
+        fs_err::create_dir_all(root.path().join(".git"))
+            .expect("Failed to create `.git` placeholder in test root directory");
+
         let temp_dir = ChildPath::new(root.path()).child("temp");
         fs_err::create_dir_all(&temp_dir).expect("Failed to create test working directory");
 

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2583,7 +2583,7 @@ fn init_inside_git_repo() {
     Initialized project `bar` at `[TEMP_DIR]/bar`
     "###);
 
-    child.child(".gitignore").assert(predicate::path::is_file());
+    child.child(".gitignore").assert(predicate::path::missing());
 }
 
 #[test]

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2571,7 +2571,7 @@ fn init_inside_git_repo() {
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
-    child.child(".gitignore").assert(predicate::path::missing());
+    child.child(".gitignore").assert(predicate::path::is_file());
 
     let child = context.temp_dir.child("bar");
     uv_snapshot!(context.filters(), context.init().arg(child.as_ref()), @r###"
@@ -2583,7 +2583,7 @@ fn init_inside_git_repo() {
     Initialized project `bar` at `[TEMP_DIR]/bar`
     "###);
 
-    child.child(".gitignore").assert(predicate::path::missing());
+    child.child(".gitignore").assert(predicate::path::is_file());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
- Allows `uv init --vcs=git` when parent dir has .git dir
- Fixes some tests in when parent dir has .git dir
- Resolves #11655

## Test Plan
- Verified locally
- Passes github CI

