### PR TITLE
fix parsing of `python-platform` in settings tomls

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -25,6 +25,7 @@ pub enum TargetTriple {
     /// A 64-bit x86 Windows target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-pc-windows-msvc"))]
     #[serde(rename = "x86_64-pc-windows-msvc")]
+    #[serde(alias = "x8664-pc-windows-msvc")]
     X8664PcWindowsMsvc,
 
     /// A 32-bit x86 Windows target.
@@ -35,6 +36,7 @@ pub enum TargetTriple {
     /// An x86 Linux target. Equivalent to `x86_64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-gnu"))]
     #[serde(rename = "x86_64-unknown-linux-gnu")]
+    #[serde(alias = "x8664-unknown-linux-gnu")]
     X8664UnknownLinuxGnu,
 
     /// An ARM-based macOS target, as seen on Apple Silicon devices
@@ -51,6 +53,7 @@ pub enum TargetTriple {
     /// the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.
     #[cfg_attr(feature = "clap", value(name = "x86_64-apple-darwin"))]
     #[serde(rename = "x86_64-apple-darwin")]
+    #[serde(alias = "x8664-apple-darwin")]
     X8664AppleDarwin,
 
     /// An ARM64 Linux target. Equivalent to `aarch64-manylinux_2_17`.
@@ -66,71 +69,85 @@ pub enum TargetTriple {
     /// An `x86_64` Linux target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-musl"))]
     #[serde(rename = "x86_64-unknown-linux-musl")]
+    #[serde(alias = "x8664-unknown-linux-musl")]
     X8664UnknownLinuxMusl,
 
     /// An `x86_64` target for the `manylinux2014` platform. Equivalent to `x86_64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux2014"))]
     #[serde(rename = "x86_64-manylinux2014")]
+    #[serde(alias = "x8664-manylinux2014")]
     X8664Manylinux2014,
 
     /// An `x86_64` target for the `manylinux_2_17` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_17"))]
     #[serde(rename = "x86_64-manylinux_2_17")]
+    #[serde(alias = "x8664-manylinux217")]
     X8664Manylinux217,
 
     /// An `x86_64` target for the `manylinux_2_28` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_28"))]
     #[serde(rename = "x86_64-manylinux_2_28")]
+    #[serde(alias = "x8664-manylinux228")]
     X8664Manylinux228,
 
     /// An `x86_64` target for the `manylinux_2_31` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_31"))]
     #[serde(rename = "x86_64-manylinux_2_31")]
+    #[serde(alias = "x8664-manylinux231")]
     X8664Manylinux231,
 
     /// An `x86_64` target for the `manylinux_2_32` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_32"))]
     #[serde(rename = "x86_64-manylinux_2_32")]
+    #[serde(alias = "x8664-manylinux232")]
     X8664Manylinux232,
 
     /// An `x86_64` target for the `manylinux_2_33` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_33"))]
     #[serde(rename = "x86_64-manylinux_2_33")]
+    #[serde(alias = "x8664-manylinux233")]
     X8664Manylinux233,
 
     /// An `x86_64` target for the `manylinux_2_34` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_34"))]
     #[serde(rename = "x86_64-manylinux_2_34")]
+    #[serde(alias = "x8664-manylinux234")]
     X8664Manylinux234,
 
     /// An `x86_64` target for the `manylinux_2_35` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_35"))]
     #[serde(rename = "x86_64-manylinux_2_35")]
+    #[serde(alias = "x8664-manylinux235")]
     X8664Manylinux235,
 
     /// An `x86_64` target for the `manylinux_2_36` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_36"))]
     #[serde(rename = "x86_64-manylinux_2_36")]
+    #[serde(alias = "x8664-manylinux236")]
     X8664Manylinux236,
 
     /// An `x86_64` target for the `manylinux_2_37` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_37"))]
     #[serde(rename = "x86_64-manylinux_2_37")]
+    #[serde(alias = "x8664-manylinux237")]
     X8664Manylinux237,
 
     /// An `x86_64` target for the `manylinux_2_38` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_38"))]
     #[serde(rename = "x86_64-manylinux_2_38")]
+    #[serde(alias = "x8664-manylinux238")]
     X8664Manylinux238,
 
     /// An `x86_64` target for the `manylinux_2_39` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_39"))]
     #[serde(rename = "x86_64-manylinux_2_39")]
+    #[serde(alias = "x8664-manylinux239")]
     X8664Manylinux239,
 
     /// An `x86_64` target for the `manylinux_2_40` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_40"))]
     #[serde(rename = "x86_64-manylinux_2_40")]
+    #[serde(alias = "x8664-manylinux240")]
     X8664Manylinux240,
 
     /// An ARM64 target for the `manylinux2014` platform. Equivalent to `aarch64-manylinux_2_17`.
@@ -141,61 +158,73 @@ pub enum TargetTriple {
     /// An ARM64 target for the `manylinux_2_17` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_17"))]
     #[serde(rename = "aarch64-manylinux_2_17")]
+    #[serde(alias = "aarch64-manylinux217")]
     Aarch64Manylinux217,
 
     /// An ARM64 target for the `manylinux_2_28` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_28"))]
     #[serde(rename = "aarch64-manylinux_2_28")]
+    #[serde(alias = "aarch64-manylinux228")]
     Aarch64Manylinux228,
 
     /// An ARM64 target for the `manylinux_2_31` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_31"))]
     #[serde(rename = "aarch64-manylinux_2_31")]
+    #[serde(alias = "aarch64-manylinux231")]
     Aarch64Manylinux231,
 
     /// An ARM64 target for the `manylinux_2_32` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_32"))]
     #[serde(rename = "aarch64-manylinux_2_32")]
+    #[serde(alias = "aarch64-manylinux232")]
     Aarch64Manylinux232,
 
     /// An ARM64 target for the `manylinux_2_33` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_33"))]
     #[serde(rename = "aarch64-manylinux_2_33")]
+    #[serde(alias = "aarch64-manylinux233")]
     Aarch64Manylinux233,
 
     /// An ARM64 target for the `manylinux_2_34` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_34"))]
     #[serde(rename = "aarch64-manylinux_2_34")]
+    #[serde(alias = "aarch64-manylinux234")]
     Aarch64Manylinux234,
 
     /// An ARM64 target for the `manylinux_2_35` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_35"))]
     #[serde(rename = "aarch64-manylinux_2_35")]
+    #[serde(alias = "aarch64-manylinux235")]
     Aarch64Manylinux235,
 
     /// An ARM64 target for the `manylinux_2_36` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_36"))]
     #[serde(rename = "aarch64-manylinux_2_36")]
+    #[serde(alias = "aarch64-manylinux236")]
     Aarch64Manylinux236,
 
     /// An ARM64 target for the `manylinux_2_37` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_37"))]
     #[serde(rename = "aarch64-manylinux_2_37")]
+    #[serde(alias = "aarch64-manylinux237")]
     Aarch64Manylinux237,
 
     /// An ARM64 target for the `manylinux_2_38` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_38"))]
     #[serde(rename = "aarch64-manylinux_2_38")]
+    #[serde(alias = "aarch64-manylinux238")]
     Aarch64Manylinux238,
 
     /// An ARM64 target for the `manylinux_2_39` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_39"))]
     #[serde(rename = "aarch64-manylinux_2_39")]
+    #[serde(alias = "aarch64-manylinux239")]
     Aarch64Manylinux239,
 
     /// An ARM64 target for the `manylinux_2_40` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_40"))]
     #[serde(rename = "aarch64-manylinux_2_40")]
+    #[serde(alias = "aarch64-manylinux240")]
     Aarch64Manylinux240,
 }
 

--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -24,17 +24,17 @@ pub enum TargetTriple {
 
     /// A 64-bit x86 Windows target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-pc-windows-msvc"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-pc-windows-msvc"))]
+    #[serde(rename = "x86_64-pc-windows-msvc")]
     X8664PcWindowsMsvc,
 
     /// A 32-bit x86 Windows target.
     #[cfg_attr(feature = "clap", value(name = "i686-pc-windows-msvc"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "i686-pc-windows-msvc"))]
+    #[serde(rename = "i686-pc-windows-msvc")]
     I686PcWindowsMsvc,
 
     /// An x86 Linux target. Equivalent to `x86_64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-gnu"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-unknown-linux-gnu"))]
+    #[serde(rename = "x86_64-unknown-linux-gnu")]
     X8664UnknownLinuxGnu,
 
     /// An ARM-based macOS target, as seen on Apple Silicon devices
@@ -42,7 +42,7 @@ pub enum TargetTriple {
     /// By default, assumes the least-recent, non-EOL macOS version (12.0), but respects
     /// the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.
     #[cfg_attr(feature = "clap", value(name = "aarch64-apple-darwin"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-apple-darwin"))]
+    #[serde(rename = "aarch64-apple-darwin")]
     Aarch64AppleDarwin,
 
     /// An x86 macOS target.
@@ -50,152 +50,152 @@ pub enum TargetTriple {
     /// By default, assumes the least-recent, non-EOL macOS version (12.0), but respects
     /// the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.
     #[cfg_attr(feature = "clap", value(name = "x86_64-apple-darwin"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-apple-darwin"))]
+    #[serde(rename = "x86_64-apple-darwin")]
     X8664AppleDarwin,
 
     /// An ARM64 Linux target. Equivalent to `aarch64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "aarch64-unknown-linux-gnu"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-unknown-linux-gnu"))]
+    #[serde(rename = "aarch64-unknown-linux-gnu")]
     Aarch64UnknownLinuxGnu,
 
     /// An ARM64 Linux target.
     #[cfg_attr(feature = "clap", value(name = "aarch64-unknown-linux-musl"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-unknown-linux-musl"))]
+    #[serde(rename = "aarch64-unknown-linux-musl")]
     Aarch64UnknownLinuxMusl,
 
     /// An `x86_64` Linux target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-musl"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-unknown-linux-musl"))]
+    #[serde(rename = "x86_64-unknown-linux-musl")]
     X8664UnknownLinuxMusl,
 
     /// An `x86_64` target for the `manylinux2014` platform. Equivalent to `x86_64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux2014"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux2014"))]
+    #[serde(rename = "x86_64-manylinux2014")]
     X8664Manylinux2014,
 
     /// An `x86_64` target for the `manylinux_2_17` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_17"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_17"))]
+    #[serde(rename = "x86_64-manylinux_2_17")]
     X8664Manylinux217,
 
     /// An `x86_64` target for the `manylinux_2_28` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_28"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_28"))]
+    #[serde(rename = "x86_64-manylinux_2_28")]
     X8664Manylinux228,
 
     /// An `x86_64` target for the `manylinux_2_31` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_31"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_31"))]
+    #[serde(rename = "x86_64-manylinux_2_31")]
     X8664Manylinux231,
 
     /// An `x86_64` target for the `manylinux_2_32` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_32"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_32"))]
+    #[serde(rename = "x86_64-manylinux_2_32")]
     X8664Manylinux232,
 
     /// An `x86_64` target for the `manylinux_2_33` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_33"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_33"))]
+    #[serde(rename = "x86_64-manylinux_2_33")]
     X8664Manylinux233,
 
     /// An `x86_64` target for the `manylinux_2_34` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_34"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_34"))]
+    #[serde(rename = "x86_64-manylinux_2_34")]
     X8664Manylinux234,
 
     /// An `x86_64` target for the `manylinux_2_35` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_35"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_35"))]
+    #[serde(rename = "x86_64-manylinux_2_35")]
     X8664Manylinux235,
 
     /// An `x86_64` target for the `manylinux_2_36` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_36"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_36"))]
+    #[serde(rename = "x86_64-manylinux_2_36")]
     X8664Manylinux236,
 
     /// An `x86_64` target for the `manylinux_2_37` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_37"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_37"))]
+    #[serde(rename = "x86_64-manylinux_2_37")]
     X8664Manylinux237,
 
     /// An `x86_64` target for the `manylinux_2_38` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_38"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_38"))]
+    #[serde(rename = "x86_64-manylinux_2_38")]
     X8664Manylinux238,
 
     /// An `x86_64` target for the `manylinux_2_39` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_39"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_39"))]
+    #[serde(rename = "x86_64-manylinux_2_39")]
     X8664Manylinux239,
 
     /// An `x86_64` target for the `manylinux_2_40` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_40"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-manylinux_2_40"))]
+    #[serde(rename = "x86_64-manylinux_2_40")]
     X8664Manylinux240,
 
     /// An ARM64 target for the `manylinux2014` platform. Equivalent to `aarch64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux2014"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux2014"))]
+    #[serde(rename = "aarch64-manylinux2014")]
     Aarch64Manylinux2014,
 
     /// An ARM64 target for the `manylinux_2_17` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_17"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_17"))]
+    #[serde(rename = "aarch64-manylinux_2_17")]
     Aarch64Manylinux217,
 
     /// An ARM64 target for the `manylinux_2_28` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_28"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_28"))]
+    #[serde(rename = "aarch64-manylinux_2_28")]
     Aarch64Manylinux228,
 
     /// An ARM64 target for the `manylinux_2_31` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_31"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_31"))]
+    #[serde(rename = "aarch64-manylinux_2_31")]
     Aarch64Manylinux231,
 
     /// An ARM64 target for the `manylinux_2_32` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_32"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_32"))]
+    #[serde(rename = "aarch64-manylinux_2_32")]
     Aarch64Manylinux232,
 
     /// An ARM64 target for the `manylinux_2_33` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_33"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_33"))]
+    #[serde(rename = "aarch64-manylinux_2_33")]
     Aarch64Manylinux233,
 
     /// An ARM64 target for the `manylinux_2_34` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_34"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_34"))]
+    #[serde(rename = "aarch64-manylinux_2_34")]
     Aarch64Manylinux234,
 
     /// An ARM64 target for the `manylinux_2_35` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_35"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_35"))]
+    #[serde(rename = "aarch64-manylinux_2_35")]
     Aarch64Manylinux235,
 
     /// An ARM64 target for the `manylinux_2_36` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_36"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_36"))]
+    #[serde(rename = "aarch64-manylinux_2_36")]
     Aarch64Manylinux236,
 
     /// An ARM64 target for the `manylinux_2_37` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_37"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_37"))]
+    #[serde(rename = "aarch64-manylinux_2_37")]
     Aarch64Manylinux237,
 
     /// An ARM64 target for the `manylinux_2_38` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_38"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_38"))]
+    #[serde(rename = "aarch64-manylinux_2_38")]
     Aarch64Manylinux238,
 
     /// An ARM64 target for the `manylinux_2_39` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_39"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_39"))]
+    #[serde(rename = "aarch64-manylinux_2_39")]
     Aarch64Manylinux239,
 
     /// An ARM64 target for the `manylinux_2_40` platform.
     #[cfg_attr(feature = "clap", value(name = "aarch64-manylinux_2_40"))]
-    #[cfg_attr(feature = "schemars", schemars(rename = "aarch64-manylinux_2_40"))]
+    #[serde(rename = "aarch64-manylinux_2_40")]
     Aarch64Manylinux240,
 }
 

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -858,6 +858,7 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         version = "0.0.0"
 
         [tool.uv.pip]
+        python-platform = "x86_64-unknown-linux-gnu"
         resolution = "lowest-direct"
         generate-hashes = true
         index-url = "https://pypi.org/simple"
@@ -997,7 +998,9 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
                 {},
             ),
             python_version: None,
-            python_platform: None,
+            python_platform: Some(
+                X8664UnknownLinuxGnu,
+            ),
             universal: false,
             exclude_newer: None,
             no_emit_package: [],


### PR DESCRIPTION
serde needs to be told where to put underscores. someone clearly noticed this when adding attributes for schemars, but they need to be present for serde too and then schemars gets them for free.

Strictly speaking this would be a breaking change for anyone who noticed the parsing was messed up and worked around it. So we add aliases for backcompat, at least for a few releases.

Fixes #12590