### PR TITLE
docs: Mention env var PYTHONUNBUFFERED

### DIFF
--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -527,6 +527,10 @@ See [`PycInvalidationMode`](https://docs.python.org/3/library/py_compile.html#py
 
 Adds directories to Python module search path (e.g., `PYTHONPATH=/path/to/modules`).
 
+### `PYTHONUNBUFFERED`
+
+If this is set to a non-empty string, forces unbuffered I/O streams for stdout and stderr, equivalent to `-u` in Python.
+
 ### `RUST_LOG`
 
 If set, uv will use this value as the log level for its `--verbose` output. Accepts


### PR DESCRIPTION
## Summary

I did not find any info about whether uv (run in particular) supports `PYTHONUNBUFFERED` but it seems to be implemented in [env_vars.rs](https://github.com/astral-sh/uv/blob/2f28d60ba3a959101a109d5912f565da08a117ba/crates/uv-static/src/env_vars.rs#L521).

(Sadly still no CLI parameter `-u` exists.)

## Test Plan

No testing as is purely a change in the markdown documentation.