### PR TITLE
Add Pyodide support

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -226,6 +226,8 @@ pub enum TargetTriple {
     #[serde(rename = "aarch64-manylinux_2_40")]
     #[serde(alias = "aarch64-manylinux240")]
     Aarch64Manylinux240,
+    #[cfg_attr(feature = "clap", value(name = "wasm32-pyodide2024"))]
+    Wasm32Pyodide2024,
 }
 
 impl TargetTriple {
@@ -450,6 +452,13 @@ impl TargetTriple {
                 },
                 Arch::Aarch64,
             ),
+            Self::Wasm32Pyodide2024 => Platform::new(
+                Os::Pyodide {
+                    major: 2024,
+                    minor: 0,
+                },
+                Arch::Wasm32,
+            ),
         }
     }
 
@@ -490,6 +499,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "aarch64",
             Self::Aarch64Manylinux239 => "aarch64",
             Self::Aarch64Manylinux240 => "aarch64",
+            Self::Wasm32Pyodide2024 => "wasm32",
         }
     }
 
@@ -530,6 +540,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "Linux",
             Self::Aarch64Manylinux239 => "Linux",
             Self::Aarch64Manylinux240 => "Linux",
+            Self::Wasm32Pyodide2024 => "Emscripten",
         }
     }
 
@@ -570,6 +581,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "",
             Self::Aarch64Manylinux239 => "",
             Self::Aarch64Manylinux240 => "",
+            Self::Wasm32Pyodide2024 => "#1",
         }
     }
 
@@ -610,6 +622,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "",
             Self::Aarch64Manylinux239 => "",
             Self::Aarch64Manylinux240 => "",
+            Self::Wasm32Pyodide2024 => "3.1.58",
         }
     }
 
@@ -650,6 +663,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "posix",
             Self::Aarch64Manylinux239 => "posix",
             Self::Aarch64Manylinux240 => "posix",
+            Self::Wasm32Pyodide2024 => "posix",
         }
     }
 
@@ -690,6 +704,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => "linux",
             Self::Aarch64Manylinux239 => "linux",
             Self::Aarch64Manylinux240 => "linux",
+            Self::Wasm32Pyodide2024 => "emscripten",
         }
     }
 
@@ -730,6 +745,7 @@ impl TargetTriple {
             Self::Aarch64Manylinux238 => true,
             Self::Aarch64Manylinux239 => true,
             Self::Aarch64Manylinux240 => true,
+            Self::Wasm32Pyodide2024 => false,
         }
     }
 

--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -43,6 +43,7 @@ pub enum Os {
     Manylinux { major: u16, minor: u16 },
     Musllinux { major: u16, minor: u16 },
     Windows,
+    Pyodide { major: u16, minor: u16 },
     Macos { major: u16, minor: u16 },
     FreeBsd { release: String },
     NetBsd { release: String },
@@ -67,6 +68,7 @@ impl fmt::Display for Os {
             Self::Illumos { .. } => write!(f, "illumos"),
             Self::Haiku { .. } => write!(f, "haiku"),
             Self::Android { .. } => write!(f, "android"),
+            Self::Pyodide { .. } => write!(f, "pyodide"),
         }
     }
 }
@@ -109,6 +111,7 @@ pub enum Arch {
     S390X,
     LoongArch64,
     Riscv64,
+    Wasm32,
 }
 
 impl fmt::Display for Arch {
@@ -126,6 +129,7 @@ impl fmt::Display for Arch {
             Self::S390X => write!(f, "s390x"),
             Self::LoongArch64 => write!(f, "loongarch64"),
             Self::Riscv64 => write!(f, "riscv64"),
+            Self::Wasm32 => write!(f, "wasm32"),
         }
     }
 }
@@ -168,7 +172,7 @@ impl Arch {
             // manylinux_2_36
             Self::LoongArch64 => Some(36),
             // unsupported
-            Self::Powerpc | Self::Armv5TEL | Self::Armv6L => None,
+            Self::Powerpc | Self::Armv5TEL | Self::Armv6L | Self::Wasm32 => None,
         }
     }
 
@@ -187,6 +191,7 @@ impl Arch {
             Self::S390X => "s390x",
             Self::LoongArch64 => "loongarch64",
             Self::Riscv64 => "riscv64",
+            Self::Wasm32 => "wasm32",
         }
     }
 

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -618,6 +618,12 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
                 arch,
             }]
         }
+        (Os::Pyodide { major, minor }, Arch::Wasm32) => {
+            vec![PlatformTag::Pyodide {
+                major: *major,
+                minor: *minor,
+            }]
+        }
         _ => {
             return Err(PlatformError::OsVersionDetectionError(format!(
                 "Unsupported operating system and architecture combination: {os} {arch}"

--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -510,6 +510,23 @@ def get_operating_system_and_architecture():
             "major": int(version[0]),
             "minor": int(version[1]),
         }
+    elif operating_system == "emscripten":
+        pyodide_abi_version = sysconfig.get_config_var("PYODIDE_ABI_VERSION")
+        if pyodide_abi_version:
+            version = pyodide_abi_version.split("_")
+            operating_system = {
+                "name": "pyodide",
+                "major": int(version[0]),
+                "minor": int(version[1]),
+            }
+        else:
+            version = version.split(".")
+            operating_system = {
+                "name": operating_system,
+                "major": int(version[0]),
+                "minor": int(version[1]),
+                "patch": int(version[2]),
+            }
     elif operating_system in [
         "freebsd",
         "netbsd",

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -316,6 +316,10 @@ impl From<&uv_platform_tags::Arch> for Arch {
                 ),
                 variant: None,
             },
+            uv_platform_tags::Arch::Wasm32 => Self {
+                family: target_lexicon::Architecture::Wasm32,
+                variant: None,
+            },
         }
     }
 }
@@ -348,6 +352,9 @@ impl From<&uv_platform_tags::Os> for Os {
             uv_platform_tags::Os::NetBsd { .. } => Self(target_lexicon::OperatingSystem::Netbsd),
             uv_platform_tags::Os::OpenBsd { .. } => Self(target_lexicon::OperatingSystem::Openbsd),
             uv_platform_tags::Os::Windows => Self(target_lexicon::OperatingSystem::Windows),
+            uv_platform_tags::Os::Pyodide { .. } => {
+                Self(target_lexicon::OperatingSystem::Emscripten)
+            }
         }
     }
 }

--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -216,7 +216,8 @@ impl TorchStrategy {
                     | Os::Dragonfly { .. }
                     | Os::Illumos { .. }
                     | Os::Haiku { .. }
-                    | Os::Android { .. } => {
+                    | Os::Android { .. }
+                    | Os::Pyodide { .. } => {
                         Either::Right(std::iter::once(TorchBackend::Cpu.index_url()))
                     }
                 }


### PR DESCRIPTION
This includes some initial work on adding Pyodide support (issue #12729). It is enough to get
```
uv pip compile -p /path/to/pyodide --extra-index-url file:/path/to/simple-index
```
to work which should already be quite useful.

## Test Plan

TODO.
