### PR TITLE
Add support for Windows legacy scripts via uv tool run

### DIFF
--- a/crates/uv-shell/src/lib.rs
+++ b/crates/uv-shell/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod runnable;
 mod shlex;
 pub mod windows;
 

--- a/crates/uv-shell/src/runnable.rs
+++ b/crates/uv-shell/src/runnable.rs
@@ -1,0 +1,100 @@
+//! Utilities for running executables and scripts. Particularly in Windows.
+
+use std::env::consts::EXE_EXTENSION;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug)]
+pub enum WindowsRunnable {
+    /// Windows PE (.exe)
+    Executable,
+    /// `PowerShell` script (.ps1)
+    PowerShell,
+    /// Command Prompt NT script (.cmd)
+    Command,
+    /// Command Prompt script (.bat)
+    Batch,
+}
+
+impl WindowsRunnable {
+    /// Returns a list of all supported Windows runnable types.
+    fn all() -> &'static [Self] {
+        &[
+            Self::Executable,
+            Self::PowerShell,
+            Self::Command,
+            Self::Batch,
+        ]
+    }
+
+    /// Returns the extension for a given Windows runnable type.
+    fn to_extension(&self) -> &'static str {
+        match self {
+            Self::Executable => EXE_EXTENSION,
+            Self::PowerShell => "ps1",
+            Self::Command => "cmd",
+            Self::Batch => "bat",
+        }
+    }
+
+    /// Determines the runnable type from a given Windows file extension.
+    fn from_extension(ext: &str) -> Option<Self> {
+        match ext {
+            EXE_EXTENSION => Some(Self::Executable),
+            "ps1" => Some(Self::PowerShell),
+            "cmd" => Some(Self::Command),
+            "bat" => Some(Self::Batch),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`Command`] to run the given type under the appropriate Windows runtime.
+    fn as_command(&self, runnable_path: &Path) -> Command {
+        match self {
+            Self::Executable => Command::new(runnable_path),
+            Self::PowerShell => {
+                let mut cmd = Command::new("powershell");
+                cmd.arg("-NoLogo").arg("-File").arg(runnable_path);
+                cmd
+            }
+            Self::Command | Self::Batch => {
+                let mut cmd = Command::new("cmd");
+                cmd.arg("/q").arg("/c").arg(runnable_path);
+                cmd
+            }
+        }
+    }
+
+    /// Handle console and legacy setuptools scripts for Windows.
+    ///
+    /// Returns [`Command`] that can be used to invoke a supported runnable on Windows
+    /// under the scripts path of an interpreter environment.
+    pub fn from_script_path(script_path: &Path, runnable_name: &OsStr) -> Command {
+        let script_path = script_path.join(runnable_name);
+
+        // Honor explicit extension if provided and recognized.
+        if let Some(script_type) = script_path
+            .extension()
+            .and_then(OsStr::to_str)
+            .and_then(Self::from_extension)
+            .filter(|_| script_path.is_file())
+        {
+            return script_type.as_command(&script_path);
+        }
+
+        // Guess the extension when an explicit one is not provided.
+        // We also add the extension when missing since for some types (e.g. PowerShell) it must be explicit.
+        Self::all()
+            .iter()
+            .map(|script_type| {
+                (
+                    script_type,
+                    script_path.with_extension(script_type.to_extension()),
+                )
+            })
+            .find(|(_, script_path)| script_path.is_file())
+            .map(|(script_type, script_path)| script_type.as_command(&script_path))
+            .unwrap_or_else(|| Command::new(runnable_name))
+    }
+}

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::env::VarError;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -33,6 +33,7 @@ use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::Lock;
 use uv_scripts::Pep723Item;
 use uv_settings::PythonInstallMirrors;
+use uv_shell::runnable::WindowsRunnable;
 use uv_static::EnvVars;
 use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache, WorkspaceError};
@@ -1127,58 +1128,6 @@ fn can_skip_ephemeral(
 }
 
 #[derive(Debug)]
