### PR TITLE
Add boolish value parser for *MANAGED_PYTHON flags

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -155,6 +155,7 @@ pub struct GlobalArgs {
         long,
         help_heading = "Python options",
         env = EnvVars::UV_MANAGED_PYTHON,
+        value_parser = clap::builder::BoolishValueParser::new(),
         overrides_with = "no_managed_python",
         conflicts_with = "python_preference"
     )]
@@ -168,6 +169,7 @@ pub struct GlobalArgs {
         long,
         help_heading = "Python options",
         env = EnvVars::UV_NO_MANAGED_PYTHON,
+        value_parser = clap::builder::BoolishValueParser::new(),
         overrides_with = "managed_python",
         conflicts_with = "python_preference"
     )]


### PR DESCRIPTION
There was a bug where `UV_MANAGED_PYTHON` and `UV_NO_MANAGED_PYTHON` only accepted `true` or `false`. This switches to the boolish value parser for those flags.

Closes #12336 
