### PR TITLE
Skip repeated directories in `PATH` when searching for Python interpreters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5526,6 +5526,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "rmp-serde",
+ "rustc-hash",
  "same-file",
  "schemars",
  "serde",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -47,6 +47,7 @@ reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
 rmp-serde = { workspace = true }
+rustc-hash = { workspace = true }
 same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/12302

The change is visible in [this commit](https://github.com/astral-sh/uv/pull/12367/commits/49be22dad9b091a39e1c013032fb740dba652abf).