### PR TITLE
Improve error message when a virtual environment Python symlink is broken

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -35,7 +35,7 @@ use crate::virtualenv::{
 };
 #[cfg(windows)]
 use crate::windows_registry::{registry_pythons, WindowsPython};
-use crate::{Interpreter, PythonVersion};
+use crate::{BrokenSymlink, Interpreter, PythonVersion};
 
 /// A request to find a Python installation.
 ///
@@ -815,7 +815,8 @@ impl Error {
                     );
                     false
                 }
-                InterpreterError::NotFound(path) | InterpreterError::BrokenVenvSymlink(path) => {
+                InterpreterError::NotFound(path)
+                | InterpreterError::BrokenSymlink(BrokenSymlink { path, .. }) => {
                     // If the interpreter is from an active, valid virtual environment, we should
                     // fail because it's broken
                     if let Some(Ok(true)) = matches!(source, PythonSource::ActiveEnvironment)
@@ -894,7 +895,7 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter at {request}");
                 match python_installation_from_executable(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenVenvSymlink(_)) => {
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
                         Ok(Err(PythonNotFound {
                             request: request.clone(),
                             python_preference: preference,
@@ -920,7 +921,7 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter in {request}");
                 match python_installation_from_directory(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenVenvSymlink(_)) => {
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
                         Ok(Err(PythonNotFound {
                             request: request.clone(),
                             python_preference: preference,

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -815,7 +815,7 @@ impl Error {
                     );
                     false
                 }
-                InterpreterError::NotFound(path) | InterpreterError::BrokenSymlink(path) => {
+                InterpreterError::NotFound(path) | InterpreterError::BrokenVenvSymlink(path) => {
                     // If the interpreter is from an active, valid virtual environment, we should
                     // fail because it's broken
                     if let Some(Ok(true)) = matches!(source, PythonSource::ActiveEnvironment)
@@ -894,7 +894,7 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter at {request}");
                 match python_installation_from_executable(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenVenvSymlink(_)) => {
                         Ok(Err(PythonNotFound {
                             request: request.clone(),
                             python_preference: preference,
@@ -920,7 +920,7 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter in {request}");
                 match python_installation_from_directory(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenVenvSymlink(_)) => {
                         Ok(Err(PythonNotFound {
                             request: request.clone(),
                             python_preference: preference,

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -815,7 +815,7 @@ impl Error {
                     );
                     false
                 }
-                InterpreterError::NotFound(path) => {
+                InterpreterError::NotFound(path) | InterpreterError::BrokenSymlink(path) => {
                     // If the interpreter is from an active, valid virtual environment, we should
                     // fail because it's broken
                     if let Some(Ok(true)) = matches!(source, PythonSource::ActiveEnvironment)

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -894,11 +894,13 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter at {request}");
                 match python_installation_from_executable(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_)) => Ok(Err(PythonNotFound {
-                        request: request.clone(),
-                        python_preference: preference,
-                        environment_preference: environments,
-                    })),
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
+                        Ok(Err(PythonNotFound {
+                            request: request.clone(),
+                            python_preference: preference,
+                            environment_preference: environments,
+                        }))
+                    }
                     Err(err) => Err(Error::Query(
                         Box::new(err),
                         path.clone(),
@@ -918,11 +920,13 @@ pub fn find_python_installations<'a>(
                 debug!("Checking for Python interpreter in {request}");
                 match python_installation_from_directory(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
-                    Err(InterpreterError::NotFound(_)) => Ok(Err(PythonNotFound {
-                        request: request.clone(),
-                        python_preference: preference,
-                        environment_preference: environments,
-                    })),
+                    Err(InterpreterError::NotFound(_) | InterpreterError::BrokenSymlink(_)) => {
+                        Ok(Err(PythonNotFound {
+                            request: request.clone(),
+                            python_preference: preference,
+                            environment_preference: environments,
+                        }))
+                    }
                     Err(err) => Err(Error::Query(
                         Box::new(err),
                         path.clone(),

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -677,14 +677,8 @@ impl Display for StatusCodeError {
 pub enum Error {
     #[error("Failed to query Python interpreter")]
     Io(#[from] io::Error),
-    #[error(
-        "Broken symlink at `{}`, was the underlying Python interpreter removed?\n\n{}{} Consider recreating the environment (e.g., with `{}`)",
-        _0.user_display(),
-        "hint".bold().cyan(),
-        ":".bold(),
-        "uv venv".green(),
-    )]
-    BrokenVenvSymlink(PathBuf),
+    #[error(transparent)]
+    BrokenSymlink(BrokenSymlink),
     #[error("Python interpreter not found at `{0}`")]
     NotFound(PathBuf),
     #[error("Failed to query Python interpreter at `{path}`")]
@@ -705,6 +699,33 @@ pub enum Error {
     },
     #[error("Failed to write to cache")]
     Encode(#[from] rmp_serde::encode::Error),
+}
+
+#[derive(Debug, Error)]
+pub struct BrokenSymlink {
+    pub path: PathBuf,
+    /// Whether the interpreter path looks like a virtual environment.
+    pub venv: bool,
+}
+
+impl Display for BrokenSymlink {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Broken symlink at `{}`, was the underlying Python interpreter removed?",
+            self.path.user_display()
+        )?;
+        if self.venv {
+            writeln!(
+                f,
+                "\n\n{}{} Consider recreating the environment (e.g., with `{}`)",
+                "hint".bold().cyan(),
+                ":".bold(),
+                "uv venv".green()
+            )?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -892,13 +913,16 @@ impl InterpreterInfo {
                     if absolute
                         .symlink_metadata()
                         .is_ok_and(|metadata| metadata.is_symlink())
-                        && executable
+                    {
+                        let venv = executable
                             .parent()
                             .and_then(Path::parent)
                             .map(|path| path.join("pyvenv.cfg").is_file())
-                            .unwrap_or(false)
-                    {
-                        Error::BrokenVenvSymlink(executable.to_path_buf())
+                            .unwrap_or(false);
+                        Error::BrokenSymlink(BrokenSymlink {
+                            path: executable.to_path_buf(),
+                            venv,
+                        })
                     } else {
                         Error::NotFound(executable.to_path_buf())
                     }

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -678,7 +678,7 @@ pub enum Error {
     #[error("Failed to query Python interpreter")]
     Io(#[from] io::Error),
     #[error(
-        "Broken symlink at `{}`, was the underlying Python interpreter removed?\n{}{} To recreate the virtual environment, run `{}`.",
+        "Broken symlink at `{}`, was the underlying Python interpreter removed?\n\n{}{} To recreate the virtual environment, run `{}`",
         _0.user_display(),
         "hint".bold().cyan(),
         ":".bold(),

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::discovery::{
 pub use crate::environment::{InvalidEnvironmentKind, PythonEnvironment};
 pub use crate::implementation::ImplementationName;
 pub use crate::installation::{PythonInstallation, PythonInstallationKey};
-pub use crate::interpreter::{Error as InterpreterError, Interpreter};
+pub use crate::interpreter::{BrokenSymlink, Error as InterpreterError, Interpreter};
 pub use crate::pointer_size::PointerSize;
 pub use crate::prefix::Prefix;
 pub use crate::python_version::PythonVersion;

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -234,7 +234,7 @@ impl InstalledTools {
 
                 Ok(None)
             }
-            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenVenvSymlink(
                 interpreter_path,
             ))) => {
                 let target_path = fs_err::read_link(&interpreter_path)?;

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -227,19 +227,22 @@ impl InstalledTools {
             Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(
                 interpreter_path,
             ))) => {
-                if interpreter_path.is_symlink() {
-                    let target_path = fs_err::read_link(&interpreter_path)?;
-                    warn!(
-                        "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
-                        interpreter_path.user_display(),
-                        target_path.user_display()
-                    );
-                } else {
-                    warn!(
-                        "Ignoring existing virtual environment with missing Python interpreter: {}",
-                        interpreter_path.user_display()
-                    );
-                }
+                warn!(
+                    "Ignoring existing virtual environment with missing Python interpreter: {}",
+                    interpreter_path.user_display()
+                );
+
+                Ok(None)
+            }
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(
+                interpreter_path,
+            ))) => {
+                let target_path = fs_err::read_link(&interpreter_path)?;
+                warn!(
+                    "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
+                    interpreter_path.user_display(),
+                    target_path.user_display()
+                );
 
                 Ok(None)
             }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -234,13 +234,13 @@ impl InstalledTools {
 
                 Ok(None)
             }
-            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenVenvSymlink(
-                interpreter_path,
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(
+                broken_symlink,
             ))) => {
-                let target_path = fs_err::read_link(&interpreter_path)?;
+                let target_path = fs_err::read_link(&broken_symlink.path)?;
                 warn!(
                     "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
-                    interpreter_path.user_display(),
+                    broken_symlink.path.user_display(),
                     target_path.user_display()
                 );
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -914,15 +914,14 @@ impl ProjectInterpreter {
                     InvalidEnvironmentKind::Empty => {}
                 }
             }
-            Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(path))) => {
-                if path.is_symlink() {
-                    let target_path = fs_err::read_link(&path)?;
-                    warn_user!(
+            Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(_))) => {}
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(path))) => {
+                let target_path = fs_err::read_link(&path)?;
+                warn_user!(
                         "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
                         path.user_display().cyan(),
                         target_path.user_display().cyan(),
                     );
-                }
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -915,13 +915,13 @@ impl ProjectInterpreter {
                 }
             }
             Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(_))) => {}
-            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(path))) => {
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenVenvSymlink(path))) => {
                 let target_path = fs_err::read_link(&path)?;
                 warn_user!(
-                        "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
-                        path.user_display().cyan(),
-                        target_path.user_display().cyan(),
-                    );
+                    "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
+                    path.user_display().cyan(),
+                    target_path.user_display().cyan(),
+                );
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -915,11 +915,13 @@ impl ProjectInterpreter {
                 }
             }
             Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(_))) => {}
-            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenVenvSymlink(path))) => {
-                let target_path = fs_err::read_link(&path)?;
+            Err(uv_python::Error::Query(uv_python::InterpreterError::BrokenSymlink(
+                broken_symlink,
+            ))) => {
+                let target_path = fs_err::read_link(&broken_symlink.path)?;
                 warn_user!(
                     "Ignoring existing virtual environment linked to non-existent Python interpreter: {} -> {}",
-                    path.user_display().cyan(),
+                    broken_symlink.path.user_display().cyan(),
                     target_path.user_display().cyan(),
                 );
             }

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -17370,7 +17370,7 @@ fn compile_broken_active_venv() -> Result<()> {
 
     // Simulate a removed Python interpreter
     fs_err::remove_file(context.interpreter())?;
-    std::os::unix::fs::symlink("/removed/python/interpreter", context.interpreter())?;
+    fs_err::os::unix::fs::symlink("/removed/python/interpreter", context.interpreter())?;
 
     uv_snapshot!(context
         .pip_compile()
@@ -17383,7 +17383,7 @@ fn compile_broken_active_venv() -> Result<()> {
     error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
       Caused by: Broken symlink at `.venv/bin/python3`, was the underlying Python interpreter removed?
 
-    hint: To recreate the virtual environment, run `uv venv`
+    hint: Consider recreating the environment (e.g., with `uv venv`)
     ");
 
     Ok(())


### PR DESCRIPTION
When removing a Python interpreter underneath an existing venv, uv currently shows a not found error:

```
error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
  Caused by: Python interpreter not found at `/home/konsti/projects/uv/.venv/bin/python3`
```

This is unintuitive, as the file for the Python interpreter does exist, it is a broken symlink that needs to be replaced with `uv venv`.

I've been encountering those occasionally, and I expect users that switch between versions a lot will, too, especially when they also use pyenv or a similar Python manager.

The new error hints at this solution:

```
error: Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
  Caused by: Broken symlink at `.venv/bin/python3`, was the underlying Python interpreter removed?

hint: To recreate the virtual environment, run `uv venv`
```