### PR TITLE
Remove `--no-config` warning from `uv pip compile` and `uv pip sync`

### DIFF
--- a/crates/uv-cli/src/compat.rs
+++ b/crates/uv-cli/src/compat.rs
@@ -133,12 +133,6 @@ impl CompatArgs for PipCompileCompatArgs {
             ));
         }
 
-        if self.no_config {
-            warn_user!(
-                "pip-compile's `--no-config` has no effect (uv does not use a configuration file)"
-            );
-        }
-
         if self.emit_options {
             return Err(anyhow!(
                 "pip-compile's `--emit-options` is unsupported (uv never emits options)"
@@ -250,12 +244,6 @@ impl CompatArgs for PipSyncCompatArgs {
             return Err(anyhow!(
                 "pip-sync's `--config` is unsupported (uv does not use a configuration file)"
             ));
-        }
-
-        if self.no_config {
-            warn_user!(
-                "pip-sync's `--no-config` has no effect (uv does not use a configuration file)"
-            );
         }
 
         if self.pip_args.is_some() {


### PR DESCRIPTION
uv has a global `--no-config` option, which indeed has an effect.

## Test Plan

```console
❯ cat pyproject.toml
[project]
name = "hello"
version = "0.1.0"

[[tool.uv.index]]
url = "http://non-exist-host.com/simple"
default = true

❯ echo requests | uv pip compile -
⠦ Resolving dependencies...                                                                                error: Failed to fetch: `http://non-exist-host.com/simple/requests/`
  Caused by: Could not connect, are you offline?
  Caused by: Request failed after 3 retries
  Caused by: error sending request for url (http://non-exist-host.com/simple/requests/)
  Caused by: client error (Connect)
  Caused by: dns error: failed to lookup address information: nodename nor servname provided, or not known
  Caused by: failed to lookup address information: nodename nor servname provided, or not known

# Before
❯ echo requests | uv pip compile --no-config -
warning: pip-compile's `--no-config` has no effect (uv does not use a configuration file)
Resolved 5 packages in 13ms
# This file was autogenerated by uv via the following command:
#    uv pip compile --no-config -
certifi==2025.1.31
    # via requests
charset-normalizer==3.4.1
    # via requests
idna==3.10
    # via requests
requests==2.32.3
urllib3==2.3.0
    # via requests

# After
❯ echo requests | uv pip compile --no-config -
Resolved 5 packages in 13ms
# This file was autogenerated by uv via the following command:
#    uv pip compile --no-config -
certifi==2025.1.31
    # via requests
charset-normalizer==3.4.1
    # via requests
idna==3.10
    # via requests
requests==2.32.3
urllib3==2.3.0
    # via requests
```