### PR TITLE
Add support for dynamic musl Python distributions on x86-64 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,9 @@ jobs:
 
       - name: "Smoke test"
         run: |
+          # Overwrite the 3.13.0 pin from the project, there are not functional
+          # musl distributions for it
+          ./uv python pin 3.13
           ./uv venv -v
           ./uv pip install ruff -v
           ./uvx -v ruff --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,6 +737,35 @@ jobs:
           eval "$(./uv generate-shell-completion bash)"
           eval "$(./uvx --generate-shell-completion bash)"
 
+  smoke-test-linux-musl:
+    timeout-minutes: 10
+    needs: build-binary-linux-musl
+    name: "check system | alpine"
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-musl-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: |
+          chmod +x ./uv
+          chmod +x ./uvx
+
+      - name: "Smoke test"
+        run: |
+          ./uv venv -v
+          ./uv pip install ruff -v
+          ./uvx -v ruff --version
+          ./uv pip install numpy -v
+          ./uv run python -c "import numpy; print(numpy.__version__)"
+          eval "$(./uv generate-shell-completion bash)"
+          eval "$(./uvx --generate-shell-completion bash)"
+
   smoke-test-macos:
     timeout-minutes: 10
     needs: build-binary-macos-x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,8 +766,6 @@ jobs:
           ./uvx -v ruff --version
           ./uv pip install numpy -v
           ./uv run python -c "import numpy; print(numpy.__version__)"
-          eval "$(./uv generate-shell-completion bash)"
-          eval "$(./uvx --generate-shell-completion bash)"
 
   smoke-test-macos:
     timeout-minutes: 10

--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -2591,22 +2591,6 @@
     "sha256": "56817aa976e4886bec1677699c136cb01c1cdfe0495104c0d8ef546541864bbb",
     "variant": null
   },
-  "cpython-3.13.1-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "15566e568211fa087c048ca5ef73692674f7136ed36c2b27aa5973c07e6dcfa4",
-    "variant": null
-  },
   "cpython-3.13.1-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -2621,22 +2605,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "905dbd718c24fad56be24454c26a15f4c7acc162d0f7e1c8c19791cefaa14f3c",
-    "variant": null
-  },
-  "cpython-3.13.1-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "420b3286ea909db207f510447b76e51310ba131e7231e247a6ba72a487ff20d5",
     "variant": null
   },
   "cpython-3.13.1-linux-x86_64_v3-gnu": {
@@ -2655,22 +2623,6 @@
     "sha256": "d6b9f9686d53d5dae86a7dc2c43f905ad2464e71dc3317c9c030c69a4d065db5",
     "variant": null
   },
-  "cpython-3.13.1-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "dfdfd8ccd40e9c02d6b19d40cbf15f3371fa5aa1b211a8f3ec5f457e0e7a36c1",
-    "variant": null
-  },
   "cpython-3.13.1-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -2685,22 +2637,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "777c72f0de3a155b1333fb8f4bb06b035c51e05c3e5ccf229ad5dbe277338a30",
-    "variant": null
-  },
-  "cpython-3.13.1-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "fec2a7fc1a245eaa2f2b0fb90290cb1c02b4e2eba0e1be500a247751dc03c1f7",
     "variant": null
   },
   "cpython-3.13.1-windows-i686-none": {
@@ -3071,22 +3007,6 @@
     "sha256": "4dee26770a9d85d8ede4facf57e35adda4788b90b261e398ab446aad7fe7e07d",
     "variant": "debug"
   },
-  "cpython-3.13.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3006660291a740da23563e8149d1d71d44b965c5ad0f55aee864f2529588345d",
-    "variant": "debug"
-  },
   "cpython-3.13.1+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -3101,22 +3021,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "35004832bcb091e2ebac252d46d9a7c791c0ea8213e4e9dff729480647e312b1",
-    "variant": "debug"
-  },
-  "cpython-3.13.1+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "96f987cf3849c900e4f7b65b5e955ba3040194df1e0f57c9e72ff873977aac40",
     "variant": "debug"
   },
   "cpython-3.13.1+debug-linux-x86_64_v3-gnu": {
@@ -3135,22 +3039,6 @@
     "sha256": "d5d1e0d91ca2985e238945412dddff4db7deb72dedaf63eb5d426e3ff941836b",
     "variant": "debug"
   },
-  "cpython-3.13.1+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "29f32bc2ddadfe025679b520d3f5bdd97e228ab5487f475d3addc5eeb912e0fd",
-    "variant": "debug"
-  },
   "cpython-3.13.1+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -3165,22 +3053,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "6d33f9e832791ac3f84e29239a8c780786f0eded43ae129537087a5b5d40549c",
-    "variant": "debug"
-  },
-  "cpython-3.13.1+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "49a6d7e4502cde7025747adffaeabd8b8f80a06e8e75f8d8f8e70a2785aa1db2",
     "variant": "debug"
   },
   "cpython-3.13.0-darwin-aarch64-none": {
@@ -3311,22 +3183,6 @@
     "sha256": "b5e74d1e16402b633c6f04519618231fc0dbae7d2f9e4b1ac17c294cc3d3d076",
     "variant": null
   },
-  "cpython-3.13.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "10978500ab6589760716c644aeadffa0f2c0bf31ea10f0c6160fee933933a567",
-    "variant": null
-  },
   "cpython-3.13.0-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -3341,22 +3197,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "5c10c0b05c66bc6fc9a87f456ac1606057fe1865cc525eb7ecd9a5640f15426a",
-    "variant": null
-  },
-  "cpython-3.13.0-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6797067b7da58c29384cd32cb77f62dc18e813e6c72f6b0baf39672d84431bf2",
     "variant": null
   },
   "cpython-3.13.0-linux-x86_64_v3-gnu": {
@@ -3375,22 +3215,6 @@
     "sha256": "a9e705f714ccbe721ba0e29b80e6f2a5f0960c39245959de58c8076fd31515e0",
     "variant": null
   },
-  "cpython-3.13.0-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "0572fbf46e49adaa5a418eeb92daeb624a080466a46d87d48e4a80f1ba9e408a",
-    "variant": null
-  },
   "cpython-3.13.0-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -3405,22 +3229,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "36bd61970dc1d3a7034f2645aa14b47b6aa1669819fb7803650b5a7919afddbf",
-    "variant": null
-  },
-  "cpython-3.13.0-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "a846556bdd4d61b3f96aa8b096c86db031d7f5b5ef50f9e614c9259527afc9de",
     "variant": null
   },
   "cpython-3.13.0-windows-i686-none": {
@@ -3759,22 +3567,6 @@
     "sha256": "cb96109e25c85e202a14aa6034a09bb474e4a5237a2b46e732300c93e0f443cc",
     "variant": "debug"
   },
-  "cpython-3.13.0+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2647425970b209fc546b0ff94d25567db5575847a8a852a0d79445a3c3806c85",
-    "variant": "debug"
-  },
   "cpython-3.13.0+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -3789,22 +3581,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "af1c336f4827ad86f4bead527145bc99afc5c1100afa7f1a1fa5550bab06d2b1",
-    "variant": "debug"
-  },
-  "cpython-3.13.0+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8a14b35b54a1d13d2cd3ce4075fa0baa02a51dcaeb277648a9c1c11a7ac83e4e",
     "variant": "debug"
   },
   "cpython-3.13.0+debug-linux-x86_64_v3-gnu": {
@@ -3823,22 +3599,6 @@
     "sha256": "b871ef5348b958178f359d7015801ae6e1491d6a4e23e6ec2a1f52318eea8505",
     "variant": "debug"
   },
-  "cpython-3.13.0+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8217b0e8d95ae57de4cabdda0c4c2061ac11af43c43e253e1e56d08532b7ba6f",
-    "variant": "debug"
-  },
   "cpython-3.13.0+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -3853,22 +3613,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "1ecf6d840a350ced04b2260f73ba7b49242cf7a083d657476a3b2da7a4d4e1c3",
-    "variant": "debug"
-  },
-  "cpython-3.13.0+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a00d3d98e56c93afeed35f245345c352e15d6af86cfa2e046ae6eef38ac48fc9",
     "variant": "debug"
   },
   "cpython-3.13.0rc3-darwin-aarch64-none": {
@@ -3999,22 +3743,6 @@
     "sha256": "445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e",
     "variant": null
   },
-  "cpython-3.13.0rc3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f",
-    "variant": null
-  },
   "cpython-3.13.0rc3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -4029,22 +3757,6 @@
     "prerelease": "rc3",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "ae477db35ccec397a19c9d61271455adf4917ab35993dbcacae8d126890f6b12",
-    "variant": null
-  },
-  "cpython-3.13.0rc3-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8c73e28a683b7e826ed5bda4cf119ec8270238fdf936e3a2b3ca0938cfcde8c9",
     "variant": null
   },
   "cpython-3.13.0rc3-linux-x86_64_v3-gnu": {
@@ -4063,22 +3775,6 @@
     "sha256": "2a505cda4d7d62dec1829a06fa502eb514a3182c193b2f2aaf9c08bccb143dc0",
     "variant": null
   },
-  "cpython-3.13.0rc3-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "27a93fc7678782b392e5ee8e654635bc29409939318bbc341df3d29386f2166f",
-    "variant": null
-  },
   "cpython-3.13.0rc3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -4093,22 +3789,6 @@
     "prerelease": "rc3",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "8c1424f2501419b88560951497df095c82e856af9b8f817f96beedeb4d8bc32d",
-    "variant": null
-  },
-  "cpython-3.13.0rc3-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8c318b2a79d75ca7ce3b76f8799a1db0337ba1278601bf0ec4433d64313d1aca",
     "variant": null
   },
   "cpython-3.13.0rc3-windows-i686-none": {
@@ -4239,22 +3919,6 @@
     "sha256": "92a80f38919a852edcff68fd489152a408e43c65e67b800c02801cc58f239b95",
     "variant": "debug"
   },
-  "cpython-3.13.0rc3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "59b19a2ae830bd67bc8190bd839ebdf2423e871ef2e5114f38b84dab652c2e1b",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -4269,22 +3933,6 @@
     "prerelease": "rc3",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "20795d2bae8b26de5554907353fa4bc022e0912b772803298f4b5679dceec71e",
-    "variant": "debug"
-  },
-  "cpython-3.13.0rc3+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "903df7b90162528c218d5bf2eaa42bea9ff329332670afa98bbeaad1aba0cc40",
     "variant": "debug"
   },
   "cpython-3.13.0rc3+debug-linux-x86_64_v3-gnu": {
@@ -4303,22 +3951,6 @@
     "sha256": "08f365ec1aa442664a9e98988edb6260e40b4739359354694c6f1ee32b58bbb9",
     "variant": "debug"
   },
-  "cpython-3.13.0rc3+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "9323f7b156b8e5220ad7f9cee082d1714d78594f8b4a725b2178e316b10cd19d",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -4333,22 +3965,6 @@
     "prerelease": "rc3",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "716c1bf5f329ac969d0b34d33169dc115e4c8b65fc9ba64f1b1d2635e50f36a6",
-    "variant": "debug"
-  },
-  "cpython-3.13.0rc3+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "609f8b75ecca24f9c4fcd704cdf7f914dfe2cddbebd765a30f319799d50a8b60",
     "variant": "debug"
   },
   "cpython-3.13.0rc2-darwin-aarch64-none": {
@@ -4479,22 +4095,6 @@
     "sha256": "1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602",
     "variant": null
   },
-  "cpython-3.13.0rc2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161",
-    "variant": null
-  },
   "cpython-3.13.0rc2-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -4509,22 +4109,6 @@
     "prerelease": "rc2",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "e60fc176fad636bbd287e92f9e9954b8b10d164984e98f51e4dc3d47314fa8a5",
-    "variant": null
-  },
-  "cpython-3.13.0rc2-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "16f23e539336fb45895b3c4fac981365b53fbbd86115feb9516b50a0716394b1",
     "variant": null
   },
   "cpython-3.13.0rc2-linux-x86_64_v3-gnu": {
@@ -4543,22 +4127,6 @@
     "sha256": "bf34803e8c05cdb4eee5df5b051cdded1732975c991116a1af823a2b15e49be3",
     "variant": null
   },
-  "cpython-3.13.0rc2-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "df60f51c87da60af67453e5d7c5673f1534c2772d92a4885ae51add3cd32848e",
-    "variant": null
-  },
   "cpython-3.13.0rc2-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -4573,22 +4141,6 @@
     "prerelease": "rc2",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "fb8d87e21bd0cb83bfbb5325f2db170365726a9cac58dd5b552fbd084671b785",
-    "variant": null
-  },
-  "cpython-3.13.0rc2-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "eafb931d1a0e6f7237486d2967d0ccacd49791bef27f233895b5d18581ae939a",
     "variant": null
   },
   "cpython-3.13.0rc2-windows-i686-none": {
@@ -4719,22 +4271,6 @@
     "sha256": "8595be42ea7fa43ffe66761c713ad4b60e6270dca1771491d54e8d6556bb617b",
     "variant": "debug"
   },
-  "cpython-3.13.0rc2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "634e538c9d9e8cec2f27aa278a1e99d6e652d7b013b4f27a0242265e0d8ad0ff",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -4749,22 +4285,6 @@
     "prerelease": "rc2",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "dcfd016f90f4cd7a8c09cd62e4ed3e809301ddbfca1d17d97b3dca3d40c4e729",
-    "variant": "debug"
-  },
-  "cpython-3.13.0rc2+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7646e5e1f544c67d6c6d093c3c6f83a10753337d5304ff994068d20abc00ad04",
     "variant": "debug"
   },
   "cpython-3.13.0rc2+debug-linux-x86_64_v3-gnu": {
@@ -4783,22 +4303,6 @@
     "sha256": "18b9afc024e540b40b656df9d58af9cec9c054a6c883693d15e58e0e4935ed08",
     "variant": "debug"
   },
-  "cpython-3.13.0rc2+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7eac181a7ea5e3cf66bb7209fadbc27e82626a5d1e8307fd355867f881a107c6",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -4813,22 +4317,6 @@
     "prerelease": "rc2",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "bd021bd31769abec42a07cf77cc4937dc83a0713b5038269e62e268f0e9639d1",
-    "variant": "debug"
-  },
-  "cpython-3.13.0rc2+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ad9a4c4856a7f05ba59841adfc8f7340a1415989674bf48a0227953ad6f6c6d0",
     "variant": "debug"
   },
   "cpython-3.12.9-darwin-aarch64-none": {
@@ -5487,22 +4975,6 @@
     "sha256": "34a5a1619aba16544ec8d6f225be59b333d650f58983eeca25193722dc9016fd",
     "variant": null
   },
-  "cpython-3.12.8-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8121b6e4a2f719546f91be348e72bf6190727d891bbbd7acc7d06becd5a182fe",
-    "variant": null
-  },
   "cpython-3.12.8-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -5517,22 +4989,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "9000f65bb17fe1afbed1a07cc603fffd1474b362da80d9a4f926ca49d28e3a24",
-    "variant": null
-  },
-  "cpython-3.12.8-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "12c53712d9728e7f320e102c6cfb48ad03e0daede8bafd2ea05d97c0c43a9649",
     "variant": null
   },
   "cpython-3.12.8-linux-x86_64_v3-gnu": {
@@ -5551,22 +5007,6 @@
     "sha256": "509a3ef6181369681ad0c35b9fadd22570288bc2490eefb7cb671aba2ccfbdd6",
     "variant": null
   },
-  "cpython-3.12.8-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8e936b03797abdc60211b8b89431fb4fd55f660cc7c8eb263423b3f9382c058e",
-    "variant": null
-  },
   "cpython-3.12.8-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -5581,22 +5021,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "41b5902edeef93cb256b62389bda81741502f7e0aee4e2e94c2e60b9d2df37fb",
-    "variant": null
-  },
-  "cpython-3.12.8-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "5d51a685e0e7b3c7babc8f1a5c8db41b4282f318161618e2b4a0603c464a3bc5",
     "variant": null
   },
   "cpython-3.12.8-windows-i686-none": {
@@ -5743,22 +5167,6 @@
     "sha256": "adb09b9c1dde8c7d83a0b3032926ccb48f7d55b509454363d9d964366a575567",
     "variant": "debug"
   },
-  "cpython-3.12.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "87226dd664254d9e5f79887765a66b04acd04c3134885ace035d3816b2f00e9a",
-    "variant": "debug"
-  },
   "cpython-3.12.8+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -5773,22 +5181,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "94f35f4d01633c708479166fa172728ef42970a950739973765c4943e0bf4993",
-    "variant": "debug"
-  },
-  "cpython-3.12.8+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8329c4ad05f2ecf1a5f88936c5cdf3ee825bcf784df44d2f770c3fe4b002c2dd",
     "variant": "debug"
   },
   "cpython-3.12.8+debug-linux-x86_64_v3-gnu": {
@@ -5807,22 +5199,6 @@
     "sha256": "828cb8b1424aad0547e1f2ee437abadade96eb96c153781fa6fe46e47a107e63",
     "variant": "debug"
   },
-  "cpython-3.12.8+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7610002dc459f53e5adc515d8ec1a75567e055ae1bb006ff11e3ef0cd79551c7",
-    "variant": "debug"
-  },
   "cpython-3.12.8+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -5837,22 +5213,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "066b2e21d3d13d4b045470387c7909175156adaa56599faf0cb9389106d27a7a",
-    "variant": "debug"
-  },
-  "cpython-3.12.8+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1c3948a82ff9f204e2cfec44152bce41475039359dac4edad5cb485831eaf4db",
     "variant": "debug"
   },
   "cpython-3.12.7-darwin-aarch64-none": {
@@ -5983,22 +5343,6 @@
     "sha256": "3a4d53a7ba3916c0c1f35cbbe57068e2571b138389f29cf5c35367fec8f4c617",
     "variant": null
   },
-  "cpython-3.12.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "9314cb4d5aa525f2dc9f8d6ac204bebcfdfa8eb0dd4d3788af68769184355484",
-    "variant": null
-  },
   "cpython-3.12.7-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -6013,22 +5357,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "205395841e6e7cbd33d504b78ac81792364831911866416da7a34d9b4a06d7d1",
-    "variant": null
-  },
-  "cpython-3.12.7-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "bfdd008fb669ddd023a8c36c16987c98b0d2bdfb99c9d45e2c9a792d87710b72",
     "variant": null
   },
   "cpython-3.12.7-linux-x86_64_v3-gnu": {
@@ -6047,22 +5375,6 @@
     "sha256": "ad1d2bfccc7006612af93e1dbf6760ede5b07148141d0ca05a7d605ea666a55f",
     "variant": null
   },
-  "cpython-3.12.7-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "2c11efdb7df78ed787ac67c094c58a75f6549a78660888d99a861fc08e88ebe2",
-    "variant": null
-  },
   "cpython-3.12.7-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -6077,22 +5389,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "172c0ab8ac018a0b44a47f03a7a78cd583bdc1e60cd5cfbf7d05b269c5d73f5c",
-    "variant": null
-  },
-  "cpython-3.12.7-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "4576e092f2eaa6f5685be048b50671f9df0fff2b261ee001f604fb983bc9bb71",
     "variant": null
   },
   "cpython-3.12.7-windows-i686-none": {
@@ -6223,22 +5519,6 @@
     "sha256": "fcc678bdb212c2f33d67b9de1caed7a2ed6439d271de8a1e765dda4d3d7a638b",
     "variant": "debug"
   },
-  "cpython-3.12.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "5c73361c6bede4dbe8de2bf81fd3006451a7941f547e5474141c3fcb400d648e",
-    "variant": "debug"
-  },
   "cpython-3.12.7+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -6253,22 +5533,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "0f089b56633c90757bd7027ea2548f024dd187a08c1702d8bd76ff9c507723b4",
-    "variant": "debug"
-  },
-  "cpython-3.12.7+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d959ee1efc3c9f4ab99399f1250a60f7bbb636da4a844929075c0f6fe1d66020",
     "variant": "debug"
   },
   "cpython-3.12.7+debug-linux-x86_64_v3-gnu": {
@@ -6287,22 +5551,6 @@
     "sha256": "e48c45264c5b2d05188912057be6506afc2f2ab05bbb162941e459c4adba50f7",
     "variant": "debug"
   },
-  "cpython-3.12.7+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2a997737209b78941666c42a8a552c3706da3646deb2d6f465bbacf68f433b3a",
-    "variant": "debug"
-  },
   "cpython-3.12.7+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -6317,22 +5565,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "27b332c2768caef93a69bc955f04e6370fb4d37ebe7db37025f5fddfe3892fd5",
-    "variant": "debug"
-  },
-  "cpython-3.12.7+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2edcf4b44cdd3488c894798919a0ddb794d2b466536f855b34a30b068ba3adc9",
     "variant": "debug"
   },
   "cpython-3.12.6-darwin-aarch64-none": {
@@ -6463,22 +5695,6 @@
     "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108",
     "variant": null
   },
-  "cpython-3.12.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef",
-    "variant": null
-  },
   "cpython-3.12.6-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -6493,22 +5709,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "3ce9eb5d974dc2109c3e2c3986f4883ec5403b3479259ea781475a319f9a6787",
-    "variant": null
-  },
-  "cpython-3.12.6-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6dab95cdd6d3f165aaaa7dcd7cb263add390d97c7b57eb62d2d1ca9a304353da",
     "variant": null
   },
   "cpython-3.12.6-linux-x86_64_v3-gnu": {
@@ -6527,22 +5727,6 @@
     "sha256": "8dcc21cd45c09b273cca17c4b144c26c1a9e373eec871d540cc0762ab9c82c12",
     "variant": null
   },
-  "cpython-3.12.6-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "f2a295a6e400c16d6b3fe51c63c5b017e6c20a0a9e21a664170ecb6b9a104d8e",
-    "variant": null
-  },
   "cpython-3.12.6-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -6557,22 +5741,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "debba8985df38a492e8fc4b7b8d2261567f56eae716aa7630b836523625c6a96",
-    "variant": null
-  },
-  "cpython-3.12.6-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "03c0ac05d6027b603ea0f5f9f2c463bd58f942706ae78dca27922b25dca8f16a",
     "variant": null
   },
   "cpython-3.12.6-windows-i686-none": {
@@ -6703,22 +5871,6 @@
     "sha256": "110a8ba95943af6b30198c7f925bb655d4257704abe28b4cfddc374ff367312e",
     "variant": "debug"
   },
-  "cpython-3.12.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1d678f6f70dc0cf32c6f5edd18f81a560ff087c7d1bb4185a810ccd1f145b0c3",
-    "variant": "debug"
-  },
   "cpython-3.12.6+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -6733,22 +5885,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "115a15f1341223ff81a20a65470f41049a7af335a4029e9b83e84679798fb550",
-    "variant": "debug"
-  },
-  "cpython-3.12.6+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "fac68ab9823b6dab76720f806a5a8bcb2caa7bfd31c025c5b0ce70c57d505100",
     "variant": "debug"
   },
   "cpython-3.12.6+debug-linux-x86_64_v3-gnu": {
@@ -6767,22 +5903,6 @@
     "sha256": "64381ee9fb2349344e0e2e06af114130f9ccb8e585ff2c25501aa0264851bdb6",
     "variant": "debug"
   },
