### PR TITLE
Add dependabot config for uv to docs

### DIFF
--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -66,5 +66,21 @@ need to be explicitly defined using
 
 ## Dependabot
 
-Support for uv is not yet available. Progress can be tracked at
-[dependabot/dependabot-core#10478](https://github.com/dependabot/dependabot-core/issues/10478).
+uv is supported by
+[Dependabot](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories)
+
+Dependabot uses the presence of a `uv.lock` or `pyproject.toml`.
+
+```yaml title=".github/dependabot.yml"
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    # Location of `uv.lock` and/or `pyproject.toml`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Refer to
+[Dependabot's documentation](`https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference`)
+for more configuration options.

--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -82,5 +82,5 @@ updates:
 ```
 
 Refer to
-[Dependabot's documentation](`https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference`)
+[Dependabot's documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)
 for more configuration options.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

uv is now fully supported in dependabot: https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/

Former description:
dependabot now supports the uv package ecosystem provided the `enable-beta-ecosystems` flag is true. `uv.lock` and dependency groups are not yet supported.

Relevant PR: https://github.com/dependabot/dependabot-core/pull/11687

Mentions of this change:
https://github.com/dependabot/dependabot-core/pull/10040#issuecomment-2696978430
https://github.com/dependabot/dependabot-core/issues/10478#issuecomment-2691330949

## Test Plan

For the dependabot configuration, I updated several of my company's repositories with the new config and dependabot then updated its PRs.

For documentation changes, I tested the changes locally and then ran:
`npx prettier --prose-wrap always --write "**/*.md" `