### PR TITLE
Avoid creating duplicate directory entries in built wheels

### DIFF
--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -506,6 +506,14 @@ fn wheel_subdir_from_globs(
             root: src.to_path_buf(),
             err,
         })?;
+
+        // Skip the root path, which is already included as `target` prior to the loop.
+        // (If `entry.path() == src`, then `relative` is empty, and `relative_licenses` is
+        // `target`.)
+        if entry.path() == src {
+            continue;
+        }
+
         // TODO(konsti): This should be prettier.
         let relative = entry
             .path()


### PR DESCRIPTION
## Summary

This is a bug in the build backend revealed via https://github.com/astral-sh/uv/pull/12196. (By upgrading, `zip` now errors on duplicate entries.)
