### PR TITLE
Continue on ignored errors when fetching wheel metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7181,6 +7181,7 @@ dependencies = [
  "papaya",
  "percent-encoding",
  "petgraph",
+ "reqwest",
  "rkyv",
  "rustc-hash",
  "same-file",

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use http::HeaderValue;
+use http::{HeaderValue, StatusCode};
 use serde::{Deserialize, Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
@@ -206,8 +206,8 @@ pub struct Index {
     /// ```
     #[serde(default)]
     pub authenticate: AuthPolicy,
-    /// Status codes that uv should ignore when deciding whether
-    /// to continue searching in the next index after a failure.
+    /// Status codes that uv should ignore when deciding whether to continue resolution after a
+    /// request to this index fails.
     ///
     /// ```toml
     /// [[tool.uv.index]]
@@ -518,6 +518,15 @@ impl Index {
         } else {
             IndexStatusCodeStrategy::from_index_url(self.url.url())
         }
+    }
+
+    /// Return whether the given status code is explicitly ignored for this index.
+    pub(crate) fn ignores_error_code(&self, status_code: StatusCode) -> bool {
+        self.ignore_error_codes.as_ref().is_some_and(|codes| {
+            codes
+                .iter()
+                .any(|ignored_status_code| **ignored_status_code == status_code)
+        })
     }
 
     /// Return the cache control header for file requests to this index, if any.

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock, RwLock};
 
+use http::StatusCode;
 use itertools::Either;
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
@@ -500,6 +501,12 @@ impl<'a> IndexLocations {
             IndexStatusCodeStrategy::Default,
             Index::status_code_strategy,
         )
+    }
+
+    /// Return whether the given status code is explicitly ignored for an [`IndexUrl`].
+    pub fn ignores_error_code_for(&self, url: &IndexUrl, status_code: StatusCode) -> bool {
+        self.index_for_url(url)
+            .is_some_and(|index| index.ignores_error_code(status_code))
     }
 
     /// Return the Simple API cache control header for an [`IndexUrl`], if configured.

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -62,6 +62,7 @@ owo-colors = { workspace = true }
 percent-encoding = { workspace = true }
 petgraph = { workspace = true }
 pubgrub = { workspace = true }
+reqwest = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
 same-file = { workspace = true }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use jiff::Timestamp;
 use owo_colors::OwoColorize;
 use pubgrub::{DerivationTree, Derived, External, Map, Range, ReportFormatter, Term};
+use reqwest::StatusCode;
 use rustc_hash::FxHashMap;
 
 use uv_configuration::{IndexStrategy, NoBinary, NoBuild};
@@ -1185,6 +1186,12 @@ impl PubGrubReportFormatter<'_> {
                     reason: reason.clone(),
                 });
             }
+            Some(UnavailablePackage::Network(status)) => {
+                hints.insert(PubGrubHint::InvalidPackageNetwork {
+                    package: name.clone(),
+                    status: *status,
+                });
+            }
             Some(UnavailablePackage::NotFound) => {}
             None => {}
         }
@@ -1224,6 +1231,13 @@ impl PubGrubReportFormatter<'_> {
                                 version: version.clone(),
                                 requires_python: requires_python.clone(),
                                 python_version: python_version.clone(),
+                            });
+                        }
+                        MetadataUnavailable::Network(status) => {
+                            hints.insert(PubGrubHint::InvalidVersionNetwork {
+                                package: name.clone(),
+                                version: version.clone(),
+                                status: *status,
                             });
                         }
                     }
@@ -1427,6 +1441,12 @@ pub enum PubGrubHint {
         // excluded from `PartialEq` and `Hash`
         reason: UnavailableErrorChain,
     },
