### PR TITLE
remove `BaseClientBuild::client`, expose `ExtraMiddleware`

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -50,7 +50,6 @@ pub struct BaseClientBuilder<'a> {
     native_tls: bool,
     retries: u32,
     pub connectivity: Connectivity,
-    client: Option<Client>,
     markers: Option<&'a MarkerEnvironment>,
     platform: Option<&'a Platform>,
     auth_integration: AuthIntegration,
@@ -85,7 +84,6 @@ impl BaseClientBuilder<'_> {
             native_tls: false,
             connectivity: Connectivity::Online,
             retries: DEFAULT_RETRIES,
-            client: None,
             markers: None,
             platform: None,
             auth_integration: AuthIntegration::default(),
@@ -124,12 +122,6 @@ impl<'a> BaseClientBuilder<'a> {
     #[must_use]
     pub fn native_tls(mut self, native_tls: bool) -> Self {
         self.native_tls = native_tls;
-        self
-    }
-
-    #[must_use]
-    pub fn client(mut self, client: Client) -> Self {
-        self.client = Some(client);
         self
     }
 

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -1,5 +1,5 @@
 pub use base_client::{
-    is_extended_transient_error, AuthIntegration, BaseClient, BaseClientBuilder,
+    is_extended_transient_error, AuthIntegration, BaseClient, BaseClientBuilder, ExtraMiddleware,
     UvRetryableStrategy, DEFAULT_RETRIES,
 };
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -8,7 +8,7 @@ use async_http_range_reader::AsyncHttpRangeReader;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::HeaderMap;
 use itertools::Either;
-use reqwest::{Client, Response, StatusCode};
+use reqwest::{Response, StatusCode};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::sync::Semaphore;
 use tracing::{info_span, instrument, trace, warn, Instrument};
@@ -112,12 +112,6 @@ impl<'a> RegistryClientBuilder<'a> {
     #[must_use]
     pub fn cache(mut self, cache: Cache) -> Self {
         self.cache = cache;
-        self
-    }
-
-    #[must_use]
-    pub fn client(mut self, client: Client) -> Self {
-        self.base_client_builder = self.base_client_builder.client(client);
         self
     }
 


### PR DESCRIPTION
close #12127 

as discussed in #12127 remove unused BaseClientBuild::client field, and make base_client::ExtraMiddleware public.