### PR TITLE
Make interpreter caching robust to OS upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5456,6 +5456,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sys-info",
  "target-lexicon",
  "temp-env",
  "tempfile",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -51,6 +51,7 @@ same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sys-info = { workspace = true }
 target-lexicon = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -848,9 +848,13 @@ impl InterpreterInfo {
 
         let cache_entry = cache.entry(
             CacheBucket::Interpreter,
-            // Shard interpreter metadata by host architecture, to avoid cache collisions when
-            // running universal binaries under Rosetta.
-            ARCH,
+            // Shard interpreter metadata by host architecture, operating system, and version, to
+            // invalidate the cache (e.g.) on OS upgrades.
+            cache_digest(&(
+                ARCH,
+                sys_info::os_type().unwrap_or_default(),
+                sys_info::os_release().unwrap_or_default(),
+            )),
             // We use the absolute path for the cache entry to avoid cache collisions for relative
             // paths. But we don't to query the executable with symbolic links resolved.
             format!("{}.msgpack", cache_digest(&absolute)),


### PR DESCRIPTION
## Summary

In. https://github.com/astral-sh/uv/issues/11857, we had a case of a user that was seeing incorrect resolution results after upgrading to a newer version of macOS, since we retained cache information about the interpreter. This PR adds the OS name and version to the cache key for the interpreter. This seems to be extremely cheap, and it's nice to make this robust so that users don't run into the same confusion in the future.

Closes https://github.com/astral-sh/uv/issues/11857.
