### PR TITLE
explicitly handle ctrl-c in confirmation prompt instead of signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4890,7 +4890,6 @@ name = "uv-console"
 version = "0.0.1"
 dependencies = [
  "console",
- "ctrlc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ cargo-util = { version = "0.2.14" }
 clap = { version = "4.5.17", features = ["derive", "env", "string", "wrap_help"] }
 clap_complete_command = { version = "0.6.1" }
 configparser = { version = "3.1.0" }
-console = { version = "0.15.8", default-features = false }
+console = { version = "0.15.11", default-features = false }
 csv = { version = "1.3.0" }
 ctrlc = { version = "3.4.5" }
 dashmap = { version = "6.1.0" }

--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -11,5 +11,4 @@ doctest = false
 workspace = true
 
 [dependencies]
-ctrlc = { workspace = true }
 console = { workspace = true }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Follow on to #11706. In the original PR, I tried to solve the issue by getting rid of the `ctrlc::set_handler` call. Unfortunately, this didn't work on windows due to an issue with the console crate. console 0.15.11 includes https://github.com/console-rs/console/pull/235, which resolves the issue, so now we can get rid of the call.

<!-- What's the purpose of the change? What does it do, and why? -->

This change is not super important but I still think it's worthwhile. For one, spinning up a background thread to handle `SIGINT`s when we're going to be raising the `SIGINT` from within the function is more technical complexity than needed, now that there's an easy way to explicitly catch the Ctrl-C from the terminal input. Secondly, `ctrlc::set_handler`'s [docs](https://docs.rs/ctrlc/3.4.5/ctrlc/fn.set_handler.html) advise that you set the handler just once, at the beginning of the program, so this use seems somewhat error prone. In fact, uv already has a second [callsite](https://github.com/astral-sh/uv/blob/461f4d9007160f7061a4fc0c4a5a84c613fdbff7/crates/uv/src/commands/project/add.rs#L596-L611) for this function (though I'm not sure if the two callsites could currently ever both occur on the same run of uv)

## Test Plan

I've tested this manually on linux (WSL ubuntu) and windows, though not on aarch64-apple-darwin as I don't have a machine running that. I would appreciate if someone would double-check that it works on such machines.

As discussed in the original PR, this change is pretty hard to test due to the fact that the behavior only occurs if stderr is connected to a tty. I experimented with using pseudoterminals to test this but it's still quite tricky due to the lack of x-platform non-blocking reads on the pty.

<!-- How was it tested? -->
