### PR TITLE
Discover registry PEP 514 Pythons cross 32/64-bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ walkdir = { version = "2.5.0" }
 which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.5.0" }
 windows-result = { version = "0.3.0" }
-windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Ioctl", "Win32_System_IO"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Ioctl", "Win32_System_IO", "Win32_System_Registry"] }
 winsafe = { version = "0.0.23", features = ["kernel"] }
 wiremock = { version = "0.6.2" }
 xz2 = { version = "0.1.7" }


### PR DESCRIPTION
Fixes #11217

By default, a 64-bit uv does not see a 32-bit global (HKLM) installation of Python in the registry (https://github.com/astral-sh/uv/issues/11217). To work around this, we manually request both 32-bit and 64-bit access using registry access flags (https://peps.python.org/pep-0514/#sample-code). The flags have no effect on 32-bit (https://stackoverflow.com/a/12796797/3549270).

This effect is that there is an asymmetry between discovery modes: For the registry-based discovery using PEP 514, we discover both 32-bit and 64-bit Pythons, while for managed installations, we are stricter and only discover those matching in bit-ness.

I tested this manually with an additional 32-bit installation of CPython on a 64-bit machine and windows with 32-bit and 64-bit (x86_64 and i686) builds of uv.