### PR TITLE
Revert "Run the `uv-build` publish sequentially after `uv` (#12022)"

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,8 +34,6 @@ jobs:
   pypi-publish-uv-build:
     name: Upload uv-build to PyPI
     runs-on: ubuntu-latest
-    # Run sequentially instead of concurrently
-    needs: pypi-publish-uv
     environment:
       name: release
     permissions:


### PR DESCRIPTION
This was not the problem