### PR TITLE
enforce crc32 checks when using async-zip

### DIFF
--- a/crates/uv-extract/src/error.rs
+++ b/crates/uv-extract/src/error.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsString;
+use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -14,6 +14,12 @@ pub enum Error {
     NonSingularArchive(Vec<OsString>),
     #[error("The top-level of the archive must only contain a list directory, but it's empty")]
     EmptyArchive,
+    #[error("Bad CRC (got {computed:08x}, expected {expected:08x}): {}", path.display())]
+    BadCrc32 {
+        path: PathBuf,
+        computed: u32,
+        expected: u32,
+    },
 }
 
 impl Error {

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -89,8 +89,14 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
             // Validate the CRC of any file we unpack
             // (It would be nice if async_zip made it harder to Not do this...)
             let reader = reader.into_inner();
-            if reader.compute_hash() != reader.entry().crc32() {
-                return Err(async_zip::error::ZipError::CRC32CheckError)?;
+            let computed = reader.compute_hash();
+            let expected = reader.entry().crc32();
+            if computed != expected {
+                return Err(Error::BadCrc32 {
+                    path: path,
+                    computed,
+                    expected,
+                });
             }
         }
 
@@ -142,6 +148,8 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
 
     Ok(())
 }
+
+pub async fn check_crc() {}
 
 /// Unpack the given tar archive into the destination directory.
 ///

--- a/crates/uv-metadata/src/lib.rs
+++ b/crates/uv-metadata/src/lib.rs
@@ -246,6 +246,13 @@ pub async fn read_metadata_async_stream<R: futures::AsyncRead + Unpin>(
             let mut contents = Vec::new();
             reader.read_to_end(&mut contents).await.unwrap();
 
+            // Validate the CRC of any file we unpack
+            // (It would be nice if async_zip made it harder to Not do this...)
+            let reader = reader.into_inner();
+            if reader.compute_hash() != reader.entry().crc32() {
+                return Err(async_zip::error::ZipError::CRC32CheckError)?;
+            }
+
             let metadata = ResolutionMetadata::parse_metadata(&contents)
                 .map_err(|err| Error::InvalidMetadata(debug_path.to_string(), Box::new(err)))?;
             return Ok(metadata);

--- a/crates/uv-metadata/src/lib.rs
+++ b/crates/uv-metadata/src/lib.rs
@@ -33,6 +33,12 @@ pub enum Error {
     InvalidName(#[from] InvalidNameError),
     #[error("The metadata at {0} is invalid")]
     InvalidMetadata(String, Box<uv_pypi_types::MetadataError>),
+    #[error("Bad CRC (got {computed:08x}, expected {expected:08x}): {path}")]
+    BadCrc32 {
+        path: String,
+        computed: u32,
+        expected: u32,
+    },
     #[error("Failed to read from zip file")]
     Zip(#[from] zip::result::ZipError),
     #[error("Failed to read from zip file")]
@@ -239,9 +245,9 @@ pub async fn read_metadata_async_stream<R: futures::AsyncRead + Unpin>(
 
     while let Some(mut entry) = zip.next_with_entry().await? {
         // Find the `METADATA` entry.
-        let path = entry.reader().entry().filename().as_str()?;
+        let path = entry.reader().entry().filename().as_str()?.to_owned();
 
-        if is_metadata_entry(path, filename)? {
+        if is_metadata_entry(&path, filename)? {
             let mut reader = entry.reader_mut().compat();
             let mut contents = Vec::new();
             reader.read_to_end(&mut contents).await.unwrap();
@@ -249,8 +255,14 @@ pub async fn read_metadata_async_stream<R: futures::AsyncRead + Unpin>(
             // Validate the CRC of any file we unpack
             // (It would be nice if async_zip made it harder to Not do this...)
             let reader = reader.into_inner();
-            if reader.compute_hash() != reader.entry().crc32() {
-                return Err(async_zip::error::ZipError::CRC32CheckError)?;
+            let computed = reader.compute_hash();
+            let expected = reader.entry().crc32();
+            if computed != expected {
+                return Err(Error::BadCrc32 {
+                    path,
+                    computed,
+                    expected,
+                });
             }
 
             let metadata = ResolutionMetadata::parse_metadata(&contents)

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8889,6 +8889,8 @@ fn missing_subdirectory_url() -> Result<()> {
     Ok(())
 }
 
+// This wheel was uploaded with a bad crc32 and we weren't detecting that
+// (Could be replaced with a checked-in hand-crafted corrupt wheel?)
 #[test]
 fn bad_crc32() -> Result<()> {
     let context = TestContext::new("3.11");

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8890,6 +8890,30 @@ fn missing_subdirectory_url() -> Result<()> {
 }
 
 #[test]
+fn bad_crc32() -> Result<()> {
+    let context = TestContext::new("3.11");
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+
+    uv_snapshot!(context.pip_install()
+        .arg("--python-platform").arg("linux")
+        .arg("osqp @ https://files.pythonhosted.org/packages/00/04/5959347582ab970e9b922f27585d34f7c794ed01125dac26fb4e7dd80205/osqp-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+      × Failed to download `osqp @ https://files.pythonhosted.org/packages/00/04/5959347582ab970e9b922f27585d34f7c794ed01125dac26fb4e7dd80205/osqp-1.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`
+      ├─▶ Failed to extract archive
+      ╰─▶ Bad CRC (got ca5f1131, expected d5c95dfa): osqp/ext_builtin.cpython-311-x86_64-linux-gnu.so
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn static_metadata_pyproject_toml() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
Fixes #12618 

Instead of succeeding the user now gets:

```
uvdloc pip install osqp==1.0.2 --reinstall --python-platform=linux
Resolved 7 packages in 171ms
  × Failed to download `osqp==1.0.2`
  ├─▶ Failed to extract archive
  ╰─▶ a computed CRC32 value did not match the expected value
```

I am not entirely sure if we have infra for testing this kind of thing, but it would be nice to check in a test or two. I'm also not entirely clear if there's any cases where these checks are overzealous.