-  "cpython-3.12.6+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "352fa6de409617cd4a1196ced30cac11c21082605a1d2a5c2507f27c640484fc",
-    "variant": "debug"
-  },
   "cpython-3.12.6+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -6797,22 +5917,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "4fe2168c7e595f83bb2bf93a84762de84ef3441aaeb9eb8720daecdaab4982c5",
-    "variant": "debug"
-  },
-  "cpython-3.12.6+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "eb717703d2482dccb40c0f9f85a3349f8651c0e44e9a87e08638bc6875c682ba",
     "variant": "debug"
   },
   "cpython-3.12.5-darwin-aarch64-none": {
@@ -6943,22 +6047,6 @@
     "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d",
     "variant": null
   },
-  "cpython-3.12.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24",
-    "variant": null
-  },
   "cpython-3.12.5-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -6973,22 +6061,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "c0064dcd97e5a09b5ff9529fc65cf6fd7a8a20f71a7050f584ecaa0cc8c33f2d",
-    "variant": null
-  },
-  "cpython-3.12.5-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "35ffd76881bef5ce09a123175f4f3419eb250802e60a6bb78649585325b8409f",
     "variant": null
   },
   "cpython-3.12.5-linux-x86_64_v3-gnu": {
@@ -7007,22 +6079,6 @@
     "sha256": "6414f1c4b0efb5c1f2eb30926c70519d01f46b1f0d97d407fe53e360865a4a23",
     "variant": null
   },
-  "cpython-3.12.5-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "302a26f5d35e1c9e9d82765aa7dbf5ceb609c402431ec97d7fa0e85d8247c023",
-    "variant": null
-  },
   "cpython-3.12.5-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -7037,22 +6093,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "d7e82fcf72ec5faedfbabf1084ca55f850971a559ba54350de312663570f4782",
-    "variant": null
-  },
-  "cpython-3.12.5-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "46771e859224aa128150160d568d5d19a69e0f9a8f27d110ea26c031b588c734",
     "variant": null
   },
   "cpython-3.12.5-windows-i686-none": {
@@ -7183,22 +6223,6 @@
     "sha256": "580caa10b1c661409d35623d20b2b56f6c8f4c263122b0e8228a3cdaa482c8be",
     "variant": "debug"
   },
-  "cpython-3.12.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a2766d5627353e8ce8a8c43b0b5c3007a77f4f095bf773739f5bb936860546cd",
-    "variant": "debug"
-  },
   "cpython-3.12.5+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -7213,22 +6237,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "38d30a3118b51d3502af6c35582a321fad85f49a93437ddf6e72b4d3c5bcbd5b",
-    "variant": "debug"
-  },
-  "cpython-3.12.5+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e11f010a082c1ce7c55a62169d15f12fa28575bb1183d0d0044e56ac42cc36f7",
     "variant": "debug"
   },
   "cpython-3.12.5+debug-linux-x86_64_v3-gnu": {
@@ -7247,22 +6255,6 @@
     "sha256": "25fa6725aaad5cbbe51ad738bd35857bd886a34a278e9ac0f7f349ef1dadb82c",
     "variant": "debug"
   },
-  "cpython-3.12.5+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "46de80152fa10f409c976493248bf107300e27fddbe33e47a7295705119e2d67",
-    "variant": "debug"
-  },
   "cpython-3.12.5+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -7277,22 +6269,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "810b9fb4978625762fb0f433ad96177af916d8eb8e28cd47bdf5e08ce4d549d7",
-    "variant": "debug"
-  },
-  "cpython-3.12.5+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "dd593a482ecbe045f870489f40b5becf1c758eb4bd69f02a43a50d998198d6f7",
     "variant": "debug"
   },
   "cpython-3.12.4-darwin-aarch64-none": {
@@ -7423,22 +6399,6 @@
     "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420",
     "variant": null
   },
-  "cpython-3.12.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6",
-    "variant": null
-  },
   "cpython-3.12.4-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -7453,22 +6413,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "798e562eb68b8d825c25c747b9995046b700c5bafbe8f7e558f41a3d8a57ceb7",
-    "variant": null
-  },
-  "cpython-3.12.4-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "762dc23608111f49729f02c19fa8459219ac886e8694b79f541ef01141bf58c5",
     "variant": null
   },
   "cpython-3.12.4-linux-x86_64_v3-gnu": {
@@ -7487,22 +6431,6 @@
     "sha256": "681d65c59f48c4b1bfe29f08ca87a50620c9aef308e27ea11fbe2ef8ce1a3764",
     "variant": null
   },
-  "cpython-3.12.4-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "304bdcdf495529a6edcac34646e4f065f0963e4c3061cef9093b76bb0e8cca90",
-    "variant": null
-  },
   "cpython-3.12.4-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -7517,22 +6445,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "507fce8676d23af12f97b1f66efa876360d19fbe89675163a0c7c5d631763c84",
-    "variant": null
-  },
-  "cpython-3.12.4-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8989f75d70f6c874f3031ba1841efd96089f589f04d445fbacd478a1f866c118",
     "variant": null
   },
   "cpython-3.12.4-windows-i686-none": {
@@ -7663,22 +6575,6 @@
     "sha256": "54324b36cf7b68af3ddbabd1ec482691a23bf059a7f46a8cb3f3615f5fd5d86d",
     "variant": "debug"
   },
-  "cpython-3.12.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "797b3d36a9df38925b7a7c5facb47e56a0d1c4031ae7b121ce41c07433fa1d2e",
-    "variant": "debug"
-  },
   "cpython-3.12.4+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -7693,22 +6589,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5449d31ad213cb19eb4e724f7cf4b8d16e5b7028593aacad0bfda722189ef4a7",
-    "variant": "debug"
-  },
-  "cpython-3.12.4+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1fffb6494f6540d915b05141ee452e76d6f59b92483bc85161f5dadd1f73b9c5",
     "variant": "debug"
   },
   "cpython-3.12.4+debug-linux-x86_64_v3-gnu": {
@@ -7727,22 +6607,6 @@
     "sha256": "f772f9ef369a690a2ca5b2ff7749acbf4e311341bcfd36a651dcf62cf547ccb7",
     "variant": "debug"
   },
-  "cpython-3.12.4+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d0d6d53510ff916b21740c0526ea3b682ba56ea3e6f859f661228a0b9963d10e",
-    "variant": "debug"
-  },
   "cpython-3.12.4+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -7757,22 +6621,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5ad401dba2d3957d3e5d4acf3d4316bec88ad44bec9d72936d04dc27ae3ec177",
-    "variant": "debug"
-  },
-  "cpython-3.12.4+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "308e7f2e48c32c32090880a8eefc7eb3ea68107ec6ebf904303f4c87c503e26d",
     "variant": "debug"
   },
   "cpython-3.12.3-darwin-aarch64-none": {
@@ -7903,22 +6751,6 @@
     "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6",
     "variant": null
   },
-  "cpython-3.12.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a",
-    "variant": null
-  },
   "cpython-3.12.3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -7933,22 +6765,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b9b91f486e2a52b6cc392101245705d6ab5dd6ad4a4e2b3492baec8e4b96508b",
-    "variant": null
-  },
-  "cpython-3.12.3-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e47a8d25c2348bf9b0e818642e4dae90700fc3fbd96ffd7f4ad9518a7206d369",
     "variant": null
   },
   "cpython-3.12.3-linux-x86_64_v3-gnu": {
@@ -7967,22 +6783,6 @@
     "sha256": "edb786bf15a92a7c40fc5ace2376736d73ff356458b7c24da0cd408f36b945bf",
     "variant": null
   },
-  "cpython-3.12.3-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9685fc300be464a9338e94e48fc7315ee0563999833f8c830f2a2dee2d750b7e",
-    "variant": null
-  },
   "cpython-3.12.3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -7997,22 +6797,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "790e70e565b3efc5f1d14294f7cc083d1fb2aa4c15074d547e8e6bb9d2adb70a",
-    "variant": null
-  },
-  "cpython-3.12.3-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c4d399923625ff5b5c20eceba0d8580c858768eff73dd9380aa8265030788850",
     "variant": null
   },
   "cpython-3.12.3-windows-i686-none": {
@@ -8143,22 +6927,6 @@
     "sha256": "ded92cd034b33df953c490d3343ef187ac065d1fcd78e8cee894be197c5f977e",
     "variant": "debug"
   },
-  "cpython-3.12.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "81d9fc9ffd6860229e09b11be5d800db5966080ba6f4b7524ae7917423fd09c6",
-    "variant": "debug"
-  },
   "cpython-3.12.3+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -8173,22 +6941,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "4e7c111a3ee36e3adf99b94de0b1ab945a856b33d67ea36e66c985ea93acbda9",
-    "variant": "debug"
-  },
-  "cpython-3.12.3+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3a1da112630be57fe088cd07568b1ce0743b133fc6aa8fe95b3c6f6cfe526e11",
     "variant": "debug"
   },
   "cpython-3.12.3+debug-linux-x86_64_v3-gnu": {
@@ -8207,22 +6959,6 @@
     "sha256": "c75d239ebfcb8b5676184541ecf3a16577b2343e88f529715928a5c6f48601b0",
     "variant": "debug"
   },
-  "cpython-3.12.3+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b3a643688ceb7b38d79c0b39f174d4790e4adb34bc13f731d95675b94fb0ad95",
-    "variant": "debug"
-  },
   "cpython-3.12.3+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -8237,22 +6973,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ddd7363bd343f1f9d38455fe357d6691d805e8f8fb6aa1e287e0f6f9256d1deb",
-    "variant": "debug"
-  },
-  "cpython-3.12.3+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b6027ddd92733e13ccdc6205daa35a9d8707fb566b0740d87f3e86c9c2a8720f",
     "variant": "debug"
   },
   "cpython-3.12.2-darwin-aarch64-none": {
@@ -8351,22 +7071,6 @@
     "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab",
     "variant": null
   },
-  "cpython-3.12.2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81",
-    "variant": null
-  },
   "cpython-3.12.2-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -8381,22 +7085,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "adfe5c1a6039b8806b3dee0aed5fe860540d55231be87df48891a7844279d76a",
-    "variant": null
-  },
-  "cpython-3.12.2-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e5c0adb646defd55791bbdd217f64d08a51855e818ee67e3ea6207521f92abee",
     "variant": null
   },
   "cpython-3.12.2-linux-x86_64_v3-gnu": {
@@ -8415,22 +7103,6 @@
     "sha256": "0ab408e31ecc30893020b617dd049af05b76cbe8bb8585b289f75557a24bcfd4",
     "variant": null
   },
-  "cpython-3.12.2-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "bcf21a4105fe82cbefbd8bdf76dfc7eb98297b51ad02f0fc0a92929bcc95d6e9",
-    "variant": null
-  },
   "cpython-3.12.2-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -8445,22 +7117,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "32ec4268b4d16a428deb642ddd875ae6e738b85558bfbdc4628018ff2e5b9e95",
-    "variant": null
-  },
-  "cpython-3.12.2-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3b0e8c27c3a1dd339d8e6b53b3fc7faee379a70755093917d6ddca00253621c9",
     "variant": null
   },
   "cpython-3.12.2-windows-i686-none": {
@@ -8559,22 +7215,6 @@
     "sha256": "15b61ed9d33b35ad014a13a68a55d8ea5ba7fb70945644747f4e53c659f2fed6",
     "variant": "debug"
   },
-  "cpython-3.12.2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2f5f088639e17981b0aeeeeab0fbb6858002d5f10bf57e26eaf32f99b4b6c765",
-    "variant": "debug"
-  },
   "cpython-3.12.2+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -8589,22 +7229,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e8632e829f3e43fd0a9aa16ec8ca14418d78ba4e042673a01dcd20e6c53ad7cc",
-    "variant": "debug"
-  },
-  "cpython-3.12.2+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "763aa4af52e78e571264d7c809bacc2079ace19192ad6485c7adddb7062e7d99",
     "variant": "debug"
   },
   "cpython-3.12.2+debug-linux-x86_64_v3-gnu": {
@@ -8623,22 +7247,6 @@
     "sha256": "9d851a88fb2e83b8e8d9e70102a71e6f8cf53c278e81a45e163b17311d4265b4",
     "variant": "debug"
   },
-  "cpython-3.12.2+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "90845652a0318d00ad056a83fa519528cdca880110e31f716275fbb3e43ffd07",
-    "variant": "debug"
-  },
   "cpython-3.12.2+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -8653,22 +7261,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e1b902755013c9c240192a92cafce68d682a54af8953bdb23f5fe88a8c985813",
-    "variant": "debug"
-  },
-  "cpython-3.12.2+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d640cd4f5a9cc77e6e7d084832f28fea747b9ac07ec4e18cfd05841943ff7196",
     "variant": "debug"
   },
   "cpython-3.12.1-darwin-aarch64-none": {
@@ -8767,22 +7359,6 @@
     "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
     "variant": null
   },
-  "cpython-3.12.1-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe",
-    "variant": null
-  },
   "cpython-3.12.1-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -8797,22 +7373,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9dd6fc5a1326985896493d475e7eae0d07f6de0d932faef3c4b04bdd81b88c0c",
-    "variant": null
-  },
-  "cpython-3.12.1-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "db45fc29b4c0389b23af6ccd2d1427c3200ed7db4a81e5fd3bfbd9a4fd011c41",
     "variant": null
   },
   "cpython-3.12.1-linux-x86_64_v3-gnu": {
@@ -8831,22 +7391,6 @@
     "sha256": "a7bcc6c9f66dbd47ea99615f30f101c5d2dd0084ca333d2f7336e64050951338",
     "variant": null
   },
-  "cpython-3.12.1-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "2585d13ac6b3e18a24d31f4baea23a810f4c7eb37306c348eeee4dfb87f84866",
-    "variant": null
-  },
   "cpython-3.12.1-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -8861,22 +7405,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "510f3f3e1841bb0e236dfac8dbd6680a4990d60a060b6972978cbc89524d4736",
-    "variant": null
-  },
-  "cpython-3.12.1-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "6f34607bafc6104d294ae16be240856af6217555015665c34ff7e94ad33dfe29",
     "variant": null
   },
   "cpython-3.12.1-windows-i686-none": {
@@ -8975,22 +7503,6 @@
     "sha256": "89ef67b617b8c9804965509b2d256f53439ceede83b5b64085315f038ad81e60",
     "variant": "debug"
   },
-  "cpython-3.12.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0823ed21f7b79129677c51c6a73d3ca53a37179931a5a40a1d53b565d54679ec",
-    "variant": "debug"
-  },
   "cpython-3.12.1+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -9005,22 +7517,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "21a5182c499954bde10344c7cc3ba9f69a39f0b485a9420871bdf65f26587bb7",
-    "variant": "debug"
-  },
-  "cpython-3.12.1+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d3d402944634b22e2d023ff6356a6e341fecbce67578e1d1ff39f5b76a22aad7",
     "variant": "debug"
   },
   "cpython-3.12.1+debug-linux-x86_64_v3-gnu": {
@@ -9039,22 +7535,6 @@
     "sha256": "d2088f53a3e160973ec34376c5a8bc4f430626ea154a57a8ae868f37b43320f3",
     "variant": "debug"
   },
-  "cpython-3.12.1+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "48666cee8413854837c57f769a61e4a99f022cbecb041607fbd2d7802cb446f1",
-    "variant": "debug"
-  },
   "cpython-3.12.1+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -9069,22 +7549,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b5c640ffdde33f3d333ed772878694c3be79caf5707de3da23aa8f77cfad4164",
-    "variant": "debug"
-  },
-  "cpython-3.12.1+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1fb2c5534aa6189ab817ffd4eec7208f5e106d0a09ed2e6ede7e2bead6248941",
     "variant": "debug"
   },
   "cpython-3.12.0-darwin-aarch64-none": {
@@ -9183,22 +7647,6 @@
     "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9",
     "variant": null
   },
-  "cpython-3.12.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5",
-    "variant": null
-  },
   "cpython-3.12.0-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -9213,22 +7661,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "6d7710c9a74f624d1fe60a5a01ed6db874659d906220b1d98a0a79a36bbcb2e6",
-    "variant": null
-  },
-  "cpython-3.12.0-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "927de631f2f37b950c2ea8ca53dc36ce8389026f34c31add31c5f730e7227bae",
     "variant": null
   },
   "cpython-3.12.0-linux-x86_64_v3-gnu": {
@@ -9247,22 +7679,6 @@
     "sha256": "dccac6b50581aba8f4ddceb4276589bcc602a672f2461e170076890f0c114444",
     "variant": null
   },
-  "cpython-3.12.0-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "28aa3b88cacb908ab57c4202010eebe4a18fad65b5c289d061aec841a0fbbdfb",
-    "variant": null
-  },
   "cpython-3.12.0-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -9277,22 +7693,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "13f4c20d3277d0bff7b14125d4904bbf5c498fe14d550d31fd584b5beabe6e0f",
-    "variant": null
-  },
-  "cpython-3.12.0-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "8c20230e3679d5b2d765c6cae2afead81207762c3a9c725249e7ba644f61d4f5",
     "variant": null
   },
   "cpython-3.12.0-windows-i686-none": {
@@ -9391,22 +7791,6 @@
     "sha256": "a8c38cd2e53136c579632e2938d1b857f22e496c7dba99ad9a7ad6a67b43274a",
     "variant": "debug"
   },
-  "cpython-3.12.0+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0b4380904d53f3322d3e5276de47bfa91a19289b7c734494c127ed0793017dde",
-    "variant": "debug"
-  },
   "cpython-3.12.0+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -9421,22 +7805,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "572f8559f0e8a086c4380ea4417d44f6f3751afd18d01e14e04099ec33e1b199",
-    "variant": "debug"
-  },
-  "cpython-3.12.0+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e07e32143dd406a2e70ab573b9bc301ea765bfcb3d5092eb06a01a39d67a636f",
     "variant": "debug"
   },
   "cpython-3.12.0+debug-linux-x86_64_v3-gnu": {
@@ -9455,22 +7823,6 @@
     "sha256": "1ae35f54bad2b473298858a3cb7bf811291fdd40c8159eff4ff593168ed8765e",
     "variant": "debug"
   },
-  "cpython-3.12.0+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7b86586733acb68e815ac027e8938689d4c6afb468b863361bbe5a9ec70a40e9",
-    "variant": "debug"
-  },
   "cpython-3.12.0+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -9485,22 +7837,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "3c900c3495453cfa7e7626026ef0d8be3adf589b2b810969f6a9f44dba3c129d",
-    "variant": "debug"
-  },
-  "cpython-3.12.0+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "615653eebf06ee913af9254f16836dfcc191a7e54ed0c05f9458d99eb5f4a507",
     "variant": "debug"
   },
   "cpython-3.11.11-darwin-aarch64-none": {
@@ -10143,22 +8479,6 @@
     "sha256": "03f15e19e2452641b6375b59ba094ff6cf2fc118315d24a6ca63ce60e4d4a6e0",
     "variant": null
   },
-  "cpython-3.11.10-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "5b33f0ff29552f15daacf81c426ed585fae24987b47d614142a7906eae6f2b04",
-    "variant": null
-  },
   "cpython-3.11.10-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -10173,22 +8493,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "64aefc042352e6bd10c4f600f1962af7dfec4586385f723c218b6369d3f211a2",
-    "variant": null
-  },
-  "cpython-3.11.10-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "3714fec489d93c1ea458788a348d3380f98de22679a40a063e761753e7a48e71",
     "variant": null
   },
   "cpython-3.11.10-linux-x86_64_v3-gnu": {
@@ -10207,22 +8511,6 @@
     "sha256": "ce94270c008e9780a3be5231223a0342e676bae04cb30b7554b0496a8fa7b799",
     "variant": null
   },
-  "cpython-3.11.10-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "a2778c2e5c8c48b555f935b4a7ff64f77f6ba0d1bdfb81b12d32905ddf7179cb",
-    "variant": null
-  },
   "cpython-3.11.10-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -10237,22 +8525,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "56ed6aeed4795235b4f4349c4c0bf4ee81fdd00ad854eaedcccd5c43388d7545",
-    "variant": null
-  },
-  "cpython-3.11.10-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "c8e8f7a3fa9d797ec0957562f82eaba4dcadf04ef304ac616bdb6332c725a609",
     "variant": null
   },
   "cpython-3.11.10-windows-i686-none": {
@@ -10383,22 +8655,6 @@
     "sha256": "a51ec678e86286da1ac4a0d7ef85eef2e889018631f0463e6b871b1a3591ad65",
     "variant": "debug"
   },
-  "cpython-3.11.10+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b18e2b848bbbf75ecda2329dd2aef00bf603dc510c8775cc36bb9cec0318f6e2",
-    "variant": "debug"
-  },
   "cpython-3.11.10+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -10413,22 +8669,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9239d2bdd139c9c461df44de59e111e2ea00c54a34775d0a9df7e7f267dba475",
-    "variant": "debug"
-  },
-  "cpython-3.11.10+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "03fa1596eb6800ff596219e93cb62c78f5a8cf1ee47a283d57beae50cc37d20c",
     "variant": "debug"
   },
   "cpython-3.11.10+debug-linux-x86_64_v3-gnu": {
@@ -10447,22 +8687,6 @@
     "sha256": "b9e6f63d6f3978d671f8214febc79e979e296e01ca1be51552c4c8138666c875",
     "variant": "debug"
   },
-  "cpython-3.11.10+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "991dff07922998dca71282287d9df2e6ef2834006d00120a50637b0d84e6c09a",
-    "variant": "debug"
-  },
   "cpython-3.11.10+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -10477,22 +8701,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "fc92219ad188e57d67116c15c0b1f2d24bbedabbad0c1db3323635da909e33e9",
-    "variant": "debug"
-  },
-  "cpython-3.11.10+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "9ba091c7f4c0d6d871a55c9dcdc7aba847f3a5019a136adde07e561f9d3361d0",
     "variant": "debug"
   },
   "cpython-3.11.9-darwin-aarch64-none": {
@@ -10623,22 +8831,6 @@
     "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9",
     "variant": null
   },
-  "cpython-3.11.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9",
-    "variant": null
-  },
   "cpython-3.11.9-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -10653,22 +8845,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "6f579d9b2ec635b7cc4eb983719ae8b4ee34248f2054939cc3b1b23b44c65c60",
-    "variant": null
-  },
-  "cpython-3.11.9-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "d776c6bfd09719f0a18fe23e25b314fed8e32c0c0474c21524020d5481bdcda1",
     "variant": null
   },
   "cpython-3.11.9-linux-x86_64_v3-gnu": {
@@ -10687,22 +8863,6 @@
     "sha256": "d6eeb714389614fa954f49e5ec4323f18eccbc700c516521c1297860364226cf",
     "variant": null
   },
-  "cpython-3.11.9-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "e8ed1a00acd996590056c8e00351038fd1ecf9910428f592989410f06a765eef",
-    "variant": null
-  },
   "cpython-3.11.9-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -10717,22 +8877,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "92247f338ba132e9ff6e4b0dffc2eacfab6958552b0354e623f5016c5e83bafd",