-enum WindowsScript {
-    /// `PowerShell` script (.ps1)
-    PowerShell,
-    /// Command Prompt NT script (.cmd)
-    Command,
-    /// Command Prompt script (.bat)
-    Batch,
-}
-
-impl WindowsScript {
-    /// Returns a list of all supported Windows script types.
-    fn all() -> &'static [Self] {
-        &[Self::PowerShell, Self::Command, Self::Batch]
-    }
-
-    /// Returns the script extension for a given Windows script type.
-    fn to_extension(&self) -> &'static str {
-        match self {
-            Self::PowerShell => "ps1",
-            Self::Command => "cmd",
-            Self::Batch => "bat",
-        }
-    }
-
-    /// Determines the script type from a given Windows file extension.
-    fn from_extension(ext: &str) -> Option<Self> {
-        match ext {
-            "ps1" => Some(Self::PowerShell),
-            "cmd" => Some(Self::Command),
-            "bat" => Some(Self::Batch),
-            _ => None,
-        }
-    }
-
-    /// Returns a [`Command`] to run the given script under the appropriate Windows command.
-    fn as_command(&self, script: &Path) -> Command {
-        match self {
-            Self::PowerShell => {
-                let mut cmd = Command::new("powershell");
-                cmd.arg("-NoLogo").arg("-File").arg(script);
-                cmd
-            }
-            Self::Command | Self::Batch => {
-                let mut cmd = Command::new("cmd");
-                cmd.arg("/q").arg("/c").arg(script);
-                cmd
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
 pub(crate) enum RunCommand {
     /// Execute `python`.
     Python(Vec<OsString>),
@@ -1237,37 +1186,6 @@ impl RunCommand {
             }
             Self::External(executable, _) => executable.to_string_lossy(),
         }
-    }
-
-    /// Handle legacy setuptools scripts for Windows.
-    ///
-    /// Returns [`Command`] that can be used to run `.ps1`, `.cmd`, or `.bat` scripts on Windows.
-    fn for_windows_script(interpreter: &Interpreter, executable: &OsStr) -> Command {
-        let script_path = interpreter.scripts().join(executable);
-
-        // Honor explicit extension if provided and recognized.
-        if let Some(script_type) = script_path
-            .extension()
-            .and_then(OsStr::to_str)
-            .and_then(WindowsScript::from_extension)
-            .filter(|_| script_path.is_file())
-        {
-            return script_type.as_command(&script_path);
-        }
-
-        // Guess the extension when an explicit one is not provided.
-        // We also add the extension when missing since for PowerShell it must be explicit.
-        WindowsScript::all()
-            .iter()
-            .map(|script_type| {
-                (
-                    script_type,
-                    script_path.with_extension(script_type.to_extension()),
-                )
-            })
-            .find(|(_, script_path)| script_path.is_file())
-            .map(|(script_type, script_path)| script_type.as_command(&script_path))
-            .unwrap_or_else(|| Command::new(executable))
     }
 
     /// Convert a [`RunCommand`] into a [`Command`].
@@ -1386,7 +1304,7 @@ impl RunCommand {
             }
             Self::External(executable, args) => {
                 let mut process = if cfg!(windows) {
-                    Self::for_windows_script(interpreter, executable)
+                    WindowsRunnable::from_script_path(interpreter.scripts(), executable).into()
                 } else {
                     Command::new(executable)
                 };

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -34,6 +34,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
+use uv_shell::runnable::WindowsRunnable;
 use uv_static::EnvVars;
 use uv_tool::{entrypoint_paths, InstalledTools};
 use uv_warnings::warn_user;
@@ -260,7 +261,12 @@ pub(crate) async fn run(
     let executable = from.executable();
 
     // Construct the command
-    let mut process = Command::new(executable);
+    let mut process = if cfg!(windows) {
+        WindowsRunnable::from_script_path(environment.scripts(), executable.as_ref()).into()
+    } else {
+        Command::new(executable)
+    };
+
     process.args(args);
 
     // Construct the `PATH` environment variable.

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -4560,7 +4560,7 @@ fn run_windows_legacy_scripts() -> Result<()> {
     Audited 1 package in [TIME]
     "###);
 
-    // Test without explicit extension (.ps1 should be used)
+    // Test without explicit extension (.ps1 should be used) as there's no .exe available.
     uv_snapshot!(context.filters(), context.run().arg("custom_pydoc"), @r###"
     success: true
     exit_code: 0

--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -64,6 +64,27 @@ print([(k, v["title"]) for k, v in data.items()][:10])
 The invocation `uv run example.py` would run _isolated_ from the project with only the given
 dependencies listed.
 
+## Legacy Windows Scripts
+
+Support is provided for
+[legacy setuptools scripts](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#scripts).
+These types of scripts are additional files installed by setuptools in `.venv\Scripts`.
+
+Currently only legacy scripts with the `.ps1`, `.cmd`, and `.bat` extensions are supported.
+
+For example, below is an example running a Command Prompt script.
+
+```console
+$ uv run --with nuitka==2.6.7 -- nuitka.cmd --version
+```
+
+In addition, you don't need to specify the extension. `uv` will automatically look for files ending
+in `.ps1`, `.cmd`, and `.bat` in that order of execution on your behalf.
+
+```console
+$ uv run --with nuitka==2.6.7 -- nuitka --version
+```
+
 ## Signal handling
 
 uv does not cede control of the process to the spawned command in order to provide better error

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -264,6 +264,27 @@ $ uv tool upgrade --python 3.10 ruff
 For more details on requesting Python versions, see the
 [Python version](../concepts/python-versions.md#requesting-a-version) concept page..
 
+## Legacy Windows Scripts
+
+Tools also support running
+[legacy setuptools scripts](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#scripts).
+These scripts are available via `$(uv tool dir)\<tool-name>\Scripts` when installed.
+
+Currently only legacy scripts with the `.ps1`, `.cmd`, and `.bat` extensions are supported.
+
+For example, below is an example running a Command Prompt script.
+
+```console
+$ uv tool run --from nuitka==2.6.7 nuitka.cmd --version
+```
+
+In addition, you don't need to specify the extension. `uvx` will automatically look for files ending
+in `.ps1`, `.cmd`, and `.bat` in that order of execution on your behalf.
+
+```console
+$ uv tool run --from nuitka==2.6.7 nuitka --version
+```
+
 ## Next steps
 
 To learn more about managing tools with uv, see the [Tools concept](../concepts/tools.md) page and


### PR DESCRIPTION
## Summary

Follow up to https://github.com/astral-sh/uv/pull/11888 with added support for uv tool run.

Changes
* Added functionality for running windows scripts in previous PR was moved from run.rs to uv_shell::runnable.
* EXE was added as a supported type, this simplified integration across both uv run and uvx while retaining a backwards compatible behavior and properly prioritizing .exe over others. Name was adjusted to runnable as a result to better represent intent.

## Test Plan

New tests added.

## Documentation

Added new documentation.