### PR TITLE
Retain end-of-line comment position when adding dependency

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1004,7 +1004,7 @@ pub fn add_dependency(
 
             let decor = value.decor_mut();
 
-            // Ensure trailing comments remain on the correct line, post-insertion
+            // Ensure comments remain on the correct line, post-insertion
             match index {
                 val if val == deps.len() => {
                     // If we're adding to the end of the list, treat trailing comments as leading comments
@@ -1031,12 +1031,12 @@ pub fn add_dependency(
                     // If the dependency is prepended to a non-empty list, do nothing
                 }
                 val => {
-                    // Retain position of trailing comments when a dependency is inserted right below it.
+                    // Retain position of end-of-line comments when a dependency is inserted right below it.
                     //
                     // For example, given:
                     // ```toml
                     // dependencies = [
-                    //     "anyio", # trailing comment
+                    //     "anyio", # end-of-line comment
                     //     "flask",
                     // ]
                     // ```
@@ -1044,7 +1044,7 @@ pub fn add_dependency(
                     // If we add `pydantic` (between `anyio` and `flask`), we want to retain the comment on `anyio`:
                     // ```toml
                     // dependencies = [
-                    //     "anyio", # trailing comment
+                    //     "anyio", # end-of-line comment
                     //     "pydantic",
                     //     "flask",
                     // ]

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1359,7 +1359,7 @@ fn split_specifiers(req: &str) -> (&str, &str) {
 #[cfg(test)]
 mod test {
     use toml_edit::Array;
-    use uv_pep508::Requirement;
+    use uv_pep508::{MarkerTree, Requirement};
 
     use super::{add_dependency, split_specifiers};
 
@@ -1403,7 +1403,7 @@ mod test {
             name: "flask".parse().unwrap(),
             extras: vec![],
             version_or_url: None,
-            marker: Default::default(),
+            marker: MarkerTree::default(),
             origin: None,
         };
 
@@ -1451,7 +1451,7 @@ mod test {
             name: "flask".parse().unwrap(),
             extras: vec![],
             version_or_url: None,
-            marker: Default::default(),
+            marker: MarkerTree::default(),
             origin: None,
         };
 

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1022,9 +1022,9 @@ pub fn add_dependency(
                     // Retain position of trailing comments when a dependency is inserted right below it.
                     //
                     // See [`test::retain_trailing_comment_position_on_non_final_dep`].
-                    let targetted_decor = deps.get_mut(val).unwrap().decor_mut();
-                    decor.set_prefix(targetted_decor.prefix().unwrap().clone());
-                    targetted_decor.set_prefix(""); // Re-formatted later by `reformat_array_multiline`
+                    let targeted_decor = deps.get_mut(val).unwrap().decor_mut();
+                    decor.set_prefix(targeted_decor.prefix().unwrap().clone());
+                    targeted_decor.set_prefix(""); // Re-formatted later by `reformat_array_multiline`
                 }
             };
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This fixes a case described in #12333, where trailing comments in dependencies can be unexpectedly shifted when a new dependency is added.

Fixes #12333.

## Test Plan

<!-- How was it tested? -->

`cargo test` (Added a snapshot test)