-    "variant": null
-  },
-  "cpython-3.11.9-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "adb10e3c2eb598560c14a375b34776d80bc83656e571f8ddc2b882630db8cd4d",
     "variant": null
   },
   "cpython-3.11.9-windows-i686-none": {
@@ -10863,22 +9007,6 @@
     "sha256": "1fbae62bc303512d4024bb69cab26766a5a8d12386aa79ed03b5fd8f4c08c77b",
     "variant": "debug"
   },
-  "cpython-3.11.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "dc4fd5dd161a0c09375457f29b2c03b1aa026702abbdaedb9db01d2ccc17650b",
-    "variant": "debug"
-  },
   "cpython-3.11.9+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -10893,22 +9021,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a09cd9e3516b3b1a1e654b768f1037b7878d27836a81e484151bb0bb61ca7cc5",
-    "variant": "debug"
-  },
-  "cpython-3.11.9+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8fdd84f3b942020aee8398cebb0e974d4852e24a855c9e566595990c51fb1709",
     "variant": "debug"
   },
   "cpython-3.11.9+debug-linux-x86_64_v3-gnu": {
@@ -10927,22 +9039,6 @@
     "sha256": "e976a7d03df90aef07c2aaafca8577bb46b9f948d580204bc3d1924b4b112ad1",
     "variant": "debug"
   },
-  "cpython-3.11.9+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "fa76d5250edd90b5075b1b69a028b6f8c0862d6c15413027dc542e97d1e417d5",
-    "variant": "debug"
-  },
   "cpython-3.11.9+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -10957,22 +9053,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9d3911236077721c80cd70ac6c3e12bfb1f37403522d82ac797581da2b79edfd",
-    "variant": "debug"
-  },
-  "cpython-3.11.9+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c55012d0d5f77ad47f77849c5324a3c1852166ada0ea41e872ccb4ab54a8c16e",
     "variant": "debug"
   },
   "cpython-3.11.8-darwin-aarch64-none": {
@@ -11071,22 +9151,6 @@
     "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987",
     "variant": null
   },
-  "cpython-3.11.8-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7",
-    "variant": null
-  },
   "cpython-3.11.8-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -11101,22 +9165,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e4f70dcb40acc2342d63103808a19f728a1c1dc9e0fad5344061daaab03a4ce5",
-    "variant": null
-  },
-  "cpython-3.11.8-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "a3f12605552d5450cfc8fe6c8fc468f99a42b2ae33f1ef42d5f49356d66ad305",
     "variant": null
   },
   "cpython-3.11.8-linux-x86_64_v3-gnu": {
@@ -11135,22 +9183,6 @@
     "sha256": "52b3e24b08e53e5098561a13a61e28d241231331fd903dcb2a1e4161f3753dc1",
     "variant": null
   },
-  "cpython-3.11.8-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "417890e151d07f9242d0b7ed2e16b7fee59b6606cd133105bba234f14823f8ce",
-    "variant": null
-  },
   "cpython-3.11.8-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -11165,22 +9197,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e363cc041a4464bd729771d6d223f3ec13c1e76dacdedc207ad1f6fb777bcb71",
-    "variant": null
-  },
-  "cpython-3.11.8-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9d430c32970e6b0f7cf030ed69dc63ee7b198543ef1e818c5a074c34052fa9e4",
     "variant": null
   },
   "cpython-3.11.8-windows-i686-none": {
@@ -11279,22 +9295,6 @@
     "sha256": "d959c43184878d564b5368ce4d753cf059600aafdf3e50280e850f94b5a4ba61",
     "variant": "debug"
   },
-  "cpython-3.11.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "868adbcbef61c119d10f4da18ecab180423443aa64be0d6c79790df2ed1d12b7",
-    "variant": "debug"
-  },
   "cpython-3.11.8+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -11309,22 +9309,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "1bed92aabc3175da3981a2fe5360d8aec3c78f55c557a1f68a5e17b1fce3b303",
-    "variant": "debug"
-  },
-  "cpython-3.11.8+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3f25e51e767c2ad7b1e76ccd80c1eb19018164eda41f0b969fa2ba63f9db3a80",
     "variant": "debug"
   },
   "cpython-3.11.8+debug-linux-x86_64_v3-gnu": {
@@ -11343,22 +9327,6 @@
     "sha256": "349ee9bf364bee09a3886568a065544e4ecca2a7ea5bf5fe6afe9ebfc2f227b2",
     "variant": "debug"
   },
-  "cpython-3.11.8+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0d8504cee4aa9f387396ef5754723b700334b84ada856b58bed96f8709938a60",
-    "variant": "debug"
-  },
   "cpython-3.11.8+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -11373,22 +9341,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7f9a600733fd202170661249644a1417636f9ec194b0f45273f76774375066d3",
-    "variant": "debug"
-  },
-  "cpython-3.11.8+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a6f3744ee9cb8bad629c86ab6185e14af35a86fa5bef695dbedd59d73f6c86e3",
     "variant": "debug"
   },
   "cpython-3.11.7-darwin-aarch64-none": {
@@ -11487,22 +9439,6 @@
     "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
     "variant": null
   },
-  "cpython-3.11.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74",
-    "variant": null
-  },
   "cpython-3.11.7-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -11517,22 +9453,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2cdd399100e647aa9d381e197e6a8c98e822ecb8fc1b6bda4b1eb554dbfb8177",
-    "variant": null
-  },
-  "cpython-3.11.7-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e9387d628e6f49587206655e61295cdbfea43944c4259c24566fa19e0596ba4e",
     "variant": null
   },
   "cpython-3.11.7-linux-x86_64_v3-gnu": {
@@ -11551,22 +9471,6 @@
     "sha256": "08dd57796b8fcc2a7307ed4dbe7a69cf35856cb29a5c79f827fe08a0663c227f",
     "variant": null
   },
-  "cpython-3.11.7-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "eec99f0614e8250027e8f72b535776b44e0ad74e24cba9716942cd4c6e08844c",
-    "variant": null
-  },
   "cpython-3.11.7-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -11581,22 +9485,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "28590cf568f192dbc5c91814321bca8bfe749cdf5e60a2aad968a0ae74d6bb4a",
-    "variant": null
-  },
-  "cpython-3.11.7-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3e3b2d4831c6353ae68808a517d59425addd857dbf925958db11b3280f46ed1e",
     "variant": null
   },
   "cpython-3.11.7-windows-i686-none": {
@@ -11695,22 +9583,6 @@
     "sha256": "01bca7a2f457d4bd2b367640d9337d12b31db73d670a16500b7a751194942103",
     "variant": "debug"
   },
-  "cpython-3.11.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "766fd4a583fdfbe65e99b1e3caea843d0eeefde5675d73f3214a53c17a832320",
-    "variant": "debug"
-  },
   "cpython-3.11.7+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -11725,22 +9597,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "24dba70107ca3999c0a2742b3bf898f740a063736f3cd208e80e056adf19cd7f",
-    "variant": "debug"
-  },
-  "cpython-3.11.7+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8490ae566f8f573031a7bfe1af403c98f42afd47bcddac09fed66573ebc11b9d",
     "variant": "debug"
   },
   "cpython-3.11.7+debug-linux-x86_64_v3-gnu": {
@@ -11759,22 +9615,6 @@
     "sha256": "6f5246b7cb8cc36a98025c70f829d2e5d197a7d20d51f21ca44b1e4242b13f0d",
     "variant": "debug"
   },
-  "cpython-3.11.7+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a5f3e309270e82c40441b4b3238cf4878e20ad5d2079887138989ccc6f8f5378",
-    "variant": "debug"
-  },
   "cpython-3.11.7+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -11789,22 +9629,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "74e5053f3f40d4ea018d79139d8a739c0ab0d457b8a9f1597a160bd88fbd58ab",
-    "variant": "debug"
-  },
-  "cpython-3.11.7+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "f14b33548f64b74f17e0d870c5adc5bc8d3e3135e18f729ea94bd0c1fe70778a",
     "variant": "debug"
   },
   "cpython-3.11.6-darwin-aarch64-none": {
@@ -11903,22 +9727,6 @@
     "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
     "variant": null
   },
-  "cpython-3.11.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46",
-    "variant": null
-  },
   "cpython-3.11.6-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -11933,22 +9741,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d93961f7d6df53f5e888ce070b92d19a7fce588bb03abfac2b6f3c5bf2923c80",
-    "variant": null
-  },
-  "cpython-3.11.6-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3bb96293951e613fc3f36e7132dcfc34190e5ed634448b12dd1e496723bedbd0",
     "variant": null
   },
   "cpython-3.11.6-linux-x86_64_v3-gnu": {
@@ -11967,22 +9759,6 @@
     "sha256": "9a2f2bb9fca7f31502e102306fbeed8ceb7f634f4376a08f9f630c1982f62fcb",
     "variant": null
   },
-  "cpython-3.11.6-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "99afdac2a24966c828faf6f13c8c100c6c432d1c888450cfadb39dbc7a7562f1",
-    "variant": null
-  },
   "cpython-3.11.6-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -11997,22 +9773,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ea850efb2de01c9389580ea0a6f55c7271dd3028b31fe0cca3ff9716fb580879",
-    "variant": null
-  },
-  "cpython-3.11.6-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ebd862470d4f66da160f9a65fc058d4feff3822a97318ccc5c3765a99e0ba439",
     "variant": null
   },
   "cpython-3.11.6-windows-i686-none": {
@@ -12111,22 +9871,6 @@
     "sha256": "6e7889a15d861f1860ed84f3f5ea4586d198aa003b22556d91e180a44184dcd7",
     "variant": "debug"
   },
-  "cpython-3.11.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c2178b505ac315ede0a2659511841acd022bc7290ef65648e052bb1acebff59f",
-    "variant": "debug"
-  },
   "cpython-3.11.6+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -12141,22 +9885,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "2ef8df0de9c400b5d57971fe5bcff36b4dca2410504a9edbd407572ea61044e0",
-    "variant": "debug"
-  },
-  "cpython-3.11.6+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "baf76c20f6f9dd1384ac7c8985d55922400f220a268ee9a2644a16526235add4",
     "variant": "debug"
   },
   "cpython-3.11.6+debug-linux-x86_64_v3-gnu": {
@@ -12175,22 +9903,6 @@
     "sha256": "d96c26d88966873184fc0ee99ca7b941d274b669b1b11e185749fc065d12908f",
     "variant": "debug"
   },
-  "cpython-3.11.6+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "66266853ca23b6dea6f977d69652052d26d61727934a33cc2c31b90c2549cac3",
-    "variant": "debug"
-  },
   "cpython-3.11.6+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -12205,22 +9917,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "865506f3eb1ff9a25f458c1b46d4fe6ceffac869ca01c203c258e3563c87630e",
-    "variant": "debug"
-  },
-  "cpython-3.11.6+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0ff0cd42a6f73b659f9306751cb3057451db6c323211c24dabbf4a1475bc3038",
     "variant": "debug"
   },
   "cpython-3.11.5-darwin-aarch64-none": {
@@ -12335,22 +10031,6 @@
     "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
     "variant": null
   },
-  "cpython-3.11.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121",
-    "variant": null
-  },
   "cpython-3.11.5-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -12365,22 +10045,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "6f25769f73827cfc9f80114dbbc04fa959e96f82bf1b1297bc56ae08afaa6a90",
-    "variant": null
-  },
-  "cpython-3.11.5-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "f442249bea0a61dfec2911d86aa49f4c047eabfa2322914d040f2377c1228b48",
     "variant": null
   },
   "cpython-3.11.5-linux-x86_64_v3-gnu": {
@@ -12399,22 +10063,6 @@
     "sha256": "5b975dd6a4648d16f278e9d82027f29feb01eda6009b239d7a7c69f421ebd519",
     "variant": null
   },
-  "cpython-3.11.5-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "41e2068884c86fc6a51670b12de140e12d6eb849bb450a970c77798f568aef72",
-    "variant": null
-  },
   "cpython-3.11.5-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -12429,22 +10077,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9759ce08bb96716f26aedd4e4d5879f810d9ca1e6f185d9881910837ae66cd29",
-    "variant": null
-  },
-  "cpython-3.11.5-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "568e7a24d390fcd91b7524869c76c4e03dac9940692b381c29ae005651c5f1d7",
     "variant": null
   },
   "cpython-3.11.5-windows-i686-none": {
@@ -12559,22 +10191,6 @@
     "sha256": "93ee095b53de5a74af18e612f55095fcf3118c3c0a87eb6344d8eaca396bfb2d",
     "variant": "debug"
   },
-  "cpython-3.11.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "96c77d4b1cbb47ac5eca384d21d689995c46e6a86d487acb73c9210eed3c5614",
-    "variant": "debug"
-  },
   "cpython-3.11.5+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -12589,22 +10205,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "d7f5abc89c66a8a1d086394c80a94a17b5b26887983dbf5a80998302f3626ab2",
-    "variant": "debug"
-  },
-  "cpython-3.11.5+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0471941b959dc707dfaadaeb730792302ddc203198d18b8a9ec64b8f0e73bb65",
     "variant": "debug"
   },
   "cpython-3.11.5+debug-linux-x86_64_v3-gnu": {
@@ -12623,22 +10223,6 @@
     "sha256": "292c37355054d6f4f864b4e772d8bd23541b744d73b3293523f461dcfcad2750",
     "variant": "debug"
   },
-  "cpython-3.11.5+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "df71fed6b655a9ae7927c988b540f5e2cb3a97f5e163552c4aeaa8669ef9c478",
-    "variant": "debug"
-  },
   "cpython-3.11.5+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -12653,22 +10237,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "dfa7e0d8fbcde146c5a952f8fa8a1a1121d4b64e7e9e0153d81a06d149a101d3",
-    "variant": "debug"
-  },
-  "cpython-3.11.5+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "17bc9d5ac04d448ecdba79125aa07a98f9eb27fb5682942b06c9eae08e8e4bc0",
     "variant": "debug"
   },
   "cpython-3.11.4-darwin-aarch64-none": {
@@ -12783,22 +10351,6 @@
     "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05",
     "variant": null
   },
-  "cpython-3.11.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806",
-    "variant": null
-  },
   "cpython-3.11.4-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -12813,22 +10365,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "dd1530d8a2e002f68e3d7ed1aa568a0e9278a5c87ba1f2ec4b9bae75777a6bc2",
-    "variant": null
-  },
-  "cpython-3.11.4-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9bea574e0f01eda7154ab1972a3d413c462a731568b5923ed2ae30174167a408",
     "variant": null
   },
   "cpython-3.11.4-linux-x86_64_v3-gnu": {
@@ -12847,22 +10383,6 @@
     "sha256": "f6882a821a02c8f727fce12044f8ed03c0814c68c483e9c074b7d62e8aaf3adf",
     "variant": null
   },
-  "cpython-3.11.4-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "d8a4a5d572e163eca53f83c91fca78955a92ec5cd2c9713e0e51ad7901add798",
-    "variant": null
-  },
   "cpython-3.11.4-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -12877,22 +10397,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3802bf8c6f305b7b841dbbf1b091d9820d9bd65e9f5b246d2d071c42baa80fec",
-    "variant": null
-  },
-  "cpython-3.11.4-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c50912dce8107bd06c93cd73f96c4bfec0714fc63ba9246c8726b253443e21a7",
     "variant": null
   },
   "cpython-3.11.4-windows-i686-none": {
@@ -13007,22 +10511,6 @@
     "sha256": "1b5fdeb2dc56c30843e7350f1684178755fae91666a0a987e5eb39074c42a052",
     "variant": "debug"
   },
-  "cpython-3.11.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d5467468ddee2b779096c5c4c0dcc74065d35fb38fea6c1c6630e7c2c904b1b9",
-    "variant": "debug"
-  },
   "cpython-3.11.4+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -13037,22 +10525,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "95ac78a3d834ce1feaa45bfe4997563df0bc65c3d2711a5d6d4f39d3c240ffd4",
-    "variant": "debug"
-  },
-  "cpython-3.11.4+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0e81ab103e2bccbf61de2b968ae705ca52c5fbd650911a89f9c412b45407a31e",
     "variant": "debug"
   },
   "cpython-3.11.4+debug-linux-x86_64_v3-gnu": {
@@ -13071,22 +10543,6 @@
     "sha256": "85859b2993d3c52506625e1dc62b0cb4d9e38816e290d7630fe258aae6b8bca4",
     "variant": "debug"
   },
-  "cpython-3.11.4+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "528c85c2cb9d63784cc84e8196c5290d1c5744e177b5b3d886c0d89c755fb8ba",
-    "variant": "debug"
-  },
   "cpython-3.11.4+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -13101,22 +10557,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a3100464c5f1bc3beb1e15c2bf01ad1aff3888d20a25a1ded1a5baff7be54ff1",
-    "variant": "debug"
-  },
-  "cpython-3.11.4+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "dc2f89c9c825049c8e00a65b6f5442828a82aec4391ec3fe32b23beb107d92c5",
     "variant": "debug"
   },
   "cpython-3.11.3-darwin-aarch64-none": {
@@ -13215,22 +10655,6 @@
     "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5",
     "variant": null
   },
-  "cpython-3.11.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0",
-    "variant": null
-  },
   "cpython-3.11.3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -13245,22 +10669,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d0191c35051ade259d3324f437c6f2422743ccb79197af6dc64c161b06eddca9",
-    "variant": null
-  },
-  "cpython-3.11.3-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9715fc26b9a6de09ebc29c978ce1bea81c0a64f730125f1230743c18f536de27",
     "variant": null
   },
   "cpython-3.11.3-linux-x86_64_v3-gnu": {
@@ -13279,22 +10687,6 @@
     "sha256": "6452fe315b5240040acffc5688e97fc264d9eb8fbfdd90c6ede0bc46b20640e0",
     "variant": null
   },
-  "cpython-3.11.3-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9ea67df4e6cafabb6cee6adcc5f863708b1e717caad47be105eb4eb7170eca11",
-    "variant": null
-  },
   "cpython-3.11.3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -13309,22 +10701,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5bc5eb3892957c0a9eae87fc3ce97f2b0b31406fd6ef1d20bfa8074a44121cb4",
-    "variant": null
-  },
-  "cpython-3.11.3-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "7b7645a773cb0660b0f0c807af580b9b4a49d49de39b89d10ccfb01372e5a573",
     "variant": null
   },
   "cpython-3.11.3-windows-i686-none": {
@@ -13423,22 +10799,6 @@
     "sha256": "4f1192179e1f62e69b8b45f7f699e6f0100fb0b8a39aad7a48472794d0c24bd4",
     "variant": "debug"
   },
-  "cpython-3.11.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b753e060ccfb783b369f1e375ff6cc7a38d864a00506ec2e01ca01ba1956abc6",
-    "variant": "debug"
-  },
   "cpython-3.11.3+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -13453,22 +10813,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f42165d39624cd664ad2c77401b03f2b86c1eaa346a8d97595dc3da9477f7ba7",
-    "variant": "debug"
-  },
-  "cpython-3.11.3+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ed1ce259ea39c292606097efeee52909b013303d9b6d6d0a0e7001137e75f334",
     "variant": "debug"
   },
   "cpython-3.11.3+debug-linux-x86_64_v3-gnu": {
@@ -13487,22 +10831,6 @@
     "sha256": "9b049c8397cb33d8ee8ce810f971569dbeddc058325120dbc9463efd05fd97f4",
     "variant": "debug"
   },
-  "cpython-3.11.3+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "36defe0869e1e8ae6a2cdb819db908c05aa57dbd795556d798958e320f9788a6",
-    "variant": "debug"
-  },
   "cpython-3.11.3+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -13517,22 +10845,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8977784dad18e495cfaaaffa4d3196cba76ddcb6ba665375a3c8d707267478b5",
-    "variant": "debug"
-  },
-  "cpython-3.11.3+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "004d126ffbe09bb969247d15d98020d413b28908ed35a354033def26bda298fc",
     "variant": "debug"
   },
   "cpython-3.11.1-darwin-aarch64-none": {
@@ -13615,22 +10927,6 @@
     "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
     "variant": null
   },
-  "cpython-3.11.1-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82",
-    "variant": null
-  },
   "cpython-3.11.1-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -13645,22 +10941,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "cc322d17b9ead6aeee4ac116fa2f802d525b4d97343fac8b8ada458810b47b40",
-    "variant": null
-  },
-  "cpython-3.11.1-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "0e7dae505cdb31bee4095f7c004a9f89d78263d6f24fe32eb225bfbc34d7f6ab",
     "variant": null
   },
   "cpython-3.11.1-linux-x86_64_v3-gnu": {
@@ -13679,22 +10959,6 @@
     "sha256": "a7b538f35630a17ea8b5e1703b38906da189b2d6054297b571c7f5e81fc953a0",
     "variant": null
   },
-  "cpython-3.11.1-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ae7add6ad69f9a1852fed17ca04ebe3412bf5f190e008d8cfbe94bfe21445c48",
-    "variant": null
-  },
   "cpython-3.11.1-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -13709,22 +10973,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "dcee403d2f3416c0a7beae2fe58d9ca5646bb73ae47c0431d43911a0a8581a62",
-    "variant": null
-  },
-  "cpython-3.11.1-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "257d4ca1a7167f0b1d65900ca27d0d0f747e1e10bd27fbadeaa4a8bf0bf5b5e3",
     "variant": null
   },
   "cpython-3.11.1-windows-i686-none": {
@@ -13807,22 +11055,6 @@
     "sha256": "b5bf700afc77588d853832d10b74ba793811cbec41b02ebc2c39a8b9987aacdd",
     "variant": "debug"
   },
-  "cpython-3.11.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7773aab3d1cbddbd0c6095c931fe841a2c511369e21744097276d22f4bc05621",
-    "variant": "debug"
-  },
   "cpython-3.11.1+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -13837,22 +11069,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ea2d1de07fbd276723d61cb9f3c8fe4415f1207b3351593a6985e8e4338e89e0",
-    "variant": "debug"
-  },
-  "cpython-3.11.1+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bfb7b5328faf30048be5d1d102d6c37ff36c13c5f56137b05bb62f2d2e224f62",
     "variant": "debug"
   },
   "cpython-3.11.1+debug-linux-x86_64_v3-gnu": {
@@ -13871,22 +11087,6 @@
     "sha256": "be1259db03ae12ca8c8cdc1a75a3f4aa47579725f2e62f71022f6049690b6498",
     "variant": "debug"
   },
-  "cpython-3.11.1+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6b7e518c8c65aba363ab1e1db15e4ad2a6c007fb1fb271ab760f32c5af931483",
-    "variant": "debug"
-  },
   "cpython-3.11.1+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -13901,22 +11101,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "abf6c9a813e3c600b095ccfe0fb8c21e2b4156df342e9cf4ea34cb5759a0ff1c",
-    "variant": "debug"
-  },
-  "cpython-3.11.1+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "4bfc948d6fab7a8b788aef0e73211b7bf70def67e34f1fcf9b8622db11ccd419",
     "variant": "debug"
   },
   "cpython-3.10.16-darwin-aarch64-none": {
@@ -14559,22 +11743,6 @@
     "sha256": "25fb8e23cd3b82b748075a04fd18f3183cc7316c11d6f59eb4b0326843892600",
     "variant": null
   },
