### PR TITLE
Make python-install-mirror configurable in single-file scripts

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -12,7 +12,7 @@ use url::Url;
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::PackageName;
 use uv_pypi_types::VerbatimParsedUrl;
-use uv_settings::{GlobalOptions, ResolverInstallerOptions};
+use uv_settings::{GlobalOptions, PythonInstallMirrors, ResolverInstallerOptions};
 use uv_workspace::pyproject::Sources;
 
 static FINDER: LazyLock<Finder> = LazyLock::new(|| Finder::new(b"# /// script"));
@@ -362,6 +362,8 @@ pub struct ToolUv {
     pub globals: GlobalOptions,
     #[serde(flatten)]
     pub top_level: ResolverInstallerOptions,
+    #[serde(flatten)]
+    pub install_mirrors: PythonInstallMirrors,
     pub override_dependencies: Option<Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,
     pub constraint_dependencies: Option<Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,
     pub build_constraint_dependencies: Option<Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -145,10 +145,11 @@ pub struct Options {
 
 impl Options {
     /// Construct an [`Options`] with the given global and top-level settings.
-    pub fn simple(globals: GlobalOptions, top_level: ResolverInstallerOptions) -> Self {
+    pub fn simple(globals: GlobalOptions, top_level: ResolverInstallerOptions, install_mirrors: PythonInstallMirrors) -> Self {
         Self {
             globals,
             top_level,
+            install_mirrors,
             ..Default::default()
         }
     }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -282,7 +282,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         .map(Pep723Item::metadata)
         .and_then(|metadata| metadata.tool.as_ref())
         .and_then(|tool| tool.uv.as_ref())
-        .map(|uv| Options::simple(uv.globals.clone(), uv.top_level.clone()))
+        .map(|uv| {
+            Options::simple(
+                uv.globals.clone(),
+                uv.top_level.clone(),
+                uv.install_mirrors.clone(),
+            )
+        })
         .map(FilesystemOptions::from)
         .combine(filesystem);
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #12522
## Test Plan

<!-- How was it tested? -->
