### PR TITLE
 Cache workspace discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
  "uv-python",
  "uv-resolver",
  "uv-types",
+ "uv-workspace",
 ]
 
 [[package]]
@@ -4712,6 +4713,7 @@ dependencies = [
  "uv-types",
  "uv-virtualenv",
  "uv-warnings",
+ "uv-workspace",
 ]
 
 [[package]]
@@ -4964,6 +4966,7 @@ dependencies = [
  "uv-resolver",
  "uv-types",
  "uv-version",
+ "uv-workspace",
 ]
 
 [[package]]
@@ -5745,6 +5748,7 @@ dependencies = [
  "uv-pep508",
  "uv-pypi-types",
  "uv-python",
+ "uv-workspace",
 ]
 
 [[package]]

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -45,6 +45,7 @@ uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }
+uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
 codspeed-criterion-compat = { version = "2.7.2", default-features = false, optional = true }

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -103,6 +103,7 @@ mod resolver {
         Resolver, ResolverEnvironment, ResolverOutput,
     };
     use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
+    use uv_workspace::WorkspaceCache;
 
     static MARKERS: LazyLock<MarkerEnvironment> = LazyLock::new(|| {
         MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
@@ -161,6 +162,7 @@ mod resolver {
         let sources = SourceStrategy::default();
         let dependency_metadata = DependencyMetadata::default();
         let conflicts = Conflicts::empty();
+        let workspace_cache = WorkspaceCache::default();
 
         let python_requirement = if universal {
             PythonRequirement::from_requires_python(
@@ -188,6 +190,7 @@ mod resolver {
             &hashes,
             exclude_newer,
             sources,
+            workspace_cache,
             concurrency,
             PreviewMode::Enabled,
         );

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -29,6 +29,7 @@ uv-static = { workspace = true }
 uv-types = { workspace = true }
 uv-virtualenv = { workspace = true }
 uv-warnings = { workspace = true }
+uv-workspace = { workspace = true }
 
 anstream = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -38,6 +38,7 @@ use uv_python::{Interpreter, PythonEnvironment};
 use uv_static::EnvVars;
 use uv_types::{AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, SourceBuildTrait};
 use uv_warnings::warn_user_once;
+use uv_workspace::WorkspaceCache;
 
 pub use crate::error::{Error, MissingHeaderCause};
 
@@ -269,6 +270,7 @@ impl SourceBuild {
         version_id: Option<&str>,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        workspace_cache: &WorkspaceCache,
         config_settings: ConfigSettings,
         build_isolation: BuildIsolation<'_>,
         build_stack: &BuildStack,
@@ -294,6 +296,7 @@ impl SourceBuild {
             fallback_package_name,
             locations,
             source_strategy,
+            workspace_cache,
             &default_backend,
         )
         .await
@@ -396,6 +399,7 @@ impl SourceBuild {
                 version_id,
                 locations,
                 source_strategy,
+                workspace_cache,
                 build_stack,
                 build_kind,
                 level,
@@ -466,6 +470,7 @@ impl SourceBuild {
         package_name: Option<&PackageName>,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        workspace_cache: &WorkspaceCache,
         default_backend: &Pep517Backend,
     ) -> Result<(Pep517Backend, Option<Project>), Box<Error>> {
         match fs::read_to_string(source_tree.join("pyproject.toml")) {
@@ -496,6 +501,7 @@ impl SourceBuild {
                                     install_path,
                                     locations,
                                     source_strategy,
+                                    workspace_cache,
                                 )
                                 .await
                                 .map_err(Error::Lowering)?;
@@ -857,6 +863,7 @@ async fn create_pep517_build_environment(
     version_id: Option<&str>,
     locations: &IndexLocations,
     source_strategy: SourceStrategy,
+    workspace_cache: &WorkspaceCache,
     build_stack: &BuildStack,
     build_kind: BuildKind,
     level: BuildOutput,
@@ -957,6 +964,7 @@ async fn create_pep517_build_environment(
                 install_path,
                 locations,
                 source_strategy,
+                workspace_cache,
             )
             .await
             .map_err(Error::Lowering)?;

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -34,6 +34,7 @@ uv-python = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }
 uv-version = { workspace = true }
+uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -38,6 +38,7 @@ use uv_types::{
     AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, EmptyInstalledPackages, HashStrategy,
     InFlight,
 };
+use uv_workspace::WorkspaceCache;
 
 #[derive(Debug, Error)]
 pub enum BuildDispatchError {
@@ -94,6 +95,7 @@ pub struct BuildDispatch<'a> {
     source_build_context: SourceBuildContext,
     build_extra_env_vars: FxHashMap<OsString, OsString>,
     sources: SourceStrategy,
+    workspace_cache: WorkspaceCache,
     concurrency: Concurrency,
     preview: PreviewMode,
 }
@@ -116,6 +118,7 @@ impl<'a> BuildDispatch<'a> {
         hasher: &'a HashStrategy,
         exclude_newer: Option<ExcludeNewer>,
         sources: SourceStrategy,
+        workspace_cache: WorkspaceCache,
         concurrency: Concurrency,
         preview: PreviewMode,
     ) -> Self {
@@ -137,8 +140,8 @@ impl<'a> BuildDispatch<'a> {
             exclude_newer,
             source_build_context: SourceBuildContext::default(),
             build_extra_env_vars: FxHashMap::default(),
-
             sources,
+            workspace_cache,
             concurrency,
             preview,
         }
@@ -198,6 +201,10 @@ impl BuildContext for BuildDispatch<'_> {
 
     fn locations(&self) -> &IndexLocations {
         self.index_locations
+    }
+
+    fn workspace_cache(&self) -> &WorkspaceCache {
+        &self.workspace_cache
     }
 
     async fn resolve<'data>(
@@ -417,6 +424,7 @@ impl BuildContext for BuildDispatch<'_> {
             version_id,
             self.index_locations,
             sources,
+            self.workspace_cache(),
             self.config_settings.clone(),
             self.build_isolation,
             &build_stack,

--- a/crates/uv-distribution/src/metadata/build_requires.rs
+++ b/crates/uv-distribution/src/metadata/build_requires.rs
@@ -5,7 +5,9 @@ use uv_configuration::SourceStrategy;
 use uv_distribution_types::IndexLocations;
 use uv_normalize::PackageName;
 use uv_workspace::pyproject::ToolUvSources;
-use uv_workspace::{DiscoveryOptions, MemberDiscovery, ProjectWorkspace, Workspace};
+use uv_workspace::{
+    DiscoveryOptions, MemberDiscovery, ProjectWorkspace, Workspace, WorkspaceCache,
+};
 
 use crate::metadata::{LoweredRequirement, MetadataError};
 
@@ -37,6 +39,7 @@ impl BuildRequires {
         install_path: &Path,
         locations: &IndexLocations,
         sources: SourceStrategy,
+        cache: &WorkspaceCache,
     ) -> Result<Self, MetadataError> {
         let discovery = match sources {
             SourceStrategy::Enabled => DiscoveryOptions::default(),
@@ -48,7 +51,7 @@ impl BuildRequires {
 
         // TODO(konsti): Cache workspace discovery.
         let Some(project_workspace) =
-            ProjectWorkspace::from_maybe_project_root(install_path, &discovery).await?
+            ProjectWorkspace::from_maybe_project_root(install_path, &discovery, cache).await?
         else {
             return Ok(Self::from_metadata23(metadata));
         };

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -9,7 +9,7 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pypi_types::{HashDigests, ResolutionMetadata};
 use uv_workspace::dependency_groups::DependencyGroupError;
-use uv_workspace::WorkspaceError;
+use uv_workspace::{WorkspaceCache, WorkspaceError};
 
 pub use crate::metadata::build_requires::BuildRequires;
 pub use crate::metadata::lowering::LoweredRequirement;
@@ -80,6 +80,7 @@ impl Metadata {
         git_source: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         sources: SourceStrategy,
+        cache: &WorkspaceCache,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let requires_dist = uv_pypi_types::RequiresDist {
@@ -100,6 +101,7 @@ impl Metadata {
             git_source,
             locations,
             sources,
+            cache,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -10,7 +10,7 @@ use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_pep508::MarkerTree;
 use uv_workspace::dependency_groups::FlatDependencyGroups;
 use uv_workspace::pyproject::{Sources, ToolUvSources};
-use uv_workspace::{DiscoveryOptions, MemberDiscovery, ProjectWorkspace};
+use uv_workspace::{DiscoveryOptions, MemberDiscovery, ProjectWorkspace, WorkspaceCache};
 
 use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
 use crate::Metadata;
@@ -49,6 +49,7 @@ impl RequiresDist {
         git_member: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         sources: SourceStrategy,
+        cache: &WorkspaceCache,
     ) -> Result<Self, MetadataError> {
         // TODO(konsti): Cache workspace discovery.
         let discovery_options = DiscoveryOptions {
@@ -64,7 +65,8 @@ impl RequiresDist {
             },
         };
         let Some(project_workspace) =
-            ProjectWorkspace::from_maybe_project_root(install_path, &discovery_options).await?
+            ProjectWorkspace::from_maybe_project_root(install_path, &discovery_options, cache)
+                .await?
         else {
             return Ok(Self::from_metadata23(metadata));
         };
@@ -475,7 +477,7 @@ mod test {
     use uv_normalize::PackageName;
     use uv_pep508::Requirement;
     use uv_workspace::pyproject::PyProjectToml;
-    use uv_workspace::{DiscoveryOptions, ProjectWorkspace};
+    use uv_workspace::{DiscoveryOptions, ProjectWorkspace, WorkspaceCache};
 
     use crate::metadata::requires_dist::FlatRequiresDist;
     use crate::RequiresDist;
@@ -494,6 +496,7 @@ mod test {
                 stop_discovery_at: Some(path),
                 ..DiscoveryOptions::default()
             },
+            &WorkspaceCache::default(),
         )
         .await?;
         let requires_dist = uv_pypi_types::RequiresDist::parse_pyproject_toml(contents)?;

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -58,6 +58,7 @@ impl RequiresDist {
                     .fetch_root
                     .parent()
                     .expect("git checkout has a parent")
+                    .to_path_buf()
             }),
             members: match sources {
                 SourceStrategy::Enabled => MemberDiscovery::default(),
@@ -493,7 +494,7 @@ mod test {
                 .context("metadata field project not found")?,
             &pyproject_toml,
             &DiscoveryOptions {
-                stop_discovery_at: Some(path),
+                stop_discovery_at: Some(path.to_path_buf()),
                 ..DiscoveryOptions::default()
             },
             &WorkspaceCache::default(),

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1171,6 +1171,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         None,
                         self.build_context.locations(),
                         self.build_context.sources(),
+                        self.build_context.workspace_cache(),
                     )
                     .await?,
                 ));
@@ -1223,6 +1224,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             None,
                             self.build_context.locations(),
                             self.build_context.sources(),
+                            self.build_context.workspace_cache(),
                         )
                         .await?,
                     ));
@@ -1271,6 +1273,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     None,
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.workspace_cache(),
                 )
                 .await?,
             ));
@@ -1328,6 +1331,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 None,
                 self.build_context.locations(),
                 self.build_context.sources(),
+                self.build_context.workspace_cache(),
             )
             .await?,
         ))
@@ -1395,6 +1399,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     None,
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.workspace_cache(),
                 )
                 .await?;
                 Ok(Some(requires_dist))
@@ -1653,6 +1658,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                             Some(&git_member),
                             self.build_context.locations(),
                             self.build_context.sources(),
+                            self.build_context.workspace_cache(),
                         )
                         .await?,
                     ));
@@ -1685,6 +1691,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                                 Some(&git_member),
                                 self.build_context.locations(),
                                 self.build_context.sources(),
+                                self.build_context.workspace_cache(),
                             )
                             .await?,
                         ));
