### PR TITLE
Run the Docker build workflow when we touch project or toolchain metadata

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,11 +14,15 @@ on:
         type: string
   pull_request:
     paths:
-      # When we change project metadata, we want to ensure that the maturin builds still work.
+      # We want to ensure that the maturin builds still work when we change
+      # Project metadata
       - pyproject.toml
       - Cargo.toml
+      - .cargo/config.toml
+      # Toolchain or dependency versions
       - Cargo.lock
-      # And when we change this workflow itself...
+      - rust-toolchain.toml
+      # And the workflow itself
       - .github/workflows/build-binaries.yml
 
 concurrency:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,6 +15,17 @@ on:
         type: string
   pull_request:
     paths:
+      # We want to ensure that the maturin builds still work when we change
+      # Project metadata
+      - pyproject.toml
+      - Cargo.toml
+      - .cargo/config.toml
+      # Toolchain or dependency versions
+      - Cargo.lock
+      - rust-toolchain.toml
+      # The Dockerfile itself
+      - Dockerfile
+      # And the workflow itself
       - .github/workflows/build-docker.yml
 
 env:


### PR DESCRIPTION
I noticed that https://github.com/astral-sh/uv/pull/11936 did not run the Docker builds, nor did #11934 

We should run these when the relevant files change so there aren't surprises at release time!

Updates the `build-binaries` workflow to include toolchain version changes and `.cargo/config.toml` changes too.