-  "cpython-3.10.15-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "a169bdcd98f62421062fb9066763495913f4a86ee88c7d36e51df86d5d3cbe62",
-    "variant": null
-  },
   "cpython-3.10.15-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -14589,22 +11757,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "a85f3481c8117a11b5aa4fda0a6eb174b54e97b122cc8f83cf773a876751785b",
-    "variant": null
-  },
-  "cpython-3.10.15-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "3f78660fd377d6073fa0ab642c20729c16fbc74fd67f8f35688e648fee014f4a",
     "variant": null
   },
   "cpython-3.10.15-linux-x86_64_v3-gnu": {
@@ -14623,22 +11775,6 @@
     "sha256": "f36b7ad24ead564455937ff8841a3ec16a194d9eb8411ed0470a0fbd627c683e",
     "variant": null
   },
-  "cpython-3.10.15-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "75df2a6b3845ce3e4aa556276d65288e509b17bc35ebb462a60230a8eff5039c",
-    "variant": null
-  },
   "cpython-3.10.15-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -14653,22 +11789,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "7d616298bffd2e4ffd0e72ab3786f2e4b9759dcd59a8cf7ac00f74a8642d5537",
-    "variant": null
-  },
-  "cpython-3.10.15-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "b343dff67fc9a6a03943b2bb2d6eb7d15f693533c706cc31f887d7db2625a70d",
     "variant": null
   },
   "cpython-3.10.15-windows-i686-none": {
@@ -14799,22 +11919,6 @@
     "sha256": "817fa16f1a2bda3435cf99743049fd0744ae7bf1ddb52913189b702bb74408dd",
     "variant": "debug"
   },
-  "cpython-3.10.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "13db15f74f19efc646544ddf7c46df543d2d6a1c3d7fba493d8b64dd3a379d5c",
-    "variant": "debug"
-  },
   "cpython-3.10.15+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -14829,22 +11933,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5f931215e13368ce05ed20837e3ad99cd425564d95b33b12b4fd1e5216c428e4",
-    "variant": "debug"
-  },
-  "cpython-3.10.15+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "edbe61dbdd6c765e1036d12ba9ea681139bbad73c1c96d83ac0a052ae3735110",
     "variant": "debug"
   },
   "cpython-3.10.15+debug-linux-x86_64_v3-gnu": {
@@ -14863,22 +11951,6 @@
     "sha256": "616d60c112149b4d3ee317ffc072ceb04b163edfa35024d435ccccbd7c9b7f47",
     "variant": "debug"
   },
-  "cpython-3.10.15+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "493250cb67299ce100e5b25e4fec20773ee3e3895285bba02e4e3eaa3ee0354b",
-    "variant": "debug"
-  },
   "cpython-3.10.15+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -14893,22 +11965,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "80240b3c4e493d78a3546f2f5275adbeca20f7b2da93d9b811e861b4e9922b9b",
-    "variant": "debug"
-  },
-  "cpython-3.10.15+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "f8faa78520e5c4324d153ebf4368701870597037cf53c25b0031028c31d36c55",
     "variant": "debug"
   },
   "cpython-3.10.14-darwin-aarch64-none": {
@@ -15039,22 +12095,6 @@
     "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17",
     "variant": null
   },
-  "cpython-3.10.14-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c",
-    "variant": null
-  },
   "cpython-3.10.14-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -15069,22 +12109,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "327049baeb8319f0a31a14d28fce5608af546c27fb09994f56e3c0e17efb48c3",
-    "variant": null
-  },
-  "cpython-3.10.14-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "cc2ed06f898466616c6534de1fd3b00d02fae415274ecb7210f5199b2550c38c",
     "variant": null
   },
   "cpython-3.10.14-linux-x86_64_v3-gnu": {
@@ -15103,22 +12127,6 @@
     "sha256": "94d7bf472551494c75a122595b30f798b3785b3fcce319e1a66f7b7358399c15",
     "variant": null
   },
-  "cpython-3.10.14-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "c3177e9c8a9b339f33fa18ca896d59dbe22853cb88be3d844ac7859c543b5913",
-    "variant": null
-  },
   "cpython-3.10.14-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -15133,22 +12141,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "5f0b093b83d5dad323463269d2cd53516e51ef0f5e965001ac8947450c3fc917",
-    "variant": null
-  },
-  "cpython-3.10.14-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "845008e1afab23633b1f8f49323d8de15f24cdda523974df2bab2d080af5bfbf",
     "variant": null
   },
   "cpython-3.10.14-windows-i686-none": {
@@ -15279,22 +12271,6 @@
     "sha256": "060bcd01e5ba9cbd3f5b8da98c16480320b19fa9f67cf9ecf94a0c20ba08db6e",
     "variant": "debug"
   },
-  "cpython-3.10.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "cd33d23d8fb79ca99db1398a555daad44af4122d01fb4065fd79e121929c5cb3",
-    "variant": "debug"
-  },
   "cpython-3.10.14+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -15309,22 +12285,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5480ed19c17a087deb3e63b51217ec5fb6a299d53152721cc152f1175dd1b63e",
-    "variant": "debug"
-  },
-  "cpython-3.10.14+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "09d771b9f11e7492cc775c7853bf34d6e8b3dcb424db0be0df762f408a814118",
     "variant": "debug"
   },
   "cpython-3.10.14+debug-linux-x86_64_v3-gnu": {
@@ -15343,22 +12303,6 @@
     "sha256": "c09a17a3441c4c82856f72faad2b76e36264580bf4104305b62fada903c1a9b5",
     "variant": "debug"
   },
-  "cpython-3.10.14+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a7df771ab670843bb66bdd96736c41bceaf6d74dbc759c2d6ad56a5176dc7dbb",
-    "variant": "debug"
-  },
   "cpython-3.10.14+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -15373,22 +12317,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f1b0d3905c719213989e96c06e77092db86c9e120811ffe310472573024c37e3",
-    "variant": "debug"
-  },
-  "cpython-3.10.14+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "05288ab3fab5d49e8d9c95687dbdf8f8ba9e5c9926aa3c3e0d75e42add811109",
     "variant": "debug"
   },
   "cpython-3.10.13-darwin-aarch64-none": {
@@ -15503,22 +12431,6 @@
     "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195",
     "variant": null
   },
-  "cpython-3.10.13-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180",
-    "variant": null
-  },
   "cpython-3.10.13-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -15533,22 +12445,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ee43e708b6c4c1ffb5b17b41c51305672e3af2fd686960e4e024a86f969c1a1e",
-    "variant": null
-  },
-  "cpython-3.10.13-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "779be1530f099b4ce0b87fe03f4621e6edca926393c7c857d581f50ffc4df66b",
     "variant": null
   },
   "cpython-3.10.13-linux-x86_64_v3-gnu": {
@@ -15567,22 +12463,6 @@
     "sha256": "325b708dccba08446658137517630c1a9fe38519780d516a760597e79a9d8d69",
     "variant": null
   },
-  "cpython-3.10.13-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "13d11d53372a058a9df956057d75e14ac229cce8daae6c42d97e742fed63f978",
-    "variant": null
-  },
   "cpython-3.10.13-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -15597,22 +12477,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c1cdc034c483794a4792571b44318f7608769b5b2d116635723e4bd702b5ea69",
-    "variant": null
-  },
-  "cpython-3.10.13-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c1e61caff30433105aad15ea47ddc20b5ced4ccafd8e3666fa85667777354584",
     "variant": null
   },
   "cpython-3.10.13-windows-i686-none": {
@@ -15727,22 +12591,6 @@
     "sha256": "41b20e9d87f57d27f608685b714a57eea81c9e079aa647d59837ec6659536626",
     "variant": "debug"
   },
-  "cpython-3.10.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3eec53aef154273c0bc30bb9905734762171f474f73ba256c8883022915b7439",
-    "variant": "debug"
-  },
   "cpython-3.10.13+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -15757,22 +12605,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "375fa4880952a1e78c095704cb50bb001d38c93c3172d0c554c1751ab4138329",
-    "variant": "debug"
-  },
-  "cpython-3.10.13+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8fda4d7bc57ab9a83644b5ba867bf45b229264c9ccdfdcc7260b41d445ae651f",
     "variant": "debug"
   },
   "cpython-3.10.13+debug-linux-x86_64_v3-gnu": {
@@ -15791,22 +12623,6 @@
     "sha256": "513d9bcdccbee4951c2d494535578220061543a7c1ae202980766641529100ab",
     "variant": "debug"
   },
-  "cpython-3.10.13+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "f96f6d5655e01c15ba8ab4844378fc39e630abc0aafd63b437c96f32dd1425fc",
-    "variant": "debug"
-  },
   "cpython-3.10.13+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -15821,22 +12637,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7baf90a643421989ee592b2c4848f1c4e515c2302067304c1b2d4e54d4282697",
-    "variant": "debug"
-  },
-  "cpython-3.10.13+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8c4068c68e0a5ecc02325ab83d6977a25bfc479e65ccb1f3886771c86af843df",
     "variant": "debug"
   },
   "cpython-3.10.12-darwin-aarch64-none": {
@@ -15951,22 +12751,6 @@
     "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3",
     "variant": null
   },
-  "cpython-3.10.12-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7",
-    "variant": null
-  },
   "cpython-3.10.12-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -15981,22 +12765,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "843504ad0f655f19614f2edb689808ed5fd2712bbf5a0eb0331ff1ebf871d457",
-    "variant": null
-  },
-  "cpython-3.10.12-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "d5d33effa6d64c83392f12b63fdf122843d943c7cfaa05ab734677699241cf93",
     "variant": null
   },
   "cpython-3.10.12-linux-x86_64_v3-gnu": {
@@ -16015,22 +12783,6 @@
     "sha256": "602e8eb7cac2921a9aa12938e9d69ef139797f6952f285ac8522a0502616a137",
     "variant": null
   },
-  "cpython-3.10.12-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "bc17cb3b279a031cbcb2427238254758e89ac44541a95a5ddec968bc13ff0181",
-    "variant": null
-  },
   "cpython-3.10.12-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -16045,22 +12797,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "7cc21bad92259bf08d60cbe0650133d55f461f102a8ac9908dbd23400d9b35fa",
-    "variant": null
-  },
-  "cpython-3.10.12-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1eef14ac488ab43ccf54144697d6892645414fc4926cd1456136cd427a8ae454",
     "variant": null
   },
   "cpython-3.10.12-windows-i686-none": {
@@ -16175,22 +12911,6 @@
     "sha256": "fb7354fcee7b17dd0793ebd3f6f1fc8b7b205332afcf8d700cc1119f2dc33ff7",
     "variant": "debug"
   },
-  "cpython-3.10.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ebff76754ae37694581afe80749efb1260a6da95a9d88f8e60aa2cab75fd5497",
-    "variant": "debug"
-  },
   "cpython-3.10.12+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -16205,22 +12925,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b4d606147bcb75735dd55928330e111dec35fb2c825d2e3fd71eca23eaa11e5f",
-    "variant": "debug"
-  },
-  "cpython-3.10.12+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e177cbab8330071fe7c7362c266ec6de6b11f8262c43d0c4a9d38f00b7c2fcba",
     "variant": "debug"
   },
   "cpython-3.10.12+debug-linux-x86_64_v3-gnu": {
@@ -16239,22 +12943,6 @@
     "sha256": "3f85d12509db9cfe11785c0947d1e5baca0167e3eaa7065f9424a65fa159fb2f",
     "variant": "debug"
   },
-  "cpython-3.10.12+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1d82da2a5c0ff2c150719cfa0108ab20fbb5afba7b7627e9a1345fe5200c57db",
-    "variant": "debug"
-  },
   "cpython-3.10.12+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -16269,22 +12957,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "259e0c20061ed25a72e72912eb212a8571d0607659edba580272db809af7206e",
-    "variant": "debug"
-  },
-  "cpython-3.10.12+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2256289741d0779f5c32a82d0b6ba9f51d8d6d3332138b4e1919583b59f5e013",
     "variant": "debug"
   },
   "cpython-3.10.11-darwin-aarch64-none": {
@@ -16383,22 +13055,6 @@
     "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79",
     "variant": null
   },
-  "cpython-3.10.11-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1",
-    "variant": null
-  },
   "cpython-3.10.11-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -16413,22 +13069,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "7e6281f9ff93ac54c38abfffe874907591ae6db431df7633b73fa5e62066582c",
-    "variant": null
-  },
-  "cpython-3.10.11-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "bc168048359070be77bf7cf03af1e4cf8c9144d348e59bd5849ebf046694462c",
     "variant": null
   },
   "cpython-3.10.11-linux-x86_64_v3-gnu": {
@@ -16447,22 +13087,6 @@
     "sha256": "d94e9958580586c9ff95a35b2e1c5afde7087b9bb0f32d3d141a5a7ec2b8a50b",
     "variant": null
   },
-  "cpython-3.10.11-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "862119d9b37def3cba4ceaf10b7415594bc171b4aa6c057e70433349ecb33474",
-    "variant": null
-  },
   "cpython-3.10.11-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -16477,22 +13101,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "488df9d6af3baca3fd2b26005e5b1a0e29b53c602bc6ecfa4f21d20715107fba",
-    "variant": null
-  },
-  "cpython-3.10.11-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "35db9299916982e0b9fbf483ae15b7a4b90a418c857ded61be241d81acbc9779",
     "variant": null
   },
   "cpython-3.10.11-windows-i686-none": {
@@ -16591,22 +13199,6 @@
     "sha256": "544e5020f71ad1525dbc92b08e429cc1e1e11866c48c07d91e99f531b9ba68b0",
     "variant": "debug"
   },
-  "cpython-3.10.11+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0d5bd092b85ada04f6f27a5ef30e026ec2df8ddc73f89d7d1d397623405011c1",
-    "variant": "debug"
-  },
   "cpython-3.10.11+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -16621,22 +13213,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "cd6316c2731d2282587475e781e240677c89a678694cf3e58f12e4c2e57add43",
-    "variant": "debug"
-  },
-  "cpython-3.10.11+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "30563500ff2d568a376fbeea09ad1ab8b377574d75806d555970b233f03034f0",
     "variant": "debug"
   },
   "cpython-3.10.11+debug-linux-x86_64_v3-gnu": {
@@ -16655,22 +13231,6 @@
     "sha256": "ea5006c1545afed6f16e833a0d4bac14ec289cc0f5911e12a4ef8704a742cf8e",
     "variant": "debug"
   },
-  "cpython-3.10.11+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "4fecdf43aeae1b08bd7d195af1c223074b3a9fcebd41097225194303a106ed47",
-    "variant": "debug"
-  },
   "cpython-3.10.11+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -16685,22 +13245,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "6ebe8edb6bb89109b351e6f4361be7f1563860e1ae1cb8926c17ca19588e5fa3",
-    "variant": "debug"
-  },
-  "cpython-3.10.11+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "38f9924b7222ad58c8cf5d26852406052aa3e140e04116b44edab9a2faddf024",
     "variant": "debug"
   },
   "cpython-3.10.9-darwin-aarch64-none": {
@@ -16783,22 +13327,6 @@
     "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
     "variant": null
   },
-  "cpython-3.10.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516",
-    "variant": null
-  },
   "cpython-3.10.9-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -16813,22 +13341,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e69b2e48696f1e19231bed30616aa4ac6ef0fb4b3760e9e525e2c9c4c30ddb61",
-    "variant": null
-  },
-  "cpython-3.10.9-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "89d13b06e73bd347e46b1424f8c56823e13920cc3cdb32a75c247852cbc84f76",
     "variant": null
   },
   "cpython-3.10.9-linux-x86_64_v3-gnu": {
@@ -16847,22 +13359,6 @@
     "sha256": "062b42b9939908f3587f112769373be3d773f0d965ea1a08c65572e2551a2af4",
     "variant": null
   },
-  "cpython-3.10.9-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e7c53f1fe15ecba006276b41c3e1947c19ae3af4d53b6fae35f86b210db4e4df",
-    "variant": null
-  },
   "cpython-3.10.9-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -16877,22 +13373,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2c40f64d283d05755b531247eaeb6172cde6d31ba6c46cfa106b97b4669cea88",
-    "variant": null
-  },
-  "cpython-3.10.9-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "8dae0e8c598003e84351a2559d87b44335d02317eb82c75ea13c51aac5891a3f",
     "variant": null
   },
   "cpython-3.10.9-windows-i686-none": {
@@ -16975,22 +13455,6 @@
     "sha256": "a90a45ba7afcbd1df9aef96a614acbb210607299ac74dadbb6bd66af22be34db",
     "variant": "debug"
   },
-  "cpython-3.10.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7e0a0094b580d285163ede7797945e86bd4905d6af3340e6554e6abba7bcb832",
-    "variant": "debug"
-  },
   "cpython-3.10.9+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17005,22 +13469,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "fbd196fc7680e499f374a6946b3618b42980e2890a6d533993337b563bd8abb0",
-    "variant": "debug"
-  },
-  "cpython-3.10.9+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ab0cd574172c836fa74fa15423a4bf6571854c26f40f65f4b4d63363facec6d8",
     "variant": "debug"
   },
   "cpython-3.10.9+debug-linux-x86_64_v3-gnu": {
@@ -17039,22 +13487,6 @@
     "sha256": "ece59c02c9fdc77500bc1b60636077bc0a9536d6e63052c727db11488ae2de8c",
     "variant": "debug"
   },
-  "cpython-3.10.9+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ad98c72428b24e18ed587a93fab176b280ea13e28d2fd688d1814a57466b31a8",
-    "variant": "debug"
-  },
   "cpython-3.10.9+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -17069,22 +13501,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f4aab4df5c104f5d438a1a3b4601e45963a13c4100cbafee832336e47f6479cb",
-    "variant": "debug"
-  },
-  "cpython-3.10.9+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "9baae621ed4304fef603c8067b86972ca1d53ac4f44b4241fa7ecf4f6785fa13",
     "variant": "debug"
   },
   "cpython-3.10.8-darwin-aarch64-none": {
@@ -17167,22 +13583,6 @@
     "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7",
     "variant": null
   },
-  "cpython-3.10.8-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d",
-    "variant": null
-  },
   "cpython-3.10.8-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17197,22 +13597,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "81eaeef0c63349f296d6c9fed6bb6ff3f2f29db649f0725351e6af147413cc90",
-    "variant": null
-  },
-  "cpython-3.10.8-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "efe550859e00a15325b6c4fff0d5df23ae08017ba8f74616bc0e9e73f899871d",
     "variant": null
   },
   "cpython-3.10.8-linux-x86_64_v3-gnu": {
@@ -17231,22 +13615,6 @@
     "sha256": "06a2fc7fa664301bf2657144650d2a655f1f2557861bc5684315df0d2b54d671",
     "variant": null
   },
-  "cpython-3.10.8-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "51ebd0a996a750d9101791d5b7789237f7262e4381c21ee5b87e3a2dd88b7628",
-    "variant": null
-  },
   "cpython-3.10.8-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -17261,22 +13629,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b2617ece01070eeaa37fd5feaf1b5835435bd5151386218e6383cf9ee57bb4d2",
-    "variant": null
-  },
-  "cpython-3.10.8-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c641d68243082094f4afbda99eee7da5226906aa7bfca5859044c217e7133db6",
     "variant": null
   },
   "cpython-3.10.8-windows-i686-none": {
@@ -17359,22 +13711,6 @@
     "sha256": "c86182951a82e761588476a0155afe99ae4ae1030e4a8e1e8bcb8e1d42f6327c",
     "variant": "debug"
   },
-  "cpython-3.10.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "935eb97e0c3ef358a2f25e78b0b56aebad68d371e3b63979a157c7588a03585b",
-    "variant": "debug"
-  },
   "cpython-3.10.8+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17389,22 +13725,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "96c8f51e23a1bd8b9a2d9adc0e2457fa74062f16d25d2d0d659b8a6c94631824",
-    "variant": "debug"
-  },
-  "cpython-3.10.8+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "9e4ca2b0141e336ee1cc137e907809e13836883df661c33c8e564921b99a58f5",
     "variant": "debug"
   },
   "cpython-3.10.8+debug-linux-x86_64_v3-gnu": {
@@ -17423,22 +13743,6 @@
     "sha256": "1053c4ca16bda71ae9f2a973cc82118b9e41aa6e426302d9709d9c74c60af50d",
     "variant": "debug"
   },
-  "cpython-3.10.8+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "cbaa62454b9ed27805c2437f5bce92332d698d275e24e6652518354358985fa5",
-    "variant": "debug"
-  },
   "cpython-3.10.8+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -17453,22 +13757,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f23f744868d70cf2e9588aa961e9682060b6c3d6f55c65a61505e23c4895b7e4",
-    "variant": "debug"
-  },
-  "cpython-3.10.8+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "177dd2840176bc39c3147dd271f8b7344067c0c1d6b29654a2a06cc586e5dc3e",
     "variant": "debug"
   },
   "cpython-3.10.7-darwin-aarch64-none": {
@@ -17551,22 +13839,6 @@
     "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711",
     "variant": null
   },
-  "cpython-3.10.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0",
-    "variant": null
-  },
   "cpython-3.10.7-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17581,22 +13853,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ae5ad8fe84d8b1fd2e6fe2f47a632c9a1244686c12ce98cdd4a553be1fda2f9e",
-    "variant": null
-  },
-  "cpython-3.10.7-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "4af5e7eb30ae33db0729c019cbca4d76c973dac27167ad4131902078531eb05b",
     "variant": null
   },
   "cpython-3.10.7-linux-x86_64_v3-gnu": {
@@ -17615,22 +13871,6 @@
     "sha256": "a85919da343455cd22f8c5cf2e748498222ae92f4dcd8f37a366fec668622cbe",
     "variant": null
   },
-  "cpython-3.10.7-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1cd4072435039557c0b6f528f18865b4d4d36c807d51abd69a6a43c73c26e9af",
-    "variant": null
-  },
   "cpython-3.10.7-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -17645,22 +13885,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f7c803a2ecd63dfc89210e1b6dffb0c509f2680ec9484e824c2d3a14f91a7803",
-    "variant": null
-  },
-  "cpython-3.10.7-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "2bef222e2469cbb4e8cac98a7b31f92b7dcd9672ec4db714fe6fe0090806ad53",
     "variant": null
   },
   "cpython-3.10.7-windows-i686-none": {
@@ -17743,22 +13967,6 @@
     "sha256": "ce3fe27e6ca3a0e75a7f4f3b6568cd1bf967230a67e73393e94a23380dddaf10",
     "variant": "debug"
   },
-  "cpython-3.10.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "08f725cdb4d4f6bd76c582b798f7d7685c8f5c5afa03e1553e28e55a3859014e",
-    "variant": "debug"
-  },
   "cpython-3.10.7+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17773,22 +13981,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "fb44d19c8e4da5d5c467b6bbfc1b0350fa7faee71462fbd6ac3d69633c2b334a",
-    "variant": "debug"
-  },
-  "cpython-3.10.7+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8aadba22a811555789a2d8c94a3deba594a82278d77ea51a4c684290915cb825",
     "variant": "debug"
   },
   "cpython-3.10.7+debug-linux-x86_64_v3-gnu": {
@@ -17807,22 +13999,6 @@
     "sha256": "c028a4c945329731be66285168a074ac2fc7f25d28c5bbb9bbbb532d45a82ab4",
     "variant": "debug"
   },
