### PR TITLE
POC: Implement `uv pip wheel`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2389,7 +2389,6 @@ pub struct PipWheelArgs {
     #[arg(long)]
     pub python_platform: Option<TargetTriple>,
 
-
     /// Perform a dry run, i.e., don't actually install anything but resolve the dependencies and
     /// print the resulting plan.
     #[arg(long)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -670,6 +670,12 @@ pub enum PipCommand {
         after_long_help = ""
     )]
     Check(PipCheckArgs),
+    /// Build wheel archives from requirements and dependencies.
+    #[command(
+        after_help = "Use `uv help pip wheel` for more details.",
+        after_long_help = ""
+    )]
+    Wheel(PipWheelArgs),
 }
 
 #[derive(Subcommand)]
@@ -2138,6 +2144,271 @@ pub struct PipCheckArgs {
 
     #[arg(long, overrides_with("system"), hide = true)]
     pub no_system: bool,
+}
+
+#[derive(Args)]
+#[command(group = clap::ArgGroup::new("sources").required(true).multiple(true))]
+#[allow(clippy::struct_excessive_bools)]
+pub struct PipWheelArgs {
+    /// Build packages into the specified directory, rather than the current working directory.
+    #[arg(long, short, alias = "wheel-dir", visible_alias = "target", value_parser=parse_maybe_file_path)]
+    pub wheel_dir: Maybe<PathBuf>,
+
+    /// Build all listed packages.
+    ///
+    /// The order of the packages is used to determine priority during resolution.
+    #[arg(group = "sources")]
+    pub package: Vec<String>,
+
+    /// Build all packages listed in the given `requirements.txt` files.
+    ///
+    /// If a `pyproject.toml`, `setup.py`, or `setup.cfg` file is provided, uv will extract the
+    /// requirements for the relevant project.
+    ///
+    /// If `-` is provided, then requirements will be read from stdin.
+    #[arg(long, short, alias = "requirement", group = "sources", value_parser = parse_file_path)]
+    pub requirements: Vec<PathBuf>,
+
+    /// Build the editable package based on the provided local file path.
+    #[arg(long, short, group = "sources")]
+    pub editable: Vec<String>,
+
+    /// Constrain versions using the given requirements files.
+    ///
+    /// Constraints files are `requirements.txt`-like files that only control the _version_ of a
+    /// requirement that's installed. However, including a package in a constraints file will _not_
+    /// trigger the installation of that package.
+    ///
+    /// This is equivalent to pip's `--constraint` option.
+    #[arg(long, short, alias = "constraint", env = EnvVars::UV_CONSTRAINT, value_delimiter = ' ', value_parser = parse_maybe_file_path)]
+    pub constraints: Vec<Maybe<PathBuf>>,
+
+    /// Override versions using the given requirements files.
+    ///
+    /// Overrides files are `requirements.txt`-like files that force a specific version of a
+    /// requirement to be installed, regardless of the requirements declared by any constituent
+    /// package, and regardless of whether this would be considered an invalid resolution.
+    ///
+    /// While constraints are _additive_, in that they're combined with the requirements of the
+    /// constituent packages, overrides are _absolute_, in that they completely replace the
+    /// requirements of the constituent packages.
+    #[arg(long, alias = "override", env = EnvVars::UV_OVERRIDE, value_delimiter = ' ', value_parser = parse_maybe_file_path)]
+    pub overrides: Vec<Maybe<PathBuf>>,
+
+    /// Constrain build dependencies using the given requirements files when building source
+    /// distributions.
+    ///
+    /// Constraints files are `requirements.txt`-like files that only control the _version_ of a
+    /// requirement that's installed. However, including a package in a constraints file will _not_
+    /// trigger the installation of that package.
+    #[arg(long, short, alias = "build-constraint", env = EnvVars::UV_BUILD_CONSTRAINT, value_delimiter = ' ', value_parser = parse_maybe_file_path)]
+    pub build_constraints: Vec<Maybe<PathBuf>>,
+
+    /// Include optional dependencies from the specified extra name; may be provided more than once.
+    ///
+    /// Only applies to `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
+    #[arg(long, conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    pub extra: Option<Vec<ExtraName>>,
+
+    /// Include all optional dependencies.
+    ///
+    /// Only applies to `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
+    #[arg(long, conflicts_with = "extra", overrides_with = "no_all_extras")]
+    pub all_extras: bool,
+
+    #[arg(long, overrides_with("all_extras"), hide = true)]
+    pub no_all_extras: bool,
+
+    #[command(flatten)]
+    pub resolver: ResolverArgs,
+
+    #[command(flatten)]
+    pub refresh: RefreshArgs,
+
+    /// Ignore package dependencies, instead only installing those packages explicitly listed
+    /// on the command line or in the requirements files.
+    #[arg(long, overrides_with("deps"))]
+    pub no_deps: bool,
+
+    #[arg(long, overrides_with("no_deps"), hide = true)]
+    pub deps: bool,
+
+    /// Install the specified dependency group from a `pyproject.toml`.
+    ///
+    /// If no path is provided, the `pyproject.toml` in the working directory is used.
+    ///
+    /// May be provided multiple times.
+    #[arg(long, group = "sources")]
+    pub group: Vec<PipGroupName>,
+
+    /// Require a matching hash for each requirement.
+    ///
+    /// By default, uv will verify any available hashes in the requirements file, but will not
+    /// require that all requirements have an associated hash.
+    ///
+    /// When `--require-hashes` is enabled, _all_ requirements must include a hash or set of hashes,
+    /// and _all_ requirements must either be pinned to exact versions (e.g., `==1.0.0`), or be
+    /// specified via direct URL.
+    ///
+    /// Hash-checking mode introduces a number of additional constraints:
+    ///
+    /// - Git dependencies are not supported.
+    /// - Editable installs are not supported.
+    /// - Local dependencies are not supported, unless they point to a specific wheel (`.whl`) or
+    ///   source archive (`.zip`, `.tar.gz`), as opposed to a directory.
+    #[arg(
+        long,
+        env = EnvVars::UV_REQUIRE_HASHES,
+        value_parser = clap::builder::BoolishValueParser::new(),
+        overrides_with("no_require_hashes"),
+    )]
+    pub require_hashes: bool,
+
+    #[arg(long, overrides_with("require_hashes"), hide = true)]
+    pub no_require_hashes: bool,
+
+    #[arg(long, overrides_with("no_verify_hashes"), hide = true)]
+    pub verify_hashes: bool,
+
+    /// Disable validation of hashes in the requirements file.
+    ///
+    /// By default, uv will verify any available hashes in the requirements file, but will not
+    /// require that all requirements have an associated hash. To enforce hash validation, use
+    /// `--require-hashes`.
+    #[arg(
+        long,
+        env = EnvVars::UV_NO_VERIFY_HASHES,
+        value_parser = clap::builder::BoolishValueParser::new(),
+        overrides_with("verify_hashes"),
+    )]
+    pub no_verify_hashes: bool,
+
+    /// The Python interpreter into which packages should be installed.
+    ///
+    /// By default, installation requires a virtual environment. A path to an alternative Python can
+    /// be provided, but it is only recommended in continuous integration (CI) environments and
+    /// should be used with caution, as it can modify the system Python installation.
+    ///
+    /// See `uv help python` for details on Python discovery and supported request formats.
+    #[arg(
+        long,
+        short,
+        env = EnvVars::UV_PYTHON,
+        verbatim_doc_comment,
+        help_heading = "Python options",
+        value_parser = parse_maybe_string,
+    )]
+    pub python: Option<Maybe<String>>,
+
+    /// Install packages into the system Python environment.
+    ///
+    /// By default, uv installs into the virtual environment in the current working directory or any
+    /// parent directory. The `--system` option instructs uv to instead use the first Python found
+    /// in the system `PATH`.
+    ///
+    /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
+    /// should be used with caution, as it can modify the system Python installation.
+    #[arg(
+        long,
+        env = EnvVars::UV_SYSTEM_PYTHON,
+        value_parser = clap::builder::BoolishValueParser::new(),
+        overrides_with("no_system")
+    )]
+    pub system: bool,
+
+    #[arg(long, overrides_with("system"), hide = true)]
+    pub no_system: bool,
+
+    /// Don't build source distributions.
+    ///
+    /// When enabled, resolving will not run arbitrary Python code. The cached wheels of
+    /// already-built source distributions will be reused, but operations that require building
+    /// distributions will exit with an error.
+    ///
+    /// Alias for `--only-binary :all:`.
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("build")
+    )]
+    pub no_build: bool,
+
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("no_build"),
+        hide = true
+    )]
+    pub build: bool,
+
+    /// Don't install pre-built wheels.
+    ///
+    /// The given packages will be built and installed from source. The resolver will still use
+    /// pre-built wheels to extract package metadata, if available.
+    ///
+    /// Multiple packages may be provided. Disable binaries for all packages with `:all:`. Clear
+    /// previously specified packages with `:none:`.
+    #[arg(long, conflicts_with = "no_build")]
+    pub no_binary: Option<Vec<PackageNameSpecifier>>,
+
+    /// Only use pre-built wheels; don't build source distributions.
+    ///
+    /// When enabled, resolving will not run code from the given packages. The cached wheels of
+    /// already-built source distributions will be reused, but operations that require building
+    /// distributions will exit with an error.
+    ///
+    /// Multiple packages may be provided. Disable binaries for all packages with `:all:`. Clear
+    /// previously specified packages with `:none:`.
+    #[arg(long, conflicts_with = "no_build")]
+    pub only_binary: Option<Vec<PackageNameSpecifier>>,
+
+    /// The minimum Python version that should be supported by the requirements (e.g., `3.7` or
+    /// `3.7.9`).
+    ///
+    /// If a patch version is omitted, the minimum patch version is assumed. For example, `3.7` is
+    /// mapped to `3.7.0`.
+    #[arg(long)]
+    pub python_version: Option<PythonVersion>,
+
+    /// The platform for which requirements should be installed.
+    ///
+    /// Represented as a "target triple", a string that describes the target platform in terms of
+    /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
+    /// `aarch64-apple-darwin`.
+    ///
+    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    ///
+    /// WARNING: When specified, uv will select wheels that are compatible with the _target_
+    /// platform; as a result, the installed distributions may not be compatible with the _current_
+    /// platform. Conversely, any distributions that are built from source may be incompatible with
+    /// the _target_ platform, as they will be built for the _current_ platform. The
+    /// `--python-platform` option is intended for advanced use cases.
+    #[arg(long)]
+    pub python_platform: Option<TargetTriple>,
+
+
+    /// Perform a dry run, i.e., don't actually install anything but resolve the dependencies and
+    /// print the resulting plan.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`, or `auto`)
+    ///
+    /// When set, uv will ignore the configured index URLs for packages in the PyTorch ecosystem,
+    /// and will instead use the defined backend.
+    ///
+    /// For example, when set to `cpu`, uv will use the CPU-only PyTorch index; when set to `cu126`,
+    /// uv will use the PyTorch index for CUDA 12.6.
+    ///
+    /// The `auto` mode will attempt to detect the appropriate PyTorch index based on the currently
+    /// installed CUDA drivers.
+    ///
+    /// This option is in preview and may change in any future release.
+    #[arg(long, value_enum, env = EnvVars::UV_TORCH_BACKEND)]
+    pub torch_backend: Option<TorchMode>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use pip::show::pip_show;
 pub(crate) use pip::sync::pip_sync;
 pub(crate) use pip::tree::pip_tree;
 pub(crate) use pip::uninstall::pip_uninstall;
