### PR TITLE
Remove redundant `activate.bat` output

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate.bat
+++ b/crates/uv-virtualenv/src/activator/activate.bat
@@ -20,9 +20,7 @@
 @REM WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 @REM This file is UTF-8 encoded, so we need to update the current code page while executing it
-@for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
-    @set _OLD_CODEPAGE=%%a
-)
+@for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do @set _OLD_CODEPAGE=%%a
 @if defined _OLD_CODEPAGE (
     @"%SystemRoot%\System32\chcp.com" 65001 > nul
 )


### PR DESCRIPTION
## Summary

See: https://github.com/pypa/virtualenv/pull/2801.

Closes https://github.com/astral-sh/uv/issues/12006.

## Test Plan

Ran `.venv\Scripts\activate.bat` on my Windows machine.
