### PR TITLE
Use resolver-returned wheel over alternate cached wheel

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -142,9 +142,9 @@ impl<'a> Planner<'a> {
                         if *entry.index.url() != wheel.best_wheel().index {
                             return None;
                         }
-                        if entry.dist.filename.version != wheel.best_wheel().filename.version {
+                        if entry.dist.filename != wheel.best_wheel().filename {
                             return None;
-                        };
+                        }
                         if entry.built && no_build {
                             return None;
                         }


### PR DESCRIPTION
## Summary

I think this is reasonable to change. Right now, if you're on Python 3.11, the resolver returns `multiprocess-0.70.17-py311-none-any.whl`, but `multiprocess-0.70.17-py310-none-any.whl` is in the cache, we'll reuse `multiprocess-0.70.17-py310-none-any.whl` (since it _is_ compatible with Python 3.11).

Instead, we now _require_ the cached wheel to match the wheel returned by the resolver.

Closes https://github.com/astral-sh/uv/issues/12273.
