### PR TITLE
Emit dedicated error message for Conda environment.yml files

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -23,7 +23,7 @@ pub enum RequirementsSource {
     SetupCfg(PathBuf),
     /// Dependencies were provided via a path to a source tree (e.g., `pip install .`).
     SourceTree(PathBuf),
-    /// Dependencies were provided via a unsupported `environment.yml` file (e.g., `pip install -r environment.yml`).
+    /// Dependencies were provided via an unsupported Conda `environment.yml` file (e.g., `pip install -r environment.yml`).
     EnvironmentYml(PathBuf),
 }
 

--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -23,6 +23,8 @@ pub enum RequirementsSource {
     SetupCfg(PathBuf),
     /// Dependencies were provided via a path to a source tree (e.g., `pip install .`).
     SourceTree(PathBuf),
+    /// Dependencies were provided via a unsupported `environment.yml` file (e.g., `pip install -r environment.yml`).
+    EnvironmentYml(PathBuf),
 }
 
 impl RequirementsSource {
@@ -35,6 +37,8 @@ impl RequirementsSource {
             Self::SetupPy(path)
         } else if path.ends_with("setup.cfg") {
             Self::SetupCfg(path)
+        } else if path.ends_with("environment.yml") {
+            Self::EnvironmentYml(path)
         } else {
             Self::RequirementsTxt(path)
         }
@@ -217,6 +221,7 @@ impl std::fmt::Display for RequirementsSource {
             | Self::PyprojectToml(path)
             | Self::SetupPy(path)
             | Self::SetupCfg(path)
+            | Self::EnvironmentYml(path)
             | Self::SourceTree(path) => {
                 write!(f, "{}", path.simplified_display())
             }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -214,7 +214,7 @@ impl RequirementsSpecification {
             }
             RequirementsSource::EnvironmentYml(path) => {
                 return Err(anyhow::anyhow!(
-                    "Conda environment file `{}` is not supported",
+                    "Conda environment files (i.e. `{}`) are not supported",
                     path.user_display()
                 ))
             }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -212,6 +212,12 @@ impl RequirementsSpecification {
                     ..Self::default()
                 }
             }
+            RequirementsSource::EnvironmentYml(path) => {
+                return Err(anyhow::anyhow!(
+                    "Conda environment file `{}` is not supported",
+                    path.user_display()
+                ))
+            }
         })
     }
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3691,7 +3691,7 @@ fn add_environment_yml_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Conda environment file `environment.yml` is not supported
+    error: Conda environment files (i.e. `environment.yml`) are not supported
     ");
 
     Ok(())

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3677,13 +3677,13 @@ fn add_environment_yml_error() -> Result<()> {
     "#})?;
 
     let environment_yml = context.temp_dir.child("environment.yml");
-    environment_yml.write_str(indoc! {r#"
+    environment_yml.write_str(indoc! {r"
         name: test-env
         channels:
           - conda-forge
         dependencies:
           - python>=3.12
-    "#})?;
+    "})?;
 
     uv_snapshot!(context.filters(), context.add().arg("-r").arg("environment.yml"), @r"
     success: false

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3662,7 +3662,7 @@ fn add_error() -> Result<()> {
     Ok(())
 }
 
-/// Emit dedicated error message when adding Conda `enviroment.yml`
+/// Emit dedicated error message when adding Conda `environment.yml`
 #[test]
 fn add_environment_yml_error() -> Result<()> {
     let context = TestContext::new("3.12");

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8028,7 +8028,7 @@ fn install_incompatible_python_version_interpreter_broken_in_path() -> Result<()
     Ok(())
 }
 
-/// Emit dedicated error message when adding Conda `enviroment.yml`
+/// Emit dedicated error message when installing Conda `environment.yml`
 #[test]
 fn install_unsupported_environment_yml() -> Result<()> {
     let context = TestContext::new("3.12");

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8034,13 +8034,13 @@ fn install_unsupported_environment_yml() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let environment_yml = context.temp_dir.child("environment.yml");
-    environment_yml.write_str(indoc! {r#"
+    environment_yml.write_str(indoc! {r"
         name: test-env
         channels:
           - conda-forge
         dependencies:
           - python>=3.12
-    "#})?;
+    "})?;
 
     uv_snapshot!(context.filters(), context.pip_install().arg("-r").arg("environment.yml"), @r"
     success: false

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8048,7 +8048,7 @@ fn install_unsupported_environment_yml() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Conda environment file `environment.yml` is not supported
+    error: Conda environment files (i.e. `environment.yml`) are not supported
     ");
 
     Ok(())

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8028,6 +8028,32 @@ fn install_incompatible_python_version_interpreter_broken_in_path() -> Result<()
     Ok(())
 }
 
+/// Emit dedicated error message when adding Conda `enviroment.yml`
+#[test]
+fn install_unsupported_environment_yml() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let environment_yml = context.temp_dir.child("environment.yml");
+    environment_yml.write_str(indoc! {r#"
+        name: test-env
+        channels:
+          - conda-forge
+        dependencies:
+          - python>=3.12
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg("-r").arg("environment.yml"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Conda environment file `environment.yml` is not supported
+    ");
+
+    Ok(())
+}
+
 /// Include a `build_constraints.txt` file with an incompatible constraint.
 #[test]
 fn incompatible_build_constraint() -> Result<()> {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Fixes #12606.

Two options considered, thanks to @zanieb's guidance are:
1. Special-casing on parse error and encountering the `environment.yml` filename, possibly at `RequirementsTxt::parse`
2. Adding a new `RequirementsSource::EnvironmentYml` variant and erroring on `RequirementSpecification::from_source`

I went with the latter for the following reasons:
- This edge case is explicitly modelled within the type system. However, it changes the semantics of `RequirementsSource` to also model _unsupported_ sources.
- (**Separation of concerns**) The special-casing would occur in the `uv-requirements-txt` crate, which seems to be relatively deep in the guts of the codebase. In my opinion, maintainers working in `uv-requirements-txt` would reasonably assume the input file to be a `requirements.txt` file, instead of having to be concerned with it being another file format (`environment.yml`, `pyproject.toml`, etc.)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Manually tested as follows:
```sh
>>> cargo run -- pip install -r environment.yml
error: Conda environment file `environment.yml` is not supported

>>> cargo run -- add -r environment.yml
error: Conda environment file `environment.yml` is not supported
``` 

If you can point me to the appropriate test module, I can write up tests for these to use `insta`.

<!-- How was it tested? -->
