### PR TITLE
Use 64-bit host for 32-bit releases to work around OOM

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -287,9 +287,9 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     strategy:
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
+        include:
+          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
+          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -304,10 +304,16 @@ jobs:
         uses: PyO3/maturin-action@22fe573c6ed0c03ab9b84e631cbfa49bddf6e20e # v1.47.3
         with:
           target: ${{ matrix.target }}
+          # Generally, we try to build in a target docker container. In this case however, a
+          # 32-bit compiler runs out of memory (4GB memory limit for 32-bit), so we cross compile
+          # from 64-bit version of the container, breaking the pattern from other builds.
+          container: quay.io/pypa/manylinux2014
           manylinux: auto
           args: --release --locked --out dist --features self-update
           # See: https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
           before-script-linux: |
+            # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
+            rustup target add ${{ matrix.target }}
             # If we're running on rhel centos, install needed packages.
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
@@ -316,11 +322,16 @@ jobs:
                 # in order to build openssl with -latomic flag.
                 if [[ ! -d "/usr/lib64" ]]; then
                     ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+                else
+                    # Support cross-compiling from 64-bit to 32-bit
+                    yum install -y glibc-devel.i686 libstdc++-devel.i686
                 fi
             else
                 # If we're running on debian-based system.
                 apt update -y && apt-get install -y libssl-dev openssl pkg-config
             fi
+        env:
+          CC: ${{ matrix.cc }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |


### PR DESCRIPTION
The i686 linux gnu release job started failing since the last release (#12430) due to an OOM with llvm breaking the 4GB limit for 32-bit processes. We work around this by using a 64-bit host targeting 32-bit.