### PR TITLE
Run the `uv-build` publish sequentially after `uv`

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,6 +34,8 @@ jobs:
   pypi-publish-uv-build:
     name: Upload uv-build to PyPI
     runs-on: ubuntu-latest
+    # Run sequentially instead of concurrently
+    needs: pypi-publish-uv
     environment:
       name: release
     permissions:


### PR DESCRIPTION
In an attempt to resolve a trusted publishing failure