+    /// The package metadata could not be fetched due to a network error.
+    InvalidPackageNetwork {
+        package: PackageName,
+        // excluded from `PartialEq` and `Hash`
+        status: StatusCode,
+    },
     /// Metadata for a package version could not be parsed.
     InvalidVersionMetadata {
         package: PackageName,
@@ -1462,6 +1482,14 @@ pub enum PubGrubHint {
         requires_python: VersionSpecifiers,
         // excluded from `PartialEq` and `Hash`
         python_version: Version,
+    },
+    /// The package metadata could not be fetched due to a network error.
+    InvalidVersionNetwork {
+        package: PackageName,
+        // excluded from `PartialEq` and `Hash`
+        version: Version,
+        // excluded from `PartialEq` and `Hash`
+        status: StatusCode,
     },
     /// The `Requires-Python` requirement was not satisfied.
     RequiresPython {
@@ -1592,6 +1620,9 @@ enum PubGrubHintCore {
     InvalidPackageStructure {
         package: PackageName,
     },
+    InvalidPackageNetwork {
+        package: PackageName,
+    },
     InvalidVersionMetadata {
         package: PackageName,
     },
@@ -1599,6 +1630,9 @@ enum PubGrubHintCore {
         package: PackageName,
     },
     InvalidVersionStructure {
+        package: PackageName,
+    },
+    InvalidVersionNetwork {
         package: PackageName,
     },
     IncompatibleBuildRequirement {
@@ -1673,6 +1707,9 @@ impl From<PubGrubHint> for PubGrubHintCore {
             PubGrubHint::InvalidPackageStructure { package, .. } => {
                 Self::InvalidPackageStructure { package }
             }
+            PubGrubHint::InvalidPackageNetwork { package, .. } => {
+                Self::InvalidPackageNetwork { package }
+            }
             PubGrubHint::InvalidVersionMetadata { package, .. } => {
                 Self::InvalidVersionMetadata { package }
             }
@@ -1681,6 +1718,9 @@ impl From<PubGrubHint> for PubGrubHintCore {
             }
             PubGrubHint::InvalidVersionStructure { package, .. } => {
                 Self::InvalidVersionStructure { package }
+            }
+            PubGrubHint::InvalidVersionNetwork { package, .. } => {
+                Self::InvalidVersionNetwork { package }
             }
             PubGrubHint::IncompatibleBuildRequirement { package, .. } => {
                 Self::IncompatibleBuildRequirement { package }
@@ -1808,6 +1848,14 @@ impl std::fmt::Display for PubGrubHint {
                     textwrap::indent(reason.to_string().as_str(), "  ")
                 )
             }
+            Self::InvalidPackageNetwork { package, status } => {
+                write!(
+                    f,
+                    "Metadata for `{}` could not be fetched; the server returned: `{}`",
+                    package.cyan(),
+                    format!("{status}").red(),
+                )
+            }
             Self::InvalidVersionMetadata {
                 package,
                 version,
@@ -1832,6 +1880,19 @@ impl std::fmt::Display for PubGrubHint {
                     package.cyan(),
                     format!("v{version}").cyan(),
                     textwrap::indent(reason, "  ")
+                )
+            }
+            Self::InvalidVersionNetwork {
+                package,
+                version,
+                status,
+            } => {
+                write!(
+                    f,
+                    "Metadata for `{}` ({}) could not be fetched; the server returned: `{}`",
+                    package.cyan(),
+                    format!("v{version}").cyan(),
+                    format!("{status}").red(),
                 )
             }
             Self::InconsistentVersionMetadata {

--- a/crates/uv-resolver/src/resolver/availability.rs
+++ b/crates/uv-resolver/src/resolver/availability.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::iter;
 use std::sync::Arc;
+
+use reqwest::StatusCode;
 
 use uv_distribution_types::IncompatibleDist;
 use uv_pep440::{Version, VersionSpecifiers};
@@ -46,6 +49,8 @@ pub enum UnavailableVersion {
     /// The source distribution has a `requires-python` requirement that is not met by the installed
     /// Python version (and static metadata is not available).
     RequiresPython(VersionSpecifiers),
+    /// The network request failed with the given status code.
+    Network(StatusCode),
 }
 
 impl UnavailableVersion {
@@ -59,6 +64,7 @@ impl UnavailableVersion {
             Self::RequiresPython(requires_python) => {
                 format!("Python {requires_python}")
             }
+            Self::Network(status) => status.to_string(),
         }
     }
 
@@ -70,6 +76,7 @@ impl UnavailableVersion {
             Self::InvalidStructure => format!("has {self}"),
             Self::Offline => format!("needs {self}"),
             Self::RequiresPython(..) => format!("requires {self}"),
+            Self::Network(..) => format!("could not be fetched from the network (`{self}`)"),
         }
     }
 
@@ -81,6 +88,7 @@ impl UnavailableVersion {
             Self::InvalidStructure => format!("have {self}"),
             Self::Offline => format!("need {self}"),
             Self::RequiresPython(..) => format!("require {self}"),
+            Self::Network(..) => format!("could not be fetched from the network (`{self}`)"),
         }
     }
 
@@ -98,6 +106,7 @@ impl UnavailableVersion {
             Self::InvalidStructure => None,
             Self::Offline => None,
             Self::RequiresPython(..) => None,
+            Self::Network(..) => None,
         }
     }
 }
@@ -118,6 +127,7 @@ impl From<&MetadataUnavailable> for UnavailableVersion {
             MetadataUnavailable::RequiresPython(requires_python, _python_version) => {
                 Self::RequiresPython(requires_python.clone())
             }
+            MetadataUnavailable::Network(status) => Self::Network(*status),
         }
     }
 }
