### PR TITLE
Docs: Clarify uvx on PyPI is unofficial.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -81,6 +81,10 @@ However, `pip` can also be used:
 $ pip install uv
 ```
 
+!!! warning
+
+    The [`uvx`](https://pypi.org/project/uvx/) package available on PyPI is not an official package. The official `uvx` tool is included as part of the [`uv`](https://pypi.org/project/uv/) package.
+
 !!! note
 
     uv ships with prebuilt distributions (wheels) for many platforms; if a wheel is not available for a given


### PR DESCRIPTION
## Summary

Due to recent instances in https://github.com/astral-sh/uv/issues/12552#issuecomment-2764503857 mistakenly used the PyPI package ``uvx`` as the official package, it's worth mentioning in the documentation.
uvx on PyPI: https://pypi.org/project/uvx/

The README currently includes pip installation instructions. However, due to uncertainty regarding the most concise way to present this information, it will be omitted for the time being.
## Test Plan
Run docs server in local
![image](https://github.com/user-attachments/assets/b0474b11-0b60-414a-9332-65fdf8024444)

<!-- How was it tested? -->
