### PR TITLE
Remove the winreg crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5674,7 +5674,9 @@ dependencies = [
  "tracing",
  "uv-fs",
  "uv-static",
- "winreg",
+ "windows-registry 0.5.0",
+ "windows-result 0.3.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6505,16 +6507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,6 @@ which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.5.0" }
 windows-result = { version = "0.3.0" }
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Ioctl", "Win32_System_IO"] }
-winreg = { version = "0.53.0" }
 winsafe = { version = "0.0.22", features = ["kernel"] }
 wiremock = { version = "0.6.2" }
 xz2 = { version = "0.1.7" }

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -20,4 +20,6 @@ same-file = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-winreg = { workspace = true }
+windows-registry = { workspace = true }
+windows-result = { workspace = true }
+windows-sys = { workspace = true }


### PR DESCRIPTION
Currently, we're using both the official `windows-*` with `windows-registry` crates as well as `winreg`, an older, community-maintained crate.

To unify the codebase, we follow the lead of rustup that already performed this migration (https://github.com/rust-lang/rustup/commit/bce3ed67d219a2b754857f9e231287794d8c770d). This is also a prerequisite to unblock the unification of the windows-sys crate versions.

I've manually tested that `uv tool update-shell` works for adding to PATH and correctly detects when PATH was already added.