### PR TITLE
Warn user on `uvx run` command

### DIFF
--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -6646,7 +6646,7 @@ fn fail_to_add_revert_project() -> Result<()> {
           ZeroDivisionError: division by zero
 
           hint: This usually indicates a problem with the package or the build environment.
-      help: `child` was included because `parent` (v0.1.0) depends on `child`
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -6757,7 +6757,7 @@ fn fail_to_edit_revert_project() -> Result<()> {
           ZeroDivisionError: division by zero
 
           hint: This usually indicates a problem with the package or the build environment.
-      help: `child` was included because `parent` (v0.1.0) depends on `child`
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -10135,7 +10135,7 @@ fn add_with_build_constraints() -> Result<()> {
     build-constraint-dependencies = ["setuptools==1"]
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("requests==1.2"), @r"
+    uv_snapshot!(context.filters(), context.add().arg("requests==1.2"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -10145,8 +10145,8 @@ fn add_with_build_constraints() -> Result<()> {
       ├─▶ Failed to resolve requirements from `setup.py` build
       ├─▶ No solution found when resolving: `setuptools>=40.8.0`
       ╰─▶ Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that your requirements are unsatisfiable.
-      help: `requests` (v1.2.0) was included because `project` (v0.1.0) depends on `requests==1.2`
-    ");
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
+    "###);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! {r#"


### PR DESCRIPTION
## Summary

If a user invokes `uvx run ...`, we hint them towards `uvx`. Otherwise, this invokes the `run` package, which is unmaintained on PyPI.

If the user is _only_ using PyPI, we show an interactive prompt here; otherwise, we just show a dedicated warning on error.

Closes https://github.com/astral-sh/uv/issues/11982.

## Test Plan

Prompting to success:

![Screenshot 2025-03-05 at 5 00 47 PM](https://github.com/user-attachments/assets/d8180606-94e1-41df-b799-19b8ba57e662)

If you use `--from`, we avoid the prompt and hint:

![Screenshot 2025-03-05 at 5 03 26 PM](https://github.com/user-attachments/assets/59919390-01d3-4ddf-97bc-bb857ae9f8b0)

If you provide another index, we don't prompt, but we do warn on failure:

![Screenshot 2025-03-05 at 5 03 43 PM](https://github.com/user-attachments/assets/0cc72c36-5744-48f1-aeff-4a214190d6fd)
