### PR TITLE
Fix version string truncation while generating cache_key

### DIFF
--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -124,7 +124,10 @@ impl WheelFilename {
 
         // Truncate the version, but avoid trailing dots, plus signs, etc. to avoid ambiguity.
         let version_width = CACHE_KEY_MAX_LEN - 1 /* dash */ - 16 /* digest */;
-        let version = format!("{:.version_width$}", self.version);
+        let mut version = self.version.to_string();
+
+        // PANIC SAFETY: version strings can only contain ASCII characters.
+        version.truncate(version_width);
         let version = version.trim_end_matches(['.', '+']);
 
         format!("{version}-{digest}")
@@ -499,8 +502,8 @@ mod tests {
 
         // Larger versions should get truncated.
         let filename = WheelFilename::from_str(
-            "example-1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.0.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            "example-1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.0.1.2.1.2.3.4.5.6.7.8.9.0.1.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         ).unwrap();
-        insta::assert_snapshot!(filename.cache_key(), @"1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.0.1.2-80bf8598e9647cf7");
+        insta::assert_snapshot!(filename.cache_key(), @"1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.0.1.2.1.2-80bf8598e9647cf7");
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Follow up for https://github.com/astral-sh/uv/pull/11738

I missed this while reviewing the truncation changes. 

`format!("{:.N}", value)` only truncates if the `fmt::Display` implementation supports it (by reading `f.precision()` in trait implementation).

So in our case `format!("{:.N}", version.to_string())` will work but not `format!("{:.N}", version)` unless `Version` supports it.

Since we only need it once, I am just truncating after the string is created. 

## Test Plan

<!-- How was it tested? -->