-  "cpython-3.10.7+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "9b3e916c03d8ec7986cd5a1b7f4f6ff7f3741134092ae4a694e25e787d4eb90e",
-    "variant": "debug"
-  },
   "cpython-3.10.7+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -17837,22 +14013,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b9ddf213ba0f69ac200dd50e5d2c6a52468307a584a64efe422ef537f446c0da",
-    "variant": "debug"
-  },
-  "cpython-3.10.7+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2bc89eb770995a5b3ad4149b75de1a23fe8cb495b982386bd2b1dd47c9e4980f",
     "variant": "debug"
   },
   "cpython-3.10.6-darwin-aarch64-none": {
@@ -17935,22 +14095,6 @@
     "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
     "variant": null
   },
-  "cpython-3.10.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7",
-    "variant": null
-  },
   "cpython-3.10.6-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -17965,22 +14109,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e5478adc739ecd6f7b770e613fa0e5757f13fe9cbeb34f7990e5522b0593d6db",
-    "variant": null
-  },
-  "cpython-3.10.6-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "6097200a90aa57ad5fe8d4446f4f09d6653b3db6dd1fec80f96cbeafcf76de12",
     "variant": null
   },
   "cpython-3.10.6-linux-x86_64_v3-gnu": {
@@ -17999,22 +14127,6 @@
     "sha256": "2601630fef417aaeb1d8d07949e81f6390e439cdd2a347ec90218731bbd24b25",
     "variant": null
   },
-  "cpython-3.10.6-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9d36dcbd9b47b3205dc5b1371a3839a5ad5317e7ba5fa353bac326635717a3a0",
-    "variant": null
-  },
   "cpython-3.10.6-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18029,22 +14141,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "327533dae8332ee61ed87dd5b7cfee3188a25a9fde65c3e27865185cb3e79b2b",
-    "variant": null
-  },
-  "cpython-3.10.6-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c09bd9d306cd1eae99ed1de66313b0b2617b63a9cafec5e9fa3c5dd82e2d43ca",
     "variant": null
   },
   "cpython-3.10.6-windows-i686-none": {
@@ -18127,22 +14223,6 @@
     "sha256": "407e5951e39f5652b32b72b715c4aa772dd8c2da1065161c58c30a1f976dd1b2",
     "variant": "debug"
   },
-  "cpython-3.10.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6cd58957e286c132dc7cdbd937144aa180b557772be8a2b70bd1c3f2644ebe65",
-    "variant": "debug"
-  },
   "cpython-3.10.6+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -18157,22 +14237,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "4a0cc9f5b57ca1eff38d0c9ee71f38f9bf28fbc34d150edd4914b32b69a84f17",
-    "variant": "debug"
-  },
-  "cpython-3.10.6+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7440ade465fb52a8da42ab9360b998465100ef50fbce9fe0aee87839a6e2e2e3",
     "variant": "debug"
   },
   "cpython-3.10.6+debug-linux-x86_64_v3-gnu": {
@@ -18191,22 +14255,6 @@
     "sha256": "38bc029b11deed33097aae7e1b2e56b6d85f06df24355ff6105bf85fbb2fcb9b",
     "variant": "debug"
   },
-  "cpython-3.10.6+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d3291ce31b13a94f2b1e5e7b27233faec0586a49625ec7ce1d9458fc3f33fca5",
-    "variant": "debug"
-  },
   "cpython-3.10.6+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18221,22 +14269,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "dc779272bd2363abda4a8a784f6dea2dd7d8b2d86cdcfae5e8970df6e5dfbd76",
-    "variant": "debug"
-  },
-  "cpython-3.10.6+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1833f880ec83d13b40c0c1ccd5406fef7cb408a05e4ddc787e44ffb6d539f49e",
     "variant": "debug"
   },
   "cpython-3.10.5-darwin-aarch64-none": {
@@ -18319,22 +14351,6 @@
     "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7",
     "variant": null
   },
-  "cpython-3.10.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0",
-    "variant": null
-  },
   "cpython-3.10.5-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -18349,22 +14365,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "81e0c857175472f62641c49186f637cd1a391e4741b43afff5f55688512de1f1",
-    "variant": null
-  },
-  "cpython-3.10.5-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "febb7ebb1df876145be4f25a1caabbb8ec05758950e7efdebc33587f7ad3ca3c",
     "variant": null
   },
   "cpython-3.10.5-linux-x86_64_v3-gnu": {
@@ -18383,22 +14383,6 @@
     "sha256": "462f88de88b450bf80e8e660610adfd7d0ee2e409270ec406e3584093d2262ce",
     "variant": null
   },
-  "cpython-3.10.5-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "f28cfb4da443626267792c81b1ac4919765782d38757b0e90daf2db525502615",
-    "variant": null
-  },
   "cpython-3.10.5-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18413,22 +14397,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "cab2739ef27fcb7920dfbc99e57f2aec1256146a4646cf01488c60a267ed9ea3",
-    "variant": null
-  },
-  "cpython-3.10.5-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "5864ccaefdb3f6372f0b59f9c823e5925526c4064a94afad2bcdc9cf919e9365",
     "variant": null
   },
   "cpython-3.10.5-windows-i686-none": {
@@ -18511,22 +14479,6 @@
     "sha256": "f8dfb83885d1cbc82febfa613258c1f6954ea88ef43ed7dc710d6df20efecdab",
     "variant": "debug"
   },
-  "cpython-3.10.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "5217476a38b5273fd98ce45b7f0efcd579b8740c4d2911c6900fa16d59368fcc",
-    "variant": "debug"
-  },
   "cpython-3.10.5+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -18541,22 +14493,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "fdf3ade3f03f4a755f378d9abea1e9eb6a6a3fb18ce4620d5b7a6cb223a59741",
-    "variant": "debug"
-  },
-  "cpython-3.10.5+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8301d837c1e7799d0a4b80b62dc8058cfff9f52e8c75c3ebb49079c511161cdc",
     "variant": "debug"
   },
   "cpython-3.10.5+debug-linux-x86_64_v3-gnu": {
@@ -18575,22 +14511,6 @@
     "sha256": "137823acc0d98178c31ce0f75cef5fb0d3850edaf692ced2fab84ef9777d2c01",
     "variant": "debug"
   },
-  "cpython-3.10.5+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b0dd2039186ce8edd5693b7ced49f48dedbff8ee2e34472c6eea67b3c40897f7",
-    "variant": "debug"
-  },
   "cpython-3.10.5+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18605,22 +14525,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "75fddbd0fa525d9455dab972c56ec8b6d39ddd62c12ab38dca81b558b1e70338",
-    "variant": "debug"
-  },
-  "cpython-3.10.5+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "23eac33183c0c16a5cd91aa28b8dc9ccbdc5b63ac1686b49fc3e5d8fce5e5dc2",
     "variant": "debug"
   },
   "cpython-3.10.4-darwin-aarch64-none": {
@@ -18703,22 +14607,6 @@
     "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee",
     "variant": null
   },
-  "cpython-3.10.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8",
-    "variant": null
-  },
   "cpython-3.10.4-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -18733,22 +14621,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "a94db687c197ac8fd9ade2695fe93ce9da392818ed52980459c25c7d39bcd73f",
-    "variant": null
-  },
-  "cpython-3.10.4-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c2bfbee97c9a4c4f5f5722ea68ea1a4d9f0e2510d02919af0f989d3061c66b3f",
     "variant": null
   },
   "cpython-3.10.4-linux-x86_64_v3-gnu": {
@@ -18767,22 +14639,6 @@
     "sha256": "96fc13a16df730afead8c17812e65e2aad53d64d57e3180ef5169cda035f33e4",
     "variant": null
   },
-  "cpython-3.10.4-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "a750ac0ba4c23de6ab3ce494fd23e9b0e47dbf961e1fd29cb543ca60e200ba44",
-    "variant": null
-  },
   "cpython-3.10.4-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18797,22 +14653,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "12b5c2f325e99499fa6d79fb9cef3562f8a7635917353f2a79d4c30ac529e7a0",
-    "variant": null
-  },
-  "cpython-3.10.4-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "70bcf588b9f9b7a6aca236ff8214f17b123caa5da039ecc00ddee4828e9cc1bb",
     "variant": null
   },
   "cpython-3.10.4-windows-i686-none": {
@@ -18895,22 +14735,6 @@
     "sha256": "7699f76ef89b436b452eacdbab508da3cd94146ba29b099f5cb6e250afba3210",
     "variant": "debug"
   },
-  "cpython-3.10.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8fb78fbf9266b23ee0eaf569f7a36d1696f7102c396106c1d71b3a991b27ad27",
-    "variant": "debug"
-  },
   "cpython-3.10.4+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -18925,22 +14749,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e0849600bee6c588f1aa5f4b0b9342292cfb6eb40de0c705f60bd71f22b713d0",
-    "variant": "debug"
-  },
-  "cpython-3.10.4+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "91e5e1021266da3917e64240bd209a9caff35e29d1a3223766f02b445050a92e",
     "variant": "debug"
   },
   "cpython-3.10.4+debug-linux-x86_64_v3-gnu": {
@@ -18959,22 +14767,6 @@
     "sha256": "2875d103a83ff9f9f7ec2ec3ebc43d0e89f20416cd715b83b541b33f91d59832",
     "variant": "debug"
   },
-  "cpython-3.10.4+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "4ecbb16e47d8c6de2ed976588336ca2cba6947e8552aba323715dd07fb70851d",
-    "variant": "debug"
-  },
   "cpython-3.10.4+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -18989,22 +14781,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "839f9cb8f1b0e0eb347164a04323f832b945091ba3482724325d3eed1a75daab",
-    "variant": "debug"
-  },
-  "cpython-3.10.4+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "646deea0c39465497b0b432f7236778b37f6e46636abcf78a240dbacecb18551",
     "variant": "debug"
   },
   "cpython-3.10.3-darwin-aarch64-none": {
@@ -19087,22 +14863,6 @@
     "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d",
     "variant": null
   },
-  "cpython-3.10.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1",
-    "variant": null
-  },
   "cpython-3.10.3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -19117,22 +14877,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "56b36066cda53fb371d92e769b7dc4b18df2d857930871946052d6be724febce",
-    "variant": null
-  },
-  "cpython-3.10.3-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "f2cd3e6824d768603d6adc911aeb31de87f12bff9d3dc93624e944c6312acbdf",
     "variant": null
   },
   "cpython-3.10.3-linux-x86_64_v3-gnu": {
@@ -19151,22 +14895,6 @@
     "sha256": "c14205c1de8febc05190c879dd4e3eac67ce9afdae962ec00bd768279b262b18",
     "variant": null
   },
-  "cpython-3.10.3-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e8ff9e1db06889cc65324a878b3d1e49de1213766a0401345b486761721ea125",
-    "variant": null
-  },
   "cpython-3.10.3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -19181,22 +14909,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "04df195d33f88ce2e1160416951eb772e9c61528aad1d15c508d9fd11041fc59",
-    "variant": null
-  },
-  "cpython-3.10.3-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "7ad8fdc6f0d26156bc350533a9af7bf582230be8ad6935934911fd8afd184085",
     "variant": null
   },
   "cpython-3.10.3-windows-i686-none": {
@@ -19279,22 +14991,6 @@
     "sha256": "04760d869234ee8f801feb08edc042a6965320f6c0a7aedf92ec35501fef3b21",
     "variant": "debug"
   },
-  "cpython-3.10.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "47637777bc44c6476e499bfcb214959c7abc386879dd66683a0d8e1b714c07cf",
-    "variant": "debug"
-  },
   "cpython-3.10.3+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -19309,22 +15005,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "65215230eacebebb87aa1e56d539fc1770870024dcfdadb5d0e18365c1b3b0a9",
-    "variant": "debug"
-  },
-  "cpython-3.10.3+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "855b17a3210d08f06ab136816bafc9c25bd816cef37a6f381cdef30109c2fd06",
     "variant": "debug"
   },
   "cpython-3.10.3+debug-linux-x86_64_v3-gnu": {
@@ -19343,22 +15023,6 @@
     "sha256": "e15dcd98efdde249e7c2857f80b93092245f8495d822cb6c7af3308a59729c21",
     "variant": "debug"
   },
-  "cpython-3.10.3+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c5eb754738a5fb8e44406d452006ced58fab45f7ac8d51587ea73d53cc8d6cd4",
-    "variant": "debug"
-  },
   "cpython-3.10.3+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -19373,22 +15037,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "412570cf01df665c848dacc213c645a3c17aa5045b1805a86c6d9fa2d82eb9ce",
-    "variant": "debug"
-  },
-  "cpython-3.10.3+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "719eccf39f552e4dceb39122936d2a5e184f922814d63416b5e183e2824c07b9",
     "variant": "debug"
   },
   "cpython-3.10.2-darwin-aarch64-none": {
@@ -19471,22 +15119,6 @@
     "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
     "variant": null
   },
-  "cpython-3.10.2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae",
-    "variant": null
-  },
   "cpython-3.10.2-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -19501,22 +15133,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "1cbd17424d858fbb37e6184bf355f72830a47d2e33a4b8de872fa87aaa49a15e",
-    "variant": null
-  },
-  "cpython-3.10.2-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1067c4c6fc40bbd2d8b747177296bbeb4abfcb54e700226f2f211c3a2b90be46",
     "variant": null
   },
   "cpython-3.10.2-linux-x86_64_v3-gnu": {
@@ -19535,22 +15151,6 @@
     "sha256": "a110dcb9cdca8ce655b215427b0c5fa2b1a374badfe38fbb57cfb0ce28db434e",
     "variant": null
   },
-  "cpython-3.10.2-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "dddc62de5f796dbb33cbc81ebdb496758ea653c918a840d12574373aa4835165",
-    "variant": null
-  },
   "cpython-3.10.2-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -19565,22 +15165,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "0493e89aae5b95b17f3092402cd7b6516494cad817aff68cc2988a4c065ae1ab",
-    "variant": null
-  },
-  "cpython-3.10.2-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "7dd9634e06daf56e58dfab4f71bea2d4d9b5c808fc30a40eb6208e76dfe24b14",
     "variant": null
   },
   "cpython-3.10.2-windows-i686-none": {
@@ -19695,22 +15279,6 @@
     "sha256": "d22d85f60b2ef982b747adda2d1bde4a32c23c3d8f652c00ce44526750859e4e",
     "variant": "debug"
   },
-  "cpython-3.10.2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a696f058a0cf69fa49c7e65c0b0b630c3fdc23474d45795e5c742c474abb8f24",
-    "variant": "debug"
-  },
   "cpython-3.10.2+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -19725,22 +15293,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8c772010a27d7fd5a3e271c835c37b73bd41bc04a737523f12a3920bf721598b",
-    "variant": "debug"
-  },
-  "cpython-3.10.2+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6541c4c356146280e57b327dfc8f3f6b4985534d06a64cc20cd1cbdf6fb743b8",
     "variant": "debug"
   },
   "cpython-3.10.2+debug-linux-x86_64_v3-gnu": {
@@ -19759,22 +15311,6 @@
     "sha256": "03a6116ea6dbd5d4e667d4bec2b5032deefd604bc068908cd105327c417d0906",
     "variant": "debug"
   },
-  "cpython-3.10.2+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "765ba7371d5a5b6ca1899ff2811e1b0960a0eeacda448cab0a677caef47e540f",
-    "variant": "debug"
-  },
   "cpython-3.10.2+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -19789,22 +15325,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "2262abca39027b52d96b397c5d3285b07a93fafd7dde52295876a331e9fb48c4",
-    "variant": "debug"
-  },
-  "cpython-3.10.2+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0129870b2c76b1b78762dc38ef4772b96b643151ce757faa9a72a1e099913243",
     "variant": "debug"
   },
   "cpython-3.10.0-darwin-aarch64-none": {
@@ -19884,22 +15404,6 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.10.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -20012,22 +15516,6 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
-  "cpython-3.10.0+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-debug-20211017T1616.tar.zst",
     "sha256": null,
     "variant": "debug"
   },
@@ -20671,22 +16159,6 @@
     "sha256": "44d9d016f9820f39e5bb542782557d46876b69d23d0a204eb2f367739da623e0",
     "variant": null
   },
-  "cpython-3.9.20-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "332ce515daa15173f73d0ecebc988fadfac5583af8355d8895b3eb8086dac813",
-    "variant": null
-  },
   "cpython-3.9.20-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -20701,22 +16173,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "1461b5364d07a56f1879390eaec72542fe0dd48fa369ce4507c555677bfe07ea",
-    "variant": null
-  },
-  "cpython-3.9.20-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "237ec3d144e488130476c1d2c70d8ca7f2b36f423eb0ead348a78c6fc1fb7abb",
     "variant": null
   },
   "cpython-3.9.20-linux-x86_64_v3-gnu": {
@@ -20735,22 +16191,6 @@
     "sha256": "0e2c93f61971e0bda6e679a211c1e1ae074f43d2113328b8304b2e38c77c5a32",
     "variant": null
   },
-  "cpython-3.9.20-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "0f99bd0d5b0d1afb207f3e6d4fb36be303bf277ac7c327dd07b7d1e6ba90f9ea",
-    "variant": null
-  },
   "cpython-3.9.20-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -20765,22 +16205,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "693a3f129a86c48c176b35db81eae0bf54faec893fe8386ec5116070638c4712",
-    "variant": null
-  },
-  "cpython-3.9.20-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "0d8f9e08f4eb14575574728b174591736ceaada37a03c1bdec17184475ffabe8",
     "variant": null
   },
   "cpython-3.9.20-windows-i686-none": {
@@ -20911,22 +16335,6 @@
     "sha256": "25cd1c9e92090f02212a649fa9d5c5dec9842917ea11fa504c66bd02e03d3d15",
     "variant": "debug"
   },
-  "cpython-3.9.20+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "acbe099ea4851fd477b8dbac410ba213331d2129f6e2e4d0967dfb1675799f6c",
-    "variant": "debug"
-  },
   "cpython-3.9.20+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -20941,22 +16349,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "76bee8dde45cd59987d0919898d7dcd0cfee17d876c00e8f35934452b63604ff",
-    "variant": "debug"
-  },
-  "cpython-3.9.20+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e1410d1c912faf10bc51294665c16fd790fc0764b39cd8645d3f79c617d6628a",
     "variant": "debug"
   },
   "cpython-3.9.20+debug-linux-x86_64_v3-gnu": {
@@ -20975,22 +16367,6 @@
     "sha256": "5ed265aa97d30c49f871013fffccb4919b5ccf8834f99ba5c944775cc829f672",
     "variant": "debug"
   },
-  "cpython-3.9.20+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "68ee615f0f4f362190561bdcc6a951ebf391487bcb03716a5cfedbe3e8705fe4",
-    "variant": "debug"
-  },
   "cpython-3.9.20+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -21005,22 +16381,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e084b89c3fc2385bcc3098212135b93f5841a690c1500c77afc86d37e3899e6d",
-    "variant": "debug"
-  },
-  "cpython-3.9.20+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2551286bc3713a73a2da0b81cceaf075e9e6a853c34b6ffdd12d1cc1f2a1d584",
     "variant": "debug"
   },
   "cpython-3.9.19-darwin-aarch64-none": {
@@ -21151,22 +16511,6 @@
     "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299",
     "variant": null
   },
-  "cpython-3.9.19-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b",
-    "variant": null
-  },
   "cpython-3.9.19-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -21181,22 +16525,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "1d8179bde4db3e6cffac45f5c6a105e342a50a854b316b26760c17ba32bb164a",
-    "variant": null
-  },
-  "cpython-3.9.19-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "2f9eac6ff7bc42a06b0f04cc28f5f24e851dcbb5d4a025a170e036ac1511a226",
     "variant": null
   },
   "cpython-3.9.19-linux-x86_64_v3-gnu": {
@@ -21215,22 +16543,6 @@
     "sha256": "66c1df96394e43826ff5ed7f980ad93241af1e3ec212ce92b48efea183e8b9db",
     "variant": null
   },
-  "cpython-3.9.19-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "3c79c2c628d9412658e2fe21864439f53d22fa2dd8bc4f355564e73115715e37",
-    "variant": null
-  },
   "cpython-3.9.19-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -21245,22 +16557,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "7098fa8e0dac6a689d5289e761b85f713b607c476bfb1c1da13b3f86edce8461",
-    "variant": null
-  },
-  "cpython-3.9.19-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "1c6c6d2113fd3965d29b2fc70621ff81a1f7165a9dd660de980b805ba61a5c39",
     "variant": null
   },
   "cpython-3.9.19-windows-i686-none": {
@@ -21391,22 +16687,6 @@
     "sha256": "9e938140a8ecd343045a0c0cad77165db8bb0b24cc68012f628c937ae8748216",
     "variant": "debug"
   },
-  "cpython-3.9.19+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bb16ecadf1bbd907da5f0e9c65e2b2bd66770e73c1f3a38ac0ca5fa9ac6fc7a2",
-    "variant": "debug"
-  },
   "cpython-3.9.19+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -21421,22 +16701,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "30aec1d450111fc618973d35a17831e77e9003cdd77395e5891e304ade874cd1",
-    "variant": "debug"
-  },
-  "cpython-3.9.19+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "59598e9108b795695c1b2f3c592236a0f81bad8a750026be52c519647aee859e",
     "variant": "debug"
   },
   "cpython-3.9.19+debug-linux-x86_64_v3-gnu": {
@@ -21455,22 +16719,6 @@
     "sha256": "59507c5036aaca19d53f0e370d97e8cc775a3e7894db821aba64c5090f098a0d",
     "variant": "debug"
   },
-  "cpython-3.9.19+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a45baeac91eefe2ed59811f6d197a0e0e4ee9d9a6300f53b7b590b7133050716",
-    "variant": "debug"
-  },
   "cpython-3.9.19+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -21485,22 +16733,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8d4a91ba4af009e0c3f14ac5dbab29002674715cbe431e319b410d56ed2b23d8",
-    "variant": "debug"
-  },
-  "cpython-3.9.19+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a7e8528a496b5eb5116a10335ec96700811aa4d7386b3632977207d52a04649d",
     "variant": "debug"
   },
   "cpython-3.9.18-darwin-aarch64-none": {
@@ -21615,22 +16847,6 @@
     "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4",
     "variant": null
   },
-  "cpython-3.9.18-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba",
-    "variant": null
-  },
   "cpython-3.9.18-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -21645,22 +16861,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ff8e33905d114a590cd13f5e17590efd6ad56c4eb841c9820863da2f55b13860",
-    "variant": null
-  },
-  "cpython-3.9.18-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "2ab7781e0d14d92272d7bcfb1383328ded38213fa9ad9ca00d1d08dae1ada26e",
     "variant": null
   },
   "cpython-3.9.18-linux-x86_64_v3-gnu": {
@@ -21679,22 +16879,6 @@
     "sha256": "e85a752197d7c7529a19b83c17efa194c8743cbc4608d5cbca77da506ab30956",
     "variant": null
   },
-  "cpython-3.9.18-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "20c45210b2ef110ce6f01038e2861435cc6b9ccf94e7f015dcb111c3f5d0b629",
-    "variant": null
-  },
   "cpython-3.9.18-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -21709,22 +16893,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "31b1548bd8e259b6b4a84d69d6ddcd27397af5971e3ffadd162f3a38eb623f6a",
