### PR TITLE
docs: Remove note about musl binary distributions

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -225,15 +225,16 @@ $ docker run -it $(docker build -q .) /bin/bash -c "cowsay -t hello"
 ### Installing Python in musl-based ARM images
 
 While uv [installs a compatible Python version](../install-python.md) if there isn't one available
-in the image, uv does not yet support installing Python for musl-based distributions on aarch64.
-For example, if you are using an Alpine Linux aarch64 base image that doesn't have Python installed,
-you need to add it with the system package manager:
+in the image, uv does not yet support installing Python for musl-based distributions on aarch64. For
+example, if you are using an Alpine Linux aarch64 base image that doesn't have Python installed, you
+need to add it with the system package manager:
 
 ```shell
 apk add --no-cache python3~=3.12
 ```
 
-As of uv 0.6.6, uv does automatically install a compatible Python version on musl-based amd64 images, but not yet on aarch64.
+As of uv 0.6.6, uv does automatically install a compatible Python version on musl-based amd64
+images, but not yet on aarch64.
 
 ## Developing in a container
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -222,6 +222,19 @@ $ docker run -it $(docker build -q .) /bin/bash -c "cowsay -t hello"
     ENV UV_TOOL_BIN_DIR=/opt/uv-bin/
     ```
 
+### Installing Python in musl-based ARM images
+
+While uv [installs a compatible Python version](../install-python.md) if there isn't one available
+in the image, uv does not yet support installing Python for musl-based distributions on aarch64.
+For example, if you are using an Alpine Linux aarch64 base image that doesn't have Python installed,
+you need to add it with the system package manager:
+
+```shell
+apk add --no-cache python3~=3.12
+```
+
+As of uv 0.6.6, uv does automatically install a compatible Python version on musl-based amd64 images, but not yet on aarch64.
+
 ## Developing in a container
 
 When developing, it's useful to mount the project directory into a container. With this setup,

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -222,17 +222,6 @@ $ docker run -it $(docker build -q .) /bin/bash -c "cowsay -t hello"
     ENV UV_TOOL_BIN_DIR=/opt/uv-bin/
     ```
 
-### Installing Python in musl-based images
-
-While uv [installs a compatible Python version](../install-python.md) if there isn't one available
-in the image, uv does not yet support installing Python for musl-based distributions. For example,
-if you are using an Alpine Linux base image that doesn't have Python installed, you need to add it
-with the system package manager:
-
-```shell
-apk add --no-cache python3~=3.12
-```
-
 ## Developing in a container
 
 When developing, it's useful to mount the project directory into a container. With this setup,


### PR DESCRIPTION
## Summary

Now that uv installs Python in musl-based environments (https://github.com/astral-sh/uv/pull/12121), the docs no longer need to call out that it cannot do this.

## Test Plan

Docs-only change.

## Question

Should this documentation still call out that it can't install Python on arm systems?