@@ -1736,6 +1743,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     Some(&git_member),
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.workspace_cache(),
                 )
                 .await?,
             ));
@@ -1793,6 +1801,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 Some(&git_member),
                 self.build_context.locations(),
                 self.build_context.sources(),
+                self.build_context.workspace_cache(),
             )
             .await?,
         ))

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -27,6 +27,7 @@ uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
+uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -17,6 +17,7 @@ use uv_git::GitResolver;
 use uv_pep508::PackageName;
 use uv_pypi_types::Requirement;
 use uv_python::{Interpreter, PythonEnvironment};
+use uv_workspace::WorkspaceCache;
 
 ///  Avoids cyclic crate dependencies between resolver, installer and builder.
 ///
@@ -87,6 +88,9 @@ pub trait BuildContext {
 
     /// The index locations being searched.
     fn locations(&self) -> &IndexLocations;
+
+    /// Workspace discovery caching.
+    fn workspace_cache(&self) -> &WorkspaceCache;
 
     /// Resolve the given requirements into a ready-to-install set of package versions.
     fn resolve<'a>(

--- a/crates/uv-workspace/src/lib.rs
+++ b/crates/uv-workspace/src/lib.rs
@@ -1,6 +1,6 @@
 pub use workspace::{
-    DiscoveryOptions, MemberDiscovery, ProjectWorkspace, VirtualProject, Workspace, WorkspaceError,
-    WorkspaceMember,
+    DiscoveryOptions, MemberDiscovery, ProjectWorkspace, VirtualProject, Workspace, WorkspaceCache,
+    WorkspaceError, WorkspaceMember,
 };
 
 pub mod dependency_groups;

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -42,7 +42,7 @@ use uv_requirements::RequirementsSource;
 use uv_resolver::{ExcludeNewer, FlatIndex, RequiresPython};
 use uv_settings::PythonInstallMirrors;
 use uv_types::{AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, HashStrategy};
-use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceError};
+use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache, WorkspaceError};
 
 #[derive(Debug, Error)]
 enum Error {
@@ -240,7 +240,13 @@ async fn build_impl(
     };
 
     // Attempt to discover the workspace; on failure, save the error for later.
-    let workspace = Workspace::discover(src.directory(), &DiscoveryOptions::default()).await;
+    let workspace_cache = WorkspaceCache::default();
+    let workspace = Workspace::discover(
+        src.directory(),
+        &DiscoveryOptions::default(),
+        &workspace_cache,
+    )
+    .await;
 
     // If a `--package` or `--all-packages` was provided, adjust the source directory.
     let packages = if let Some(package) = package {
@@ -551,6 +557,7 @@ async fn build_package(
 
     // Initialize any shared state.
     let state = SharedState::default();
+    let workspace_cache = WorkspaceCache::default();
 
     // Create a build dispatch.
     let build_dispatch = BuildDispatch::new(
@@ -570,6 +577,7 @@ async fn build_package(
         &hasher,
         exclude_newer,
         sources,
+        workspace_cache,
         concurrency,
         preview,
     );

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -40,6 +40,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::warn_user;
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::pip::{operations, resolution_environment};
@@ -395,6 +396,7 @@ pub(crate) async fn pip_compile(
         &build_hashes,
         exclude_newer,
         sources,
+        WorkspaceCache::default(),
         concurrency,
         preview,
     );

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -34,6 +34,7 @@ use uv_resolver::{
     ResolutionMode, ResolverEnvironment,
 };
 use uv_types::{BuildIsolation, HashStrategy};
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
 use crate::commands::pip::operations::Modifications;
@@ -400,6 +401,7 @@ pub(crate) async fn pip_install(
         &build_hasher,
         exclude_newer,
         sources,
+        WorkspaceCache::default(),
         concurrency,
         preview,
     );

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -31,6 +31,7 @@ use uv_resolver::{
     ResolutionMode, ResolverEnvironment,
 };
 use uv_types::{BuildIsolation, HashStrategy};
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
@@ -333,6 +334,7 @@ pub(crate) async fn pip_sync(
         &build_hasher,
         exclude_newer,
         sources,
+        WorkspaceCache::default(),
         concurrency,
         preview,
     );

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -297,7 +297,7 @@ async fn init_project(
         match Workspace::discover(
             parent,
             &DiscoveryOptions {
-                members: MemberDiscovery::Ignore(std::iter::once(path).collect()),
+                members: MemberDiscovery::Ignore(std::iter::once(path.to_path_buf()).collect()),
                 ..DiscoveryOptions::default()
             },
             &workspace_cache,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -26,7 +26,7 @@ use uv_scripts::{Pep723Script, ScriptTag};
 use uv_settings::PythonInstallMirrors;
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
-use uv_workspace::{DiscoveryOptions, MemberDiscovery, Workspace, WorkspaceError};
+use uv_workspace::{DiscoveryOptions, MemberDiscovery, Workspace, WorkspaceCache, WorkspaceError};
 
 use crate::commands::project::{find_requires_python, init_script_python_requirement};
 use crate::commands::reporters::PythonDownloadReporter;
@@ -291,6 +291,7 @@ async fn init_project(
     printer: Printer,
 ) -> Result<()> {
     // Discover the current workspace, if it exists.
+    let workspace_cache = WorkspaceCache::default();
     let workspace = {
         let parent = path.parent().expect("Project path has no parent");
         match Workspace::discover(
@@ -299,6 +300,7 @@ async fn init_project(
                 members: MemberDiscovery::Ignore(std::iter::once(path).collect()),
                 ..DiscoveryOptions::default()
             },
+            &workspace_cache,
         )
         .await
         {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -45,7 +45,7 @@ use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::dependency_groups::DependencyGroupError;
 use uv_workspace::pyproject::PyProjectToml;
-use uv_workspace::Workspace;
+use uv_workspace::{Workspace, WorkspaceCache};
 
 use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::pip::operations::{Changelog, Modifications};
@@ -1481,6 +1481,7 @@ pub(crate) async fn resolve_names(
     state: &SharedState,
     concurrency: Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: PreviewMode,
 ) -> Result<Vec<Requirement>, uv_requirements::Error> {
@@ -1581,6 +1582,7 @@ pub(crate) async fn resolve_names(
         &build_hasher,
         *exclude_newer,
         *sources,
+        workspace_cache.clone(),
         concurrency,
         preview,
     );
@@ -1751,6 +1753,8 @@ pub(crate) async fn resolve_environment(
         FlatIndex::from_entries(entries, Some(tags), &hasher, build_options)
     };
 
+    let workspace_cache = WorkspaceCache::default();
+
     // Create a build dispatch.
     let resolve_dispatch = BuildDispatch::new(
         &client,
@@ -1769,6 +1773,7 @@ pub(crate) async fn resolve_environment(
         &build_hasher,
         exclude_newer,
         sources,
+        workspace_cache,
         concurrency,
         preview,
     );
@@ -1879,6 +1884,7 @@ pub(crate) async fn sync_environment(
     let build_hasher = HashStrategy::default();
     let dry_run = DryRun::default();
     let hasher = HashStrategy::default();
+    let workspace_cache = WorkspaceCache::default();
 
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {
@@ -1907,6 +1913,7 @@ pub(crate) async fn sync_environment(
         &build_hasher,
         exclude_newer,
         sources,
+        workspace_cache,
         concurrency,
         preview,
     );
@@ -1972,6 +1979,7 @@ pub(crate) async fn update_environment(
     installer_metadata: bool,
     concurrency: Concurrency,
     cache: &Cache,
+    workspace_cache: WorkspaceCache,
     dry_run: DryRun,
     printer: Printer,
     preview: PreviewMode,
@@ -2124,6 +2132,7 @@ pub(crate) async fn update_environment(
         &build_hasher,
         *exclude_newer,
         *sources,
+        workspace_cache,
         concurrency,
         preview,
     );

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -14,7 +14,7 @@ use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion}
 use uv_resolver::{PackageMap, TreeDisplay};
 use uv_scripts::{Pep723ItemRef, Pep723Script};
 use uv_settings::PythonInstallMirrors;
-use uv_workspace::{DiscoveryOptions, Workspace};
+use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
 
 use crate::commands::pip::latest::LatestClient;
 use crate::commands::pip::loggers::DefaultResolveLogger;
@@ -59,11 +59,14 @@ pub(crate) async fn tree(
     preview: PreviewMode,
 ) -> Result<ExitStatus> {
     // Find the project requirements.
+    let workspace_cache = WorkspaceCache::default();
     let workspace;
     let target = if let Some(script) = script.as_ref() {
         LockTarget::Script(script)
     } else {
-        workspace = Workspace::discover(project_dir, &DiscoveryOptions::default()).await?;
+        workspace =
+            Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+                .await?;
         LockTarget::Workspace(&workspace)
     };
 

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -6,7 +6,7 @@ use uv_cache::Cache;
 use uv_fs::Simplified;
 use uv_python::{EnvironmentPreference, PythonInstallation, PythonPreference, PythonRequest};
 use uv_warnings::{warn_user, warn_user_once};
-use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceError};
+use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceError};
 
 use crate::commands::{
     project::{validate_project_requires_python, WorkspacePython},
@@ -29,10 +29,13 @@ pub(crate) async fn find(
         EnvironmentPreference::Any
     };
 
+    let workspace_cache = WorkspaceCache::default();
     let project = if no_project {
         None
     } else {
-        match VirtualProject::discover(project_dir, &DiscoveryOptions::default()).await {
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+            .await
+        {
             Ok(project) => Some(project),
             Err(WorkspaceError::MissingProject(_)) => None,
             Err(WorkspaceError::MissingPyprojectToml) => None,

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -13,7 +13,7 @@ use uv_python::{
     VersionFileDiscoveryOptions, PYTHON_VERSION_FILENAME,
 };
 use uv_warnings::warn_user_once;
-use uv_workspace::{DiscoveryOptions, VirtualProject};
+use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
 
 use crate::commands::{project::find_requires_python, ExitStatus};
 use crate::printer::Printer;
@@ -28,10 +28,13 @@ pub(crate) async fn pin(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
+    let workspace_cache = WorkspaceCache::default();
     let virtual_project = if no_project {
         None
     } else {
-        match VirtualProject::discover(project_dir, &DiscoveryOptions::default()).await {
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+            .await
+        {
             Ok(virtual_project) => Some(virtual_project),
             Err(err) => {
                 debug!("Failed to discover virtual project: {err}");

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -21,9 +21,9 @@ use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_tool::InstalledTools;
 use uv_warnings::warn_user;
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
-
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::{
     resolve_environment, resolve_names, sync_environment, update_environment,
@@ -86,6 +86,7 @@ pub(crate) async fn install(
 
     // Initialize any shared state.
     let state = PlatformState::default();
+    let workspace_cache = WorkspaceCache::default();
 
     let client_builder = BaseClientBuilder::new()
         .connectivity(network_settings.connectivity)
@@ -133,6 +134,7 @@ pub(crate) async fn install(
                 &state,
                 concurrency,
                 &cache,
+                &workspace_cache,
                 printer,
                 preview,
             )
@@ -245,6 +247,7 @@ pub(crate) async fn install(
                 &state,
                 concurrency,
                 &cache,
+                &workspace_cache,
                 printer,
                 preview,
             )
@@ -269,6 +272,7 @@ pub(crate) async fn install(
         &state,
         concurrency,
         &cache,
+        &workspace_cache,
         printer,
         preview,
     )
@@ -400,6 +404,7 @@ pub(crate) async fn install(
             installer_metadata,
             concurrency,
             &cache,
+            workspace_cache,
             DryRun::Disabled,
             printer,
             preview,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -37,6 +37,7 @@ use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_static::EnvVars;
 use uv_tool::{entrypoint_paths, InstalledTools};
 use uv_warnings::warn_user;
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{
     DefaultInstallLogger, DefaultResolveLogger, SummaryInstallLogger, SummaryResolveLogger,
@@ -625,6 +626,7 @@ async fn get_or_create_environment(
 
     // Initialize any shared state.
     let state = PlatformState::default();
+    let workspace_cache = WorkspaceCache::default();
 
     let from = if request.is_python() {
         ToolRequirement::Python
@@ -668,6 +670,7 @@ async fn get_or_create_environment(
                     &state,
                     concurrency,
                     cache,
+                    &workspace_cache,
                     printer,
                     preview,
                 )
@@ -760,6 +763,7 @@ async fn get_or_create_environment(
                 &state,
                 concurrency,
                 cache,
+                &workspace_cache,
                 printer,
                 preview,
             )
@@ -785,6 +789,7 @@ async fn get_or_create_environment(
         &state,
         concurrency,
         cache,
+        &workspace_cache,
         printer,
         preview,
     )

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -18,6 +18,7 @@ use uv_python::{
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_tool::InstalledTools;
+use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{
     DefaultInstallLogger, SummaryResolveLogger, UpgradeInstallLogger,
@@ -281,6 +282,7 @@ async fn upgrade_tool(
 
     // Initialize any shared state.
     let state = PlatformState::default();
+    let workspace_cache = WorkspaceCache::default();
 
     // Check if we need to create a new environment — if so, resolve it first, then
     // install the requested tool
@@ -340,6 +342,7 @@ async fn upgrade_tool(
             installer_metadata,
             concurrency,
             cache,
+            workspace_cache,
             DryRun::Disabled,
             printer,
             preview,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -31,7 +31,7 @@ use uv_scripts::{Pep723Error, Pep723Item, Pep723Metadata, Pep723Script};
 use uv_settings::{Combine, FilesystemOptions, Options};
 use uv_static::EnvVars;
 use uv_warnings::{warn_user, warn_user_once};
-use uv_workspace::{DiscoveryOptions, Workspace};
+use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
 
 use crate::commands::{ExitStatus, RunCommand, ScriptPath, ToolRunCommand};
 use crate::printer::Printer;
@@ -109,6 +109,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     //    If found, this file is combined with the user configuration file.
     // 3. The nearest configuration file (`uv.toml` or `pyproject.toml`) in the directory tree,
     //    starting from the current directory.
+    let workspace_cache = WorkspaceCache::default();
     let filesystem = if let Some(config_file) = cli.top_level.config_file.as_ref() {
         if config_file
             .file_name()
@@ -123,7 +124,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         // For commands that operate at the user-level, ignore local configuration.
         FilesystemOptions::user()?.combine(FilesystemOptions::system()?)
     } else if let Ok(workspace) =
-        Workspace::discover(&project_dir, &DiscoveryOptions::default()).await
+        Workspace::discover(&project_dir, &DiscoveryOptions::default(), &workspace_cache).await
     {
         let project = FilesystemOptions::find(workspace.install_path())?;
         let system = FilesystemOptions::system()?;

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15194,7 +15194,7 @@ fn lock_explicit_default_index() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.lock().arg("--verbose"), @r###"
+    uv_snapshot!(context.filters(), context.lock().arg("--verbose"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -15202,7 +15202,7 @@ fn lock_explicit_default_index() -> Result<()> {
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Found workspace root: `[TEMP_DIR]/`
-    DEBUG Adding current workspace member: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
     DEBUG Using Python request `>=3.12` from `requires-python` metadata
     DEBUG Checking for Python environment at `.venv`
     DEBUG The virtual environment's Python version satisfies `>=3.12`
@@ -15226,7 +15226,7 @@ fn lock_explicit_default_index() -> Result<()> {
       ╰─▶ Because anyio was not found in the provided package locations and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
 
           hint: Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `--find-links <uri>`)
-    "###);
+    "#);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 


### PR DESCRIPTION
Reduce the overhead of `uv run` in large workspaces. Instead of re-discovering the entire workspace each time we resolve the metadata of a member, we can the discovered set of workspace members. Care needs to be taken to not cache the discovery for `uv init`, `uv add` and `uv remove`, which change the definitions of workspace members.

Below is apache airflow e3fe06382df4b19f2c0de40ce7c0bdc726754c74 `uv run python` with a minimal payload. With this change, we avoid a ~350ms overhead of each `uv run` invocation.

```
$ hyperfine --warmup 2 \
    "uv run --no-dev python -c \"print('hi')\"" \
    "uv-profiling run --no-dev python -c \"print('hi')\""
Benchmark 1: uv run --no-dev python -c "print('hi')"
  Time (mean ± σ):     492.6 ms ±   7.0 ms    [User: 393.2 ms, System: 97.1 ms]
  Range (min … max):   482.3 ms … 501.5 ms    10 runs
 
Benchmark 2: uv-profiling run --no-dev python -c "print('hi')"
  Time (mean ± σ):     129.7 ms ±   2.5 ms    [User: 105.4 ms, System: 23.2 ms]
  Range (min … max):   126.0 ms … 136.1 ms    22 runs
 
Summary
  uv-profiling run --no-dev python -c "print('hi')" ran
    3.80 ± 0.09 times faster than uv run --no-dev python -c "print('hi')"
```

The profile after those change below. We still spend a large chunk in toml parsing (both `uv.lock` and `pyproject.toml`), but it's not excessive anymore.

![image](https://github.com/user-attachments/assets/6fe78510-7e25-48ee-8a6d-220ee98ad120)