-    "variant": null
-  },
-  "cpython-3.9.18-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "61db6789f2974b6cf85fefc0e06950e43898e4a468d3c643cc35427d8ebf4fc0",
     "variant": null
   },
   "cpython-3.9.18-windows-i686-none": {
@@ -21839,22 +17007,6 @@
     "sha256": "e1fa92798fab6f3b44a48f24b8e284660c34738d560681b206f0deb0616465f9",
     "variant": "debug"
   },
-  "cpython-3.9.18+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6f199ddd447d3946381c3ccbb89c0f67643fb8a98205b89caa8e217ad0a20fd7",
-    "variant": "debug"
-  },
   "cpython-3.9.18+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -21869,22 +17021,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "1574a99758cae4dbfaa7ff0f06464fe90ab5fe6e7dadcd567aa31d8a25a53f32",
-    "variant": "debug"
-  },
-  "cpython-3.9.18+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "13c4edbc64b62c7d3fedcde6cae58dbacc05ef2bf03c0f8a50e385066a0f7690",
     "variant": "debug"
   },
   "cpython-3.9.18+debug-linux-x86_64_v3-gnu": {
@@ -21903,22 +17039,6 @@
     "sha256": "bc1cd137b083c9eb51d1b226750e3ecc484c6757bd52385bc9587d0f90689dc3",
     "variant": "debug"
   },
-  "cpython-3.9.18+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a70d9ed0166bf32d711e80b68d83c28d7722f64e36a1d56b7472c01bff1864aa",
-    "variant": "debug"
-  },
   "cpython-3.9.18+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -21933,22 +17053,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7fab85ea9595d031ea78a8b2f122d11ed6d19f65e02deddb05a232cf6ef758f7",
-    "variant": "debug"
-  },
-  "cpython-3.9.18+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "79525f4aea8e369ea18f256c1005068a15120456387f5d2d2183506367f73b61",
     "variant": "debug"
   },
   "cpython-3.9.17-darwin-aarch64-none": {
@@ -22063,22 +17167,6 @@
     "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637",
     "variant": null
   },
-  "cpython-3.9.17-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d",
-    "variant": null
-  },
   "cpython-3.9.17-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -22093,22 +17181,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3d9275e70d39030030f7e9db5f05fc07e2be6fb4964af0053f4a461bac9ba1bd",
-    "variant": null
-  },
-  "cpython-3.9.17-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "cdfe58799d017947c414bc8513ddb51bc7f4c25b2e603faa8dfcfd931a47392f",
     "variant": null
   },
   "cpython-3.9.17-linux-x86_64_v3-gnu": {
@@ -22127,22 +17199,6 @@
     "sha256": "be15573d9213c20ead1de62f500817f5e069510d41a4f48a78c3086953c1693e",
     "variant": null
   },
-  "cpython-3.9.17-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "4a541fb47184505c165adcb88490fa9df11e7d34fd9bd0117f70b42c50dcc7e1",
-    "variant": null
-  },
   "cpython-3.9.17-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -22157,22 +17213,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "114573e1c4919116e5ecf4c6425f44e09b03527fcddffe3d53f73fe1ce9df7d8",
-    "variant": null
-  },
-  "cpython-3.9.17-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "53a1b8cd550e803e258ba04192a18ccfe2ce4cbca2dc776cec47b2eba2507305",
     "variant": null
   },
   "cpython-3.9.17-windows-i686-none": {
@@ -22287,22 +17327,6 @@
     "sha256": "649fff6048f4cb9e64a85eaf8e720eb4c3257e27e7c4ee46f75bfa48c18c6826",
     "variant": "debug"
   },
-  "cpython-3.9.17+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "5a117bc64d6545821083afbfb4a381afee05ddaeb0dd45d2c5adbf3b0a67ec88",
-    "variant": "debug"
-  },
   "cpython-3.9.17+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -22317,22 +17341,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "3faab5cb6c0bbb601be92575540036454fb34c0d7e4045760c62d782d8455f88",
-    "variant": "debug"
-  },
-  "cpython-3.9.17+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e3da342005da3bc938a5869e2f4da7c21056470afb31465aa83f39cd362408c9",
     "variant": "debug"
   },
   "cpython-3.9.17+debug-linux-x86_64_v3-gnu": {
@@ -22351,22 +17359,6 @@
     "sha256": "c38db0bd66d15fd2f29bd6299dd74040a93fbe780c811827c3f3eca04f9aa3ca",
     "variant": "debug"
   },
-  "cpython-3.9.17+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "62f7b3c70dcd3bf197239fe814e64a937659cd53a4272193dd0e5b955ab9632a",
-    "variant": "debug"
-  },
   "cpython-3.9.17+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -22381,22 +17373,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "c9188a2b7edfb9e24d7cdfde239363ff8c79904901201041c0400d3f82923cb5",
-    "variant": "debug"
-  },
-  "cpython-3.9.17+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0bd787c0b13676a64c01464276ffe02722e2b353bcdb2bffc9fb8d2d0da33b94",
     "variant": "debug"
   },
   "cpython-3.9.16-darwin-aarch64-none": {
@@ -22495,22 +17471,6 @@
     "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
     "variant": null
   },
-  "cpython-3.9.16-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3",
-    "variant": null
-  },
   "cpython-3.9.16-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -22525,22 +17485,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "08acda6031601b35291fa54f98888dc17d36c9ff35bdb2adea4631df81e24271",
-    "variant": null
-  },
-  "cpython-3.9.16-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "b78dbd216e23a8f4adda881fbe11f6749371c09b4235dd519a4b4be761dd1504",
     "variant": null
   },
   "cpython-3.9.16-linux-x86_64_v3-gnu": {
@@ -22559,22 +17503,6 @@
     "sha256": "337fb379e9c46b6145e4c52f827513989c2feb9c84beac17c38decb50af5b53a",
     "variant": null
   },
-  "cpython-3.9.16-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "675b7d77d653f47561536eae8fcd1ffaedd467ffcf43afdd9c96d2d32e8e84c4",
-    "variant": null
-  },
   "cpython-3.9.16-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -22589,22 +17517,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fc289e674fb61ca4e39a4676ee11971e3f87bab607951898336b5df53b6ca328",
-    "variant": null
-  },
-  "cpython-3.9.16-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9bdb07f9e9dc429553d12b434293f270c9e281ea7c7ffe5be4f6e8b2cc151e03",
     "variant": null
   },
   "cpython-3.9.16-windows-i686-none": {
@@ -22703,22 +17615,6 @@
     "sha256": "cdc1290b9bdb2f74a6c48ab24531919551128e39773365c6f3e17668216275a0",
     "variant": "debug"
   },
-  "cpython-3.9.16+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e698c7a51e7e998e893b0dd25886d477778a14296bd560e6e585352b9d6194f8",
-    "variant": "debug"
-  },
   "cpython-3.9.16+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -22733,22 +17629,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "35dcaff7a658b8c6bf5ffe1c4e2db95df5d647d28b4880a90f09bf3a70f42e8b",
-    "variant": "debug"
-  },
-  "cpython-3.9.16+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "f5fb5562fd733ac97a703638bd2c0cf24ec15ec9986083a7883282feeb710ddb",
     "variant": "debug"
   },
   "cpython-3.9.16+debug-linux-x86_64_v3-gnu": {
@@ -22767,22 +17647,6 @@
     "sha256": "4c00f35b9218e19065ba9e06c123505f056173a4f9b7eeb72ef768d0dfe8f867",
     "variant": "debug"
   },
-  "cpython-3.9.16+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3659a7d30491ffc73721b438775d7f3b195f5754cc27f30e1e637b1755ed8cc0",
-    "variant": "debug"
-  },
   "cpython-3.9.16+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -22797,22 +17661,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b61ccbfd13415891a9120eaaa37ad5e3f6fac3bfad6123c951c955dbaafec6c3",
-    "variant": "debug"
-  },
-  "cpython-3.9.16+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e69baf81675c03c967e67aba2c77d3218197d6c62d0598270c976d139a8ab938",
     "variant": "debug"
   },
   "cpython-3.9.15-darwin-aarch64-none": {
@@ -22895,22 +17743,6 @@
     "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e",
     "variant": null
   },
-  "cpython-3.9.15-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391",
-    "variant": null
-  },
   "cpython-3.9.15-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -22925,22 +17757,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "436c35bd809abdd028f386cc623ae020c77e6b544eaaca405098387c4daa444c",
-    "variant": null
-  },
-  "cpython-3.9.15-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "52e774f1ccbbc61a30da2a95286348700ee7d7707412ef10035420f43469c39f",
     "variant": null
   },
   "cpython-3.9.15-linux-x86_64_v3-gnu": {
@@ -22959,22 +17775,6 @@
     "sha256": "6a3d25cb22b65355dd793bfb4838a16a5cd85edc07e3dac8cc22adad860f2c89",
     "variant": null
   },
-  "cpython-3.9.15-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "a7c4dcff34014b01de397ffe6497787935575f604f489d01cdd843b41dd320e6",
-    "variant": null
-  },
   "cpython-3.9.15-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -22989,22 +17789,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "65350987640f33876d072a44d03e6e397dcf5d2512819bd8765c892ec5c0f153",
-    "variant": null
-  },
-  "cpython-3.9.15-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "33b227fdde7a236e69635dafc0cfbfcee76594b9892092357ffd35a0dcb303e7",
     "variant": null
   },
   "cpython-3.9.15-windows-i686-none": {
@@ -23087,22 +17871,6 @@
     "sha256": "6a08761bb725b8d3a92144f81628febeab8b12326ca264ffe28255fa67c7bf17",
     "variant": "debug"
   },
-  "cpython-3.9.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c4bf3bd40dc301eb41984b205a204fb85ebe190bfe35fe73c79b749b48ec7a31",
-    "variant": "debug"
-  },
   "cpython-3.9.15+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -23117,22 +17885,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "6222695583b32845fbbf17ec4a43981126ce0d6bb08b47a8c8853396e0f5e9f7",
-    "variant": "debug"
-  },
-  "cpython-3.9.15+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0369aee7ce8a0f208e9146d17f903e3a3acaa594975a1ae5d1799388c2990d7f",
     "variant": "debug"
   },
   "cpython-3.9.15+debug-linux-x86_64_v3-gnu": {
@@ -23151,22 +17903,6 @@
     "sha256": "b5fbe25175f4338d6f5bb6f13ea6d714a4373a69b4d193c5037e8424ce5f53fb",
     "variant": "debug"
   },
-  "cpython-3.9.15+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "87fcfc6fe35719215faa676ee86f26de00483d528143c74a1c30e27f860ac12a",
-    "variant": "debug"
-  },
   "cpython-3.9.15+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -23181,22 +17917,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5bc44523a504d220e9af9acaa141ba9ac67e2fe998817cbca99b1bcc9a85d3cd",
-    "variant": "debug"
-  },
-  "cpython-3.9.15+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a668f5aa1e4ff77ea0275205ed82c555e8070ed9d70a2003714aac38445848fa",
     "variant": "debug"
   },
   "cpython-3.9.14-darwin-aarch64-none": {
@@ -23279,22 +17999,6 @@
     "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7",
     "variant": null
   },
-  "cpython-3.9.14-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8",
-    "variant": null
-  },
   "cpython-3.9.14-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -23309,22 +18013,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3b858cd4a187db8cd1eaedddd5ff80a077783092ca4d84970097127220f55cd4",
-    "variant": null
-  },
-  "cpython-3.9.14-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "d912966b120f5406046bf5a5252a6585cfb7620fe5d570a265cd221dfd8fbeb3",
     "variant": null
   },
   "cpython-3.9.14-linux-x86_64_v3-gnu": {
@@ -23343,22 +18031,6 @@
     "sha256": "798cd9d019885fb2f0010a234873ebe7de35e4eb8fc4e2ba1d40ea31b6abb0bf",
     "variant": null
   },
-  "cpython-3.9.14-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "46cd2e2b988bb5f6e12b184f2130d678ee781f84520dee1d8c487f2e0d1e3371",
-    "variant": null
-  },
   "cpython-3.9.14-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -23373,22 +18045,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f14391bc3b71dadc8855577325e3a49b17f351d428cc4caad8b1216b90f3ad80",
-    "variant": null
-  },
-  "cpython-3.9.14-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "355b1b5c3098b45f9b3dd1602321787c6731a70e574846efe29d96aef31d1e5b",
     "variant": null
   },
   "cpython-3.9.14-windows-i686-none": {
@@ -23471,22 +18127,6 @@
     "sha256": "54529c0a8ffe621f5c9c6bdd22968cac9d3207cbd5dcd9c07bbe61140c49937e",
     "variant": "debug"
   },
-  "cpython-3.9.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "598de16fbb955c2de02ac7765f162bee74601e28b3de9b6efeeecf30d97aecd6",
-    "variant": "debug"
-  },
   "cpython-3.9.14+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -23501,22 +18141,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a78cb80ca372ea98aca28d33a220b3fe91761c6dadaf92f646b82f3b569822c1",
-    "variant": "debug"
-  },
-  "cpython-3.9.14+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b9a1b56faaade8fdfe646f3893487ee76463277c65df1dfe7b9d0ca7a0df0aaf",
     "variant": "debug"
   },
   "cpython-3.9.14+debug-linux-x86_64_v3-gnu": {
@@ -23535,22 +18159,6 @@
     "sha256": "53d3c637264a57317b304a88ddd418463fe0b37b874495e3ae55940b5c62b363",
     "variant": "debug"
   },
-  "cpython-3.9.14+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "12333172d06f094381245d612404a46836522ab77b3fceb0a2a5dbbf6b2af75a",
-    "variant": "debug"
-  },
   "cpython-3.9.14+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -23565,22 +18173,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "92e5a9fd569c0b1c161958e2e1d3198cb4e27b524d02cf3008b260dba658961f",
-    "variant": "debug"
-  },
-  "cpython-3.9.14+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6e9ba8f2b5d320c0a9451fe80d69fd6870bcee75cbb0a1206a274883c5a31565",
     "variant": "debug"
   },
   "cpython-3.9.13-darwin-aarch64-none": {
@@ -23663,22 +18255,6 @@
     "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df",
     "variant": null
   },
-  "cpython-3.9.13-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f",
-    "variant": null
-  },
   "cpython-3.9.13-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -23693,22 +18269,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "1e1b522a91ed805287793427013762bc8f6c02440147e9fa5306316369307e58",
-    "variant": null
-  },
-  "cpython-3.9.13-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e3142427ed091bfe0986cf49954fa3fcbe7754f42d66e4fd0ce68f41a513c3c1",
     "variant": null
   },
   "cpython-3.9.13-linux-x86_64_v3-gnu": {
@@ -23727,22 +18287,6 @@
     "sha256": "315a9fbc75e2a0545254edf8974d88577ec64537ee04322ad1a7ce9752353f33",
     "variant": null
   },
-  "cpython-3.9.13-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "40be6728331395abce574e080e5411e781c0a8a3a5d5175ae10534cee8d83ae2",
-    "variant": null
-  },
   "cpython-3.9.13-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -23757,22 +18301,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b4c5a9908a77e4cae37901f8df2655380186d0e10723902672ef5e5296093071",
-    "variant": null
-  },
-  "cpython-3.9.13-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3b21780f0eba88519f0c00032cfb8ddb959b31a76cf21611a26da5d8296a9200",
     "variant": null
   },
   "cpython-3.9.13-windows-i686-none": {
@@ -23855,22 +18383,6 @@
     "sha256": "352d00a4630d0665387bcb158aec3f6c7fc5a4d14d65ac26e1b826e20611222f",
     "variant": "debug"
   },
-  "cpython-3.9.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "fd18bcb560764e7456431b577ce3b35057c3dd4cda60dfb98a9af8739ec95c43",
-    "variant": "debug"
-  },
   "cpython-3.9.13+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -23885,22 +18397,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "37ace8159aa2f5157abea2c0d854434f21e6676b90eeaf58d313778f64540ca7",
-    "variant": "debug"
-  },
-  "cpython-3.9.13+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "145f9fec457ac6f3ea642b5d90d275cb9f317cf36f0ef7df4902f871db9725bf",
     "variant": "debug"
   },
   "cpython-3.9.13+debug-linux-x86_64_v3-gnu": {
@@ -23919,22 +18415,6 @@
     "sha256": "59a24171f794139b41d47b3e734c82d02bc11956a4c092a3d28d94a5d0ab7f54",
     "variant": "debug"
   },
-  "cpython-3.9.13+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bb403edaed2809e90d035a74dd3b6cd33b53c13ee37ade2c01876565596c4235",
-    "variant": "debug"
-  },
   "cpython-3.9.13+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -23949,22 +18429,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "920fd94d4352495a804d4ee725764ae7499b29c5f1c15d11cc4380a873498dbf",
-    "variant": "debug"
-  },
-  "cpython-3.9.13+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b75b92f652498a3073110661062be7a696ace3827c73c63ecd5fbe8ddb3a86a9",
     "variant": "debug"
   },
   "cpython-3.9.12-darwin-aarch64-none": {
@@ -24047,22 +18511,6 @@
     "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816",
     "variant": null
   },
-  "cpython-3.9.12-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6",
-    "variant": null
-  },
   "cpython-3.9.12-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -24077,22 +18525,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "72085205843949f783c9245ad42902a63a00dd35367f1e5ea6f4aa709b2029ce",
-    "variant": null
-  },
-  "cpython-3.9.12-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "140ea77e2924fc312ecd266337f1add09e560084422843673b08ff847259a93f",
     "variant": null
   },
   "cpython-3.9.12-linux-x86_64_v3-gnu": {
@@ -24111,22 +18543,6 @@
     "sha256": "bb702440330bf8cd852cf36735a47ee10aa3941271b5d2f96cd6bfa6ac7a46b4",
     "variant": null
   },
-  "cpython-3.9.12-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "afceda37726445a1472b023ca7e6fb1b169557c7fc26a2ffa53e2b59247e1c6c",
-    "variant": null
-  },
   "cpython-3.9.12-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -24141,22 +18557,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "7a5fcad095ad183049b2f975cd55efd8a2ce3e4d894ee67cb5fa01186f50203e",
-    "variant": null
-  },
-  "cpython-3.9.12-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "81138b9b65bc01ed441bf0ab0fa2225c3d131a3b13838cc698c9e4aaef4cab11",
     "variant": null
   },
   "cpython-3.9.12-windows-i686-none": {
@@ -24239,22 +18639,6 @@
     "sha256": "7290ac14e43749afdb37d3c9690f300f5f0786f19982e8960566ecdc3e42c3eb",
     "variant": "debug"
   },
-  "cpython-3.9.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "410d7e68366f0e4fce4540a73ab3228060aa469949154fc08dc00d9da8ad51c6",
-    "variant": "debug"
-  },
   "cpython-3.9.12+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -24269,22 +18653,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "53dadc107ce8d1ba5f94ca87edbeef485c8a07b2c0e942a99a7c7e163fafb6f4",
-    "variant": "debug"
-  },
-  "cpython-3.9.12+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "465ef90b1462dc316bd14c5368d88acdeb2074464efdfeb9f35d3d1a47ec8f99",
     "variant": "debug"
   },
   "cpython-3.9.12+debug-linux-x86_64_v3-gnu": {
@@ -24303,22 +18671,6 @@
     "sha256": "e7ba8a790a3194a0847ef0b09b8dd8542b9c2ca689b2f4ee4ecb771a44ea41f2",
     "variant": "debug"
   },
-  "cpython-3.9.12+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e3f26b24858786ce3e756d10e6e16edc5bf136ab4df7fd55378312b0c61c42ca",
-    "variant": "debug"
-  },
   "cpython-3.9.12+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -24333,22 +18685,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "afdd26e418ab5a2e5e10b42eb98c79bafd7c198363f70aad8628266b7f3532ab",
-    "variant": "debug"
-  },
-  "cpython-3.9.12+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a6c3b487b913c514a105d06c55f97e65508bc3d2253f1666b350bc1294643043",
     "variant": "debug"
   },
   "cpython-3.9.11-darwin-aarch64-none": {
@@ -24431,22 +18767,6 @@
     "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882",
     "variant": null
   },
-  "cpython-3.9.11-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d",
-    "variant": null
-  },
   "cpython-3.9.11-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -24461,22 +18781,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bd9d808283eef69882e8e0c2529fe400c8605b7c08ef64e679d1766c1a87ef95",
-    "variant": null
-  },
-  "cpython-3.9.11-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "69439fb7c2e8f8bda28f2d5f4c71634116800d71a06f7cbeeb8f21ebca829fd2",
     "variant": null
   },
   "cpython-3.9.11-linux-x86_64_v3-gnu": {
@@ -24495,22 +18799,6 @@
     "sha256": "9cb5ab650efad6e475026f7782f852094a9403966bcc1f795065b1a4a33e362b",
     "variant": null
   },
-  "cpython-3.9.11-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "190cb2cc081d0d6ffca9232e877a959915452f6fd3808cfe128f6ebc392fcfb2",
-    "variant": null
-  },
   "cpython-3.9.11-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -24525,22 +18813,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8d7eee9c085e08f3cc6cdf56be7cc0dc8a3e25e053856c1a933efb3529c087de",
-    "variant": null
-  },
-  "cpython-3.9.11-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "0455c95330532edf5c30d4a30873140e7e6c715fbca921ac127769865382050b",
     "variant": null
   },
   "cpython-3.9.11-windows-i686-none": {
@@ -24623,22 +18895,6 @@
     "sha256": "020bcbfff16dc5ce35a898763be3d847c97df2e14dabf483a8ec88b0455ff971",
     "variant": "debug"
   },
-  "cpython-3.9.11+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "046c027a79ab60b70f2853ef978d89a97d2d35d9af3e7d7e9684d20b66afa6bc",
-    "variant": "debug"
-  },
   "cpython-3.9.11+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -24653,22 +18909,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7d7a745a3d6eade5fd7352b444c4c91ce562a2d188716d6995155c2ed5d1e337",
-    "variant": "debug"
-  },
-  "cpython-3.9.11+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b0b1389d83b844aed6bfa73270fefd902a9869403e9dae79772506f9a0344578",
     "variant": "debug"
   },
   "cpython-3.9.11+debug-linux-x86_64_v3-gnu": {
@@ -24687,22 +18927,6 @@
     "sha256": "ea43a4a473ebf99af4f7b9ae1d00e3bd6c5a2a329096e5657590ed5d823903dd",
     "variant": "debug"
   },
-  "cpython-3.9.11+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bd1d91ca3f95e1b7314604d9377013a0b537c6ae32408d0b25ef0e46792d1146",
-    "variant": "debug"
-  },
   "cpython-3.9.11+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -24717,22 +18941,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a1e7c4554d200d4fa50dc43cda6db020df99f75bb105dd7c44139c44d5040fae",
-    "variant": "debug"
-  },
-  "cpython-3.9.11+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d61f3edf4284c0d1a9acf4e68b684eb518db0cea191be20188ee58a59546b286",
     "variant": "debug"
   },
   "cpython-3.9.10-darwin-aarch64-none": {
@@ -24815,22 +19023,6 @@
     "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
     "variant": null
   },
