### PR TITLE
Add `Bearer` support to `Credentials`

### DIFF
--- a/crates/uv-auth/src/cache.rs
+++ b/crates/uv-auth/src/cache.rs
@@ -245,19 +245,19 @@ mod tests {
 
     #[test]
     fn test_trie() {
-        let credentials1 = Arc::new(Credentials::new(
+        let credentials1 = Arc::new(Credentials::basic(
             Some("username1".to_string()),
             Some("password1".to_string()),
         ));
-        let credentials2 = Arc::new(Credentials::new(
+        let credentials2 = Arc::new(Credentials::basic(
             Some("username2".to_string()),
             Some("password2".to_string()),
         ));
-        let credentials3 = Arc::new(Credentials::new(
+        let credentials3 = Arc::new(Credentials::basic(
             Some("username3".to_string()),
             Some("password3".to_string()),
         ));
-        let credentials4 = Arc::new(Credentials::new(
+        let credentials4 = Arc::new(Credentials::basic(
             Some("username4".to_string()),
             Some("password4".to_string()),
         ));

--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -80,7 +80,7 @@ impl KeyringProvider {
             };
         }
 
-        credentials.map(|(username, password)| Credentials::new(Some(username), Some(password)))
+        credentials.map(|(username, password)| Credentials::basic(Some(username), Some(password)))
     }
 
     #[instrument(skip(self))]
@@ -265,7 +265,7 @@ mod tests {
         let keyring = KeyringProvider::dummy([(url.host_str().unwrap(), "user", "password")]);
         assert_eq!(
             keyring.fetch(&url, Some("user")).await,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("password".to_string())
             ))
@@ -274,7 +274,7 @@ mod tests {
             keyring
                 .fetch(&url.join("test").unwrap(), Some("user"))
                 .await,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("password".to_string())
             ))
@@ -298,21 +298,21 @@ mod tests {
         ]);
         assert_eq!(
             keyring.fetch(&url.join("foo").unwrap(), Some("user")).await,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("password".to_string())
             ))
         );
         assert_eq!(
             keyring.fetch(&url, Some("user")).await,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("other-password".to_string())
             ))
         );
         assert_eq!(
             keyring.fetch(&url.join("bar").unwrap(), Some("user")).await,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("other-password".to_string())
             ))
@@ -326,7 +326,7 @@ mod tests {
         let credentials = keyring.fetch(&url, Some("user")).await;
         assert_eq!(
             credentials,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("password".to_string())
             ))
@@ -340,7 +340,7 @@ mod tests {
         let credentials = keyring.fetch(&url, None).await;
         assert_eq!(
             credentials,
-            Some(Credentials::new(
+            Some(Credentials::basic(
                 Some("user".to_string()),
                 Some("password".to_string())
             ))

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -397,7 +397,7 @@ impl AuthMiddleware {
             None
         } else if let Some(credentials) = self
             .cache()
-            .get_url(request.url(), credentials.as_username())
+            .get_url(request.url(), credentials.as_username().as_ref())
         {
             request = credentials.authenticate(request);
             // Do not insert already-cached credentials
@@ -653,7 +653,7 @@ mod tests {
         let cache = CredentialsCache::new();
         cache.insert(
             &base_url,
-            Arc::new(Credentials::new(
+            Arc::new(Credentials::basic(
                 Some(username.to_string()),
                 Some(password.to_string()),
             )),
@@ -707,7 +707,7 @@ mod tests {
         let cache = CredentialsCache::new();
         cache.insert(
             &base_url,
-            Arc::new(Credentials::new(Some(username.to_string()), None)),
+            Arc::new(Credentials::basic(Some(username.to_string()), None)),
         );
 
         let client = test_client_builder()
@@ -1097,7 +1097,7 @@ mod tests {
         // URL.
         cache.insert(
             &base_url,
-            Arc::new(Credentials::new(Some(username.to_string()), None)),
+            Arc::new(Credentials::basic(Some(username.to_string()), None)),
         );
         let client = test_client_builder()
             .with(AuthMiddleware::new().with_cache(cache).with_keyring(Some(
@@ -1146,14 +1146,14 @@ mod tests {
         // Seed the cache with our credentials
         cache.insert(
             &base_url_1,
-            Arc::new(Credentials::new(
+            Arc::new(Credentials::basic(
                 Some(username_1.to_string()),
                 Some(password_1.to_string()),
             )),
         );
         cache.insert(
             &base_url_2,
-            Arc::new(Credentials::new(
+            Arc::new(Credentials::basic(
                 Some(username_2.to_string()),
                 Some(password_2.to_string()),
             )),
@@ -1341,14 +1341,14 @@ mod tests {
         // Seed the cache with our credentials
         cache.insert(
             &base_url_1,
-            Arc::new(Credentials::new(
+            Arc::new(Credentials::basic(
                 Some(username_1.to_string()),
                 Some(password_1.to_string()),
             )),
         );
         cache.insert(
             &base_url_2,
-            Arc::new(Credentials::new(
+            Arc::new(Credentials::basic(
                 Some(username_2.to_string()),
                 Some(password_2.to_string()),
             )),


### PR DESCRIPTION
## Summary

I noticed that these only support Basic credentials, but we may want to allow users to provide Bearer tokens? This PR just generalizes the type.
