### PR TITLE
Make testpypi index explicit in example snippet

### DIFF
--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -82,6 +82,7 @@ If you're using a custom index through `[[tool.uv.index]]`, add `publish-url` an
 name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
+explicit = true
 ```
 
 !!! note


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Update this example snippet adding test.pypi.org as a publishing index to mark the index with `explicit = true`. This will help prevent users from unexpected behavior if no other indices are defined and users don't select a different index selection algorithm (with `--index-strategy`). When `test.pypi.org` is the selected index for package management, packages resolve to odd versions like 0.0.1 and `uv` spits out lots of errors.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

N/A, documentation only change
<!-- How was it tested? -->
