### PR TITLE
Fix 2 typos in MRE docs

### DIFF
--- a/docs/reference/troubleshooting/reproducible-examples.md
+++ b/docs/reference/troubleshooting/reproducible-examples.md
@@ -9,7 +9,7 @@ a maintainer much longer to identify the root cause of the problem.
 
 ## How to write a reproducible example
 
-When writing a reproducible examaple, the goal is to provide all of the context necessary for
+When writing a reproducible example, the goal is to provide all of the context necessary for
 someone else to reproduce your example. This includes:
 
 - The platform you're using (e.g., the operating system and architecture)

--- a/docs/reference/troubleshooting/reproducible-examples.md
+++ b/docs/reference/troubleshooting/reproducible-examples.md
@@ -13,7 +13,7 @@ When writing a reproducible example, the goal is to provide all of the context n
 someone else to reproduce your example. This includes:
 
 - The platform you're using (e.g., the operating system and architecture)
-- Any relevant system state (e.g., )
+- Any relevant system state (e.g., explicitly set environment variables)
 - The version of uv
 - The version of other relevant tools
 - The relevant files (the `uv.lock`, `pyproject.toml`, etc.)

--- a/docs/reference/troubleshooting/reproducible-examples.md
+++ b/docs/reference/troubleshooting/reproducible-examples.md
@@ -9,8 +9,8 @@ a maintainer much longer to identify the root cause of the problem.
 
 ## How to write a reproducible example
 
-When writing a reproducible example, the goal is to provide all of the context necessary for
-someone else to reproduce your example. This includes:
+When writing a reproducible example, the goal is to provide all of the context necessary for someone
+else to reproduce your example. This includes:
 
 - The platform you're using (e.g., the operating system and architecture)
 - Any relevant system state (e.g., explicitly set environment variables)


### PR DESCRIPTION
2 fixes:

1. `examaple` -> `example`.
2. `"Any relevant system state (e.g., )"` was missing the part after `"e.g.,"`, so I'm adding an example there.