-  "cpython-3.9.10-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d",
-    "variant": null
-  },
   "cpython-3.9.10-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -24845,22 +19037,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f9c6b0412c0773e604a1f95d5db97f79f98d960bcf0e85215e533ea573721216",
-    "variant": null
-  },
-  "cpython-3.9.10-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "5e4bde1751608e7f3ae2d9029c8866d0325db24c5a3b8441b62bef14fb8484be",
     "variant": null
   },
   "cpython-3.9.10-linux-x86_64_v3-gnu": {
@@ -24879,22 +19055,6 @@
     "sha256": "5c23a5f13356adfcf26d27df7e48885e634489e3a2383e67c013c3f1ec2e082e",
     "variant": null
   },
-  "cpython-3.9.10-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "649371a944665efa5b286d530c76808fb4f6ae4694f59c2ced8596fbe65d5164",
-    "variant": null
-  },
   "cpython-3.9.10-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -24909,22 +19069,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e97477ab9d30b52faf7de9e364ff50acf4490a28f7bf6fa11887f5a26e56ec93",
-    "variant": null
-  },
-  "cpython-3.9.10-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "6bcba95a5d6f1378821ba16c5d5b8a2e02bb365c1314d0492f66545973459ae4",
     "variant": null
   },
   "cpython-3.9.10-windows-i686-none": {
@@ -25039,22 +19183,6 @@
     "sha256": "d453abf741c3196ffc8470f3ea6404a3e2b55b2674a501bb79162f06122423e5",
     "variant": "debug"
   },
-  "cpython-3.9.10+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3ea1f4b06710a87a4f817b9084f60cc7ea481eb1090adc81306031ac4b382131",
-    "variant": "debug"
-  },
   "cpython-3.9.10+debug-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": {
@@ -25069,22 +19197,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8317251d7480b9fc8b4f0b76dbb91b339bc55760cc92715e66f91a3055396497",
-    "variant": "debug"
-  },
-  "cpython-3.9.10+debug-linux-x86_64_v2-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v2"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2d99f49e6ae4c56f63653a0a85eccf3d8e39077c1f9585e8d15d77835ecab976",
     "variant": "debug"
   },
   "cpython-3.9.10+debug-linux-x86_64_v3-gnu": {
@@ -25103,22 +19215,6 @@
     "sha256": "c2a8ef2fd0f2c033371e931c2588444c5872b3c1fe7c787e0139e9ee03177ea6",
     "variant": "debug"
   },
-  "cpython-3.9.10+debug-linux-x86_64_v3-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v3"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bca138192f93c76d0b26d48bd7fdbd31e75dae403a5a34cb826284748549dba7",
-    "variant": "debug"
-  },
   "cpython-3.9.10+debug-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": {
@@ -25133,22 +19229,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "162da56c07f3bec783c3c202b274c89ab115dae82ab7783b04404c7e315b819f",
-    "variant": "debug"
-  },
-  "cpython-3.9.10+debug-linux-x86_64_v4-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": "v4"
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ecd1b5c6a1183ab24284dd7a71b4cfe72dc1c9759c67d4266733fb839d7b3a99",
     "variant": "debug"
   },
   "cpython-3.9.7-darwin-aarch64-none": {
@@ -25228,22 +19308,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -25359,22 +19423,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-debug-20211017T1616.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.6-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -25452,22 +19500,6 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -25583,22 +19615,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-debug-20210724T1424.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.5-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -25660,22 +19676,6 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -25775,22 +19775,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-debug-20210506T0943.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.4-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -25852,22 +19836,6 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -25967,22 +19935,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-debug-20210414T1515.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.3-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -26028,22 +19980,6 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-pgo%2Blto-20210413T2055.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -26127,22 +20063,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-debug-20210413T2055.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.2-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -26204,22 +20124,6 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -26319,22 +20223,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-debug-20210327T1202.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.1-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -26364,22 +20252,6 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.1-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-noopt-20210103T1125.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -26447,22 +20319,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.9.0-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -26492,22 +20348,6 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.9.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-noopt-20201020T0627.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -26575,22 +20415,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.9.0+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.20-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -26653,22 +20477,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11",
-    "variant": null
-  },
-  "cpython-3.8.20-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa",
     "variant": null
   },
   "cpython-3.8.20-windows-i686-none": {
@@ -26735,22 +20543,6 @@
     "sha256": "311c259280fb53844d281f2c2a2f4d7343fc520628a79cff488ee7e045843751",
     "variant": "debug"
   },
-  "cpython-3.8.20+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "451432b8c869484464f26690839857dd7380aa588c3c052314c5324a26b5727e",
-    "variant": "debug"
-  },
   "cpython-3.8.19-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -26813,22 +20605,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b",
-    "variant": null
-  },
-  "cpython-3.8.19-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c",
     "variant": null
   },
   "cpython-3.8.19-windows-i686-none": {
@@ -26895,22 +20671,6 @@
     "sha256": "0bd4dc46b451d40c04ff329ecb30e6a9eb375973d9457421e7afaaaa86614f74",
     "variant": "debug"
   },
-  "cpython-3.8.19+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a165c74be970b1804bda7acba186b7e3b96bd76e4e38fafd95bf7a40e21c8128",
-    "variant": "debug"
-  },
   "cpython-3.8.18-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -26975,22 +20735,6 @@
     "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7",
     "variant": null
   },
-  "cpython-3.8.18-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37",
-    "variant": null
-  },
   "cpython-3.8.18-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -27053,22 +20797,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "189ae3b8249c57217e3253f9fc89857e088763cf2107a3f22ab2ac2398f41a65",
-    "variant": "debug"
-  },
-  "cpython-3.8.18+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "375d241bbd7d8704794fbda9387de8328999b5fb377f091ebb026bdace4abc24",
     "variant": "debug"
   },
   "cpython-3.8.17-darwin-aarch64-none": {
@@ -27151,22 +20879,6 @@
     "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8",
     "variant": null
   },
-  "cpython-3.8.17-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307",
-    "variant": null
-  },
   "cpython-3.8.17-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -27245,22 +20957,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f499750ab0019f36ccb4d964e222051d0d49a1d1e8dbada98abae738cf48c9dc",
-    "variant": "debug"
-  },
-  "cpython-3.8.17+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c396b744f28286fc0980073efd08ce55eef5bd0197a4944c3bae5c339ef91269",
     "variant": "debug"
   },
   "cpython-3.8.16-darwin-aarch64-none": {
@@ -27343,22 +21039,6 @@
     "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f",
     "variant": null
   },
-  "cpython-3.8.16-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc",
-    "variant": null
-  },
   "cpython-3.8.16-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -27437,22 +21117,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f12f5cb38f796ca48dc73262c05506a6f21f59d24e709ea0390b18bf71c2e1f9",
-    "variant": "debug"
-  },
-  "cpython-3.8.16+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "54898fbd313530295cf103bb4e7c7922096ed1c56f46a955975ecd4fb5b02987",
     "variant": "debug"
   },
   "cpython-3.8.15-darwin-aarch64-none": {
@@ -27535,22 +21199,6 @@
     "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56",
     "variant": null
   },
-  "cpython-3.8.15-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f",
-    "variant": null
-  },
   "cpython-3.8.15-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -27629,22 +21277,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "c3c8c23e34bddb4a2b90333ff17041f344401775d505700f1ceddb3ad9d589e0",
-    "variant": "debug"
-  },
-  "cpython-3.8.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ef23e1c394127b770995e021aff6b1ee3580d5c4f3d12abd6d5c64e007b972cf",
     "variant": "debug"
   },
   "cpython-3.8.14-darwin-aarch64-none": {
@@ -27727,22 +21359,6 @@
     "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0",
     "variant": null
   },
-  "cpython-3.8.14-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4",
-    "variant": null
-  },
   "cpython-3.8.14-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -27821,22 +21437,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "bd1e8e09edccaab82fbd75b457205a076847d62e3354c3d9b5abe985181047fc",
-    "variant": "debug"
-  },
-  "cpython-3.8.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a63a6565153b0f8b2e23611c7622ded3b5cb488d090f26fb4895bd396f8f72ea",
     "variant": "debug"
   },
   "cpython-3.8.13-darwin-aarch64-none": {
@@ -27919,22 +21519,6 @@
     "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187",
     "variant": null
   },
-  "cpython-3.8.13-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984",
-    "variant": null
-  },
   "cpython-3.8.13-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -28015,22 +21599,6 @@
     "sha256": "891b5d7b0e936b98a62f65bc0b28fff61ca9002125a2fc1ebb9c72f6b0056712",
     "variant": "debug"
   },
-  "cpython-3.8.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "45802706624fe2b2aa57bd42418b5d2f9f94f5372f31c664762393316223389e",
-    "variant": "debug"
-  },
   "cpython-3.8.12-darwin-aarch64-none": {
     "name": "cpython",
     "arch": {
@@ -28093,22 +21661,6 @@
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
-    "variant": null
-  },
-  "cpython-3.8.12-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25",
     "variant": null
   },
   "cpython-3.8.12-windows-i686-none": {
@@ -28191,22 +21743,6 @@
     "sha256": "9ad20c520c291d08087e9afb4390f389d2b66c7fc97f23fffc1313ebafc5fee0",
     "variant": "debug"
   },
-  "cpython-3.8.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "10bca8ab83f2ebb0f7b308a9e2bfebe9a0e638485f6947da9cdb26d95889ef32",
-    "variant": "debug"
-  },
   "cpython-3.8.11-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -28252,22 +21788,6 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.11-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -28351,22 +21871,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.11+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-debug-20210724T1424.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.10-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -28412,22 +21916,6 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.10-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -28511,22 +21999,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.10+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-debug-20210506T0943.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.9-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -28572,22 +22044,6 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -28671,22 +22127,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-debug-20210414T1515.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.8-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -28732,22 +22172,6 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.8-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -28831,22 +22255,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-debug-20210327T1202.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -28876,22 +22284,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-noopt-20210103T1125.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -28959,22 +22351,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -29004,22 +22380,6 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-noopt-20201020T0627.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -29087,22 +22447,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -29132,22 +22476,6 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-noopt-20200823T0036.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -29215,22 +22543,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -29260,22 +22572,6 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-noopt-20200518T0040.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -29343,22 +22639,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.8.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.8.2-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -29388,22 +22668,6 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.8.2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-musl-noopt-20200418T2309.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -29503,22 +22767,6 @@
     "sha256": null,
     "variant": null
   },
-  "cpython-3.7.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-noopt-20200823T0036.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
   "cpython-3.7.9-windows-i686-none": {
     "name": "cpython",
     "arch": {
@@ -29583,22 +22831,6 @@
     "sha256": null,
     "variant": "debug"
   },
-  "cpython-3.7.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
   "cpython-3.7.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": {
@@ -29628,22 +22860,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-    "sha256": null,
-    "variant": null
-  },
-  "cpython-3.7.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-noopt-20200518T0040.tar.zst",
     "sha256": null,
     "variant": null
   },
@@ -29708,22 +22924,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-debug-20200518T0040.tar.zst",
-    "sha256": null,
-    "variant": "debug"
-  },
-  "cpython-3.7.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": {
-      "family": "x86_64",
-      "variant": null
-    },
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
     "sha256": null,
     "variant": "debug"
   },

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -258,7 +258,10 @@ class CPythonFinder(Finder):
                     download = self._parse_download_url(url)
                     if download is None:
                         continue
