### PR TITLE
Add support for global `uv python pin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,6 +4579,7 @@ dependencies = [
  "uv-client",
  "uv-configuration",
  "uv-console",
+ "uv-dirs",
  "uv-dispatch",
  "uv-distribution",
  "uv-distribution-filename",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4672,6 +4672,15 @@ pub struct PythonPinArgs {
     /// `requires-python` constraint.
     #[arg(long, alias = "no-workspace")]
     pub no_project: bool,
+
+    /// Pin the global (user-level) Python version.
+    ///
+    /// This causes uv to write the specified version to a user-level
+    /// `.python-version` file. This will be used as a fallback for any
+    /// project that doesn't contain a `.python-version` file in its
+    /// local directory or ancestor directories.
+    #[arg(long)]
+    pub global: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv-dirs/src/lib.rs
+++ b/crates/uv-dirs/src/lib.rs
@@ -103,6 +103,13 @@ pub fn user_config_dir() -> Option<PathBuf> {
         .ok()
 }
 
+pub fn user_uv_config_dir() -> Option<PathBuf> {
+    user_config_dir().map(|mut path| {
+        path.push("uv");
+        path
+    })
+}
+
 #[cfg(not(windows))]
 fn locate_system_config_xdg(value: Option<&str>) -> Option<PathBuf> {
     // On Linux and macOS, read the `XDG_CONFIG_DIRS` environment variable.

--- a/crates/uv-pypi-types/src/conflicts.rs
+++ b/crates/uv-pypi-types/src/conflicts.rs
@@ -149,8 +149,6 @@ impl Conflicts {
         }
 
         let Ok(topo_nodes) = toposort(&graph, None) else {
-            // FIXME: If we hit a cycle, we are currently bailing and waiting for
-            // more detailed cycle detection downstream. Is this what we want?
             return;
         };
         // Propagate canonical items through the graph and populate substitutions.

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -24,6 +24,7 @@ uv-cli = { workspace = true }
 uv-client = { workspace = true }
 uv-configuration = { workspace = true }
 uv-console = { workspace = true }
+uv-dirs = { workspace = true }
 uv-dispatch = { workspace = true }
 uv-distribution = { workspace = true }
 uv-distribution-filename = { workspace = true }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1257,6 +1257,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.resolved,
                 globals.python_preference,
                 args.no_project,
+                args.global,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -979,6 +979,7 @@ pub(crate) struct PythonPinSettings {
     pub(crate) request: Option<String>,
     pub(crate) resolved: bool,
     pub(crate) no_project: bool,
+    pub(crate) global: bool,
 }
 
 impl PythonPinSettings {
@@ -990,12 +991,14 @@ impl PythonPinSettings {
             no_resolved,
             resolved,
             no_project,
+            global,
         } = args;
 
         Self {
             request,
             resolved: flag(resolved, no_resolved).unwrap_or(false),
             no_project,
+            global,
         }
     }
 }

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -18,7 +18,8 @@ fn add_shared_args(mut command: Command, cwd: &Path) -> Command {
         .env(EnvVars::UV_CONCURRENT_BUILDS, "16")
         .env(EnvVars::UV_CONCURRENT_INSTALLS, "8")
         // Set an explicit `XDG_CONFIG_DIRS` to avoid loading system configuration.
-        .env(EnvVars::XDG_CONFIG_DIRS, cwd);
+        .env(EnvVars::XDG_CONFIG_DIRS, cwd)
+        .env(EnvVars::XDG_CONFIG_HOME, cwd);
 
     if cfg!(unix) {
         // Avoid locale issues in tests

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5184,6 +5184,10 @@ uv python pin [OPTIONS] [REQUEST]
 
 <p>See <code>--project</code> to only change the project root directory.</p>
 
+</dd><dt id="uv-python-pin--global"><a href="#uv-python-pin--global"><code>--global</code></a></dt><dd><p>Pin the global (user-level) Python version.</p>
+
+<p>This causes uv to write the specified version to a user-level <code>.python-version</code> file. This will be used as a fallback for any project that doesn&#8217;t contain a <code>.python-version</code> file in its local directory or ancestor directories.</p>
+
 </dd><dt id="uv-python-pin--help"><a href="#uv-python-pin--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
 </dd><dt id="uv-python-pin--native-tls"><a href="#uv-python-pin--native-tls"><code>--native-tls</code></a></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>


### PR DESCRIPTION
These changes add support for

```
uv python pin 3.12 --global 
```

This adds the specified version to a `.python-version` file in the user-level config directory. uv will now use the user-level version as a fallback if no version is found in the project directory or its ancestors.

Open question: is `--global` the correct parameter here? `--user` is more precise, but might not communicate the intent as clearly.

TODO: User documentation.

Closes #4972
