### PR TITLE
Make deserialization non-fatal when assessing source tree revisions

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1363,9 +1363,17 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map_err(Error::CacheRead)?
             .is_fresh()
         {
-            if let Some(pointer) = LocalRevisionPointer::read_from(&entry)? {
-                if *pointer.cache_info() == cache_info {
-                    return Ok(pointer);
+            match LocalRevisionPointer::read_from(&entry) {
+                Ok(Some(pointer)) => {
+                    if *pointer.cache_info() == cache_info {
+                        return Ok(pointer);
+                    }
+
+                    debug!("Cached revision does not match expected cache info for: {source}");
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    debug!("Failed to deserialize cached revision for: {source} ({err})",);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/12318.
