### PR TITLE
Fix non-directory in workspace on Windows

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -728,13 +728,6 @@ impl Workspace {
                 let member_root = std::path::absolute(&member_root)
                     .map_err(WorkspaceError::Normalize)?
                     .clone();
-                if !fs_err::metadata(&member_root)?.is_dir() {
-                    warn!(
-                        "Ignoring non-directory workspace member: `{}`",
-                        member_root.simplified_display()
-                    );
-                    continue;
-                }
 
                 // If the directory is explicitly ignored, skip it.
                 let skip = match &options.members {
@@ -769,26 +762,38 @@ impl Workspace {
                 let pyproject_path = member_root.join("pyproject.toml");
                 let contents = match fs_err::tokio::read_to_string(&pyproject_path).await {
                     Ok(contents) => contents,
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        // If the directory is hidden, skip it.
-                        if member_root
-                            .file_name()
-                            .map(|name| name.as_encoded_bytes().starts_with(b"."))
-                            .unwrap_or(false)
-                        {
-                            debug!(
-                                "Ignoring hidden workspace member: `{}`",
+                    Err(err) => {
+                        if !fs_err::metadata(&member_root)?.is_dir() {
+                            warn!(
+                                "Ignoring non-directory workspace member: `{}`",
                                 member_root.simplified_display()
                             );
                             continue;
                         }
 
-                        return Err(WorkspaceError::MissingPyprojectTomlMember(
-                            member_root,
-                            member_glob.to_string(),
-                        ));
+                        // A directory exists, but it doesn't contain a `pyproject.toml`.
+                        if err.kind() == std::io::ErrorKind::NotFound {
+                            // If the directory is hidden, skip it.
+                            if member_root
+                                .file_name()
+                                .map(|name| name.as_encoded_bytes().starts_with(b"."))
+                                .unwrap_or(false)
+                            {
+                                debug!(
+                                    "Ignoring hidden workspace member: `{}`",
+                                    member_root.simplified_display()
+                                );
+                                continue;
+                            }
+
+                            return Err(WorkspaceError::MissingPyprojectTomlMember(
+                                member_root,
+                                member_glob.to_string(),
+                            ));
+                        }
+
+                        return Err(err.into());
                     }
-                    Err(err) => return Err(err.into()),
                 };
                 let pyproject_toml = PyProjectToml::from_string(contents)
                     .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -728,6 +728,13 @@ impl Workspace {
                 let member_root = std::path::absolute(&member_root)
                     .map_err(WorkspaceError::Normalize)?
                     .clone();
+                if !fs_err::metadata(&member_root)?.is_dir() {
+                    warn!(
+                        "Ignoring non-directory workspace member: `{}`",
+                        member_root.simplified_display()
+                    );
+                    continue;
+                }
 
                 // If the directory is explicitly ignored, skip it.
                 let skip = match &options.members {
@@ -780,14 +787,6 @@ impl Workspace {
                             member_root,
                             member_glob.to_string(),
                         ));
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => {
-                        warn!(
-                            "Ignoring non-directory workspace member: `{}`",
-                            member_root.simplified_display()
-                        );
-
-                        continue;
                     }
                     Err(err) => return Err(err.into()),
                 };

--- a/scripts/workspaces/albatross-virtual-workspace/packages/Unrelated.md
+++ b/scripts/workspaces/albatross-virtual-workspace/packages/Unrelated.md
@@ -1,0 +1,2 @@
+This file is included in `packages/*`, but it is not a directory (it can't contain a package), so we
+have to ignore it.


### PR DESCRIPTION
Fixes #11793

On Windows, trying to read a file inside what is not a directory but another file results in a not found error, while on Unix we get a not a directory error. We check explicitly if something included in a workspace glob is a non-directory to fix the behavior on Windows.