### PR TITLE
Add `NO_BUILD` and `NO_BUILD_PACKAGE` environment variables

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4818,7 +4818,13 @@ pub struct BuildOptionsArgs {
     /// When enabled, resolving will not run arbitrary Python code. The cached wheels of
     /// already-built source distributions will be reused, but operations that require building
     /// distributions will exit with an error.
-    #[arg(long, overrides_with("build"), help_heading = "Build options")]
+    #[arg(
+        long,
+        env = EnvVars::UV_NO_BUILD,
+        overrides_with("build"),
+        value_parser = clap::builder::BoolishValueParser::new(),
+        help_heading = "Build options",
+    )]
     pub no_build: bool,
 
     #[arg(
@@ -4830,7 +4836,7 @@ pub struct BuildOptionsArgs {
     pub build: bool,
 
     /// Don't build source distributions for a specific package.
-    #[arg(long, help_heading = "Build options")]
+    #[arg(long, help_heading = "Build options", env = EnvVars::UV_NO_BUILD_PACKAGE, value_delimiter = ' ')]
     pub no_build_package: Vec<PackageName>,
 
     /// Don't install pre-built wheels.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -162,6 +162,14 @@ impl EnvVars {
     /// not use pre-built wheels for the given space-delimited list of packages.
     pub const UV_NO_BINARY_PACKAGE: &'static str = "UV_NO_BINARY_PACKAGE";
 
+    /// Equivalent to the `--no-build` command-line argument. If set, uv will not build
+    /// source distributions.
+    pub const UV_NO_BUILD: &'static str = "UV_NO_BUILD";
+
+    /// Equivalent to the `--no-build-package` command line argument. If set, uv will
+    /// not build source distributions for the given space-delimited list of packages.
+    pub const UV_NO_BUILD_PACKAGE: &'static str = "UV_NO_BUILD_PACKAGE";
+
     /// Equivalent to the `--publish-url` command-line argument. The URL of the upload
     /// endpoint of the index to use with `uv publish`.
     pub const UV_PUBLISH_URL: &'static str = "UV_PUBLISH_URL";

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -4543,6 +4543,19 @@ fn no_build() -> Result<()> {
 
     assert!(context.temp_dir.child("uv.lock").exists());
 
+    uv_snapshot!(context.filters(), context.sync().arg("--reinstall").env("UV_NO_BUILD_PACKAGE", "iniconfig"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ iniconfig==2.0.0
+    "###);
+
     Ok(())
 }
 
@@ -4571,6 +4584,47 @@ fn no_build_error() -> Result<()> {
     ----- stderr -----
     Resolved 19 packages in [TIME]
     error: Distribution `django-allauth==0.51.0 @ registry+https://pypi.org/simple` can't be installed because it is marked as `--no-build` but has no binary distribution
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync().arg("--no-build"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 19 packages in [TIME]
+    error: Distribution `project==0.1.0 @ virtual+.` can't be installed because it is marked as `--no-build` but has no binary distribution
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync().arg("--reinstall").env("UV_NO_BUILD", "1"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 19 packages in [TIME]
+    error: Distribution `project==0.1.0 @ virtual+.` can't be installed because it is marked as `--no-build` but has no binary distribution
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync().arg("--reinstall").env("UV_NO_BUILD_PACKAGE", "django-allauth"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 19 packages in [TIME]
+    error: Distribution `django-allauth==0.51.0 @ registry+https://pypi.org/simple` can't be installed because it is marked as `--no-build` but has no binary distribution
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync().arg("--reinstall").env("UV_NO_BUILD", "django-allauth"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value 'django-allauth' for '--no-build': value was not a boolean
+
+    For more information, try '--help'.
     "###);
 
     assert!(context.temp_dir.child("uv.lock").exists());

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -195,10 +195,20 @@ extract package metadata, if available.
 Equivalent to the `--no-binary-package` command line argument. If set, uv will
 not use pre-built wheels for the given space-delimited list of packages.
 
+### `UV_NO_BUILD`
+
+Equivalent to the `--no-build` command-line argument. If set, uv will not build
+source distributions.
+
 ### `UV_NO_BUILD_ISOLATION`
 
 Equivalent to the `--no-build-isolation` command-line argument. If set, uv will
 skip isolation when building source distributions.
+
+### `UV_NO_BUILD_PACKAGE`
+
+Equivalent to the `--no-build-package` command line argument. If set, uv will
+not build source distributions for the given space-delimited list of packages.
 
 ### `UV_NO_CACHE`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -307,6 +307,7 @@ uv run [OPTIONS] [COMMAND]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-run--no-build-isolation"><a href="#uv-run--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -318,6 +319,7 @@ uv run [OPTIONS] [COMMAND]
 
 </dd><dt id="uv-run--no-build-package"><a href="#uv-run--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-run--no-cache"><a href="#uv-run--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -968,6 +970,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-add--no-build-isolation"><a href="#uv-add--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -979,6 +982,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 </dd><dt id="uv-add--no-build-package"><a href="#uv-add--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-add--no-cache"><a href="#uv-add--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -1331,6 +1335,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-remove--no-build-isolation"><a href="#uv-remove--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -1342,6 +1347,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 </dd><dt id="uv-remove--no-build-package"><a href="#uv-remove--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-remove--no-cache"><a href="#uv-remove--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -1706,6 +1712,7 @@ uv sync [OPTIONS]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-sync--no-build-isolation"><a href="#uv-sync--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -1717,6 +1724,7 @@ uv sync [OPTIONS]
 
 </dd><dt id="uv-sync--no-build-package"><a href="#uv-sync--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-sync--no-cache"><a href="#uv-sync--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -2079,6 +2087,7 @@ uv lock [OPTIONS]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-lock--no-build-isolation"><a href="#uv-lock--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -2090,6 +2099,7 @@ uv lock [OPTIONS]
 
 </dd><dt id="uv-lock--no-build-package"><a href="#uv-lock--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-lock--no-cache"><a href="#uv-lock--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -2426,6 +2436,7 @@ uv export [OPTIONS]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-export--no-build-isolation"><a href="#uv-export--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -2437,6 +2448,7 @@ uv export [OPTIONS]
 
 </dd><dt id="uv-export--no-build-package"><a href="#uv-export--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-export--no-cache"><a href="#uv-export--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -2806,6 +2818,7 @@ uv tree [OPTIONS]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-tree--no-build-isolation"><a href="#uv-tree--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -2817,6 +2830,7 @@ uv tree [OPTIONS]
 
 </dd><dt id="uv-tree--no-build-package"><a href="#uv-tree--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-tree--no-cache"><a href="#uv-tree--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -3288,6 +3302,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-tool-run--no-build-isolation"><a href="#uv-tool-run--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -3299,6 +3314,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 </dd><dt id="uv-tool-run--no-build-package"><a href="#uv-tool-run--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-tool-run--no-cache"><a href="#uv-tool-run--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -3626,6 +3642,7 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-tool-install--no-build-isolation"><a href="#uv-tool-install--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -3637,6 +3654,7 @@ uv tool install [OPTIONS] <PACKAGE>
 
 </dd><dt id="uv-tool-install--no-build-package"><a href="#uv-tool-install--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-tool-install--no-cache"><a href="#uv-tool-install--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -3951,6 +3969,7 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-tool-upgrade--no-build-isolation"><a href="#uv-tool-upgrade--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -3962,6 +3981,7 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 </dd><dt id="uv-tool-upgrade--no-build-package"><a href="#uv-tool-upgrade--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-tool-upgrade--no-cache"><a href="#uv-tool-upgrade--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
@@ -8397,6 +8417,7 @@ uv build [OPTIONS] [SRC]
 
 <p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
 
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
 </dd><dt id="uv-build--no-build-isolation"><a href="#uv-build--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
 
 <p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
@@ -8410,6 +8431,7 @@ uv build [OPTIONS] [SRC]
 
 </dd><dt id="uv-build--no-build-package"><a href="#uv-build--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
 </dd><dt id="uv-build--no-cache"><a href="#uv-build--no-cache"><code>--no-cache</code></a>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
 
 <p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Similar to https://github.com/astral-sh/uv/pull/11399

This adds `UV_NO_BUILD` and `UV_NO_BUILD_PACKAGE` environment variables for non-pip commands.

## Test Plan

<!-- How was it tested? -->
Tested manually and with snapshot tests.


Fixes #11963