### PR TITLE
Pass around index with associated metadata

### DIFF
--- a/crates/uv-auth/src/policy.rs
+++ b/crates/uv-auth/src/policy.rs
@@ -3,7 +3,17 @@ use url::Url;
 
 /// When to use authentication.
 #[derive(
-    Copy, Clone, Debug, Default, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/uv-distribution-types/src/index_name.rs
+++ b/crates/uv-distribution-types/src/index_name.rs
@@ -9,7 +9,7 @@ use uv_small_str::SmallString;
 /// The normalized name of an index.
 ///
 /// Index names may contain letters, digits, hyphens, underscores, and periods, and must be ASCII.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, serde::Serialize)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, serde::Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IndexName(SmallString);
 

--- a/crates/uv-distribution-types/src/origin.rs
+++ b/crates/uv-distribution-types/src/origin.rs
@@ -1,5 +1,5 @@
 /// The origin of a piece of configuration.
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Origin {
     /// The setting was provided via the CLI.
     Cli,

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -3,7 +3,9 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerTree;
 use uv_pypi_types::{HashDigest, HashDigests};
 
-use crate::{BuiltDist, Diagnostic, Dist, Name, RequirementSource, ResolvedDist, SourceDist};
+use crate::{
+    BuiltDist, Diagnostic, Dist, IndexMetadata, Name, RequirementSource, ResolvedDist, SourceDist,
+};
 
 /// A set of packages pinned at specific versions.
 ///
@@ -229,7 +231,7 @@ impl From<&ResolvedDist> for RequirementSource {
                                 wheel.filename.version.clone(),
                             ),
                         ),
-                        index: Some(wheel.index.url().clone()),
+                        index: Some(IndexMetadata::from(wheel.index.clone())),
                         conflict: None,
                     }
                 }
