### PR TITLE
Update --prune help arg from PRUNE to PACKAGE

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3769,7 +3769,7 @@ pub struct ExportArgs {
     ///
     /// Pruned packages will be excluded from the exported requirements file, as will any
     /// dependencies that are no longer required after the pruned package is removed.
-    #[arg(long, conflicts_with = "all_packages")]
+    #[arg(long, conflicts_with = "all_packages", value_name = "PACKAGE")]
     pub prune: Vec<PackageName>,
 
     /// Include optional dependencies from the specified extra name.


### PR DESCRIPTION
## Summary

This fixes https://github.com/astral-sh/uv/issues/12426 which helps use a more accurate arg name in the help output.

## Test Plan

I didn't test it locally, @charliermarsh gave me guidance on what to change so I looked around that file for another example of `value_name` and repeated what I saw. I kept it formatted to 1 line based on it not being a long line. The other example of `value_name` had everything on separate lines because there were a bunch of parameters passed in.
