### PR TITLE
Add `--show-version` to `uv python find`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4759,6 +4759,10 @@ pub struct PythonFindArgs {
         conflicts_with = "no_system"
     )]
     pub script: Option<PathBuf>,
+
+    /// Show the Python version that would be used instead of the path to the interpreter.
+    #[arg(long)]
+    pub show_version: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -1,4 +1,3 @@
-use anstream::println;
 use anyhow::Result;
 use std::fmt::Write;
 use std::path::Path;
@@ -31,6 +30,7 @@ pub(crate) async fn find(
     system: bool,
     python_preference: PythonPreference,
     cache: &Cache,
+    printer: Printer,
 ) -> Result<ExitStatus> {
     let environment_preference = if system {
         EnvironmentPreference::OnlySystem
@@ -91,12 +91,17 @@ pub(crate) async fn find(
     };
 
     if show_version {
-        println!("{}", python.interpreter().python_version());
+        writeln!(
+            printer.stdout(),
+            "{}",
+            python.interpreter().python_version()
+        )?;
     } else {
-        println!(
+        writeln!(
+            printer.stdout(),
             "{}",
             std::path::absolute(python.interpreter().sys_executable())?.simplified_display()
-        );
+        )?;
     }
 
     Ok(ExitStatus::Success)
@@ -135,12 +140,13 @@ pub(crate) async fn find_script(
     };
 
     if show_version {
-        println!("{}", interpreter.python_version());
+        writeln!(printer.stdout(), "{}", interpreter.python_version())?;
     } else {
-        println!(
+        writeln!(
+            printer.stdout(),
             "{}",
             std::path::absolute(interpreter.sys_executable())?.simplified_display()
-        );
+        )?;
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1354,6 +1354,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     args.system,
                     globals.python_preference,
                     &cache,
+                    printer,
                 )
                 .await
             }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1335,6 +1335,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             if let Some(Pep723Item::Script(script)) = script {
                 commands::python_find_script(
                     Pep723ItemRef::Script(&script),
+                    args.show_version,
                     &globals.network_settings,
                     globals.python_preference,
                     globals.python_downloads,
@@ -1347,6 +1348,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 commands::python_find(
                     &project_dir,
                     args.request,
+                    args.show_version,
                     args.no_project,
                     cli.top_level.no_config,
                     args.system,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -963,6 +963,7 @@ impl PythonUninstallSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct PythonFindSettings {
     pub(crate) request: Option<String>,
+    pub(crate) show_version: bool,
     pub(crate) no_project: bool,
     pub(crate) system: bool,
 }
@@ -973,6 +974,7 @@ impl PythonFindSettings {
     pub(crate) fn resolve(args: PythonFindArgs, _filesystem: Option<FilesystemOptions>) -> Self {
         let PythonFindArgs {
             request,
+            show_version,
             no_project,
             system,
             no_system,
@@ -981,6 +983,7 @@ impl PythonFindSettings {
 
         Self {
             request,
+            show_version,
             no_project,
             system: flag(system, no_system).unwrap_or_default(),
         }

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -859,3 +859,49 @@ fn python_find_script_no_such_version() {
     No interpreter found for Python >=3.14 in [PYTHON SOURCES]
     ");
 }
+
+#[test]
+fn python_find_show_version() {
+    let context: TestContext =
+        TestContext::new_with_versions(&["3.11", "3.12"]).with_filtered_python_sources();
+
+    // No interpreters found
+    uv_snapshot!(context.filters(), context.python_find().env(EnvVars::UV_TEST_PYTHON_PATH, "").arg("--show-version"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found in [PYTHON SOURCES]
+    ");
+
+    // Show the first version found
+    uv_snapshot!(context.filters(), context.python_find().arg("--show-version"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11.[X]
+
+    ----- stderr -----
+    ");
+
+    // Request Python 3.12
+    uv_snapshot!(context.filters(), context.python_find().arg("--show-version").arg("3.12"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.[X]
+
+    ----- stderr -----
+    ");
+
+    // Request Python 3.11
+    uv_snapshot!(context.filters(), context.python_find().arg("--show-version").arg("3.11"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11.[X]
+
+    ----- stderr -----
+    ");
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5024,6 +5024,8 @@ uv python find [OPTIONS] [REQUEST]
 
 </dd><dt id="uv-python-find--script"><a href="#uv-python-find--script"><code>--script</code></a> <i>script</i></dt><dd><p>Find the environment for a Python script, rather than the current project</p>
 
+</dd><dt id="uv-python-find--show-version"><a href="#uv-python-find--show-version"><code>--show-version</code></a></dt><dd><p>Show the Python version that would be used instead of the path to the interpreter</p>
+
 </dd><dt id="uv-python-find--system"><a href="#uv-python-find--system"><code>--system</code></a></dt><dd><p>Only find system Python interpreters.</p>
 
 <p>By default, uv will report the first Python interpreter it would use, including those in an active virtual environment or a virtual environment in the current working directory or any parent directory.</p>


### PR DESCRIPTION
@jtfmumm mentioned a desire for this. I'm not sure how we should do this. I kind of want to change this to something like...

```
$ uv python find
CPython 3.13 @ <path>
$ uv python find --only-path
<path>
$ uv python find --short
<path>
$ uv python find --only-version 
3.13
```

The change in defaults would be breaking though.