### PR TITLE
Prefer stable releases over pre-releases in `uv python install`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2294,9 +2294,9 @@ impl VersionRequest {
         match self {
             Self::Default => false,
             Self::Any => true,
-            Self::Major(..) => true,
-            Self::MajorMinor(..) => true,
-            Self::MajorMinorPatch(..) => true,
+            Self::Major(..) => false,
+            Self::MajorMinor(..) => false,
+            Self::MajorMinorPatch(..) => false,
             Self::MajorMinorPrerelease(..) => true,
             Self::Range(specifiers, _) => specifiers.iter().any(VersionSpecifier::any_prerelease),
         }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -206,9 +206,9 @@ impl TestContext {
                 .push(("python.exe".to_string(), "python".to_string()));
         } else {
             self.filters
-                .push((r"python\d".to_string(), "python".to_string()));
-            self.filters
                 .push((r"python\d.\d\d".to_string(), "python".to_string()));
+            self.filters
+                .push((r"python\d".to_string(), "python".to_string()));
         }
         self
     }
@@ -221,6 +221,25 @@ impl TestContext {
             format!(r"[\\/]{}", venv_bin_path(PathBuf::new()).to_string_lossy()),
             "/[BIN]".to_string(),
         ));
+        self
+    }
+
+    /// Add extra standard filtering for Python installation `bin/` directories, which are not
+    /// present on Windows but are on Unix. See [`TestContext::with_filtered_virtualenv_bin`] for
+    /// the virtual environment equivalent.
+    #[must_use]
+    pub fn with_filtered_python_install_bin(mut self) -> Self {
+        if cfg!(unix) {
+            self.filters.push((
+                r"[\\/]bin/python".to_string(),
+                "/[INSTALL-BIN]/python".to_string(),
+            ));
+        } else {
+            self.filters.push((
+                r"[\\/]python".to_string(),
+                "/[INSTALL-BIN]/python".to_string(),
+            ));
+        }
         self
     }
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1217,8 +1217,8 @@ fn python_install_314() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.14.0a5 in [TIME]
-     + cpython-3.14.0a5-[PLATFORM]
+    Installed Python 3.14.0a6 in [TIME]
+     + cpython-3.14.0a6-[PLATFORM]
     ");
 
     // Install a specific pre-release
@@ -1230,5 +1230,45 @@ fn python_install_314() {
     ----- stderr -----
     Installed Python 3.14.0a4 in [TIME]
      + cpython-3.14.0a4-[PLATFORM]
+    ");
+
+    // We should be able to find this version without opt-in, because there is no stable release
+    // installed
+    uv_snapshot!(context.filters(), context.python_find().arg("3.14"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/bin/python3.14
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.python_find().arg("3"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/bin/python3.14
+
+    ----- stderr -----
+    ");
+
+    // If we install a stable version, that should be preferred though
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.13.2 in [TIME]
+     + cpython-3.13.2-[PLATFORM]
+    ");
+
+    uv_snapshot!(context.filters(), context.python_find().arg("3"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/managed/cpython-3.13.2-[PLATFORM]/bin/python3.13
+
+    ----- stderr -----
     ");
 }

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1207,7 +1207,9 @@ fn python_install_314() {
     let context: TestContext = TestContext::new_with_versions(&[])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_python_names()
+        .with_filtered_python_install_bin();
 
     // Install 3.14
     // For now, this provides test coverage of pre-release handling
@@ -1238,7 +1240,7 @@ fn python_install_314() {
     success: true
     exit_code: 0
     ----- stdout -----
-    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/bin/python3.14
+    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/[INSTALL-BIN]/python
 
     ----- stderr -----
     ");
@@ -1247,7 +1249,7 @@ fn python_install_314() {
     success: true
     exit_code: 0
     ----- stdout -----
-    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/bin/python3.14
+    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/[INSTALL-BIN]/python
 
     ----- stderr -----
     ");
@@ -1259,15 +1261,15 @@ fn python_install_314() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.13.2 in [TIME]
-     + cpython-3.13.2-[PLATFORM]
+    Installed Python 3.13.3 in [TIME]
+     + cpython-3.13.3-[PLATFORM]
     ");
 
     uv_snapshot!(context.filters(), context.python_find().arg("3"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
-    [TEMP_DIR]/managed/cpython-3.13.2-[PLATFORM]/bin/python3.13
+    [TEMP_DIR]/managed/cpython-3.13.3-[PLATFORM]/[INSTALL-BIN]/python
 
     ----- stderr -----
     ");

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1201,3 +1201,34 @@ fn python_install_patch_dylib() {
     ----- stderr -----
     "###);
 }
+
+#[test]
+fn python_install_314() {
+    let context: TestContext = TestContext::new_with_versions(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs();
+
+    // Install 3.14
+    // For now, this provides test coverage of pre-release handling
+    uv_snapshot!(context.filters(), context.python_install().arg("3.14"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.14.0a5 in [TIME]
+     + cpython-3.14.0a5-[PLATFORM]
+    ");
+
+    // Install a specific pre-release
+    uv_snapshot!(context.filters(), context.python_install().arg("3.14.0a4"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.14.0a4 in [TIME]
+     + cpython-3.14.0a4-[PLATFORM]
+    ");
+}


### PR DESCRIPTION
e.g., `uv python install 3` should not install the 3.14 alpha

Closes #12184 