### PR TITLE
Bump least-recent non-EOL macOS version to 13.0

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -39,7 +39,7 @@ pub enum TargetTriple {
 
     /// An ARM-based macOS target, as seen on Apple Silicon devices
     ///
-    /// By default, assumes the least-recent, non-EOL macOS version (12.0), but respects
+    /// By default, assumes the least-recent, non-EOL macOS version (13.0), but respects
     /// the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.
     #[cfg_attr(feature = "clap", value(name = "aarch64-apple-darwin"))]
     #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-apple-darwin"))]
@@ -47,7 +47,7 @@ pub enum TargetTriple {
 
     /// An x86 macOS target.
     ///
-    /// By default, assumes the least-recent, non-EOL macOS version (12.0), but respects
+    /// By default, assumes the least-recent, non-EOL macOS version (13.0), but respects
     /// the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.
     #[cfg_attr(feature = "clap", value(name = "x86_64-apple-darwin"))]
     #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-apple-darwin"))]
@@ -212,7 +212,7 @@ impl TargetTriple {
                 Arch::X86_64,
             ),
             Self::Macos | Self::Aarch64AppleDarwin => {
-                let (major, minor) = macos_deployment_target().map_or((12, 0), |(major, minor)| {
+                let (major, minor) = macos_deployment_target().map_or((13, 0), |(major, minor)| {
                     debug!("Found macOS deployment target: {}.{}", major, minor);
                     (major, minor)
                 });
@@ -220,7 +220,7 @@ impl TargetTriple {
             }
             Self::I686PcWindowsMsvc => Platform::new(Os::Windows, Arch::X86),
             Self::X8664AppleDarwin => {
-                let (major, minor) = macos_deployment_target().map_or((12, 0), |(major, minor)| {
+                let (major, minor) = macos_deployment_target().map_or((13, 0), |(major, minor)| {
                     debug!("Found macOS deployment target: {}.{}", major, minor);
                     (major, minor)
                 });

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -437,7 +437,7 @@ impl EnvVars {
     /// Used with `--python-platform macos` and related variants to set the
     /// deployment target (i.e., the minimum supported macOS version).
     ///
-    /// Defaults to `12.0`, the least-recent non-EOL macOS version at time of writing.
+    /// Defaults to `13.0`, the least-recent non-EOL macOS version at time of writing.
     pub const MACOSX_DEPLOYMENT_TARGET: &'static str = "MACOSX_DEPLOYMENT_TARGET";
 
     /// Disables colored output (takes precedence over `FORCE_COLOR`).

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -496,7 +496,7 @@ Used to look for Microsoft Store Pythons installations.
 Used with `--python-platform macos` and related variants to set the
 deployment target (i.e., the minimum supported macOS version).
 
-Defaults to `12.0`, the least-recent non-EOL macOS version at time of writing.
+Defaults to `13.0`, the least-recent non-EOL macOS version at time of writing.
 
 ### `NETRC`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1989,14 +1989,14 @@
           ]
         },
         {
-          "description": "An ARM-based macOS target, as seen on Apple Silicon devices\n\nBy default, assumes the least-recent, non-EOL macOS version (12.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
+          "description": "An ARM-based macOS target, as seen on Apple Silicon devices\n\nBy default, assumes the least-recent, non-EOL macOS version (13.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
           "type": "string",
           "enum": [
             "aarch64-apple-darwin"
           ]
         },
         {
-          "description": "An x86 macOS target.\n\nBy default, assumes the least-recent, non-EOL macOS version (12.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
+          "description": "An x86 macOS target.\n\nBy default, assumes the least-recent, non-EOL macOS version (13.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
           "type": "string",
           "enum": [
             "x86_64-apple-darwin"


### PR DESCRIPTION
## Summary

We use the least-recent non-EOL macOS version by default, and this has since changed (i.e., macOS 12 went EOL).

Closes https://github.com/astral-sh/uv/issues/12487.