@@ -158,16 +168,19 @@ pub enum UnavailablePackage {
     InvalidMetadata(UnavailableErrorChain),
     /// The package has an invalid structure.
     InvalidStructure(UnavailableErrorChain),
+    /// The network request failed with the given status code.
+    Network(StatusCode),
 }
 
 impl UnavailablePackage {
-    fn message(&self) -> &'static str {
+    fn message(&self) -> Cow<'static, str> {
         match self {
-            Self::NoIndex => "not found in the provided package locations",
-            Self::Offline => "not found in the cache",
-            Self::NotFound => "not found in the package registry",
-            Self::InvalidMetadata(_) => "invalid metadata",
-            Self::InvalidStructure(_) => "an invalid package format",
+            Self::NoIndex => Cow::Borrowed("not found in the provided package locations"),
+            Self::Offline => Cow::Borrowed("not found in the cache"),
+            Self::NotFound => Cow::Borrowed("not found in the package registry"),
+            Self::InvalidMetadata(_) => Cow::Borrowed("invalid metadata"),
+            Self::InvalidStructure(_) => Cow::Borrowed("an invalid package format"),
+            Self::Network(status) => Cow::Owned(status.to_string()),
         }
     }
 
@@ -178,13 +191,14 @@ impl UnavailablePackage {
             Self::NotFound => format!("was {self}"),
             Self::InvalidMetadata(_) => format!("has {self}"),
             Self::InvalidStructure(_) => format!("has {self}"),
+            Self::Network(_) => format!("could not be fetched from the network (`{self}`)"),
         }
     }
 }
 
 impl Display for UnavailablePackage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.message())
+        f.write_str(self.message().as_ref())
     }
 }
 
@@ -204,6 +218,7 @@ impl From<&MetadataUnavailable> for UnavailablePackage {
             MetadataUnavailable::RequiresPython(..) => {
                 unreachable!("`requires-python` is only known upfront for registry distributions")
             }
+            MetadataUnavailable::Network(status) => Self::Network(*status),
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -1,5 +1,8 @@
 use std::future::Future;
 use std::sync::Arc;
+
+use reqwest::StatusCode;
+
 use uv_client::MetadataFormat;
 use uv_configuration::BuildOptions;
 use uv_distribution::{ArchiveMetadata, DistributionDatabase, Reporter};
@@ -61,6 +64,8 @@ pub enum MetadataUnavailable {
     /// The source distribution has a `requires-python` requirement that is not met by the installed
     /// Python version (and static metadata is not available).
     RequiresPython(VersionSpecifiers, Version),
+    /// The wheel metadata could not be fetched due to a network error.
+    Network(StatusCode),
 }
 
 impl MetadataUnavailable {
@@ -72,7 +77,7 @@ impl MetadataUnavailable {
             Self::InvalidMetadata(err) => Some(err),
             Self::InconsistentMetadata(err) => Some(err),
             Self::InvalidStructure(err) => Some(err),
-            Self::RequiresPython(_, _) => None,
+            Self::RequiresPython(..) | Self::Network(..) => None,
         }
     }
 }
@@ -291,6 +296,20 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                             Ok(MetadataResponse::Unavailable(
                                 MetadataUnavailable::InvalidStructure(Arc::new(err)),
                             ))
