### PR TITLE
More descriptive error message for `uv run pythonx.xx`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1110,9 +1110,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 let version_part = executable.strip_prefix("python").unwrap_or("");
                 let current_executable_python_version = base_interpreter.python_version().only_release();
                 // Determine the environment type
-                let env_type = if project_found { "the project" } else { "the" };
+                let env_type = if project_found { "project" } else { "virtual" };
 
-                // Construct the message dynamically
                 let message_suffix = if project_found {
                     format!(
                         "Did you mean to change the environment to Python {version_part} with `uv run -p {version_part} python`?"
@@ -1123,7 +1122,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     )
                 };
                 anyhow!(
-                    "`{}` not available in {} environment, which uses python `{}`. {}",
+                    "`{}` not available in the {} environment, which uses python `{}`. {}",
                     executable,
                     env_type,
                     current_executable_python_version,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1578,8 +1578,8 @@ fn read_recursion_depth_from_environment_variable() -> anyhow::Result<u32> {
 }
 
 /// Matches valid Python executable names:
-/// - ✅ "python", "python3", "python3.9", "python4", "python3.10", "python3.13.3"
-/// - ❌ "python39", "python3abc", "python3.12b3", "", "python-foo"
+/// - ✅ "python", "python39", "python3", "python3.9", "python4", "python3.10", "python3.13.3"
+/// - ❌ "python3abc", "python3.12b3", "", "python-foo"
 fn is_python_executable(executable_command: &str) -> bool {
     executable_command
         .strip_prefix("python")

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1092,7 +1092,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
     // Ensure `VIRTUAL_ENV` is set.
     if interpreter.is_virtualenv() {
         process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
-    };
+    }
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
@@ -1107,18 +1107,18 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             if err.kind() == std::io::ErrorKind::NotFound && is_python_executable(&executable) {
                 // Get version from python command string
                 // e.g. python3.12 -> "3.12" or "" if python version not specified. 
-                let version_part = executable.strip_prefix("python").unwrap_or("");
+                let specified_version = executable.strip_prefix("python").unwrap_or("");
                 let current_executable_python_version = base_interpreter.python_version().only_release();
                 // Determine the environment type
                 let env_type = if project_found { "project" } else { "virtual" };
 
                 let message_suffix = if project_found {
                     format!(
-                        "Did you mean to change the environment to Python {version_part} with `uv run -p {version_part} python`?"
+                        "Did you mean to change the environment to Python {specified_version} with `uv run -p {specified_version} python`?"
                     )
                 } else {
                     format!(
-                        "Did you mean to search for a Python {version_part} environment with `uv run -p {version_part} python`?"
+                        "Did you mean to search for a Python {specified_version} environment with `uv run -p {specified_version} python`?"
                     )
                 };
                 anyhow!(

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -188,8 +188,11 @@ fn run_matching_python_patch_version() -> Result<()> {
 #[test]
 fn run_missing_python_minor_version_no_project() {
     let context = TestContext::new_with_versions(&["3.12"]);
+    let bin_dir = context.temp_dir.child("bin");
 
-    uv_snapshot!(context.filters(), context.run().arg("python3.11"), @r"
+    uv_snapshot!(context.filters(), context.run()
+        .arg("python3.11")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -206,8 +209,11 @@ fn run_missing_python_patch_version_no_project() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs();
+    let bin_dir = context.temp_dir.child("bin");
 
-    uv_snapshot!(context.filters(), context.run().arg("python3.11.9"), @r"
+    uv_snapshot!(context.filters(), context.run()
+        .arg("python3.11.9")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -224,6 +230,7 @@ fn run_missing_python_minor_version_in_project() -> Result<()> {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs();
+    let bin_dir = context.temp_dir.child("bin");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -235,7 +242,9 @@ fn run_missing_python_minor_version_in_project() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.run().arg("python3.11"), @r"
+    uv_snapshot!(context.filters(), context.run()
+        .arg("python3.11")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -258,6 +267,7 @@ fn run_missing_python_patch_version_in_project() -> Result<()> {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs();
+    let bin_dir = context.temp_dir.child("bin");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -269,7 +279,9 @@ fn run_missing_python_patch_version_in_project() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.filters(), context.run().arg("python3.11.9"), @r"
+    uv_snapshot!(context.filters(), context.run()
+        .arg("python3.11.9")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @r"
     success: false
     exit_code: 2
     ----- stdout -----

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -167,7 +167,7 @@ fn run_matching_python_patch_version() -> Result<()> {
      + cpython-3.11.9-[PLATFORM]
     ");
 
-    // Try runnning a patch version with the same as installed.
+    // Try running a patch version with the same as installed.
     uv_snapshot!(context.filters(), context.run().arg("python3.11.9"), @r"
     success: false
     exit_code: 2
@@ -186,7 +186,7 @@ fn run_matching_python_patch_version() -> Result<()> {
 }
 
 #[test]
-fn run_missing_python_minor_version_no_project() -> Result<()> {
+fn run_missing_python_minor_version_no_project() {
     let context = TestContext::new_with_versions(&["3.12"]);
 
     uv_snapshot!(context.filters(), context.run().arg("python3.11"), @r"
@@ -198,12 +198,10 @@ fn run_missing_python_minor_version_no_project() -> Result<()> {
     error: Failed to spawn: `python3.11`
       Caused by: `python3.11` not available in the virtual environment, which uses python `3.12.[X]`. Did you mean to search for a Python 3.11 environment with `uv run -p 3.11 python`?
     ");
-
-    Ok(())
 }
 
 #[test]
-fn run_missing_python_patch_version_no_project() -> Result<()> {
+fn run_missing_python_patch_version_no_project() {
     let context = TestContext::new_with_versions(&["3.12"])
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
@@ -218,8 +216,6 @@ fn run_missing_python_patch_version_no_project() -> Result<()> {
     error: Failed to spawn: `python3.11.9`
       Caused by: `python3.11.9` not available in the virtual environment, which uses python `3.12.[X]`. Did you mean to search for a Python 3.11.9 environment with `uv run -p 3.11.9 python`?
     ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -179,7 +179,7 @@ fn run_matching_python_patch_version() -> Result<()> {
     Resolved 1 package in [TIME]
     Audited in [TIME]
     error: Failed to spawn: `python3.11.9`
-      Caused by: `python3.11.9` not available in the project environment, which uses python `3.11.9`. Did you mean to change the environment to Python 3.11.9 with `uv run -p 3.11.9 python`?
+      Caused by: Please omit patch version. Try: `uv run python3.11`. Did you mean to change the environment to Python 3.11.9 with `uv run -p 3.11.9 python`?
     ");
 
     Ok(())
@@ -220,7 +220,7 @@ fn run_missing_python_patch_version_no_project() {
 
     ----- stderr -----
     error: Failed to spawn: `python3.11.9`
-      Caused by: `python3.11.9` not available in the virtual environment, which uses python `3.12.[X]`. Did you mean to search for a Python 3.11.9 environment with `uv run -p 3.11.9 python`?
+      Caused by: Please omit patch version. Try: `uv run python3.11`. Did you mean to search for a Python 3.11.9 environment with `uv run -p 3.11.9 python`?
     ");
 }
 
@@ -292,7 +292,7 @@ fn run_missing_python_patch_version_in_project() -> Result<()> {
     Resolved 1 package in [TIME]
     Audited in [TIME]
     error: Failed to spawn: `python3.11.9`
-      Caused by: `python3.11.9` not available in the project environment, which uses python `3.12.[X]`. Did you mean to change the environment to Python 3.11.9 with `uv run -p 3.11.9 python`?
+      Caused by: Please omit patch version. Try: `uv run python3.11`. Did you mean to change the environment to Python 3.11.9 with `uv run -p 3.11.9 python`?
     ");
 
     Ok(())


### PR DESCRIPTION
## Related Issue 

https://github.com/astral-sh/uv/issues/11796

## Summary

1. Add meaningful message when user invokes uv with `run python<valid-python-version>`. 

 ✅ "python", "python3", "python3.9", "python4", "python3.10", "python3.13.3", "python39" (yes, python39 might still be released in 100 years 😆 )
 ❌ "python3abc", "python3.12b3", "", "python-foo"
 
 2. Contextual information added depending on whether the command was run inside of a `uv project` or not. See: https://github.com/astral-sh/uv/pull/12201/files#diff-423c3a82aab6dba4068dd7675391fc9328a66682131dbf2043e7847ab4ba8661R1092
 
 ## Automated Tests

1. Added unit test for new functions created for parsing and validating python executable entered by user
2. TODO: Once specs are finalized through discussions in PR, will create integration tests if necessary
 
 ## Need to Discuss

1. Invoking python via its patch version - E.g. `python3.11.9` is invalid. However, uv supports `uv run -p 3.11.9 python`, which is why when we do the following: 

```python
uv run python3.11.9
```

We will get the following error:

```shell
error: Failed to spawn: `python3.11.9`
  Caused by: `python3.11.9` not available in the environment, which uses python `3.11.9`. Did you mean to search for a Python 3.11.9 environment with `uv run -p 3.11.9 python`?
```

Is this okay? If not, we need to define the specs in the PR here.

2. Supported python executable specs are defined as: 
- is stable version
- is not `post` version

See:https://github.com/astral-sh/uv/pull/12201/files#diff-423c3a82aab6dba4068dd7675391fc9328a66682131dbf2043e7847ab4ba8661R1572-R1574

Would this be okay?
We can change the specs if needed. Lets discuss.

## Manual Test

### Case 1: run outside of project

1. Case where no project is created. Look for a python executable version that is not available in my local machine (in my case, it was `python3.9`)
4. Run `cargo run -- run python3.9.3`

```Shell
error: Failed to spawn: `python3.9.3`
  Caused by: `python3.9.3` not available in the environment, which uses python `3.11.9`. Did you mean to search for a Python 3.9.3 environment with `uv run -p 3.9.3 python`?
```

5.  Run `cargo run -- run python3.9`

```shell
error: Failed to spawn: `python3.9`
  Caused by: `python3.9` not available in the environment, which uses python `3.11.9`. Did you mean to search for a Python 3.9 environment with `uv run -p 3.9 python`?
```

6. Run `cargo run -- run python3.11`

```Shell
Running `target/debug/uv run python3.11`
Python 3.11.9 (main, Apr  2 2024, 08:25:04) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```

7. Run `cargo run -- run python3.11.9`

```Shell
 Running `target/debug/uv run python3.11.9`
error: Failed to spawn: `python3.11.9`
  Caused by: `python3.11.9` not available in the environment, which uses python `3.11.9`. Did you mean to search for a Python 3.11.9 environment with `uv run -p 3.11.9 python`?
```

**IMPORTANT**: Is this acceptable? Invoking python by its patch version is not supported, so this is the expected behavior, but we need to discuss whether this behavior is acceptable.

### Case 2: run inside of project

Create project using `uv init example-app`

1. `uv run python3.13` 

```shell
error: Failed to spawn: `python3.13`
  Caused by: `python3.13` not available in the project environment, which uses python `3.12.5`. Did you mean to change the environment to Python 3.13 with `uv run -p 3.13 python`?
```

2. `uv run python3` 

```shell
uv run python3
Python 3.12.5 (main, Aug  6 2024, 19:08:49) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```
