### PR TITLE
[Issue #11637] Use suffix on uvx binary when searching for uv binary

### DIFF
--- a/crates/uv/src/bin/uvx.rs
+++ b/crates/uv/src/bin/uvx.rs
@@ -32,20 +32,17 @@ fn get_uvx_suffix(current_exe: &Path) -> std::io::Result<&str> {
     };
     let Some(file_name_str) = os_file_name.to_str() else {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Could not determine the file name of the `uvx` binary",
+            std::io::ErrorKind::InvalidData,
+            "Unable to convert executable name of `uvx` binary into a valid UTF-8 string",
         ));
     };
-    let Some(file_name_no_ext) = file_name_str.strip_suffix(std::env::consts::EXE_SUFFIX) else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Could not determine the file name of the `uvx` binary",
-        ));
-    };
+    let file_name_no_ext = file_name_str
+        .strip_suffix(std::env::consts::EXE_SUFFIX)
+        .unwrap_or(file_name_str);
     let Some(uvx_suffix) = file_name_no_ext.strip_prefix("uvx") else {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Could not determine the file name of the `uvx` binary",
+            std::io::ErrorKind::InvalidData,
+            "Current executable name does not contain `uvx`",
         ));
     };
     Ok(uvx_suffix)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When running uvx that has been installed using a pipx suffix, the corresponding uv binary cannot be found due to uvx always looking for an executable called `uv` on the PATH, while it has instead been installed using a suffix.  This change makes it so that uvx discovers the suffix to its name and then searches for a uv binary with the same suffix.  For example, if uvx is called `uvx@0.6.2`, then it will search for `uv@0.6.2` instead of `uv`.

## Test Plan

1. Remove all `uv` and `uvx` binaries from the PATH
2. Build code on `main`
3. Rename `uvx` -> `uvx@0.6.2` and `uv` -> `uv@0.6.2`
4. Run `uvx@0.6.2` and observe that it produces the following output:
```
error: Could not find the `uv` binary at: /Users/me/.local/bin/uv
```
5. Delete the `uv@0.6.2` and `uvx@0.6.2` binaries
6. Build the code on this branch
7. Run `uvx` and observe that it behaves like normal (maintains current behavior)
8. Rename `uvx` -> `uvx@0.6.2` and `uv` -> `uv@0.6.2`
9. Run `uvx@0.6.2` and observe that it behaves like normal (exhibits correct behavior for suffixed executable names)
10. Rename `uv@0.6.2` -> `uv`
11. Run `uvx@0.6.2` and observe that it emits a warning about falling back to bare `uv`, followed by normal `uvx` output
```
warning: Unable to find /Users/jane.doe/code/uv/target/debug/uv@0.6.2, defaulting to /Users/jane.doe/code/uv/target/debug/uv
Provide a command to run with `uvx <command>`.

The following tools are installed:

- keyring v25.5.0

See `uvx --help` for more information.
```
12. Run `uvx@0.6.2` and observe that it presents an error message stating that `uv` could not be found either with the suffixed name or with the bare name
```
error: Could not find uv binary at /Users/jane.doe/uv/target/debug/uv@0.6.2 or /Users/jane.doe/uv/target/debug/uv
```

Resolves #11637 