### PR TITLE
Use consistent commas around i.e. and e.g.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ Changelog entries and version bumps are automated. First, run:
 
 Then, editorialize the `CHANGELOG.md` file to ensure entries are consistently styled.
 
-Then, open a pull request e.g. `Bump version to ...`.
+Then, open a pull request, e.g., `Bump version to ...`.
 
 Binary builds will automatically be tested for the release.
 

--- a/changelogs/0.1.x.md
+++ b/changelogs/0.1.x.md
@@ -1050,11 +1050,11 @@ See [#2976](https://github.com/astral-sh/uv/pull/2976#discussion_r1566521453) fo
 
 ### Bug fixes
 
-- Fix HTTP authentication when the password includes percent encoded characters (e.g. with Google
+- Fix HTTP authentication when the password includes percent encoded characters (e.g., with Google
   Artifact Registry) ([#2822](https://github.com/astral-sh/uv/issues/2822))
 - Use usernames from URLs when looking for credentials in netrc files and the keyring
   [#2563](https://github.com/astral-sh/uv/issues/2563))
-- Skip `HEAD` requests for indexes that return 403 (e.g. PyPICloud)
+- Skip `HEAD` requests for indexes that return 403 (e.g., PyPICloud)
   ([#3070](https://github.com/astral-sh/uv/pull/3070))
 - Use kebab-case consistently ([#3080](https://github.com/astral-sh/uv/pull/3080))
 - Show package name in no version for direct dependency error

--- a/changelogs/0.5.x.md
+++ b/changelogs/0.5.x.md
@@ -45,7 +45,7 @@ abundance of caution. We expect most users to be able to upgrade without making 
 - **Implement PEP 440-compliant local version semantics**
   ([#8797](https://github.com/astral-sh/uv/pull/8797))
 
-  Previously, uv's implementation of local versions (e.g. `2.0+cpu`) was not compliant with the
+  Previously, uv's implementation of local versions (e.g., `2.0+cpu`) was not compliant with the
   specification due to the technical complexity of implementing the local version semantics in the
   PubGrub algorithm. Thanks to the work of @ericmarkmartin, uv now has a spec-compliant
   implementation. Namely, uv will now allow a request for `torch==2.1.0` to install

--- a/crates/uv-globfilter/README.md
+++ b/crates/uv-globfilter/README.md
@@ -24,8 +24,8 @@ This crate supports the cross-language, restricted glob syntax from
   - `?`: Matches a single character except the path separator
   - `**`: Matches any number of characters including path separators
   - `[]`, containing only the verbatim matched characters: Matches a single of the characters
-    contained. Within `[...]`, the hyphen indicates a locale-agnostic range (e.g. `a-z`, order based
-    on Unicode code points). Hyphens at the start or end are matched literally.
+    contained. Within `[...]`, the hyphen indicates a locale-agnostic range (e.g., `a-z`, order
+    based on Unicode code points). Hyphens at the start or end are matched literally.
 - The path separator is the forward slash character (`/`). Patterns are relative to the given
   directory, a leading slash character for absolute paths is not supported.
 - Parent directory indicators (`..`) are not allowed.

--- a/crates/uv-pep440/Readme.md
+++ b/crates/uv-pep440/Readme.md
@@ -24,7 +24,7 @@ assert!(version_specifiers.contains(&version));
 
 PEP 440 has a lot of unintuitive features, including:
 
-- An epoch that you can prefix the version which, e.g. `1!1.2.3`. Lower epoch always means lower
+- An epoch that you can prefix the version with, e.g., `1!1.2.3`. Lower epoch always means lower
   version (`1.0 <=2!0.1`)
 
 * post versions, which can be attached to both stable releases and pre-releases
@@ -40,6 +40,6 @@ PEP 440 has a lot of unintuitive features, including:
 * local versions on top of all the others, which are added with a + and have implicitly typed string
   and number segments
 * no semver-caret (`^`), but a pseudo-semver tilde (`~=`)
-* ordering contradicts matching: We have e.g. `1.0+local > 1.0` when sorting, but `==1.0` matches
+* ordering contradicts matching: We have, e.g., `1.0+local > 1.0` when sorting, but `==1.0` matches
   `1.0+local`. While the ordering of versions itself is a total order the version matching needs to
   catch all sorts of special cases

--- a/crates/uv-pep508/Readme.md
+++ b/crates/uv-pep508/Readme.md
@@ -22,7 +22,7 @@ assert_eq!(dependency_specification.extras, Some(vec!["security".to_string(), "t
 ## Markers
 
 Markers allow you to install dependencies only in specific environments (python version, operating
-system, architecture, etc.) or when a specific feature is activated. E.g. you can say
+system, architecture, etc.) or when a specific feature is activated. E.g., you can say
 `importlib-metadata ; python_version < "3.8"` or `itsdangerous (>=1.1.0) ; extra == 'security'`.
 Unfortunately, the marker grammar has some oversights (e.g.
 <https://github.com/pypa/packaging.python.org/pull/1181>) and the design of comparisons (PEP 440

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -665,6 +665,6 @@ impl EnvVars {
 
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
     ///
-    /// This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
+    /// This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.
     pub const COLUMNS: &'static str = "COLUMNS";
 }

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -165,7 +165,7 @@ The `UV_PROJECT_ENVIRONMENT` environment variable can be used to configure the p
 environment path (`.venv` by default).
 
 If a relative path is provided, it will be resolved relative to the workspace root. If an absolute
-path is provided, it will be used as-is, i.e. a child directory will not be created for the
+path is provided, it will be used as-is, i.e., a child directory will not be created for the
 environment. If an environment is not present at the provided path, uv will create it.
 
 This option can be used to write to the system Python environment, though it is not recommended.

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -792,7 +792,7 @@ interpreted as "a version of `foo` that's at least 1.2.3, but less than 2, and n
 
 Specifiers are padded with trailing zeros if required, so `foo ==2` matches foo 2.0.0, too.
 
-A star can be used for the last digit with equals, e.g. `foo ==2.1.*` will accept any release from
+A star can be used for the last digit with equals, e.g., `foo ==2.1.*` will accept any release from
 the 2.1 series. Similarly, `~=` matches where the last digit is equal or higher, e.g., `foo ~=1.2`
 is equal to `foo >=1.2,<2`, and `foo ~=1.2.3` is equal to `foo >=1.2.3,<1.3`.
 

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -31,19 +31,19 @@ create the virtual environment with it.
 
 The following Python version request formats are supported:
 
-- `<version>` e.g. `3`, `3.12`, `3.12.3`
-- `<version-specifier>` e.g. `>=3.12,<3.13`
-- `<implementation>` e.g. `cpython` or `cp`
-- `<implementation>@<version>` e.g. `cpython@3.12`
-- `<implementation><version>` e.g. `cpython3.12` or `cp312`
-- `<implementation><version-specifier>` e.g. `cpython>=3.12,<3.13`
-- `<implementation>-<version>-<os>-<arch>-<libc>` e.g. `cpython-3.12.3-macos-aarch64-none`
+- `<version>` (e.g., `3`, `3.12`, `3.12.3`)
+- `<version-specifier>` (e.g., `>=3.12,<3.13`)
+- `<implementation>` (e.g., `cpython` or `cp`)
+- `<implementation>@<version>` (e.g., `cpython@3.12`)
+- `<implementation><version>` (e.g., `cpython3.12` or `cp312`)
+- `<implementation><version-specifier>` (e.g., `cpython>=3.12,<3.13`)
+- `<implementation>-<version>-<os>-<arch>-<libc>` (e.g., `cpython-3.12.3-macos-aarch64-none`)
 
 Additionally, a specific system Python interpreter can be requested with:
 
-- `<executable-path>` e.g. `/opt/homebrew/bin/python3`
-- `<executable-name>` e.g. `mypython3`
-- `<install-dir>` e.g. `/some/environment/`
+- `<executable-path>` (e.g., `/opt/homebrew/bin/python3`)
+- `<executable-name>` (e.g., `mypython3`)
+- `<install-dir>` (e.g., `/some/environment/`)
 
 By default, uv will automatically download Python versions if they cannot be found on the system.
 This behavior can be

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -218,7 +218,7 @@ required-environments = [
 
 ## Dependency preferences
 
-If resolution output file exists, i.e. a uv lockfile (`uv.lock`) or a requirements output file
+If resolution output file exists, i.e., a uv lockfile (`uv.lock`) or a requirements output file
 (`requirements.txt`), uv will _prefer_ the dependency versions listed there. Similarly, if
 installing a package into a virtual environment, uv will prefer the already installed version if
 present. This means that locked or installed versions will not change unless an incompatible version

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -7,8 +7,8 @@ with private repositories.
 
 Using SSH:
 
-- `git+ssh://git@<hostname>/...` (e.g. `git+ssh://git@github.com/astral-sh/uv`)
-- `git+ssh://git@<host>/...` (e.g. `git+ssh://git@github.com-key-2/astral-sh/uv`)
+- `git+ssh://git@<hostname>/...` (e.g., `git+ssh://git@github.com/astral-sh/uv`)
+- `git+ssh://git@<host>/...` (e.g., `git+ssh://git@github.com-key-2/astral-sh/uv`)
 
 See the
 [GitHub SSH documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh)
@@ -16,10 +16,10 @@ for more details on how to configure SSH.
 
 Using a password or token:
 
-- `git+https://<user>:<token>@<hostname>/...` (e.g.
+- `git+https://<user>:<token>@<hostname>/...` (e.g.,
   `git+https://git:github_pat_asdf@github.com/astral-sh/uv`)
-- `git+https://<token>@<hostname>/...` (e.g. `git+https://github_pat_asdf@github.com/astral-sh/uv`)
-- `git+https://<user>@<hostname>/...` (e.g. `git+https://git@github.com/astral-sh/uv`)
+- `git+https://<token>@<hostname>/...` (e.g., `git+https://github_pat_asdf@github.com/astral-sh/uv`)
+- `git+https://<user>@<hostname>/...` (e.g., `git+https://git@github.com/astral-sh/uv`)
 
 When using a GitHub personal access token, the username is arbitrary. GitHub does not support
 logging in with password directly, although other hosts may. If a username is provided without

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -419,7 +419,7 @@ Use to control color via `anstyle`.
 
 Overrides terminal width used for wrapping. This variable is not read by uv directly.
 
-This is a quasi-standard variable, described e.g. in `ncurses(3x)`.
+This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.
 
 ### `CONDA_DEFAULT_ENV`
 

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -50,7 +50,7 @@ To install multiple Python versions:
 $ uv python install 3.11 3.12
 ```
 
-To install an alternative Python implementation, e.g. PyPy:
+To install an alternative Python implementation, e.g., PyPy:
 
 ```console
 $ uv python install pypy@3.10

--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -86,7 +86,7 @@ publish-url = "https://test.pypi.org/legacy/"
 
 !!! note
 
-    When using `uv publish --index <name>`, the `pyproject.toml` must be present, i.e. you need to
+    When using `uv publish --index <name>`, the `pyproject.toml` must be present, i.e., you need to
     have a checkout step in a publish CI job.
 
 Even though `uv publish` retries failed uploads, it can happen that publishing fails in the middle,

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -76,7 +76,7 @@ print("hello world!")
 EOF
 ```
 
-Note that if you use `uv run` in a _project_, i.e. a directory with a `pyproject.toml`, it will
+Note that if you use `uv run` in a _project_, i.e., a directory with a `pyproject.toml`, it will
 install the current project before running the script. If your script does not depend on the
 project, use the `--no-project` flag to skip this:
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -65,7 +65,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
 When `uvx ruff` is invoked, uv installs the `ruff` package which provides the `ruff` command.
 However, sometimes the package and command names differ.
 
-The `--from` option can be used to invoke a command from a specific package, e.g. `http` which is
+The `--from` option can be used to invoke a command from a specific package, e.g., `http` which is
 provided by `httpie`:
 
 ```console

--- a/docs/reference/troubleshooting/build-failures.md
+++ b/docs/reference/troubleshooting/build-failures.md
@@ -259,7 +259,7 @@ dependencies of the package, e.g, `setuptools`.
 
 If a package fails to build during resolution and the version that failed to build is older than the
 version you want to use, try adding a [constraint](../settings.md#constraint-dependencies) with a
-lower bound (e.g. `numpy>=1.17`). Sometimes, due to algorithmic limitations, the uv resolver tries
+lower bound (e.g., `numpy>=1.17`). Sometimes, due to algorithmic limitations, the uv resolver tries
 to find a fitting version using unreasonably old packages, which can be prevented by using lower
 bounds.
 


### PR DESCRIPTION
## Summary

Only in user-facing docs -- I didn't bother with the rustdoc. (This is in the style guide already.)
