### PR TITLE
Instruct Renovate to pin GitHub Actions based on SHA

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,17 @@
     enabled: true,
   },
   packageRules: [
+    // Pin GitHub Actions to immutable SHAs.
+    {
+      matchDepTypes: ["action"],
+      pinDigests: true,
+    },
+    // Annotate GitHub Actions SHAs with a SemVer version.
+    {
+      extends: ["helpers:pinGitHubActionDigests"],
+      extractVersion: "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
+      versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+    },
     {
       // Disable updates of `zip-rs`; intentionally pinned for now due to ownership change
       // See: https://github.com/astral-sh/uv/issues/3642


### PR DESCRIPTION
## Summary

The intent here is that all actions should be pinned to an immutable SHA (but that Renovate should annotate each SHA with the corresponding SemVer version).