+                        }
+                        uv_client::ErrorKind::WrappedReqwestError(url, err) => {
+                            let Some(status) = err.status().filter(StatusCode::is_client_error)
+                            else {
+                                return Err(uv_client::Error::new(
+                                    uv_client::ErrorKind::WrappedReqwestError(url, err),
+                                    retries,
+                                    duration,
+                                )
+                                .into());
+                            };
+                            Ok(MetadataResponse::Unavailable(MetadataUnavailable::Network(
+                                status,
+                            )))
                         }
                         kind => Err(uv_client::Error::new(kind, retries, duration).into()),
                     }

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -298,8 +298,11 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                             ))
                         }
                         uv_client::ErrorKind::WrappedReqwestError(url, err) => {
-                            let Some(status) = err.status().filter(StatusCode::is_client_error)
-                            else {
+                            let Some(status) = err.status().filter(|status| {
+                                dist.index().is_some_and(|index| {
+                                    self.index_locations.ignores_error_code_for(index, *status)
+                                })
+                            }) else {
                                 return Err(uv_client::Error::new(
                                     uv_client::ErrorKind::WrappedReqwestError(url, err),
                                     retries,

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -14033,6 +14033,46 @@ async fn add_auth_policy_never_with_url_credentials() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.add().arg("anyio"), @"
     success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
+      Caused by: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
+    "
+    );
+
+    Ok(())
+}
+
+/// In authentication "never", client errors that are configured to be ignored should allow the
+/// resolver to try another version.
+#[tokio::test]
+async fn add_auth_policy_never_with_url_credentials_ignored() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc!(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11, <4"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "my-index"
+        url = "{proxy_auth_uri}/basic-auth/simple"
+        authenticate = "never"
+        ignore-error-codes = [401]
+        default = true
+        "#,
+        proxy_auth_uri = proxy.authenticated_uri("public", "heron")
+    ))?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio"), @"
+    success: false
     exit_code: 1
     ----- stdout -----
 

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -14033,12 +14033,16 @@ async fn add_auth_policy_never_with_url_credentials() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.add().arg("anyio"), @"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
-      Caused by: HTTP status client error (401 Unauthorized) for url (http://[LOCALHOST]/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only anyio==4.3.0 is available and anyio==4.3.0 could not be fetched from the network (`401 Unauthorized`), we can conclude that all versions of anyio cannot be used.
+          And because your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+
+    hint: Metadata for `anyio` (v4.3.0) could not be fetched; the server returned: `401 Unauthorized`
+    hint: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing
     "
     );
 

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -212,14 +212,18 @@ authenticate = "always"
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
 credentials cannot be found.
 
-### Ignoring error codes when searching across indexes
+### Ignoring error codes
 
 When using the [first-index strategy](#searching-across-multiple-indexes), uv will stop searching
 across indexes if an HTTP 401 Unauthorized or HTTP 403 Forbidden status code is encountered. The one
 exception is that uv will ignore 403s when searching the `pytorch` index (since this index returns a
 403 when a package is not present).
 
-To configure which error codes are ignored for an index, use the `ignored-error-codes` setting. For
+By default, uv will also stop resolution if an HTTP error is encountered when fetching distribution
+metadata or an archive from an index. Ignoring that error marks the affected package version as
+unavailable, allowing the resolver to try another version.
+
+To configure which error codes are ignored for an index, use the `ignore-error-codes` setting. For
 example, to ignore 403s (but not 401s) for a private index:
 
 ```toml


### PR DESCRIPTION
## Summary

When uv fetches wheel metadata during resolution, an HTTP error currently aborts immediately, even if another package version might be usable. This is common with repository firewalls that expose a package in the Simple API but block selected wheel downloads.

This extends the existing per-index `ignore-error-codes` setting to wheel metadata fetches, including when uv must download a wheel to read its metadata. If a configured status code is returned, uv marks the affected version unavailable and lets the resolver try another version; unconfigured errors keep the existing fail-fast behavior. The built-in PyTorch 403 exception remains limited to package-index lookup, so wheel metadata fallback is explicitly opt-in.

For example:

```toml
[[tool.uv.index]]
name = "private-index"
url = "https://private-index.example/simple"
ignore-error-codes = [403]
```

If every compatible version returns an ignored error, the resolution diagnostic reports the unavailable version and returned status code.

Closes https://github.com/astral-sh/uv/issues/5260.
