### PR TITLE
Update PyTorch/Python version tip

### DIFF
--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -52,8 +52,8 @@ dependencies = [
 
 !!! tip "Supported Python versions"
 
-    At time of writing, PyTorch does not yet publish wheels for Python 3.13; as such projects with
-    `requires-python = ">=3.13"` may fail to resolve. See the
+    At time of writing, PyTorch does not yet publish wheels for Python 3.14; as such projects with
+    `requires-python = ">=3.14"` may fail to resolve. See the
     [compatibility matrix](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix).
 
 This is a valid configuration for projects that want to use CPU builds on Windows and macOS, and


### PR DESCRIPTION
PyTorch 2.6.0 supports Python 3.13, and publishes wheels for it. Update the tip to reflect this.


## Summary

Clarify docs.

## Test Plan

Look for "cp313" at the following URLs:
- [x] https://download.pytorch.org/whl/cu124/torch/
- [x] https://download.pytorch.org/whl/torch/
