### PR TITLE
Add a newline after metadata when initializing scripts with other metadata blocks

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -173,7 +173,7 @@ impl Pep723Script {
 
         // Add a newline to the beginning if it starts with a valid metadata comment line.
         let postlude = if postlude.starts_with("# ") || postlude.starts_with("#\n") {
-            format!("\n{}", postlude)
+            format!("\n{postlude}")
         } else {
             postlude
         };

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -709,6 +709,7 @@ mod tests {
         assert_eq!(actual.metadata, expected_metadata);
         assert_eq!(actual.postlude, expected_data);
     }
+
     #[test]
     fn embedded_comment() {
         let contents = indoc::indoc! {r"
@@ -772,7 +773,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_metadata_formatting() {
+    fn serialize_metadata_formatting() {
         let metadata = indoc::indoc! {r"
         requires-python = '>=3.11'
         dependencies = [
@@ -796,7 +797,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_metadata_empty() {
+    fn serialize_metadata_empty() {
         let metadata = "";
         let expected_output = "# /// script\n# ///\n";
 
@@ -805,7 +806,7 @@ mod tests {
     }
 
     #[test]
-    fn test_script_init_empty() {
+    fn script_init_empty() {
         let contents = "".as_bytes();
         let (prelude, metadata, postlude) =
             Pep723Script::init_metadata(contents, &uv_pep440::VersionSpecifiers::default())
@@ -822,7 +823,7 @@ mod tests {
     }
 
     #[test]
-    fn test_script_init_with_hashbang() {
+    fn script_init_with_hashbang() {
         let contents = indoc::indoc! {r#"
         #!/usr/bin/env python3
 
@@ -850,7 +851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_script_init_with_other_metadata() {
+    fn script_init_with_other_metadata() {
         let contents = indoc::indoc! {r#"
         # /// noscript
         # Hello,
@@ -889,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn test_script_init_with_hashbang_and_other_metadata() {
+    fn script_init_with_hashbang_and_other_metadata() {
         let contents = indoc::indoc! {r#"
         #!/usr/bin/env python3
         # /// noscript
@@ -927,8 +928,9 @@ mod tests {
             "#}
         );
     }
+
     #[test]
-    fn test_script_init_with_valid_metadata_line() {
+    fn script_init_with_valid_metadata_line() {
         let contents = indoc::indoc! {r#"
         # Hello,
         # /// noscript
@@ -965,8 +967,9 @@ mod tests {
             "#}
         );
     }
+
     #[test]
-    fn test_script_init_with_valid_empty_metadata_line() {
+    fn script_init_with_valid_empty_metadata_line() {
         let contents = indoc::indoc! {r#"
         #
         # /// noscript
@@ -1003,8 +1006,9 @@ mod tests {
             "#}
         );
     }
+
     #[test]
-    fn test_script_init_with_non_metadata_comment() {
+    fn script_init_with_non_metadata_comment() {
         let contents = indoc::indoc! {r#"
         #Hello,
         # /// noscript

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -171,6 +171,13 @@ impl Pep723Script {
         //  Extract the shebang and script content.
         let (shebang, postlude) = extract_shebang(&contents)?;
 
+        // Add a newline to the beginning if it starts with a valid metadata comment line.
+        let postlude = if postlude.starts_with("# ") || postlude.starts_with("#\n") {
+            format!("\n{}", postlude)
+        } else {
+            postlude
+        };
+
         Ok(Self {
             path: std::path::absolute(file)?,
             prelude: if shebang.is_empty() {

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -187,7 +187,12 @@ impl Pep723Script {
         let (shebang, postlude) = extract_shebang(contents)?;
 
         // Add a newline to the beginning if it starts with a valid metadata comment line.
-        let postlude = if postlude.starts_with("# ") || postlude.starts_with("#\n") {
+        let postlude = if postlude.strip_prefix('#').is_some_and(|postlude| {
+            postlude
+                .chars()
+                .next()
+                .is_some_and(|c| matches!(c, ' ' | '\r' | '\n'))
+        }) {
             format!("\n{postlude}")
         } else {
             postlude
@@ -913,7 +918,7 @@ mod tests {
             dependencies = []
             "#}
         );
-        // Note the extra line at the beginning
+        // Note the extra line at the beginning.
         assert_eq!(
             postlude,
             indoc::indoc! {r#"


### PR DESCRIPTION
## Summary

uv doesn't separate the metadata block from other blocks when adding the `script` block to a script, which results in the next block being considered part of the script block and causes errors when running.

See #12499 for more details.

Closes #12499

## Test Plan

I manually tested the most common scenario, but there's a few edge cases that would be good to have tests for.

I would have written the tests also, but I was running into errors like this:
```bash
$ cargo test --package uv-scripts
   Compiling uv-configuration v0.0.1 (/home/merlin/Projects/uv/crates/uv-configuration)
error: cannot find attribute `value` in this scope
 --> crates/uv-configuration/src/project_build_backend.rs:8:38
  |
8 |     #[cfg_attr(feature = "schemars", value(hide = true))]
  |                                      ^^^^^

error: could not compile `uv-configuration` (lib) due to 1 previous error
```