### PR TITLE
Fix system site packages detection default

### DIFF
--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -192,7 +192,7 @@ impl PyVenvConfiguration {
         let mut uv = false;
         let mut relocatable = false;
         let mut seed = false;
-        let mut include_system_side_packages = false;
+        let mut include_system_side_packages = true;
 
         // Per https://snarky.ca/how-virtual-environments-work/, the `pyvenv.cfg` file is not a
         // valid INI file, and is instead expected to be parsed by partitioning each line on the


### PR DESCRIPTION
See https://docs.python.org/3/library/site.html and https://github.com/python/cpython/blob/a549f439384b4509b25639337ffea21c2e55d452/Lib/site.py#L614-L639: The default is for system site packages is true, they have to be disabled by setting the key to something that is not true.