### PR TITLE
Allow overrides in all satisfies checks

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -239,10 +239,9 @@ pub(crate) async fn pip_install(
     if reinstall.is_none()
         && upgrade.is_none()
         && source_trees.is_empty()
-        && overrides.is_empty()
         && matches!(modifications, Modifications::Sufficient)
     {
-        match site_packages.satisfies(&requirements, &constraints, &marker_env)? {
+        match site_packages.satisfies_spec(&requirements, &constraints, &overrides, &marker_env)? {
             // If the requirements are already satisfied, we're done.
             SatisfiesResult::Fresh {
                 recursive_requirements,
@@ -250,7 +249,7 @@ pub(crate) async fn pip_install(
                 if enabled!(Level::DEBUG) {
                     for requirement in recursive_requirements
                         .iter()
-                        .map(|entry| entry.requirement.to_string())
+                        .map(ToString::to_string)
                         .sorted()
                     {
                         debug!("Requirement satisfied: {requirement}");

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2009,8 +2009,8 @@ pub(crate) async fn update_environment(
 
     // Check if the current environment satisfies the requirements
     let site_packages = SitePackages::from_environment(&venv)?;
-    if source_trees.is_empty() && reinstall.is_none() && upgrade.is_none() && overrides.is_empty() {
-        match site_packages.satisfies(&requirements, &constraints, &marker_env)? {
+    if source_trees.is_empty() && reinstall.is_none() && upgrade.is_none() {
+        match site_packages.satisfies_spec(&requirements, &constraints, &overrides, &marker_env)? {
             // If the requirements are already satisfied, we're done.
             SatisfiesResult::Fresh {
                 recursive_requirements,
@@ -2022,7 +2022,7 @@ pub(crate) async fn update_environment(
                         "All requirements satisfied: {}",
                         recursive_requirements
                             .iter()
-                            .map(|entry| entry.requirement.to_string())
+                            .map(ToString::to_string)
                             .sorted()
                             .join(" | ")
                     );

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1084,9 +1084,10 @@ fn can_skip_ephemeral(
         return false;
     }
 
-    match site_packages.satisfies(
+    match site_packages.satisfies_spec(
         &spec.requirements,
         &spec.constraints,
+        &spec.overrides,
         &base_interpreter.resolver_marker_environment(),
     ) {
         // If the requirements are already satisfied, we're done.
@@ -1097,7 +1098,7 @@ fn can_skip_ephemeral(
                 "Base environment satisfies requirements: {}",
                 recursive_requirements
                     .iter()
-                    .map(|entry| entry.requirement.to_string())
+                    .map(ToString::to_string)
                     .sorted()
                     .join(" | ")
             );

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -814,28 +814,11 @@ async fn get_or_create_environment(
                 {
                     // Check if the installed packages meet the requirements.
                     let site_packages = SitePackages::from_environment(&environment)?;
-
-                    let requirements = requirements
-                        .iter()
-                        .cloned()
-                        .map(NameRequirementSpecification::from)
-                        .collect::<Vec<_>>();
-                    let constraints = constraints
-                        .iter()
-                        .cloned()
-                        .map(NameRequirementSpecification::from)
-                        .collect::<Vec<_>>();
-                    let overrides = overrides
-                        .iter()
-                        .cloned()
-                        .map(NameRequirementSpecification::from)
-                        .collect::<Vec<_>>();
-
                     if matches!(
-                        site_packages.satisfies_names(
-                            &requirements,
-                            &constraints,
-                            &overrides,
+                        site_packages.satisfies_requirements(
+                            requirements.iter(),
+                            constraints.iter(),
+                            overrides.iter(),
                             &interpreter.resolver_marker_environment()
                         ),
                         Ok(SatisfiesResult::Fresh { .. })


### PR DESCRIPTION
## Summary

This PR adds support for `SitePackages::satisfies` with unnamed overrides and requirements.

The main challenge here was cases like: you have a `requirements.in` with `git+https://github.com/pallets/flask` in it, and an `overrides.txt` with `flask==2.0.0` in it. You _need_ to include `flask==2.0.0`, but you can't know that without resolving the unnamed URL requirement (since overrides only take effect when the package is included, like constraints).

We now make the assumption that any unnamed overrides _are_ relevant, for the purpose of the satisfies check. This is conservative, but this whole check is an optimization anyway.
