### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/scripts/popular_packages/download.sh
+++ b/scripts/popular_packages/download.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-curl https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json | jq -r ".rows | .[].project" > pypi_8k_downloads.txt
+curl https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json | jq -r ".rows | .[].project" > pypi_8k_downloads.txt
 curl https://gist.githubusercontent.com/charliermarsh/07afd9f543dfea68408a4a42cede4be4/raw/6639cd58a2e10d6bb7821f891f00322c8630b60a/pypi_10k_most_dependents.txt > pypi_10k_most_dependents.txt


### PR DESCRIPTION

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.


## Test Plan

<!-- How was it tested? -->

```sh
curl https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json | jq -r ❯ 
curl https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json | jq -r ".rows | .
diff pypi_8k_downloads_original.txt pypi_8k_downloads_new.txt
```
