### PR TITLE
Update code page to 65001 before setting environment variables, fix #11828

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate.bat
+++ b/crates/uv-virtualenv/src/activator/activate.bat
@@ -19,6 +19,14 @@
 @REM OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 @REM WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+@REM This file is UTF-8 encoded, so we need to update the current code page while executing it
+@for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+    @set _OLD_CODEPAGE=%%a
+)
+@if defined _OLD_CODEPAGE (
+    @"%SystemRoot%\System32\chcp.com" 65001 > nul
+)
+
 @for %%i in ("{{ VIRTUAL_ENV_DIR }}") do @set "VIRTUAL_ENV=%%~fi"
 
 @set "VIRTUAL_ENV_PROMPT={{ VIRTUAL_PROMPT }}"
@@ -57,3 +65,9 @@
 :ENDIFVPATH2
 
 @set "PATH=%VIRTUAL_ENV%\{{ BIN_NAME }};%PATH%"
+
+:END
+@if defined _OLD_CODEPAGE (
+    @"%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    @set _OLD_CODEPAGE=
+)


### PR DESCRIPTION
## Summary

When executing `.venv\Scripts\activate` in `cmd`, the script uses the local codepage for execution. This causes issues when the file path contains non-ASCII characters, resulting in corrupted environment variables such as `VIRTUAL_ENV`.

See #11828.

Code used to fix the issue was adapted from https://github.com/python/cpython/blob/3.13/Lib/venv/scripts/nt/activate.bat#L3-L9.

## Test Plan

Before:
![image](https://github.com/user-attachments/assets/f8a50675-a688-4b4b-9d1b-0a5d5f736123)

After:
![image](https://github.com/user-attachments/assets/3aed978e-4c9b-40e4-a689-9a602f95b725)
(`chcp` command cleared the history lol)