### PR TITLE
Add qualification to authenticate always documentation

### DIFF
--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -207,9 +207,9 @@ authenticate = "always"
 ```
 
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
-credentials cannot be found. Since this is scoped to a specific index, if authentication fails, uv
-will still continue consulting the other indexes you have defined (as well as PyPI, if you have not
-overridden it as the default index).
+credentials cannot be found. If the discovered credentials are not valid (i.e., the index returns a HTTP 401 or 403), then
+uv will treat packages as unavailable and query the next configured index as described in
+the [index strategy](#searching-across-multiple-indexes) section.
 
 ### Disabling authentication
 

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -207,9 +207,9 @@ authenticate = "always"
 ```
 
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
-credentials cannot be found. If the discovered credentials are not valid (i.e., the index returns a HTTP 401 or 403), then
-uv will treat packages as unavailable and query the next configured index as described in
-the [index strategy](#searching-across-multiple-indexes) section.
+credentials cannot be found. If the discovered credentials are not valid (i.e., the index returns a
+HTTP 401 or 403), then uv will treat packages as unavailable and query the next configured index as
+described in the [index strategy](#searching-across-multiple-indexes) section.
 
 ### Disabling authentication
 

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -209,7 +209,7 @@ authenticate = "always"
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
 credentials cannot be found. Since this is scoped to a specific index, if authentication fails, uv
 will still continue consulting the other indexes you have defined (as well as PyPI, if you have not
-overriden it as the default index).
+overridden it as the default index).
 
 ### Disabling authentication
 

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -207,7 +207,9 @@ authenticate = "always"
 ```
 
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
-credentials cannot be found.
+credentials cannot be found. Since this is scoped to a specific index, uv will still continue
+consulting the other indexes you have defined (as well as PyPI, if you have not overriden it as the
+default index).
 
 ### Disabling authentication
 

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -207,9 +207,9 @@ authenticate = "always"
 ```
 
 When `authenticate` is set to `always`, uv will eagerly search for credentials and error if
-credentials cannot be found. Since this is scoped to a specific index, uv will still continue
-consulting the other indexes you have defined (as well as PyPI, if you have not overriden it as the
-default index).
+credentials cannot be found. Since this is scoped to a specific index, if authentication fails, uv
+will still continue consulting the other indexes you have defined (as well as PyPI, if you have not
+overriden it as the default index).
 
 ### Disabling authentication
 


### PR DESCRIPTION
It might not be obvious to some users that authenticate always will not prevent uv from consulting other indexes.
