### PR TITLE
Report the queried executable path in `uv python list`

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -54,6 +54,7 @@ pub struct Interpreter {
     prefix: Option<Prefix>,
     pointer_size: PointerSize,
     gil_disabled: bool,
+    real_executable: PathBuf,
 }
 
 impl Interpreter {
@@ -86,6 +87,7 @@ impl Interpreter {
             tags: OnceLock::new(),
             target: None,
             prefix: None,
+            real_executable: executable.as_ref().to_path_buf(),
         })
     }
 
@@ -391,6 +393,11 @@ impl Interpreter {
     /// Return the `sys.executable` path for this Python interpreter.
     pub fn sys_executable(&self) -> &Path {
         &self.sys_executable
+    }
+
+    /// Return the "real" queried executable path for this Python interpreter.
+    pub fn real_executable(&self) -> &Path {
+        &self.real_executable
     }
 
     /// Return the `sys.path` for this Python interpreter.

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -148,7 +148,7 @@ pub(crate) async fn list(
             output.insert((
                 installation.key(),
                 kind,
-                Either::Left(installation.interpreter().sys_executable().to_path_buf()),
+                Either::Left(installation.interpreter().real_executable().to_path_buf()),
             ));
         }
     }


### PR DESCRIPTION
In an attempt to avoid reporting shims as their resolved `sys.executable` path, we report the queried executable path instead. This seems more correct for this command, broadly? Interestingly, it changes the reported paths for Homebrew Python

<img width="1430" alt="Screenshot 2025-04-02 at 11 05 18 AM" src="https://github.com/user-attachments/assets/0e1600e8-fb07-40c7-a6d6-56eaeb4b9293" />

Closes #9979 