### PR TITLE
Docs : Quote versions string in python-versions.md

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -206,7 +206,7 @@ This interface also supports many [request formats](#requesting-a-version), e.g.
 executable that has a version of 3.11 or newer:
 
 ```console
-$ uv python find >=3.11
+$ uv python find '>=3.11'
 ```
 
 By default, `uv python find` will include Python versions from virtual environments. If a `.venv`


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The command `uv python find >=3.11` doesn't work . The version should be quoted otherwise the terminal interprets the `>`  and pipes output to a file named `=3.11`. I've used single quotes as used on line 90 of this file.

## Test Plan

Locally
