### PR TITLE
Documentation for --package and --all-packages options for the sync command

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -146,6 +146,31 @@ The `foo` group would not be installed.
 See the [development dependencies](./dependencies.md#development-dependencies) documentation for
 details on how to manage development dependencies.
 
+### Syncing workspaces
+
+In a workspace setup, using `uv sync` in the project root folder will only sync the project
+package. All workspace depencies will be removed and the workspace packages will not be included
+in the python path when running a python program using the `uv run` command.
+If you use `uv sync` in a workspace folder, it will only sync the current workspace and the parent
+project. It will remove all dependencies from the virtual environment that may have been installed 
+for other worspaces in the project and only the current workspace source code folder and the project
+root will be included in the python path when running a python program using the `uv run` command.
+
+To sync the entire workspace and have all workspace packages added to the python path when using
+the `uv run` command, use the `--all-packages` option when running `uv saync` in the project root:
+```console
+$ uv sync --all-packages
+```
+To sync only specific packages in the workspace use the `--packages <package name>` option for each
+package you wish to sync when running `uv sync` in the project root:
+```console
+$ uv sync --package beta --package delta
+```
+
+To prevent losing installed workspace depencies when syncing 1 or more specific workspace packages,
+use the `--inexact` option. This will also prevent removal of any workspace packages automatically
+added to the python path when running a python program using the `uv run` command.
+
 ## Upgrading locked package versions
 
 With an existing `uv.lock` file, uv will prefer the previously locked versions of packages when

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -165,6 +165,14 @@ project command invocations. The first Python version that is compatible with th
 be used, unless a version is otherwise requested, e.g., via a `.python-version` file or the
 `--python` flag.
 
+If for some reason you need to change the default python version for your project after it has been
+created use the [`uv python pin`](../reference/cli.md/#uv-python-pin) command specifying the desired version:
+
+```console
+$ uv python pin 3.12
+```
+This will update the `.python-version` file for the project.
+
 ## Viewing available Python versions
 
 To list installed and available Python versions:


### PR DESCRIPTION
## Summary
This provides documentation for the --package and --all-packages options for the sync command when using workspaces.
Also adds usage of `uv python pin <version>` cammand in managing python project versions.
 
## Test Plan
Nont required since this is only documentation

Relates to this issue: 
#12107 
