### PR TITLE
Add support for Python version requests in `uv python list`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4577,6 +4577,11 @@ pub enum PythonCommand {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct PythonListArgs {
+    /// A Python request to filter by.
+    ///
+    /// See `uv help python` to view supported request formats.
+    pub request: Option<String>,
+
     /// List all Python versions, including old patch versions.
     ///
     /// By default, only the latest patch version is shown for each minor version.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1272,6 +1272,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             let cache = cache.init()?;
 
             commands::python_list(
+                args.request,
                 args.kinds,
                 args.all_versions,
                 args.all_platforms,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -826,6 +826,7 @@ pub(crate) enum PythonListKinds {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct PythonListSettings {
+    pub(crate) request: Option<String>,
     pub(crate) kinds: PythonListKinds,
     pub(crate) all_platforms: bool,
     pub(crate) all_arches: bool,
@@ -839,6 +840,7 @@ impl PythonListSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: PythonListArgs, _filesystem: Option<FilesystemOptions>) -> Self {
         let PythonListArgs {
+            request,
             all_versions,
             all_platforms,
             all_arches,
@@ -857,6 +859,7 @@ impl PythonListSettings {
         };
 
         Self {
+            request,
             kinds,
             all_platforms,
             all_arches,

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -1,3 +1,4 @@
+use uv_python::platform::{Arch, Os};
 use uv_static::EnvVars;
 
 use crate::common::{uv_snapshot, TestContext};

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -173,6 +173,18 @@ To list installed and available Python versions:
 $ uv python list
 ```
 
+To filter the Python versions, provide a request, e.g., to show all Python 3.13 interpreters:
+
+```console
+$ uv python list 3.13
+```
+
+Or, to show all PyPy interpreters:
+
+```console
+$ uv python list pypy
+```
+
 By default, downloads for other platforms and old patch versions are hidden.
 
 To view all versions:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4603,8 +4603,16 @@ Use `--only-installed` to omit available downloads.
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv python list [OPTIONS]
+uv python list [OPTIONS] [REQUEST]
 ```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="uv-python-list--request"><a href="#uv-python-list--request"<code>REQUEST</code></a></dt><dd><p>A Python request to filter by.</p>
+
+<p>See <a href="#uv-python">uv python</a> to view supported request formats.</p>
+
+</dd></dl>
 
 <h3 class="cli-reference">Options</h3>
 


### PR DESCRIPTION
Allows `uv python list <request>` to filter the installed list. I often want this and it's not hard to add.

I tested the remote download filtering locally (#12381 is needed for snapshot tests)

```
❯ cargo run -q -- python list --all-versions 3.13
cpython-3.13.2-macos-aarch64-none    <download available>
cpython-3.13.1-macos-aarch64-none    /opt/homebrew/opt/python@3.13/bin/python3.13 -> ../Frameworks/Python.framework/Versions/3.13/bin/python3.13
cpython-3.13.1-macos-aarch64-none    <download available>
cpython-3.13.0-macos-aarch64-none    /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
❯ cargo run -q -- python list --all-versions 3.13 --only-installed
cpython-3.13.1-macos-aarch64-none    /opt/homebrew/opt/python@3.13/bin/python3.13 -> ../Frameworks/Python.framework/Versions/3.13/bin/python3.13
cpython-3.13.0-macos-aarch64-none    /Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none/bin/python3.13
```