### PR TITLE
Edition 2024 prep: Escape `r#gen` and remove redundant ref

### DIFF
--- a/crates/uv-configuration/src/dev.rs
+++ b/crates/uv-configuration/src/dev.rs
@@ -162,7 +162,7 @@ impl DevGroupsSpecificationInner {
     /// you should ignore the project itself and all its dependencies,
     /// and instead just install the dependency-groups.
     ///
-    /// (This is really just asking if an --only flag was passed.)  
+    /// (This is really just asking if an --only flag was passed.)
     pub fn prod(&self) -> bool {
         !self.only_groups
     }

--- a/crates/uv-configuration/src/name_specifiers.rs
+++ b/crates/uv-configuration/src/name_specifiers.rs
@@ -67,7 +67,7 @@ impl schemars::JsonSchema for PackageNameSpecifier {
         "PackageNameSpecifier".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             string: Some(Box::new(schemars::schema::StringValidation {

--- a/crates/uv-configuration/src/required_version.rs
+++ b/crates/uv-configuration/src/required_version.rs
@@ -35,7 +35,7 @@ impl schemars::JsonSchema for RequiredVersion {
         String::from("RequiredVersion")
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-configuration/src/trusted_host.rs
+++ b/crates/uv-configuration/src/trusted_host.rs
@@ -147,7 +147,7 @@ impl schemars::JsonSchema for TrustedHost {
         "TrustedHost".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -72,7 +72,7 @@ impl schemars::JsonSchema for IndexUrl {
         "IndexUrl".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -54,8 +54,10 @@ macro_rules! impl_index {
                 IndexUrl::schema_name()
             }
 
-            fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-                IndexUrl::json_schema(gen)
+            fn json_schema(
+                r#gen: &mut schemars::r#gen::SchemaGenerator,
+            ) -> schemars::schema::Schema {
+                IndexUrl::json_schema(r#gen)
             }
         }
     };

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -352,7 +352,7 @@ impl schemars::JsonSchema for PortablePathBuf {
         PathBuf::schema_name()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         PathBuf::json_schema(_gen)
     }
 }

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -140,7 +140,7 @@ impl FromStr for Operator {
             other => {
                 return Err(OperatorParseError {
                     got: other.to_string(),
-                })
+                });
             }
         };
         Ok(operator)
@@ -483,7 +483,7 @@ impl Version {
     /// last number in the release component.
     #[inline]
     fn push_release(&mut self, n: u64) {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.push_release(n) {
                 return;
             }
@@ -498,8 +498,8 @@ impl Version {
     #[inline]
     fn clear_release(&mut self) {
         match &mut self.inner {
-            VersionInner::Small { ref mut small } => small.clear_release(),
-            VersionInner::Full { ref mut full } => {
+            VersionInner::Small { small } => small.clear_release(),
+            VersionInner::Full { full } => {
                 Arc::make_mut(full).release.clear();
             }
         }
@@ -509,7 +509,7 @@ impl Version {
     #[inline]
     #[must_use]
     pub fn with_epoch(mut self, value: u64) -> Self {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_epoch(value) {
                 return self;
             }
@@ -522,7 +522,7 @@ impl Version {
     #[inline]
     #[must_use]
     pub fn with_pre(mut self, value: Option<Prerelease>) -> Self {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_pre(value) {
                 return self;
             }
@@ -535,7 +535,7 @@ impl Version {
     #[inline]
     #[must_use]
     pub fn with_post(mut self, value: Option<u64>) -> Self {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_post(value) {
                 return self;
             }
@@ -548,7 +548,7 @@ impl Version {
     #[inline]
     #[must_use]
     pub fn with_dev(mut self, value: Option<u64>) -> Self {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_dev(value) {
                 return self;
             }
@@ -576,7 +576,7 @@ impl Version {
         match value {
             LocalVersion::Segments(segments) => self.with_local_segments(segments),
             LocalVersion::Max => {
-                if let VersionInner::Small { ref mut small } = &mut self.inner {
+                if let VersionInner::Small { small } = &mut self.inner {
                     if small.set_local(LocalVersion::Max) {
                         return self;
                     }
@@ -594,7 +594,7 @@ impl Version {
     #[inline]
     #[must_use]
     pub fn without_local(mut self) -> Self {
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_local(LocalVersion::empty()) {
                 return self;
             }
@@ -635,7 +635,7 @@ impl Version {
     pub fn with_min(mut self, value: Option<u64>) -> Self {
         debug_assert!(!self.is_pre(), "min is not allowed on pre-release versions");
         debug_assert!(!self.is_dev(), "min is not allowed on dev versions");
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_min(value) {
                 return self;
             }
@@ -657,7 +657,7 @@ impl Version {
             "max is not allowed on post-release versions"
         );
         debug_assert!(!self.is_dev(), "max is not allowed on dev versions");
-        if let VersionInner::Small { ref mut small } = &mut self.inner {
+        if let VersionInner::Small { small } = &mut self.inner {
             if small.set_max(value) {
                 return self;
             }
@@ -687,7 +687,7 @@ impl Version {
             };
         }
         match &mut self.inner {
-            VersionInner::Full { ref mut full } => Arc::make_mut(full),
+            VersionInner::Full { full } => Arc::make_mut(full),
             VersionInner::Small { .. } => unreachable!(),
         }
     }
@@ -1616,7 +1616,7 @@ impl LocalVersionSlice<'_> {
 
     /// Returns `true` if the local version is empty.
     pub fn is_empty(&self) -> bool {
-        matches!(self, Self::Segments(&[]))
+        matches!(self, &Self::Segments(&[]))
     }
 }
 

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -299,7 +299,7 @@ impl<T: Pep508Url> schemars::JsonSchema for Requirement<T> {
         "Requirement".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -631,7 +631,7 @@ impl InternerGuard<'_> {
         // we recursively simplify.
         let Node {
             var: Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion),
-            children: Edges::Version { ref edges },
+            children: Edges::Version { edges },
         } = node
         else {
             // Simplify all nodes recursively.
@@ -713,7 +713,7 @@ impl InternerGuard<'_> {
         let node = self.shared.node(i);
         let Node {
             var: Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion),
-            children: Edges::Version { ref edges },
+            children: Edges::Version { edges },
         } = node
         else {
             // Complexify all nodes recursively.
@@ -1630,7 +1630,7 @@ fn python_version_to_full_version(specifier: VersionSpecifier) -> Result<Version
         Ok(match specifier.operator() {
             // `python_version` cannot have more than two release segments, so equality is impossible.
             Operator::Equal | Operator::ExactEqual | Operator::EqualStar | Operator::TildeEqual => {
-                return Err(NodeId::FALSE)
+                return Err(NodeId::FALSE);
             }
 
             // Similarly, inequalities are always `true`.

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1711,7 +1711,7 @@ impl schemars::JsonSchema for MarkerTree {
         "MarkerTree".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-pypi-types/src/conflicts.rs
+++ b/crates/uv-pypi-types/src/conflicts.rs
@@ -443,8 +443,8 @@ impl schemars::JsonSchema for SchemaConflictItem {
         "SchemaConflictItem".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <ConflictItemWire as schemars::JsonSchema>::json_schema(gen)
+    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <ConflictItemWire as schemars::JsonSchema>::json_schema(r#gen)
     }
 }
 

--- a/crates/uv-python/src/python_version.rs
+++ b/crates/uv-python/src/python_version.rs
@@ -42,7 +42,7 @@ impl schemars::JsonSchema for PythonVersion {
         String::from("PythonVersion")
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             string: Some(Box::new(schemars::schema::StringValidation {

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -71,7 +71,7 @@ impl schemars::JsonSchema for ExcludeNewer {
         "ExcludeNewer".to_string()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             string: Some(Box::new(schemars::schema::StringValidation {

--- a/crates/uv-small-str/src/lib.rs
+++ b/crates/uv-small-str/src/lib.rs
@@ -155,7 +155,7 @@ impl schemars::JsonSchema for SmallString {
         String::schema_name()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         String::json_schema(_gen)
     }
 }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -36,9 +36,13 @@ pub enum PyprojectTomlError {
     TomlSyntax(#[from] toml_edit::TomlError),
     #[error(transparent)]
     TomlSchema(#[from] toml_edit::de::Error),
-    #[error("`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set")]
+    #[error(
+        "`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set"
+    )]
     MissingName,
-    #[error("`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list")]
+    #[error(
+        "`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list"
+    )]
     MissingVersion,
 }
 
@@ -780,8 +784,8 @@ impl schemars::JsonSchema for SerdePattern {
         <String as schemars::JsonSchema>::schema_name()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <String as schemars::JsonSchema>::json_schema(gen)
+    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(r#gen)
     }
 }
 
@@ -1193,7 +1197,7 @@ impl<'de> Deserialize<'de> for Source {
                 _ => {
                     return Err(serde::de::Error::custom(
                         "expected at most one of `rev`, `tag`, or `branch`",
-                    ))
+                    ));
                 }
             };
 
@@ -1434,23 +1438,36 @@ pub enum SourceError {
     WorkspacePackageUrl(String),
     #[error("Workspace dependency `{0}` must refer to local directory, not a file")]
     WorkspacePackageFile(String),
-    #[error("`{0}` did not resolve to a Git repository, but a Git reference (`--rev {1}`) was provided.")]
+    #[error(
+        "`{0}` did not resolve to a Git repository, but a Git reference (`--rev {1}`) was provided."
+    )]
     UnusedRev(String, String),
-    #[error("`{0}` did not resolve to a Git repository, but a Git reference (`--tag {1}`) was provided.")]
+    #[error(
+        "`{0}` did not resolve to a Git repository, but a Git reference (`--tag {1}`) was provided."
+    )]
     UnusedTag(String, String),
-    #[error("`{0}` did not resolve to a Git repository, but a Git reference (`--branch {1}`) was provided.")]
+    #[error(
+        "`{0}` did not resolve to a Git repository, but a Git reference (`--branch {1}`) was provided."
+    )]
     UnusedBranch(String, String),
-    #[error("`{0}` did not resolve to a local directory, but the `--editable` flag was provided. Editable installs are only supported for local directories.")]
+    #[error(
+        "`{0}` did not resolve to a local directory, but the `--editable` flag was provided. Editable installs are only supported for local directories."
+    )]
     UnusedEditable(String),
-    #[error("Workspace dependency `{0}` was marked as `--no-editable`, but workspace dependencies are always added in editable mode. Pass `--no-editable` to `uv sync` or `uv run` to install workspace dependencies in non-editable mode.")]
+    #[error(
+        "Workspace dependency `{0}` was marked as `--no-editable`, but workspace dependencies are always added in editable mode. Pass `--no-editable` to `uv sync` or `uv run` to install workspace dependencies in non-editable mode."
+    )]
     UnusedNoEditable(String),
     #[error("Failed to resolve absolute path")]
     Absolute(#[from] std::io::Error),
     #[error("Path contains invalid characters: `{}`", _0.display())]
     NonUtf8Path(PathBuf),
-    #[error("Source markers must be disjoint, but the following markers overlap: `{0}` and `{1}`.\n\n{hint}{colon} replace `{1}` with `{2}`.", hint = "hint".bold().cyan(), colon = ":".bold())]
+    #[error("Source markers must be disjoint, but the following markers overlap: `{0}` and `{1}`.\n\n{hint}{colon} replace `{1}` with `{2}`.", hint = "hint".bold().cyan(), colon = ":".bold()
+    )]
     OverlappingMarkers(String, String, String),
-    #[error("When multiple sources are provided, each source must include a platform marker (e.g., `marker = \"sys_platform == 'linux'\"`)")]
+    #[error(
+        "When multiple sources are provided, each source must include a platform marker (e.g., `marker = \"sys_platform == 'linux'\"`)"
+    )]
     MissingMarkers,
     #[error("Must provide at least one source")]
     EmptySources,


### PR DESCRIPTION
Three edition 2021 compatible sets of changes in preparation for the edition 2025 split out from #11724.

In edition 2025, `gen` is a keyword, so we escape it as `r#gen`. `ref` and `ref mut` are not allowed anymore for `&T` and `&mut T`, so we remove them. `cargo fmt` now formats inside of macros, which the 2021 formatter doesn't undo.