-                    if download.release < CPYTHON_MUSL_STATIC_RELEASE_END and download.triple.libc == "musl":
+                    if (
+                        download.release < CPYTHON_MUSL_STATIC_RELEASE_END
+                        and download.triple.libc == "musl"
+                    ):
                         continue
                     logging.debug("Found %s (%s)", download.key(), download.filename)
                     downloads_by_version.setdefault(download.version, []).append(

--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -2159,24 +2159,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("15566e568211fa087c048ca5ef73692674f7136ed36c2b27aa5973c07e6dcfa4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -2185,24 +2167,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("905dbd718c24fad56be24454c26a15f4c7acc162d0f7e1c8c19791cefaa14f3c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("420b3286ea909db207f510447b76e51310ba131e7231e247a6ba72a487ff20d5")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2231,24 +2195,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("dfdfd8ccd40e9c02d6b19d40cbf15f3371fa5aa1b211a8f3ec5f457e0e7a36c1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -2257,24 +2203,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("777c72f0de3a155b1333fb8f4bb06b035c51e05c3e5ccf229ad5dbe277338a30")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.13.1%2B20250115-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("fec2a7fc1a245eaa2f2b0fb90290cb1c02b4e2eba0e1be500a247751dc03c1f7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2717,24 +2645,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("10978500ab6589760716c644aeadffa0f2c0bf31ea10f0c6160fee933933a567")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -2743,24 +2653,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("5c10c0b05c66bc6fc9a87f456ac1606057fe1865cc525eb7ecd9a5640f15426a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("6797067b7da58c29384cd32cb77f62dc18e813e6c72f6b0baf39672d84431bf2")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2789,24 +2681,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("0572fbf46e49adaa5a418eeb92daeb624a080466a46d87d48e4a80f1ba9e408a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -2815,24 +2689,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("36bd61970dc1d3a7034f2645aa14b47b6aa1669819fb7803650b5a7919afddbf")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.13.0%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("a846556bdd4d61b3f96aa8b096c86db031d7f5b5ef50f9e614c9259527afc9de")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3257,24 +3113,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -3283,24 +3121,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("ae477db35ccec397a19c9d61271455adf4917ab35993dbcacae8d126890f6b12")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8c73e28a683b7e826ed5bda4cf119ec8270238fdf936e3a2b3ca0938cfcde8c9")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3329,24 +3149,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("27a93fc7678782b392e5ee8e654635bc29409939318bbc341df3d29386f2166f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -3355,24 +3157,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("8c1424f2501419b88560951497df095c82e856af9b8f817f96beedeb4d8bc32d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 3 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8c318b2a79d75ca7ce3b76f8799a1db0337ba1278601bf0ec4433d64313d1aca")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3563,24 +3347,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -3589,24 +3355,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("e60fc176fad636bbd287e92f9e9954b8b10d164984e98f51e4dc3d47314fa8a5")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("16f23e539336fb45895b3c4fac981365b53fbbd86115feb9516b50a0716394b1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3635,24 +3383,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("df60f51c87da60af67453e5d7c5673f1534c2772d92a4885ae51add3cd32848e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -3661,24 +3391,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("fb8d87e21bd0cb83bfbb5325f2db170365726a9cac58dd5b552fbd084671b785")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Some(Prerelease { kind: PrereleaseKind::Rc, number: 2 }),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("eafb931d1a0e6f7237486d2967d0ccacd49791bef27f233895b5d18581ae939a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4211,24 +3923,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8121b6e4a2f719546f91be348e72bf6190727d891bbbd7acc7d06becd5a182fe")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4237,24 +3931,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("9000f65bb17fe1afbed1a07cc603fffd1474b362da80d9a4f926ca49d28e3a24")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("12c53712d9728e7f320e102c6cfb48ad03e0daede8bafd2ea05d97c0c43a9649")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4283,24 +3959,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8e936b03797abdc60211b8b89431fb4fd55f660cc7c8eb263423b3f9382c058e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4309,24 +3967,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("41b5902edeef93cb256b62389bda81741502f7e0aee4e2e94c2e60b9d2df37fb")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20250115/cpython-3.12.8%2B20250115-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("5d51a685e0e7b3c7babc8f1a5c8db41b4282f318161618e2b4a0603c464a3bc5")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4517,24 +4157,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("9314cb4d5aa525f2dc9f8d6ac204bebcfdfa8eb0dd4d3788af68769184355484")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4543,24 +4165,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("205395841e6e7cbd33d504b78ac81792364831911866416da7a34d9b4a06d7d1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("bfdd008fb669ddd023a8c36c16987c98b0d2bdfb99c9d45e2c9a792d87710b72")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4589,24 +4193,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("2c11efdb7df78ed787ac67c094c58a75f6549a78660888d99a861fc08e88ebe2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4615,24 +4201,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("172c0ab8ac018a0b44a47f03a7a78cd583bdc1e60cd5cfbf7d05b269c5d73f5c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.12.7%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("4576e092f2eaa6f5685be048b50671f9df0fff2b261ee001f604fb983bc9bb71")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4823,24 +4391,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4849,24 +4399,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("3ce9eb5d974dc2109c3e2c3986f4883ec5403b3479259ea781475a319f9a6787")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("6dab95cdd6d3f165aaaa7dcd7cb263add390d97c7b57eb62d2d1ca9a304353da")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4895,24 +4427,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("f2a295a6e400c16d6b3fe51c63c5b017e6c20a0a9e21a664170ecb6b9a104d8e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -4921,24 +4435,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("debba8985df38a492e8fc4b7b8d2261567f56eae716aa7630b836523625c6a96")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("03c0ac05d6027b603ea0f5f9f2c463bd58f942706ae78dca27922b25dca8f16a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5129,24 +4625,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5155,24 +4633,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("c0064dcd97e5a09b5ff9529fc65cf6fd7a8a20f71a7050f584ecaa0cc8c33f2d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("35ffd76881bef5ce09a123175f4f3419eb250802e60a6bb78649585325b8409f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5201,24 +4661,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("302a26f5d35e1c9e9d82765aa7dbf5ceb609c402431ec97d7fa0e85d8247c023")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5227,24 +4669,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("d7e82fcf72ec5faedfbabf1084ca55f850971a559ba54350de312663570f4782")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("46771e859224aa128150160d568d5d19a69e0f9a8f27d110ea26c031b588c734")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5435,24 +4859,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5461,24 +4867,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("798e562eb68b8d825c25c747b9995046b700c5bafbe8f7e558f41a3d8a57ceb7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("762dc23608111f49729f02c19fa8459219ac886e8694b79f541ef01141bf58c5")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5507,24 +4895,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("304bdcdf495529a6edcac34646e4f065f0963e4c3061cef9093b76bb0e8cca90")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5533,24 +4903,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("507fce8676d23af12f97b1f66efa876360d19fbe89675163a0c7c5d631763c84")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8989f75d70f6c874f3031ba1841efd96089f589f04d445fbacd478a1f866c118")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5741,24 +5093,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5767,24 +5101,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b9b91f486e2a52b6cc392101245705d6ab5dd6ad4a4e2b3492baec8e4b96508b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e47a8d25c2348bf9b0e818642e4dae90700fc3fbd96ffd7f4ad9518a7206d369")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5813,24 +5129,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9685fc300be464a9338e94e48fc7315ee0563999833f8c830f2a2dee2d750b7e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -5839,24 +5137,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("790e70e565b3efc5f1d14294f7cc083d1fb2aa4c15074d547e8e6bb9d2adb70a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c4d399923625ff5b5c20eceba0d8580c858768eff73dd9380aa8265030788850")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6011,24 +5291,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6037,24 +5299,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("adfe5c1a6039b8806b3dee0aed5fe860540d55231be87df48891a7844279d76a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e5c0adb646defd55791bbdd217f64d08a51855e818ee67e3ea6207521f92abee")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6083,24 +5327,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("bcf21a4105fe82cbefbd8bdf76dfc7eb98297b51ad02f0fc0a92929bcc95d6e9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6109,24 +5335,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("32ec4268b4d16a428deb642ddd875ae6e738b85558bfbdc4628018ff2e5b9e95")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("3b0e8c27c3a1dd339d8e6b53b3fc7faee379a70755093917d6ddca00253621c9")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6281,24 +5489,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6307,24 +5497,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9dd6fc5a1326985896493d475e7eae0d07f6de0d932faef3c4b04bdd81b88c0c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("db45fc29b4c0389b23af6ccd2d1427c3200ed7db4a81e5fd3bfbd9a4fd011c41")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6353,24 +5525,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("2585d13ac6b3e18a24d31f4baea23a810f4c7eb37306c348eeee4dfb87f84866")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6379,24 +5533,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("510f3f3e1841bb0e236dfac8dbd6680a4990d60a060b6972978cbc89524d4736")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("6f34607bafc6104d294ae16be240856af6217555015665c34ff7e94ad33dfe29")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6551,24 +5687,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6577,24 +5695,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("6d7710c9a74f624d1fe60a5a01ed6db874659d906220b1d98a0a79a36bbcb2e6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("927de631f2f37b950c2ea8ca53dc36ce8389026f34c31add31c5f730e7227bae")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6623,24 +5723,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("28aa3b88cacb908ab57c4202010eebe4a18fad65b5c289d061aec841a0fbbdfb")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -6649,24 +5731,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("13f4c20d3277d0bff7b14125d4904bbf5c498fe14d550d31fd584b5beabe6e0f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("8c20230e3679d5b2d765c6cae2afead81207762c3a9c725249e7ba644f61d4f5")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7181,24 +6245,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("5b33f0ff29552f15daacf81c426ed585fae24987b47d614142a7906eae6f2b04")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7207,24 +6253,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("64aefc042352e6bd10c4f600f1962af7dfec4586385f723c218b6369d3f211a2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("3714fec489d93c1ea458788a348d3380f98de22679a40a063e761753e7a48e71")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7253,24 +6281,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("a2778c2e5c8c48b555f935b4a7ff64f77f6ba0d1bdfb81b12d32905ddf7179cb")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7279,24 +6289,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("56ed6aeed4795235b4f4349c4c0bf4ee81fdd00ad854eaedcccd5c43388d7545")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.11.10%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("c8e8f7a3fa9d797ec0957562f82eaba4dcadf04ef304ac616bdb6332c725a609")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7487,24 +6479,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7513,24 +6487,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("6f579d9b2ec635b7cc4eb983719ae8b4ee34248f2054939cc3b1b23b44c65c60")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("d776c6bfd09719f0a18fe23e25b314fed8e32c0c0474c21524020d5481bdcda1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7559,24 +6515,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("e8ed1a00acd996590056c8e00351038fd1ecf9910428f592989410f06a765eef")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7585,24 +6523,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("92247f338ba132e9ff6e4b0dffc2eacfab6958552b0354e623f5016c5e83bafd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("adb10e3c2eb598560c14a375b34776d80bc83656e571f8ddc2b882630db8cd4d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7757,24 +6677,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7783,24 +6685,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e4f70dcb40acc2342d63103808a19f728a1c1dc9e0fad5344061daaab03a4ce5")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("a3f12605552d5450cfc8fe6c8fc468f99a42b2ae33f1ef42d5f49356d66ad305")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7829,24 +6713,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("417890e151d07f9242d0b7ed2e16b7fee59b6606cd133105bba234f14823f8ce")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -7855,24 +6721,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e363cc041a4464bd729771d6d223f3ec13c1e76dacdedc207ad1f6fb777bcb71")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9d430c32970e6b0f7cf030ed69dc63ee7b198543ef1e818c5a074c34052fa9e4")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8027,24 +6875,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8053,24 +6883,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2cdd399100e647aa9d381e197e6a8c98e822ecb8fc1b6bda4b1eb554dbfb8177")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e9387d628e6f49587206655e61295cdbfea43944c4259c24566fa19e0596ba4e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8099,24 +6911,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("eec99f0614e8250027e8f72b535776b44e0ad74e24cba9716942cd4c6e08844c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8125,24 +6919,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("28590cf568f192dbc5c91814321bca8bfe749cdf5e60a2aad968a0ae74d6bb4a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("3e3b2d4831c6353ae68808a517d59425addd857dbf925958db11b3280f46ed1e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8297,24 +7073,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8323,24 +7081,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d93961f7d6df53f5e888ce070b92d19a7fce588bb03abfac2b6f3c5bf2923c80")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("3bb96293951e613fc3f36e7132dcfc34190e5ed634448b12dd1e496723bedbd0")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8369,24 +7109,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("99afdac2a24966c828faf6f13c8c100c6c432d1c888450cfadb39dbc7a7562f1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8395,24 +7117,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ea850efb2de01c9389580ea0a6f55c7271dd3028b31fe0cca3ff9716fb580879")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("ebd862470d4f66da160f9a65fc058d4feff3822a97318ccc5c3765a99e0ba439")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8585,24 +7289,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8611,24 +7297,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("6f25769f73827cfc9f80114dbbc04fa959e96f82bf1b1297bc56ae08afaa6a90")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("f442249bea0a61dfec2911d86aa49f4c047eabfa2322914d040f2377c1228b48")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8657,24 +7325,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("41e2068884c86fc6a51670b12de140e12d6eb849bb450a970c77798f568aef72")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8683,24 +7333,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9759ce08bb96716f26aedd4e4d5879f810d9ca1e6f185d9881910837ae66cd29")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("568e7a24d390fcd91b7524869c76c4e03dac9940692b381c29ae005651c5f1d7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8873,24 +7505,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8899,24 +7513,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("dd1530d8a2e002f68e3d7ed1aa568a0e9278a5c87ba1f2ec4b9bae75777a6bc2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9bea574e0f01eda7154ab1972a3d413c462a731568b5923ed2ae30174167a408")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8945,24 +7541,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("d8a4a5d572e163eca53f83c91fca78955a92ec5cd2c9713e0e51ad7901add798")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -8971,24 +7549,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3802bf8c6f305b7b841dbbf1b091d9820d9bd65e9f5b246d2d071c42baa80fec")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c50912dce8107bd06c93cd73f96c4bfec0714fc63ba9246c8726b253443e21a7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9143,24 +7703,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -9169,24 +7711,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d0191c35051ade259d3324f437c6f2422743ccb79197af6dc64c161b06eddca9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9715fc26b9a6de09ebc29c978ce1bea81c0a64f730125f1230743c18f536de27")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9215,24 +7739,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9ea67df4e6cafabb6cee6adcc5f863708b1e717caad47be105eb4eb7170eca11")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -9241,24 +7747,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5bc5eb3892957c0a9eae87fc3ce97f2b0b31406fd6ef1d20bfa8074a44121cb4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("7b7645a773cb0660b0f0c807af580b9b4a49d49de39b89d10ccfb01372e5a573")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9395,24 +7883,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -9421,24 +7891,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("cc322d17b9ead6aeee4ac116fa2f802d525b4d97343fac8b8ada458810b47b40")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("0e7dae505cdb31bee4095f7c004a9f89d78263d6f24fe32eb225bfbc34d7f6ab")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9467,24 +7919,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("ae7add6ad69f9a1852fed17ca04ebe3412bf5f190e008d8cfbe94bfe21445c48")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -9493,24 +7927,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("dcee403d2f3416c0a7beae2fe58d9ca5646bb73ae47c0431d43911a0a8581a62")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("257d4ca1a7167f0b1d65900ca27d0d0f747e1e10bd27fbadeaa4a8bf0bf5b5e3")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10025,24 +8441,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("a169bdcd98f62421062fb9066763495913f4a86ee88c7d36e51df86d5d3cbe62")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10051,24 +8449,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("a85f3481c8117a11b5aa4fda0a6eb174b54e97b122cc8f83cf773a876751785b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("3f78660fd377d6073fa0ab642c20729c16fbc74fd67f8f35688e648fee014f4a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10097,24 +8477,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("75df2a6b3845ce3e4aa556276d65288e509b17bc35ebb462a60230a8eff5039c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10123,24 +8485,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("7d616298bffd2e4ffd0e72ab3786f2e4b9759dcd59a8cf7ac00f74a8642d5537")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.10.15%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("b343dff67fc9a6a03943b2bb2d6eb7d15f693533c706cc31f887d7db2625a70d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10331,24 +8675,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10357,24 +8683,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("327049baeb8319f0a31a14d28fce5608af546c27fb09994f56e3c0e17efb48c3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("cc2ed06f898466616c6534de1fd3b00d02fae415274ecb7210f5199b2550c38c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10403,24 +8711,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("c3177e9c8a9b339f33fa18ca896d59dbe22853cb88be3d844ac7859c543b5913")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10429,24 +8719,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("5f0b093b83d5dad323463269d2cd53516e51ef0f5e965001ac8947450c3fc917")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("845008e1afab23633b1f8f49323d8de15f24cdda523974df2bab2d080af5bfbf")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10619,24 +8891,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10645,24 +8899,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ee43e708b6c4c1ffb5b17b41c51305672e3af2fd686960e4e024a86f969c1a1e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("779be1530f099b4ce0b87fe03f4621e6edca926393c7c857d581f50ffc4df66b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10691,24 +8927,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("13d11d53372a058a9df956057d75e14ac229cce8daae6c42d97e742fed63f978")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10717,24 +8935,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c1cdc034c483794a4792571b44318f7608769b5b2d116635723e4bd702b5ea69")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c1e61caff30433105aad15ea47ddc20b5ced4ccafd8e3666fa85667777354584")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10907,24 +9107,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -10933,24 +9115,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("843504ad0f655f19614f2edb689808ed5fd2712bbf5a0eb0331ff1ebf871d457")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("d5d33effa6d64c83392f12b63fdf122843d943c7cfaa05ab734677699241cf93")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10979,24 +9143,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("bc17cb3b279a031cbcb2427238254758e89ac44541a95a5ddec968bc13ff0181")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11005,24 +9151,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("7cc21bad92259bf08d60cbe0650133d55f461f102a8ac9908dbd23400d9b35fa")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("1eef14ac488ab43ccf54144697d6892645414fc4926cd1456136cd427a8ae454")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11177,24 +9305,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11203,24 +9313,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("7e6281f9ff93ac54c38abfffe874907591ae6db431df7633b73fa5e62066582c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("bc168048359070be77bf7cf03af1e4cf8c9144d348e59bd5849ebf046694462c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11249,24 +9341,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("862119d9b37def3cba4ceaf10b7415594bc171b4aa6c057e70433349ecb33474")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11275,24 +9349,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("488df9d6af3baca3fd2b26005e5b1a0e29b53c602bc6ecfa4f21d20715107fba")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("35db9299916982e0b9fbf483ae15b7a4b90a418c857ded61be241d81acbc9779")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11429,24 +9485,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11455,24 +9493,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e69b2e48696f1e19231bed30616aa4ac6ef0fb4b3760e9e525e2c9c4c30ddb61")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("89d13b06e73bd347e46b1424f8c56823e13920cc3cdb32a75c247852cbc84f76")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11501,24 +9521,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e7c53f1fe15ecba006276b41c3e1947c19ae3af4d53b6fae35f86b210db4e4df")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11527,24 +9529,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2c40f64d283d05755b531247eaeb6172cde6d31ba6c46cfa106b97b4669cea88")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("8dae0e8c598003e84351a2559d87b44335d02317eb82c75ea13c51aac5891a3f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11681,24 +9665,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11707,24 +9673,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("81eaeef0c63349f296d6c9fed6bb6ff3f2f29db649f0725351e6af147413cc90")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("efe550859e00a15325b6c4fff0d5df23ae08017ba8f74616bc0e9e73f899871d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11753,24 +9701,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("51ebd0a996a750d9101791d5b7789237f7262e4381c21ee5b87e3a2dd88b7628")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11779,24 +9709,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b2617ece01070eeaa37fd5feaf1b5835435bd5151386218e6383cf9ee57bb4d2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c641d68243082094f4afbda99eee7da5226906aa7bfca5859044c217e7133db6")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -11933,24 +9845,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -11959,24 +9853,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ae5ad8fe84d8b1fd2e6fe2f47a632c9a1244686c12ce98cdd4a553be1fda2f9e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("4af5e7eb30ae33db0729c019cbca4d76c973dac27167ad4131902078531eb05b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12005,24 +9881,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("1cd4072435039557c0b6f528f18865b4d4d36c807d51abd69a6a43c73c26e9af")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12031,24 +9889,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f7c803a2ecd63dfc89210e1b6dffb0c509f2680ec9484e824c2d3a14f91a7803")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("2bef222e2469cbb4e8cac98a7b31f92b7dcd9672ec4db714fe6fe0090806ad53")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12185,24 +10025,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12211,24 +10033,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e5478adc739ecd6f7b770e613fa0e5757f13fe9cbeb34f7990e5522b0593d6db")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("6097200a90aa57ad5fe8d4446f4f09d6653b3db6dd1fec80f96cbeafcf76de12")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12257,24 +10061,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9d36dcbd9b47b3205dc5b1371a3839a5ad5317e7ba5fa353bac326635717a3a0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12283,24 +10069,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("327533dae8332ee61ed87dd5b7cfee3188a25a9fde65c3e27865185cb3e79b2b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c09bd9d306cd1eae99ed1de66313b0b2617b63a9cafec5e9fa3c5dd82e2d43ca")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12437,24 +10205,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12463,24 +10213,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("81e0c857175472f62641c49186f637cd1a391e4741b43afff5f55688512de1f1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("febb7ebb1df876145be4f25a1caabbb8ec05758950e7efdebc33587f7ad3ca3c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12509,24 +10241,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("f28cfb4da443626267792c81b1ac4919765782d38757b0e90daf2db525502615")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12535,24 +10249,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("cab2739ef27fcb7920dfbc99e57f2aec1256146a4646cf01488c60a267ed9ea3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("5864ccaefdb3f6372f0b59f9c823e5925526c4064a94afad2bcdc9cf919e9365")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12689,24 +10385,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12715,24 +10393,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("a94db687c197ac8fd9ade2695fe93ce9da392818ed52980459c25c7d39bcd73f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c2bfbee97c9a4c4f5f5722ea68ea1a4d9f0e2510d02919af0f989d3061c66b3f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12761,24 +10421,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("a750ac0ba4c23de6ab3ce494fd23e9b0e47dbf961e1fd29cb543ca60e200ba44")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12787,24 +10429,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("12b5c2f325e99499fa6d79fb9cef3562f8a7635917353f2a79d4c30ac529e7a0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("70bcf588b9f9b7a6aca236ff8214f17b123caa5da039ecc00ddee4828e9cc1bb")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -12941,24 +10565,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -12967,24 +10573,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("56b36066cda53fb371d92e769b7dc4b18df2d857930871946052d6be724febce")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("f2cd3e6824d768603d6adc911aeb31de87f12bff9d3dc93624e944c6312acbdf")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -13013,24 +10601,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e8ff9e1db06889cc65324a878b3d1e49de1213766a0401345b486761721ea125")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -13039,24 +10609,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("04df195d33f88ce2e1160416951eb772e9c61528aad1d15c508d9fd11041fc59")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("7ad8fdc6f0d26156bc350533a9af7bf582230be8ad6935934911fd8afd184085")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -13193,24 +10745,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -13219,24 +10753,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("1cbd17424d858fbb37e6184bf355f72830a47d2e33a4b8de872fa87aaa49a15e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("1067c4c6fc40bbd2d8b747177296bbeb4abfcb54e700226f2f211c3a2b90be46")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -13265,24 +10781,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("dddc62de5f796dbb33cbc81ebdb496758ea653c918a840d12574373aa4835165")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -13291,24 +10789,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("0493e89aae5b95b17f3092402cd7b6516494cad817aff68cc2988a4c065ae1ab")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("7dd9634e06daf56e58dfab4f71bea2d4d9b5c808fc30a40eb6208e76dfe24b14")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -13434,24 +10914,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -13967,24 +11429,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("332ce515daa15173f73d0ecebc988fadfac5583af8355d8895b3eb8086dac813")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -13993,24 +11437,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1461b5364d07a56f1879390eaec72542fe0dd48fa369ce4507c555677bfe07ea")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("237ec3d144e488130476c1d2c70d8ca7f2b36f423eb0ead348a78c6fc1fb7abb")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14039,24 +11465,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("0f99bd0d5b0d1afb207f3e6d4fb36be303bf277ac7c327dd07b7d1e6ba90f9ea")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14065,24 +11473,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("693a3f129a86c48c176b35db81eae0bf54faec893fe8386ec5116070638c4712")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241016/cpython-3.9.20%2B20241016-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("0d8f9e08f4eb14575574728b174591736ceaada37a03c1bdec17184475ffabe8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14273,24 +11663,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14299,24 +11671,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1d8179bde4db3e6cffac45f5c6a105e342a50a854b316b26760c17ba32bb164a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v2-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("2f9eac6ff7bc42a06b0f04cc28f5f24e851dcbb5d4a025a170e036ac1511a226")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14345,24 +11699,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v3-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("3c79c2c628d9412658e2fe21864439f53d22fa2dd8bc4f355564e73115715e37")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14371,24 +11707,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("7098fa8e0dac6a689d5289e761b85f713b607c476bfb1c1da13b3f86edce8461")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64_v4-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("1c6c6d2113fd3965d29b2fc70621ff81a1f7165a9dd660de980b805ba61a5c39")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14561,24 +11879,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14587,24 +11887,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ff8e33905d114a590cd13f5e17590efd6ad56c4eb841c9820863da2f55b13860")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("2ab7781e0d14d92272d7bcfb1383328ded38213fa9ad9ca00d1d08dae1ada26e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14633,24 +11915,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("20c45210b2ef110ce6f01038e2861435cc6b9ccf94e7f015dcb111c3f5d0b629")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14659,24 +11923,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("31b1548bd8e259b6b4a84d69d6ddcd27397af5971e3ffadd162f3a38eb623f6a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("61db6789f2974b6cf85fefc0e06950e43898e4a468d3c643cc35427d8ebf4fc0")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14849,24 +12095,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14875,24 +12103,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3d9275e70d39030030f7e9db5f05fc07e2be6fb4964af0053f4a461bac9ba1bd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("cdfe58799d017947c414bc8513ddb51bc7f4c25b2e603faa8dfcfd931a47392f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -14921,24 +12131,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("4a541fb47184505c165adcb88490fa9df11e7d34fd9bd0117f70b42c50dcc7e1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -14947,24 +12139,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("114573e1c4919116e5ecf4c6425f44e09b03527fcddffe3d53f73fe1ce9df7d8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("53a1b8cd550e803e258ba04192a18ccfe2ce4cbca2dc776cec47b2eba2507305")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15119,24 +12293,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15145,24 +12301,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("08acda6031601b35291fa54f98888dc17d36c9ff35bdb2adea4631df81e24271")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("b78dbd216e23a8f4adda881fbe11f6749371c09b4235dd519a4b4be761dd1504")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15191,24 +12329,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("675b7d77d653f47561536eae8fcd1ffaedd467ffcf43afdd9c96d2d32e8e84c4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15217,24 +12337,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fc289e674fb61ca4e39a4676ee11971e3f87bab607951898336b5df53b6ca328")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("9bdb07f9e9dc429553d12b434293f270c9e281ea7c7ffe5be4f6e8b2cc151e03")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15371,24 +12473,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15397,24 +12481,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("436c35bd809abdd028f386cc623ae020c77e6b544eaaca405098387c4daa444c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("52e774f1ccbbc61a30da2a95286348700ee7d7707412ef10035420f43469c39f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15443,24 +12509,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("a7c4dcff34014b01de397ffe6497787935575f604f489d01cdd843b41dd320e6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15469,24 +12517,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("65350987640f33876d072a44d03e6e397dcf5d2512819bd8765c892ec5c0f153")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("33b227fdde7a236e69635dafc0cfbfcee76594b9892092357ffd35a0dcb303e7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15623,24 +12653,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15649,24 +12661,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3b858cd4a187db8cd1eaedddd5ff80a077783092ca4d84970097127220f55cd4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("d912966b120f5406046bf5a5252a6585cfb7620fe5d570a265cd221dfd8fbeb3")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15695,24 +12689,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("46cd2e2b988bb5f6e12b184f2130d678ee781f84520dee1d8c487f2e0d1e3371")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15721,24 +12697,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f14391bc3b71dadc8855577325e3a49b17f351d428cc4caad8b1216b90f3ad80")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("355b1b5c3098b45f9b3dd1602321787c6731a70e574846efe29d96aef31d1e5b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15875,24 +12833,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15901,24 +12841,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("1e1b522a91ed805287793427013762bc8f6c02440147e9fa5306316369307e58")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e3142427ed091bfe0986cf49954fa3fcbe7754f42d66e4fd0ce68f41a513c3c1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -15947,24 +12869,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("40be6728331395abce574e080e5411e781c0a8a3a5d5175ae10534cee8d83ae2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -15973,24 +12877,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b4c5a9908a77e4cae37901f8df2655380186d0e10723902672ef5e5296093071")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("3b21780f0eba88519f0c00032cfb8ddb959b31a76cf21611a26da5d8296a9200")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16127,24 +13013,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16153,24 +13021,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("72085205843949f783c9245ad42902a63a00dd35367f1e5ea6f4aa709b2029ce")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("140ea77e2924fc312ecd266337f1add09e560084422843673b08ff847259a93f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16199,24 +13049,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("afceda37726445a1472b023ca7e6fb1b169557c7fc26a2ffa53e2b59247e1c6c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16225,24 +13057,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("7a5fcad095ad183049b2f975cd55efd8a2ce3e4d894ee67cb5fa01186f50203e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("81138b9b65bc01ed441bf0ab0fa2225c3d131a3b13838cc698c9e4aaef4cab11")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16379,24 +13193,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16405,24 +13201,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("bd9d808283eef69882e8e0c2529fe400c8605b7c08ef64e679d1766c1a87ef95")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("69439fb7c2e8f8bda28f2d5f4c71634116800d71a06f7cbeeb8f21ebca829fd2")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16451,24 +13229,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("190cb2cc081d0d6ffca9232e877a959915452f6fd3808cfe128f6ebc392fcfb2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16477,24 +13237,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8d7eee9c085e08f3cc6cdf56be7cc0dc8a3e25e053856c1a933efb3529c087de")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("0455c95330532edf5c30d4a30873140e7e6c715fbca921ac127769865382050b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16631,24 +13373,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V2),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16657,24 +13381,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f9c6b0412c0773e604a1f95d5db97f79f98d960bcf0e85215e533ea573721216")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V2),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("5e4bde1751608e7f3ae2d9029c8866d0325db24c5a3b8441b62bef14fb8484be")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16703,24 +13409,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
                 family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V3),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("649371a944665efa5b286d530c76808fb4f6ae4694f59c2ced8596fbe65d5164")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
                 variant: Some(ArchVariant::V4),
             },
             os: Os(target_lexicon::OperatingSystem::Linux),
@@ -16729,24 +13417,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e97477ab9d30b52faf7de9e364ff50acf4490a28f7bf6fa11887f5a26e56ec93")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: Some(ArchVariant::V4),
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("6bcba95a5d6f1378821ba16c5d5b8a2e02bb365c1314d0492f66545973459ae4")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -16872,24 +13542,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -17026,24 +13678,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -17142,24 +13776,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -17278,24 +13894,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -17376,24 +13974,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-pgo%2Blto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -17512,24 +14092,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -17602,24 +14164,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-noopt-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -17682,24 +14226,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-noopt-20201020T0627.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -17818,24 +14344,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 20,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -17944,24 +14452,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-        sha256: Some("6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 19,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -18061,24 +14551,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 18,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -18214,24 +14686,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 17,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -18349,24 +14803,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 16,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -18502,24 +14938,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 15,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -18637,24 +15055,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 14,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -18790,24 +15190,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 13,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -18916,24 +15298,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-        sha256: Some("27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 12,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19014,24 +15378,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -19132,24 +15478,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19230,24 +15558,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -19348,24 +15658,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19428,24 +15720,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-noopt-20210103T1125.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -19528,24 +15802,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-noopt-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19608,24 +15864,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-noopt-20200823T0036.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -19708,24 +15946,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-noopt-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19788,24 +16008,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-musl-noopt-20200418T2309.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -19888,24 +16090,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-noopt-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
                 family: target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686),
                 variant: None,
             },
@@ -19968,24 +16152,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             variant: PythonVariant::Default
         },
         url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch{
-                family: target_lexicon::Architecture::X86_64,
-                variant: None,
-            },
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-            variant: PythonVariant::Default
-        },
-        url: "https://github.com/astral-sh/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-noopt-20200518T0040.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -466,11 +466,7 @@ impl ManagedPythonDownload {
 
     /// Iterate over all [`ManagedPythonDownload`]s.
     pub fn iter_all() -> impl Iterator<Item = &'static ManagedPythonDownload> {
-        PYTHON_DOWNLOADS
-            .iter()
-            // TODO(konsti): musl python-build-standalone builds are currently broken (statically
-            // linked), so we pretend they don't exist. https://github.com/astral-sh/uv/issues/4242
-            .filter(|download| download.key.libc != Libc::Some(target_lexicon::Environment::Musl))
+        PYTHON_DOWNLOADS.iter()
     }
 
     pub fn url(&self) -> &'static str {

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -126,6 +126,10 @@ impl Arch {
     pub fn family(&self) -> target_lexicon::Architecture {
         self.family
     }
+
+    pub fn is_arm(&self) -> bool {
+        matches!(self.family, target_lexicon::Architecture::Arm(_))
+    }
 }
 
 impl Display for Libc {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -13,11 +13,10 @@ use tracing::{debug, trace};
 
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
-use uv_python::downloads::{self, DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
+use uv_python::downloads::{DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
 use uv_python::managed::{
     python_executable_dir, ManagedPythonInstallation, ManagedPythonInstallations,
 };
-use uv_python::platform::Libc;
 use uv_python::{
     PythonDownloads, PythonInstallationKey, PythonRequest, PythonVersionFile,
     VersionFileDiscoveryOptions, VersionFilePreference,
@@ -55,17 +54,7 @@ impl InstallRequest {
             .fill()?;
 
         // Find a matching download
-        let download = match ManagedPythonDownload::from_request(&download_request) {
-            Ok(download) => download,
-            Err(downloads::Error::NoDownloadFound(request))
-                if request.libc().is_some_and(Libc::is_musl) =>
-            {
-                return Err(anyhow::anyhow!(
-                    "uv does not yet provide musl Python distributions. See https://github.com/astral-sh/uv/issues/6890 to track support."
-                ));
-            }
-            Err(err) => return Err(err.into()),
-        };
+        let download = ManagedPythonDownload::from_request(&download_request)?;
 
         Ok(Self {
             request,


### PR DESCRIPTION
Following the upstream release and #12120, removes gating preventing installation of the managed musl Python versions.

Of note

- The filtering of musl Python distributions has moved from the Rust runtime to the metadata fetcher
- The filtering is now conditional on the PBS release date, removing all old static musl distributions
- We could support the `+static` musl downloads in the future; right now, they are deprioritized when selecting a variant
- I added test to CI which uses Alpine and installs numpy