### PR TITLE
changed where the fish completions get installed to where fish docs recommend

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -179,7 +179,7 @@ To enable shell autocompletion for uv commands, run one of the following:
 === "fish"
 
     ```bash
-    echo 'uv generate-shell-completion fish | source' >> ~/.config/fish/config.fish
+    echo 'uv generate-shell-completion fish | source' >> ~/.config/fish/completions/uv.fish
     ```
 
 === "Elvish"
@@ -214,7 +214,7 @@ To enable shell autocompletion for uvx, run one of the following:
 === "fish"
 
     ```bash
-    echo 'uvx --generate-shell-completion fish | source' >> ~/.config/fish/config.fish
+    echo 'uvx --generate-shell-completion fish | source' >> ~/.config/fish/completions/uvx.fish
     ```
 
 === "Elvish"


### PR DESCRIPTION
## Summary
I only changed the location of where the fish completions get sent, from `~/.config/fish/config.fish` to `~/.config/fish/completions/uv.fish` and `~/.config/fish/completions/uvx.fish` respectively

## Test Plan
I have tested and putting the completions in those paths works fine and complies with the fish docs. Also keeps your `config.fish` clean


### edit:
refer to https://fishshell.com/docs/current/completions.html#where-to-put-completions
> This wide search may be confusing. If you are unsure, your completions probably belong in `~/.config/fish/completions`.