### PR TITLE
docs: add instructions on dependabot with uv

### DIFF
--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -66,8 +66,10 @@ need to be explicitly defined using
 
 ## Dependabot
 
-Support for uv is now available. To configure Dependabot, create a `.github/dependabot.yml` file in
-the root of your repository and copy the following configuration into it:
+Support for uv is now
+[available](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/).
+To configure Dependabot, create a `.github/dependabot.yml` file in the root of your repository and
+copy the following configuration into it:
 
 ```yaml
 version: 2
@@ -80,3 +82,6 @@ updates:
     schedule:
       interval: "daily"
 ```
+
+For more information on how to configure Dependabot, refer to the
+[Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates).

--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -66,5 +66,17 @@ need to be explicitly defined using
 
 ## Dependabot
 
-Support for uv is not yet available. Progress can be tracked at
-[dependabot/dependabot-core#10478](https://github.com/dependabot/dependabot-core/issues/10478).
+Support for uv is now available. To configure Dependabot, create a `.github/dependabot.yml` file in
+the root of your repository and copy the following configuration into it:
+
+```yaml
+version: 2
+updates:
+  # Enable version updates for uv
+  - package-ecosystem: "uv"
+    # Look for `pyproject.toml` and `uv.lock` files in the `root` directory
+    directory: "/"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+```


### PR DESCRIPTION
## Summary

This PR updates the documentation on Dependabot for `uv` since [Dependabot now supports it](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/).

Ref: [dependabot/dependabot-core#10478](https://github.com/dependabot/dependabot-core/issues/10478#issuecomment-2722722972)
Ref: [Updated JSON schema on SchemaStore](https://json.schemastore.org/dependabot-2.0.json)

## Test Plan

This is documentation so no code was touched.
