### PR TITLE
Ignore `--find-links` entries for pinned indexes

### DIFF
--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -160,6 +160,9 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             })
             .await;
 
+        // If a package is pinned to an explicit index, ignore any `--find-links` entries.
+        let flat_index = index.is_none().then_some(&self.flat_index);
+
         match result {
             Ok(results) => Ok(VersionsResponse::Found(
                 results
@@ -174,7 +177,9 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                             &self.allowed_yanks,
                             &self.hasher,
                             self.exclude_newer.as_ref(),
-                            self.flat_index.get(package_name).cloned(),
+                            flat_index
+                                .and_then(|flat_index| flat_index.get(package_name))
+                                .cloned(),
                             self.build_options,
                         )
                     })
@@ -182,23 +187,32 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             )),
             Err(err) => match err.into_kind() {
                 uv_client::ErrorKind::PackageNotFound(_) => {
-                    if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
+                    if let Some(flat_index) = flat_index
+                        .and_then(|flat_index| flat_index.get(package_name))
+                        .cloned()
+                    {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
                     } else {
                         Ok(VersionsResponse::NotFound)
                     }
                 }
                 uv_client::ErrorKind::NoIndex(_) => {
-                    if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
+                    if let Some(flat_index) = flat_index
+                        .and_then(|flat_index| flat_index.get(package_name))
+                        .cloned()
+                    {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
-                    } else if self.flat_index.offline() {
+                    } else if flat_index.is_some_and(FlatIndex::offline) {
                         Ok(VersionsResponse::Offline)
                     } else {
                         Ok(VersionsResponse::NoIndex)
                     }
                 }
                 uv_client::ErrorKind::Offline(_) => {
-                    if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
+                    if let Some(flat_index) = flat_index
+                        .and_then(|flat_index| flat_index.get(package_name))
+                        .cloned()
+                    {
                         Ok(VersionsResponse::Found(vec![VersionMap::from(flat_index)]))
                     } else {
                         Ok(VersionsResponse::Offline)


### PR DESCRIPTION
## Summary

In general, we merge `--find-links` entries into each index. If a package is pinned to an index, though, it seems surprising (and wrong) that we'd ever select a distribution from `--find-links`. This PR modifies the provider to ignore `--find-links` for any explicitly pinned packages.