+pub(crate) use pip::wheel::pip_wheel;
 pub(crate) use project::add::add;
 pub(crate) use project::export::export;
 pub(crate) use project::init::{init, InitKind, InitProjectKind};

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod show;
 pub(crate) mod sync;
 pub(crate) mod tree;
 pub(crate) mod uninstall;
+pub(crate) mod wheel;
 
 pub(crate) fn resolution_markers(
     python_version: Option<&PythonVersion>,

--- a/crates/uv/src/commands/pip/wheel.rs
+++ b/crates/uv/src/commands/pip/wheel.rs
@@ -1,0 +1,478 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use itertools::Itertools;
+use owo_colors::OwoColorize;
+use tracing::{debug, enabled, Level};
+
+use uv_auth::UrlAuthPolicies;
+use uv_cache::Cache;
+use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
+use uv_configuration::{
+    BuildOptions, Concurrency, ConfigSettings, Constraints, DryRun, ExtrasSpecification,
+    HashCheckingMode, IndexStrategy, PreviewMode, Reinstall, SourceStrategy, Upgrade,
+};
+use uv_configuration::{KeyringProviderType, TargetTriple};
+use uv_dispatch::{BuildDispatch, SharedState};
+use uv_distribution::DistributionDatabase;
+use uv_distribution_filename::WheelFilename;
+use uv_distribution_types::{
+    DependencyMetadata, Index, IndexLocations, NameRequirementSpecification, Origin, Requirement,
+    Resolution, UnresolvedRequirementSpecification,
+};
+use uv_fs::Simplified;
+use uv_install_wheel::LinkMode;
+use uv_installer::{Plan, Planner, Preparer, SatisfiesResult, SitePackages};
+use uv_normalize::GroupName;
+use uv_pep508::PackageName;
+use uv_pypi_types::Conflicts;
+use uv_python::{
+    EnvironmentPreference, Prefix, PythonEnvironment, PythonInstallation, PythonPreference,
+    PythonRequest, PythonVersion, Target,
+};
+use uv_requirements::{RequirementsSource, RequirementsSpecification};
+use uv_resolver::{
+    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PythonRequirement,
+    ResolutionMode, ResolverEnvironment,
+};
+use uv_torch::{TorchMode, TorchStrategy};
+use uv_types::{BuildIsolation, HashStrategy};
+use uv_warnings::warn_user;
+use uv_workspace::WorkspaceCache;
+
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
+use crate::commands::pip::operations::Modifications;
+use crate::commands::pip::operations::{report_interpreter, report_target_environment};
+use crate::commands::pip::{operations, resolution_markers, resolution_tags};
+use crate::commands::reporters::PrepareReporter;
+use crate::commands::{diagnostics, ExitStatus};
+use crate::printer::Printer;
+use crate::settings::NetworkSettings;
+use zip::{ZipWriter, CompressionMethod, write::FileOptions};
+use walkdir::WalkDir;
+
+
+/// Puts wheels into the current environment.
+#[allow(clippy::fn_params_excessive_bools)]
+pub(crate) async fn pip_wheel(
+    target: Target,
+    requirements: &[RequirementsSource],
+    constraints: &[RequirementsSource],
+    overrides: &[RequirementsSource],
+    build_constraints: &[RequirementsSource],
+    constraints_from_workspace: Vec<Requirement>,
+    overrides_from_workspace: Vec<Requirement>,
+    build_constraints_from_workspace: Vec<Requirement>,
+    extras: &ExtrasSpecification,
+    groups: BTreeMap<PathBuf, Vec<GroupName>>,
+    resolution_mode: ResolutionMode,
+    prerelease_mode: PrereleaseMode,
+    dependency_mode: DependencyMode,
+    upgrade: Upgrade,
+    index_locations: IndexLocations,
+    index_strategy: IndexStrategy,
+    torch_backend: Option<TorchMode>,
+    dependency_metadata: DependencyMetadata,
+    keyring_provider: KeyringProviderType,
+    network_settings: &NetworkSettings,
+    reinstall: Reinstall,
+    link_mode: LinkMode,
+    hash_checking: Option<HashCheckingMode>,
+    installer_metadata: bool,
+    config_settings: &ConfigSettings,
+    no_build_isolation: bool,
+    no_build_isolation_package: Vec<PackageName>,
+    build_options: BuildOptions,
+    python_version: Option<PythonVersion>,
+    python_platform: Option<TargetTriple>,
+    exclude_newer: Option<ExcludeNewer>,
+    sources: SourceStrategy,
+    python: Option<String>,
+    system: bool,
+    python_preference: PythonPreference,
+    concurrency: Concurrency,
+    cache: Cache,
+    dry_run: DryRun,
+    printer: Printer,
+    preview: PreviewMode,
+) -> anyhow::Result<ExitStatus> {
+    let start = std::time::Instant::now();
+
+    let client_builder = BaseClientBuilder::new()
+        .connectivity(network_settings.connectivity)
+        .native_tls(network_settings.native_tls)
+        .keyring(keyring_provider)
+        .allow_insecure_host(network_settings.allow_insecure_host.clone());
+
+    // Read all requirements from the provided sources.
+    let RequirementsSpecification {
+        project,
+        requirements,
+        constraints,
+        overrides,
+        source_trees,
+        groups,
+        index_url,
+        extra_index_urls,
+        no_index,
+        find_links,
+        no_binary,
+        no_build,
+        extras: _,
+    } = operations::read_requirements(
+        requirements,
+        constraints,
+        overrides,
+        extras,
+        groups,
+        &client_builder,
+    )
+    .await?;
+
+    let constraints: Vec<NameRequirementSpecification> = constraints
+        .iter()
+        .cloned()
+        .chain(
+            constraints_from_workspace
+                .into_iter()
+                .map(NameRequirementSpecification::from),
+        )
+        .collect();
+
+    let overrides: Vec<UnresolvedRequirementSpecification> = overrides
+        .iter()
+        .cloned()
+        .chain(
+            overrides_from_workspace
+                .into_iter()
+                .map(UnresolvedRequirementSpecification::from),
+        )
+        .collect();
+
+    // Read build constraints.
+    let build_constraints: Vec<NameRequirementSpecification> =
+        operations::read_constraints(build_constraints, &client_builder)
+            .await?
+            .iter()
+            .cloned()
+            .chain(
+                build_constraints_from_workspace
+                    .iter()
+                    .cloned()
+                    .map(NameRequirementSpecification::from),
+            )
+            .collect();
+
+    let environment = {
+        let installation = PythonInstallation::find(
+            &python
+                .as_deref()
+                .map(PythonRequest::parse)
+                .unwrap_or_default(),
+            EnvironmentPreference::from_system_flag(system, false),
+            python_preference,
+            &cache,
+        )?;
+        report_interpreter(&installation, true, printer)?;
+        PythonEnvironment::from_installation(installation)
+    };
+
+    let _lock = environment.lock().await?;
+
+    // Determine the markers to use for the resolution.
+    let interpreter = environment.interpreter();
+    let marker_env = resolution_markers(
+        python_version.as_ref(),
+        python_platform.as_ref(),
+        interpreter,
+    );
+
+    // Determine the set of installed packages.
+    let site_packages = SitePackages::from_environment(&environment)?;
+
+    // Determine the Python requirement, if the user requested a specific version.
+    let python_requirement = if let Some(python_version) = python_version.as_ref() {
+        PythonRequirement::from_python_version(interpreter, python_version)
+    } else {
+        PythonRequirement::from_interpreter(interpreter)
+    };
+
+    // Determine the tags to use for the resolution.
+    let tags = resolution_tags(
+        python_version.as_ref(),
+        python_platform.as_ref(),
+        interpreter,
+    )?;
+
+    // Collect the set of required hashes.
+    let hasher = if let Some(hash_checking) = hash_checking {
+        HashStrategy::from_requirements(
+            requirements
+                .iter()
+                .chain(overrides.iter())
+                .map(|entry| (&entry.requirement, entry.hashes.as_slice())),
+            constraints
+                .iter()
+                .map(|entry| (&entry.requirement, entry.hashes.as_slice())),
+            Some(&marker_env),
+            hash_checking,
+        )?
+    } else {
+        HashStrategy::None
+    };
+
+    // When resolving, don't take any external preferences into account.
+    let preferences = Vec::default();
+
+    // Incorporate any index locations from the provided sources.
+    let index_locations = index_locations.combine(
+        extra_index_urls
+            .into_iter()
+            .map(Index::from_extra_index_url)
+            .chain(index_url.map(Index::from_index_url))
+            .map(|index| index.with_origin(Origin::RequirementsTxt))
+            .collect(),
+        find_links
+            .into_iter()
+            .map(Index::from_find_links)
+            .map(|index| index.with_origin(Origin::RequirementsTxt))
+            .collect(),
+        no_index,
+    );
+
+    // Add all authenticated sources to the cache.
+    for index in index_locations.allowed_indexes() {
+        if let Some(credentials) = index.credentials() {
+            let credentials = Arc::new(credentials);
+            uv_auth::store_credentials(index.raw_url(), credentials.clone());
+            if let Some(root_url) = index.root_url() {
+                uv_auth::store_credentials(&root_url, credentials.clone());
+            }
+        }
+    }
+
+    // Determine the PyTorch backend.
+    let torch_backend = torch_backend.map(|mode| {
+        if preview.is_disabled() {
+            warn_user!("The `--torch-backend` setting is experimental and may change without warning. Pass `--preview` to disable this warning.");
+        }
+
+        TorchStrategy::from_mode(
+            mode,
+            python_platform
+                .map(TargetTriple::platform)
+                .as_ref()
+                .unwrap_or(interpreter.platform())
+                .os(),
+        )
+    }).transpose()?;
+
+    // Initialize the registry client.
+    let client = RegistryClientBuilder::try_from(client_builder)?
+        .cache(cache.clone())
+        .index_urls(index_locations.index_urls())
+        .index_strategy(index_strategy)
+        .url_auth_policies(UrlAuthPolicies::from(&index_locations))
+        .torch_backend(torch_backend)
+        .markers(interpreter.markers())
+        .platform(interpreter.platform())
+        .build();
+
+    // Combine the `--no-binary` and `--no-build` flags from the requirements files.
+    let build_options = build_options.combine(no_binary, no_build);
+
+    // Resolve the flat indexes from `--find-links`.
+    let flat_index = {
+        let client = FlatIndexClient::new(client.cached_client(), client.connectivity(), &cache);
+        let entries = client
+            .fetch_all(index_locations.flat_indexes().map(Index::url))
+            .await?;
+        FlatIndex::from_entries(entries, Some(&tags), &hasher, &build_options)
+    };
+
+    // Determine whether to enable build isolation.
+    let build_isolation = if no_build_isolation {
+        BuildIsolation::Shared(&environment)
+    } else if no_build_isolation_package.is_empty() {
+        BuildIsolation::Isolated
+    } else {
+        BuildIsolation::SharedPackage(&environment, &no_build_isolation_package)
+    };
+
+    // Enforce (but never require) the build constraints, if `--require-hashes` or `--verify-hashes`
+    // is provided. _Requiring_ hashes would be too strict, and would break with pip.
+    let build_hasher = if hash_checking.is_some() {
+        HashStrategy::from_requirements(
+            std::iter::empty(),
+            build_constraints
+                .iter()
+                .map(|entry| (&entry.requirement, entry.hashes.as_slice())),
+            Some(&marker_env),
+            HashCheckingMode::Verify,
+        )?
+    } else {
+        HashStrategy::None
+    };
+    let build_constraints = Constraints::from_requirements(
+        build_constraints
+            .iter()
+            .map(|constraint| constraint.requirement.clone()),
+    );
+
+    // Initialize any shared state.
+    let state = SharedState::default();
+
+    // Create a build dispatch.
+    let build_dispatch = BuildDispatch::new(
+        &client,
+        &cache,
+        build_constraints,
+        interpreter,
+        &index_locations,
+        &flat_index,
+        &dependency_metadata,
+        state.clone(),
+        index_strategy,
+        config_settings,
+        build_isolation,
+        link_mode,
+        &build_options,
+        &build_hasher,
+        exclude_newer,
+        sources,
+        WorkspaceCache::default(),
+        concurrency,
+        preview,
+    );
+
+    let options = OptionsBuilder::new()
+        .resolution_mode(resolution_mode)
+        .prerelease_mode(prerelease_mode)
+        .dependency_mode(dependency_mode)
+        .exclude_newer(exclude_newer)
+        .index_strategy(index_strategy)
+        .build_options(build_options.clone())
+        .build();
+
+    // Resolve the requirements.
+    let resolution = match operations::resolve(
+        requirements,
+        constraints,
+        overrides,
+        source_trees,
+        project,
+        BTreeSet::default(),
+        extras,
+        &groups,
+        preferences,
+        site_packages.clone(),
+        &hasher,
+        &reinstall,
+        &upgrade,
+        Some(&tags),
+        ResolverEnvironment::specific(marker_env.clone()),
+        python_requirement,
+        Conflicts::empty(),
+        &client,
+        &flat_index,
+        state.index(),
+        &build_dispatch,
+        concurrency,
+        options,
+        Box::new(DefaultResolveLogger),
+        printer,
+    )
+    .await
+    {
+        Ok(graph) => Resolution::from(graph),
+        Err(err) => {
+            return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+        }
+    };
+
+    let plan = Planner::new(&resolution)
+        .build(
+            site_packages,
+            &reinstall,
+            &build_options,
+            &hasher,
+            &index_locations,
+            config_settings,
+            &cache,
+            &environment,
+            &tags,
+        )
+        .context("Failed to determine installation plan")?;
+
+    let Plan {
+        cached,
+        remote,
+        reinstalls,
+        extraneous,
+    } = plan;
+
+    let wheels = if remote.is_empty() {
+        vec![]
+    } else {
+        let start = std::time::Instant::now();
+
+        let preparer = Preparer::new(
+            &cache,
+            &tags,
+            &hasher,
+            &build_options,
+            DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads),
+        )
+        .with_reporter(Arc::new(
+            PrepareReporter::from(printer).with_length(remote.len() as u64),
+        ));
+
+        preparer
+            .prepare(remote.clone(), state.in_flight(), &resolution)
+            .await?
+    };
+
+    let total_wheels = wheels.into_iter().chain(cached).collect::<Vec<_>>();
+    if !total_wheels.is_empty() {
+        let output_path = target.root();
+         for wheel in &total_wheels {
+            let wheel_output = output_path.join(wheel.filename().to_string());
+            let wheel_dir = wheel.path();
+            let file = File::create(wheel_output)?;
+            let mut zip = ZipWriter::new(file);
+            let options = zip::write::SimpleFileOptions::default()
+                .unix_permissions(664)
+                .compression_method(CompressionMethod::Deflated);
+
+            let source_dir = wheel_dir;
+
+            for entry in WalkDir::new(source_dir).min_depth(1) {
+                let entry = entry?;
+                let path = entry.path();
+
+                if path.is_dir() {
+                    continue;
+                }
+
+                let name = path.strip_prefix(source_dir)
+                    .unwrap()
+                    .to_string_lossy();
+
+                zip.start_file(name.to_string(), options)?;
+                let mut file = File::open(path)?;
+                io::copy(&mut file, &mut zip)?;
+            }
+
+            zip.finish()?;
+        }
+    }
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/uv/src/commands/pip/wheel.rs
+++ b/crates/uv/src/commands/pip/wheel.rs
@@ -1,14 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Write;
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context;
-use itertools::Itertools;
-use owo_colors::OwoColorize;
-use tracing::{debug, enabled, Level};
 
 use uv_auth::UrlAuthPolicies;
 use uv_cache::Cache;
@@ -20,19 +16,17 @@ use uv_configuration::{
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::{BuildDispatch, SharedState};
 use uv_distribution::DistributionDatabase;
-use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{
     DependencyMetadata, Index, IndexLocations, NameRequirementSpecification, Origin, Requirement,
     Resolution, UnresolvedRequirementSpecification,
 };
-use uv_fs::Simplified;
 use uv_install_wheel::LinkMode;
-use uv_installer::{Plan, Planner, Preparer, SatisfiesResult, SitePackages};
+use uv_installer::{Plan, Planner, Preparer, SitePackages};
 use uv_normalize::GroupName;
 use uv_pep508::PackageName;
 use uv_pypi_types::Conflicts;
 use uv_python::{
-    EnvironmentPreference, Prefix, PythonEnvironment, PythonInstallation, PythonPreference,
+    EnvironmentPreference, PythonEnvironment, PythonInstallation, PythonPreference,
     PythonRequest, PythonVersion, Target,
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
@@ -45,17 +39,15 @@ use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user;
 use uv_workspace::WorkspaceCache;
 
-use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
-use crate::commands::pip::operations::Modifications;
-use crate::commands::pip::operations::{report_interpreter, report_target_environment};
+use crate::commands::pip::loggers::DefaultResolveLogger;
+use crate::commands::pip::operations::report_interpreter;
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
 use crate::commands::reporters::PrepareReporter;
 use crate::commands::{diagnostics, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::NetworkSettings;
-use zip::{ZipWriter, CompressionMethod, write::FileOptions};
 use walkdir::WalkDir;
-
+use zip::{CompressionMethod, ZipWriter};
 
 /// Puts wheels into the current environment.
 #[allow(clippy::fn_params_excessive_bools)]
@@ -442,7 +434,7 @@ pub(crate) async fn pip_wheel(
     let total_wheels = wheels.into_iter().chain(cached).collect::<Vec<_>>();
     if !total_wheels.is_empty() {
         let output_path = target.root();
-         for wheel in &total_wheels {
+        for wheel in &total_wheels {
             let wheel_output = output_path.join(wheel.filename().to_string());
             let wheel_dir = wheel.path();
             let file = File::create(wheel_output)?;
@@ -461,9 +453,7 @@ pub(crate) async fn pip_wheel(
                     continue;
                 }
 
-                let name = path.strip_prefix(source_dir)
-                    .unwrap()
-                    .to_string_lossy();
+                let name = path.strip_prefix(source_dir).unwrap().to_string_lossy();
 
                 zip.start_file(name.to_string(), options)?;
                 let mut file = File::open(path)?;

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -16,9 +16,10 @@ use uv_cli::{
 use uv_cli::{
     AddArgs, ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe,
     PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
-    PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
-    PythonListFormat, PythonPinArgs, PythonUninstallArgs, RemoveArgs, RunArgs, SyncArgs,
-    ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs,
+    PipSyncArgs, PipTreeArgs, PipUninstallArgs, PipWheelArgs, PythonFindArgs, PythonInstallArgs,
+    PythonListArgs, PythonListFormat, PythonPinArgs, PythonUninstallArgs, RemoveArgs, RunArgs,
+    SyncArgs, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs,
+    VenvArgs,
 };
 use uv_client::Connectivity;
 use uv_configuration::{
@@ -2281,6 +2282,148 @@ impl PipCheckSettings {
                     python: python.and_then(Maybe::into_option),
                     system: flag(system, no_system),
                     ..PipOptions::default()
+                },
+                filesystem,
+            ),
+        }
+    }
+}
+
+/// The resolved settings to use for a `pip wheel` invocation.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct PipWheelSettings {
+    pub(crate) package: Vec<String>,
+    pub(crate) requirements: Vec<PathBuf>,
+    pub(crate) editables: Vec<String>,
+    pub(crate) constraints: Vec<PathBuf>,
+    pub(crate) overrides: Vec<PathBuf>,
+    pub(crate) build_constraints: Vec<PathBuf>,
+    pub(crate) dry_run: DryRun,
+    pub(crate) constraints_from_workspace: Vec<Requirement>,
+    pub(crate) overrides_from_workspace: Vec<Requirement>,
+    pub(crate) build_constraints_from_workspace: Vec<Requirement>,
+    pub(crate) refresh: Refresh,
+    pub(crate) settings: PipSettings,
+}
+
+impl PipWheelSettings {
+    /// Resolve the [`PipWheelSettings`] from the CLI and filesystem configuration.
+    pub(crate) fn resolve(args: PipWheelArgs, filesystem: Option<FilesystemOptions>) -> Self {
+        let PipWheelArgs {
+            wheel_dir,
+            package,
+            requirements,
+            editable,
+            constraints,
+            overrides,
+            build_constraints,
+            extra,
+            all_extras,
+            no_all_extras,
+            resolver,
+            refresh,
+            no_deps,
+            deps,
+            group,
+            require_hashes,
+            no_require_hashes,
+            verify_hashes,
+            no_verify_hashes,
+            python,
+            system,
+            no_system,
+            no_build,
+            build,
+            no_binary,
+            only_binary,
+            python_version,
+            python_platform,
+            dry_run,
+            torch_backend,
+        } = args;
+
+        let constraints_from_workspace = if let Some(configuration) = &filesystem {
+            configuration
+                .constraint_dependencies
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|requirement| {
+                    Requirement::from(requirement.with_origin(RequirementOrigin::Workspace))
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let overrides_from_workspace = if let Some(configuration) = &filesystem {
+            configuration
+                .override_dependencies
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|requirement| {
+                    Requirement::from(requirement.with_origin(RequirementOrigin::Workspace))
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let build_constraints_from_workspace = if let Some(configuration) = &filesystem {
+            configuration
+                .build_constraint_dependencies
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|requirement| {
+                    Requirement::from(requirement.with_origin(RequirementOrigin::Workspace))
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            package,
+            requirements,
+            editables: editable,
+            constraints: constraints
+                .into_iter()
+                .filter_map(Maybe::into_option)
+                .collect(),
+            overrides: overrides
+                .into_iter()
+                .filter_map(Maybe::into_option)
+                .collect(),
+            build_constraints: build_constraints
+                .into_iter()
+                .filter_map(Maybe::into_option)
+                .collect(),
+            dry_run: DryRun::from_args(dry_run),
+            constraints_from_workspace,
+            overrides_from_workspace,
+            build_constraints_from_workspace,
+            refresh: Refresh::from(refresh),
+            settings: PipSettings::combine(
+                PipOptions {
+                    python: python.and_then(Maybe::into_option),
+                    system: flag(system, no_system),
+                    target: wheel_dir.into_option(),
+                    no_build: flag(no_build, build),
+                    no_binary,
+                    only_binary,
+                    extra,
+                    all_extras: flag(all_extras, no_all_extras),
+                    group: Some(group),
+                    no_deps: flag(no_deps, deps),
+                    python_version,
+                    python_platform,
+                    require_hashes: flag(require_hashes, no_require_hashes),
+                    verify_hashes: flag(verify_hashes, no_verify_hashes),
+                    torch_backend,
+                    ..PipOptions::from(resolver)
                 },
                 filesystem,
             ),


### PR DESCRIPTION
## Summary

Implements a rudimentary `uv pip wheel` command. This is simply a repackaged `uv pip install` that short-circuits at the actual install step and instead takes the cached wheels and zips them up. Marked as draft because I don't really like my implementation, it's a bit messy and duplicates a lot of `uv pip install`, and there's questions about the semantics of `pip wheel` that I don't have enough knowledge to answer.

Resolves #1681 

## TODO:

1. De-duplicate most of the logic between `uv pip wheel` and `uv pip install`
2. Decide whether a notion of `resolving dependencies` is really how `pip wheel` is supposed to behave
3. Introduce a separate crate for writing a zipped wheel (I basically just copied from `uv-build-backend`)
4. Write tests / integration tests.

(On the last point: I can `uv pip wheel` and install said wheels, and they're identical to `uv pip wheel`, sans the records being slightly different due to console scripts not being included. I do think this is an actual bug though, which is why I want to use the logic in `uv-build-backend` which has already solved this, though it will need to be in a new crate).