### PR TITLE
Update the `index.authenticate` docs

### DIFF
--- a/crates/uv-auth/src/policy.rs
+++ b/crates/uv-auth/src/policy.rs
@@ -1,18 +1,28 @@
 use rustc_hash::FxHashMap;
 use url::Url;
 
+/// When to use authentication.
 #[derive(
     Copy, Clone, Debug, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize,
 )]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AuthPolicy {
-    /// Try unauthenticated request. Fallback to authenticated request.
+    /// Authenticate when necessary.
+    ///
+    /// If credentials are provided, they will be used. Otherwise, an unauthenticated request will
+    /// be attempted first. If the request fails, uv will search for credentials. If credentials are
+    /// found, an authenticated request will be attempted.
     #[default]
     Auto,
     /// Always authenticate.
+    ///
+    /// If credentials are not provided, uv will eagerly search for credentials. If credentials
+    /// cannot be found, uv will error instead of attempting an unauthenticated request.
     Always,
     /// Never authenticate.
+    ///
+    /// If credentials are provided, uv will error. uv will not search for credentials.
     Never,
 }
 

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -82,19 +82,7 @@ pub struct Index {
     /// publish-url = "https://upload.pypi.org/legacy/"
     /// ```
     pub publish_url: Option<Url>,
-    /// The authentication policy for the index.
-    ///
-    /// There are three policies: "auto", "always", and "never".
-    ///
-    /// * "auto" will first attempt an unauthenticated request to the index.
-    ///   If that fails it will attempt an authenticated request.
-    /// * "always" will always attempt to make an authenticated request and will
-    ///   fail if the authenticated request fails.
-    /// * "never" will never attempt to make an authenticated request and will
-    ///   fail if an authenticated request fails.
-    ///
-    /// The authentication policy will apply to requests made to URLs with
-    /// this index URL as a prefix.
+    /// When uv should use authentication for requests to the index.
     ///
     /// ```toml
     /// [[tool.uv.index]]

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -50,13 +50,22 @@ argument to uv, or set `UV_KEYRING_PROVIDER=subprocess`.
 
 Authentication may be used for hosts specified in the following contexts:
 
+- `[index]`
 - `index-url`
 - `extra-index-url`
 - `find-links`
 - `package @ https://...`
 
+See the [index authentication documentation](./indexes.md#authentication) for details on
+authenticating index URLs.
+
 See the [`pip` compatibility guide](../pip/compatibility.md#registry-authentication) for details on
 differences from `pip`.
+
+## Authentication with alternative package indexes
+
+See the [alternative indexes integration guide](../guides/integration/alternative-indexes.md) for
+details on authentication with popular alternative Python package indexes.
 
 ## Custom CA certificates
 
@@ -93,14 +102,3 @@ insecure.
 
 Use `allow-insecure-host` with caution and only in trusted environments, as it can expose you to
 security risks due to the lack of certificate verification.
-
-## Authentication with alternative package indexes
-
-See the [alternative indexes integration guide](../guides/integration/alternative-indexes.md) for
-details on authentication with popular alternative Python package indexes.
-
-## Configuring authentication for indexes
-
-It is possible to configure how uv will handle authentication for requests to indexes. See
-[configuring authentication for indexes](indexes.md#configuring-authentication-for-indexes) for more
-details.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -558,23 +558,24 @@
       ]
     },
     "AuthPolicy": {
+      "description": "When to use authentication.",
       "oneOf": [
         {
-          "description": "Try unauthenticated request. Fallback to authenticated request.",
+          "description": "Authenticate when necessary.\n\nIf credentials are provided, they will be used. Otherwise, an unauthenticated request will be attempted first. If the request fails, uv will search for credentials. If credentials are found, an authenticated request will be attempted.",
           "type": "string",
           "enum": [
             "auto"
           ]
         },
         {
-          "description": "Always authenticate.",
+          "description": "Always authenticate.\n\nIf credentials are not provided, uv will eagerly search for credentials. If credentials cannot be found, uv will error instead of attempting an unauthenticated request.",
           "type": "string",
           "enum": [
             "always"
           ]
         },
         {
-          "description": "Never authenticate.",
+          "description": "Never authenticate.\n\nIf credentials are provided, uv will error. uv will not search for credentials.",
           "type": "string",
           "enum": [
             "never"
@@ -735,7 +736,7 @@
       ],
       "properties": {
         "authenticate": {
-          "description": "The authentication policy for the index.\n\nThere are three policies: \"auto\", \"always\", and \"never\".\n\n* \"auto\" will first attempt an unauthenticated request to the index. If that fails it will attempt an authenticated request. * \"always\" will always attempt to make an authenticated request and will fail if the authenticated request fails. * \"never\" will never attempt to make an authenticated request and will fail if an authenticated request fails.\n\nThe authentication policy will apply to requests made to URLs with this index URL as a prefix.\n\n```toml [[tool.uv.index]] name = \"my-index\" url = \"https://<omitted>/simple\" authenticate = \"always\" ```",
+          "description": "When uv should use authentication for requests to the index.\n\n```toml [[tool.uv.index]] name = \"my-index\" url = \"https://<omitted>/simple\" authenticate = \"always\" ```",
           "default": "auto",
           "allOf": [
             {


### PR DESCRIPTION
Follow-up to #11896 

Reframes the documentation a bit.

Looking into why the `[index]` child fields aren't generate in the reference correctly too.