### PR TITLE
Integration test uv_build package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1405,7 +1405,8 @@ jobs:
           rm -rf scripts/packages/built-by-uv/dist/
           ./uv venv -v
           ./uv pip install build
-          UV_OFFLINE=1 UV_FIND_LINKS=crates/uv-build/dist ./uv run --no-project python -m build -v --installer uv scripts/packages/built-by-uv
+          # Add the uv binary to PATH for `build` to find
+          PATH="$(pwd):$PATH" UV_OFFLINE=1 UV_FIND_LINKS=crates/uv-build/dist ./uv run --no-project python -m build -v --installer uv scripts/packages/built-by-uv
           ./uv pip install -v scripts/packages/built-by-uv/dist/*.tar.gz --find-links crates/uv-build/dist --offline --no-deps
           ./uv run --no-project python -c "from built_by_uv import greet; print(greet())"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1369,8 +1369,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1386,15 +1386,28 @@ jobs:
 
       - name: "Test uv_build package"
         run: |
+          # Build the Python package, which is not covered by uv's integration tests since they can't depend on having
+          # a Python package (only the binary itself is built before running Rust's tests)
           ./uv build -v crates/uv-build
-          ./uv venv -v --seed
+
           # Test the main path (`build_wheel`) through pip
+          ./uv venv -v --seed
           ./uv run --no-project python -m pip install -v scripts/packages/built-by-uv --find-links crates/uv-build/dist --no-index --no-deps
           ./uv run --no-project python -c "from built_by_uv import greet; print(greet())"
+
           # Test both `build_wheel` and `build_sdist` through uv
           ./uv venv -v
           ./uv build -v --force-pep517 scripts/packages/built-by-uv --find-links crates/uv-build/dist --offline
           ./uv pip install -v scripts/packages/built-by-uv/dist/*.tar.gz --find-links crates/uv-build/dist --offline --no-deps
+          ./uv run --no-project python -c "from built_by_uv import greet; print(greet())"
+
+          # Test both `build_wheel` and `build_sdist` through the official `build`
+          rm -rf scripts/packages/built-by-uv/dist/
+          ./uv venv -v
+          ./uv pip install build
+          UV_OFFLINE=1 UV_FIND_LINKS=crates/uv-build/dist ./uv run --no-project python -m build -v --installer uv scripts/packages/built-by-uv
+          ./uv pip install -v scripts/packages/built-by-uv/dist/*.tar.gz --find-links crates/uv-build/dist --offline --no-deps
+          ./uv run --no-project python -c "from built_by_uv import greet; print(greet())"
 
   cache-test-ubuntu:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1362,6 +1362,42 @@ jobs:
           UV_TEST_PUBLISH_CLOUDSMITH_TOKEN: ${{ secrets.UV_TEST_PUBLISH_CLOUDSMITH_TOKEN }}
           UV_TEST_PUBLISH_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
 
+  integration-uv-build-backend:
+    timeout-minutes: 10
+    needs: build-binary-linux-libc
+    name: "integration test | uv_build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-libc-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: |
+          chmod +x ./uv
+          chmod +x ./uvx
+
+      - name: "Test uv_build package"
+        run: |
+          ./uv build -v crates/uv-build
+          ./uv venv -v --seed
+          # Test the main path (`build_wheel`) through pip
+          ./uv run --no-project python -m pip install -v scripts/packages/built-by-uv --find-links crates/uv-build/dist --no-index --no-deps
+          ./uv run --no-project python -c "from built_by_uv import greet; print(greet())"
+          # Test both `build_wheel` and `build_sdist` through uv
+          ./uv venv -v
+          ./uv build -v --force-pep517 scripts/packages/built-by-uv --find-links crates/uv-build/dist --offline
+          ./uv pip install -v scripts/packages/built-by-uv/dist/*.tar.gz --find-links crates/uv-build/dist --offline --no-deps
+
   cache-test-ubuntu:
     timeout-minutes: 10
     needs: build-binary-linux-libc

--- a/crates/uv-build/python/uv_build/__init__.py
+++ b/crates/uv-build/python/uv_build/__init__.py
@@ -60,7 +60,7 @@ def build_sdist(
     sdist_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 517 hook `build_sdist`."""
-    args = ["build-backend", "build-sdist", sdist_directory]
+    args = ["build-sdist", sdist_directory]
     return call(args, config_settings)
 
 
@@ -70,9 +70,9 @@ def build_wheel(
     metadata_directory: "str | None" = None,
 ) -> str:
     """PEP 517 hook `build_wheel`."""
-    args = ["build-backend", "build-wheel", wheel_directory]
+    args = ["build-wheel", wheel_directory]
     if metadata_directory:
-        args.extend(["--metadata-directory", metadata_directory])
+        args.extend([metadata_directory])
     return call(args, config_settings)
 
 
@@ -96,7 +96,7 @@ def prepare_metadata_for_build_wheel(
     metadata_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 517 hook `prepare_metadata_for_build_wheel`."""
-    args = ["build-backend", "prepare-metadata-for-build-wheel", metadata_directory]
+    args = ["prepare-metadata-for-build-wheel", metadata_directory]
     return call(args, config_settings)
 
 
@@ -106,9 +106,9 @@ def build_editable(
     metadata_directory: "str | None" = None,
 ) -> str:
     """PEP 660 hook `build_editable`."""
-    args = ["build-backend", "build-editable", wheel_directory]
+    args = ["build-editable", wheel_directory]
     if metadata_directory:
-        args.extend(["--metadata-directory", metadata_directory])
+        args.extend([metadata_directory])
     return call(args, config_settings)
 
 
@@ -124,5 +124,5 @@ def prepare_metadata_for_build_editable(
     metadata_directory: str, config_settings: "Mapping[Any, Any] | None" = None
 ) -> str:
     """PEP 660 hook `prepare_metadata_for_build_editable`."""
-    args = ["build-backend", "prepare-metadata-for-build-editable", metadata_directory]
+    args = ["prepare-metadata-for-build-editable", metadata_directory]
     return call(args, config_settings)


### PR DESCRIPTION
I somehow missed running an actual integration test of the PEP 517 API in CI and the python shim was using the old uv CLI interface still.

The tests include pip, uv and `python -m build`. They must be a in CI job since we can't depend on the Python package in the Rust tests (we only get the binary in `cargo test`, not the `uv_build` wheel).