### PR TITLE
Fix error message suggesting `--user` instead of `--username`

### DIFF
--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -253,8 +253,8 @@ async fn gather_credentials(
     if password.is_some() && username.is_none() {
         bail!(
             "Attempted to publish with a password, but no username. Either provide a username \
-            with `--user` (`UV_PUBLISH_USERNAME`), or use `--token` (`UV_PUBLISH_TOKEN`) instead \
-            of a password."
+            with `--username` (`UV_PUBLISH_USERNAME`), or use `--token` (`UV_PUBLISH_TOKEN`) \
+            instead of a password."
         );
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fix error message suggesting `--user` instead of `--username`:
```
   > uv publish --publish-url ... ... --password $(cat ~/.token)
Publishing 1 file to ...
error: Attempted to publish with a password, but no username. Either provide a username with `--user` (`UV_PUBLISH_USERNAME`), or use `--token` (`UV_PUBLISH_TOKEN`) instead of a password.

   > uv publish --publish-url ... ... --user lewis --password $(cat ~/.token)
error: unexpected argument '--user' found

  tip: a similar argument exists: '--username'

Usage: uv publish <FILES|--index <INDEX>|--username <USERNAME>|--password <PASSWORD>|--token <TOKEN>|--trusted-publishing <TRUSTED_PUBLISHING>|--keyring-provider <KEYRING_PROVIDER>|--publish-url <PUBLISH_URL>|--check-url <CHECK_URL>|--skip-existing>

For more information, try '--help'.
```

## Test Plan
I have not tested manually, I'm hoping this isn't necessary and there will be sufficient CI coverage.