### PR TITLE
Fix cache_prune::prune_unzipped test to match updated error message format

### DIFF
--- a/crates/uv/tests/it/cache_prune.rs
+++ b/crates/uv/tests/it/cache_prune.rs
@@ -257,7 +257,7 @@ fn prune_unzipped() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because all versions of iniconfig need to be downloaded from a registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because iniconfig<=2.0.0 needs to be downloaded from a registry and you require iniconfig, we can conclude that your requirements are unsatisfiable.
 
           hint: Pre-releases are available for `iniconfig` in the requested range (e.g., 0.2.dev0), but pre-releases weren't enabled (try: `--prerelease=allow`)
 


### PR DESCRIPTION
## Summary

Fixes the failing `cache_prune::prune_unzipped` test that was causing CI failures in my other PR (#12328) and others like PR #12327.

The error message format changed to show a specific version constraint (`iniconfig<=2.0.0`) rather than the generic 'all versions' message. This PR updates the test to expect the new, more specific error message.

## Test Plan
Ran `cargo test -p uv cache_prune::prune_unzipped` to verify the test now passes.