@@ -252,7 +254,7 @@ impl From<&ResolvedDist> for RequirementSource {
                     specifier: uv_pep440::VersionSpecifiers::from(
                         uv_pep440::VersionSpecifier::equals_version(sdist.version.clone()),
                     ),
-                    index: Some(sdist.index.url().clone()),
+                    index: Some(IndexMetadata::from(sdist.index.clone())),
                     conflict: None,
                 },
                 Dist::Source(SourceDist::DirectUrl(sdist)) => {

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -479,7 +479,7 @@ pub async fn check_url(
     let response = match registry_client
         .simple(
             filename.name(),
-            Some(index_url),
+            Some(index_url.into()),
             index_capabilities,
             download_concurrency,
         )

--- a/crates/uv-resolver/src/fork_indexes.rs
+++ b/crates/uv-resolver/src/fork_indexes.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use uv_distribution_types::IndexUrl;
+use uv_distribution_types::IndexMetadata;
 use uv_normalize::PackageName;
 
 use crate::resolver::ResolverEnvironment;
@@ -7,24 +7,24 @@ use crate::ResolveError;
 
 /// See [`crate::resolver::ForkState`].
 #[derive(Default, Debug, Clone)]
-pub(crate) struct ForkIndexes(FxHashMap<PackageName, IndexUrl>);
+pub(crate) struct ForkIndexes(FxHashMap<PackageName, IndexMetadata>);
 
 impl ForkIndexes {
-    /// Get the [`IndexUrl`] previously used for a package in this fork.
-    pub(crate) fn get(&self, package_name: &PackageName) -> Option<&IndexUrl> {
+    /// Get the [`Index`] previously used for a package in this fork.
+    pub(crate) fn get(&self, package_name: &PackageName) -> Option<&IndexMetadata> {
         self.0.get(package_name)
     }
 
-    /// Check that this is the only [`IndexUrl`] used for this package in this fork.
+    /// Check that this is the only [`Index`] used for this package in this fork.
     pub(crate) fn insert(
         &mut self,
         package_name: &PackageName,
-        index: &IndexUrl,
+        index: &IndexMetadata,
         env: &ResolverEnvironment,
     ) -> Result<(), ResolveError> {
         if let Some(previous) = self.0.insert(package_name.clone(), index.clone()) {
             if &previous != index {
-                let mut conflicts = vec![previous.to_string(), index.to_string()];
+                let mut conflicts = vec![previous.url.to_string(), index.url.to_string()];
                 conflicts.sort();
                 return Err(ResolveError::ConflictingIndexesForEnvironment {
                     package_name: package_name.clone(),

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use uv_configuration::{IndexStrategy, NoBinary, NoBuild};
 use uv_distribution_types::{
     IncompatibleDist, IncompatibleSource, IncompatibleWheel, Index, IndexCapabilities,
-    IndexLocations, IndexUrl,
+    IndexLocations, IndexMetadata, IndexUrl,
 };
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifiers};
@@ -727,7 +727,7 @@ impl PubGrubReportFormatter<'_> {
         env: &ResolverEnvironment,
         tags: Option<&Tags>,
     ) -> Option<PubGrubHint> {
-        let response = if let Some(url) = fork_indexes.get(name) {
+        let response = if let Some(url) = fork_indexes.get(name).map(IndexMetadata::url) {
             index.explicit().get(&(name.clone(), url.clone()))
         } else {
             index.implicit().get(name)

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -13,7 +13,9 @@ use crate::resolver::Request;
 use crate::{
     InMemoryIndex, PythonRequirement, ResolveError, ResolverEnvironment, VersionsResponse,
 };
-use uv_distribution_types::{CompatibleDist, DistributionMetadata, IndexCapabilities, IndexUrl};
+use uv_distribution_types::{
+    CompatibleDist, DistributionMetadata, IndexCapabilities, IndexMetadata,
+};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
@@ -81,7 +83,7 @@ impl BatchPrefetcher {
     pub(crate) fn prefetch_batches(
         &mut self,
         next: &PubGrubPackage,
-        index: Option<&IndexUrl>,
+        index: Option<&IndexMetadata>,
         version: &Version,
         current_range: &Range<Version>,
         unchangeable_constraints: Option<&Term<Range<Version>>>,
@@ -110,7 +112,7 @@ impl BatchPrefetcher {
             self.prefetch_runner
                 .index
                 .explicit()
-                .wait_blocking(&(name.clone(), index.clone()))
+                .wait_blocking(&(name.clone(), index.url().clone()))
                 .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?
         } else {
             self.prefetch_runner

--- a/crates/uv-resolver/src/resolver/indexes.rs
+++ b/crates/uv-resolver/src/resolver/indexes.rs
@@ -1,6 +1,5 @@
-use uv_distribution_types::{IndexUrl, RequirementSource};
+use uv_distribution_types::{IndexMetadata, RequirementSource};
 use uv_normalize::PackageName;
-use uv_pep508::VerbatimUrl;
 use uv_pypi_types::ConflictItem;
 
 use crate::resolver::ForkMap;
@@ -24,7 +23,7 @@ pub(crate) struct Indexes(ForkMap<Entry>);
 
 #[derive(Debug, Clone)]
 struct Entry {
-    index: IndexUrl,
+    index: IndexMetadata,
     conflict: Option<ConflictItem>,
 }
 
@@ -46,7 +45,9 @@ impl Indexes {
             else {
                 continue;
             };
-            let index = IndexUrl::from(VerbatimUrl::from_url(index.clone()));
+            let index = IndexMetadata {
+                url: index.url.clone(),
+            };
             let conflict = conflict.clone();
             indexes.add(&requirement, Entry { index, conflict });
         }
@@ -60,7 +61,7 @@ impl Indexes {
     }
 
     /// Return the explicit index used for a package in the given fork.
-    pub(crate) fn get(&self, name: &PackageName, env: &ResolverEnvironment) -> Vec<&IndexUrl> {
+    pub(crate) fn get(&self, name: &PackageName, env: &ResolverEnvironment) -> Vec<&IndexMetadata> {
         let entries = self.0.get(name, env);
         entries
             .iter()

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -2,7 +2,7 @@ use tokio::sync::Semaphore;
 use tracing::debug;
 use uv_client::{RegistryClient, VersionFiles};
 use uv_distribution_filename::DistFilename;
-use uv_distribution_types::{IndexCapabilities, IndexUrl};
+use uv_distribution_types::{IndexCapabilities, IndexMetadataRef, IndexUrl};
 use uv_normalize::PackageName;
 use uv_platform_tags::Tags;
 use uv_resolver::{ExcludeNewer, PrereleaseMode, RequiresPython};
@@ -34,7 +34,12 @@ impl LatestClient<'_> {
 
         let archives = match self
             .client
-            .simple(package, index, self.capabilities, download_concurrency)
+            .simple(
+                package,
+                index.map(IndexMetadataRef::from),
+                self.capabilities,
+                download_concurrency,
+            )
             .await
         {
             Ok(archives) => archives,

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -1,17 +1,15 @@
-use crate::commands::reporters::PublishReporter;
-use crate::commands::{human_readable_bytes, ExitStatus};
-use crate::printer::Printer;
-use crate::settings::NetworkSettings;
-use anyhow::{bail, Context, Result};
-use console::Term;
-use owo_colors::OwoColorize;
 use std::fmt::Write;
 use std::iter;
 use std::sync::Arc;
 use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use console::Term;
+use owo_colors::OwoColorize;
 use tokio::sync::Semaphore;
 use tracing::{debug, info};
 use url::Url;
+
 use uv_cache::Cache;
 use uv_client::{AuthIntegration, BaseClient, BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
@@ -20,6 +18,11 @@ use uv_publish::{
     check_trusted_publishing, files_for_publishing, upload, CheckUrlClient, TrustedPublishResult,
 };
 use uv_warnings::warn_user_once;
+
+use crate::commands::reporters::PublishReporter;
+use crate::commands::{human_readable_bytes, ExitStatus};
+use crate::printer::Printer;
+use crate::settings::NetworkSettings;
 
 pub(crate) async fn publish(
     paths: Vec<String>,

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15331,7 +15331,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG No workspace root found, using project root
     DEBUG Ignoring existing lockfile due to mismatched requirements for: `project==0.1.0`
       Requested: {Requirement { name: PackageName("anyio"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([]), index: None, conflict: None }, origin: None }}
-      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }]), index: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }), conflict: None }, origin: None }}
+      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }]), index: Some(IndexMetadata { url: Url(VerbatimUrl { url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }, given: None }) }), conflict: None }, origin: None }}
     DEBUG Solving with installed Python version: 3.12.[X]
     DEBUG Solving with target Python version: >=3.12
     DEBUG Adding direct dependency: project*


### PR DESCRIPTION
## Summary

This PR modifies the requirement source entities to store a (new) container struct that wraps `IndexUrl`. This will allow us to store user-defined metadata alongside `IndexUrl`, and propagate that metadata throughout resolution.

Specifically, I need to store the "kind" of the index (Simple API vs. `--find-links`), but I also ran into this problem when I tried to add support for overriding `Cache-Control` headers on a per-index basis: at present, we have no way to passing around metadata alongside an `IndexUrl`.