### PR TITLE
Error when `tool.uv.sources` is set in system-level configuration file

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -64,8 +64,11 @@ impl FilesystemOptions {
         let Some(file) = system_config_file() else {
             return Ok(None);
         };
+
         tracing::debug!("Found system configuration in: `{}`", file.display());
-        Ok(Some(Self(read_file(&file)?)))
+        let options = read_file(&file)?;
+        validate_uv_toml(&file, &options)?;
+        Ok(Some(Self(options)))
     }
 
     /// Find the [`FilesystemOptions`] for the given path.


### PR DESCRIPTION
## Summary

I think the lack of enforcement here is an oversight. We _do_ already enforce this for user-level configuration files (contrary to the issue -- at least, in my testing and from reading the code).

Closes https://github.com/astral-sh/uv/issues/12753.
