### PR TITLE
Use index-level instead of realm-level credential caching for known indexes

### DIFF
--- a/crates/uv-auth/src/cache.rs
+++ b/crates/uv-auth/src/cache.rs
@@ -17,8 +17,8 @@ type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
 pub struct CredentialsCache {
     /// A cache per realm and username
     realms: RwLock<FxHashMap<(Realm, Username), Arc<Credentials>>>,
-    /// A cache tracking the result of fetches from external services
-    pub(crate) fetches: FxOnceMap<(Realm, Username), Option<Arc<Credentials>>>,
+    /// A cache tracking the result of realm or index URL fetches from external services
+    pub(crate) fetches: FxOnceMap<(String, Username), Option<Arc<Credentials>>>,
     /// A cache per URL, uses a trie for efficient prefix queries.
     urls: RwLock<UrlTrie>,
 }

--- a/crates/uv-auth/src/index.rs
+++ b/crates/uv-auth/src/index.rs
@@ -83,7 +83,7 @@ impl Indexes {
         // efficient search.
         self.0
             .iter()
-            .find(|index| url.as_str().starts_with(index.root_url.as_str()))
+            .find(|index| is_url_prefix(&index.root_url, url))
             .map(|index| &index.root_url)
     }
 
@@ -93,10 +93,21 @@ impl Indexes {
         // but we could use a trie instead of a HashMap here for more
         // efficient search.
         for index in &self.0 {
-            if url.as_str().starts_with(index.root_url.as_str()) {
+            if is_url_prefix(&index.root_url, url) {
                 return index.auth_policy;
             }
         }
         AuthPolicy::Auto
     }
+}
+
+fn is_url_prefix(base: &Url, url: &Url) -> bool {
+    if base.scheme() != url.scheme()
+        || base.host_str() != url.host_str()
+        || base.port_or_known_default() != url.port_or_known_default()
+    {
+        return false;
+    }
+
+    url.path().starts_with(base.path())
 }

--- a/docs/configuration/authentication.md
+++ b/docs/configuration/authentication.md
@@ -38,9 +38,9 @@ Authentication can come from the following sources, in order of precedence:
 - A [`.netrc`](https://everything.curl.dev/usingcurl/netrc) configuration file
 - A [keyring](https://github.com/jaraco/keyring) provider (requires opt-in)
 
-If authentication is found for a single net location (scheme, host, and port), it will be cached for
-the duration of the command and used for other queries to that net location. Authentication is not
-cached across invocations of uv.
+If authentication is found for a single index URL or net location (scheme, host, and port), it will
+be cached for the duration of the command and used for other queries to that index or net location.
+Authentication is not cached across invocations of uv.
 
 `.netrc` authentication is enabled by default, and will respect the `NETRC` environment variable if
 defined, falling back to `~/.netrc` if not.


### PR DESCRIPTION
The current uv behavior is to cache credentials either at the request URL or realm level. But in general, the expected behavior for indexes is to apply credentials at the index level (as implemented in #12651). This means that we also need to cache credentials at this level. Note that when uv does not detect an index URL for a request URL, it will continue to apply the old behavior.

Depends on #12651. 
