### PR TITLE
Support `--with-requirements script.py` to include inline dependency metadata from another script

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4081,7 +4081,8 @@ pub struct ToolRunArgs {
     #[arg(long)]
     pub with_editable: Vec<comma::CommaSeparatedRequirements>,
 
-    /// Run with all packages listed in the given `requirements.txt` files.
+    /// Run with all packages listed in the given `requirements.txt` files or PEP 723 Python
+    /// scripts.
     #[arg(long, value_delimiter = ',', value_parser = parse_maybe_file_path)]
     pub with_requirements: Vec<Maybe<PathBuf>>,
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -33,6 +33,7 @@ use uv_python::{
     PythonPreference, PythonRequest,
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
+use uv_scripts::Pep723Script;
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use uv_shell::runnable::WindowsRunnable;
 use uv_static::EnvVars;
@@ -82,6 +83,7 @@ pub(crate) async fn run(
     with: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
+    scripts: &[Pep723Script],
     show_resolution: bool,
     python: Option<String>,
     install_mirrors: PythonInstallMirrors,
@@ -249,6 +251,7 @@ pub(crate) async fn run(
         with,
         constraints,
         overrides,
+        scripts,
         show_resolution,
         python.as_deref(),
         install_mirrors,
@@ -602,6 +605,7 @@ async fn get_or_create_environment(
     with: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
+    scripts: &[Pep723Script],
     show_resolution: bool,
     python: Option<&str>,
     install_mirrors: PythonInstallMirrors,
@@ -799,13 +803,22 @@ async fn get_or_create_environment(
     )
     .await?;
 
+    // Read script dependencies.
+    let script_dependencies = scripts
+        .iter()
+        .filter_map(|script| script.metadata.dependencies.as_ref())
+        .flatten()
+        .map(|requirement| requirement.to_owned().into());
+
     // Resolve the `--from` and `--with` requirements.
     let requirements = {
-        let mut requirements = Vec::with_capacity(1 + with.len());
+        let mut requirements =
+            Vec::with_capacity(1 + with.len() + script_dependencies.try_len().unwrap_or_default());
         match &from {
             ToolRequirement::Python => {}
             ToolRequirement::Package { requirement, .. } => requirements.push(requirement.clone()),
         }
+        requirements.extend(script_dependencies);
         requirements.extend(
             resolve_names(
                 spec.requirements.clone(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::stdout;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
@@ -12,6 +12,7 @@ use anstream::eprintln;
 use anyhow::{bail, Context, Result};
 use clap::error::{ContextKind, ContextValue};
 use clap::{CommandFactory, Parser};
+use futures::future::join_all;
 use futures::FutureExt;
 use owo_colors::OwoColorize;
 use settings::PipTreeSettings;
@@ -1076,6 +1077,43 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     .combine(Refresh::from(args.settings.resolver.upgrade.clone())),
             );
 
+            let is_py_file = |file: &PathBuf| {
+                file.extension().map(|ext| ext == "py").unwrap_or(false)
+                    && file
+                        .file_name()
+                        .map(|name| name != "setup.py")
+                        .unwrap_or(true)
+            };
+
+            let pep723_results = join_all(
+                args.with_requirements
+                    .iter()
+                    .filter(|file| is_py_file(file))
+                    .map(|file| async move {
+                        let result = Pep723Script::read(&file).await;
+                        (file, result)
+                    }),
+            )
+            .await;
+
+            let mut scripts = Vec::new();
+            for (file, result) in pep723_results {
+                match result {
+                    Ok(Some(script)) => {
+                        scripts.push(script);
+                    }
+                    Ok(None) => {
+                        bail!("No script found in file: {}", file.user_display());
+                    }
+                    Err(Pep723Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                        bail!("File not found {}", file.user_display());
+                    }
+                    Err(error) => {
+                        bail!("Failed to parse file {}: {:?}", file.user_display(), error);
+                    }
+                }
+            }
+
             let requirements = {
                 let mut requirements = Vec::with_capacity(
                     args.with.len() + args.with_editable.len() + args.with_requirements.len(),
@@ -1089,6 +1127,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 requirements.extend(
                     args.with_requirements
                         .into_iter()
+                        .filter(|file| !is_py_file(file))
                         .map(RequirementsSource::from_requirements_file),
                 );
                 requirements
@@ -1110,6 +1149,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 &requirements,
                 &constraints,
                 &overrides,
+                &scripts,
                 args.show_resolution || globals.verbose > 0,
                 args.python,
                 args.install_mirrors,

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1,4 +1,5 @@
 use crate::common::{uv_snapshot, TestContext};
+use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
@@ -2352,6 +2353,81 @@ fn tool_run_with_script_and_from_script() {
 
     hint: If you meant to run a command from the `script-py` package, use the normalized package name instead to disambiguate, e.g., `uv tool run --from script-py other-script.py`
     ");
+}
+
+#[test]
+fn tool_run_with_dependencies_from_script() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "anyio",
+        # ]
+        # ///
+
+        import anyio
+    "#})?;
+
+    // script dependencies (anyio and idna) are now installed.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--with-requirements")
+        .arg("script.py")
+        .arg("black")
+        .arg("script.py"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 9 packages in [TIME]
+    Prepared 9 packages in [TIME]
+    Installed 9 packages in [TIME]
+     + anyio==4.3.0
+     + black==24.3.0
+     + click==8.1.7
+     + idna==3.6
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+     + sniffio==1.3.1
+    All done! ✨ 🍰 ✨
+    1 file left unchanged.
+    "###);
+
+    // Error when the script is not a valid PEP723 script.
+    let script = context.temp_dir.child("not_pep723_script.py");
+    script.write_str("import anyio")?;
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--with-requirements")
+        .arg("not_pep723_script.py")
+        .arg("black"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No script found in file: not_pep723_script.py
+    "###);
+
+    // Error when the script doesn't exist.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--with-requirements")
+        .arg("missing_file.py")
+        .arg("black"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: File not found missing_file.py
+    "###);
+
+    Ok(())
 }
 
 /// Test windows runnable types, namely console scripts and legacy setuptools scripts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3431,7 +3431,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>When used in a project, these dependencies will be layered on top of the uv tool&#8217;s environment in a separate, ephemeral environment. These dependencies are allowed to conflict with those specified.</p>
 
-</dd><dt id="uv-tool-run--with-requirements"><a href="#uv-tool-run--with-requirements"><code>--with-requirements</code></a> <i>with-requirements</i></dt><dd><p>Run with all packages listed in the given <code>requirements.txt</code> files</p>
+</dd><dt id="uv-tool-run--with-requirements"><a href="#uv-tool-run--with-requirements"><code>--with-requirements</code></a> <i>with-requirements</i></dt><dd><p>Run with all packages listed in the given <code>requirements.txt</code> files or PEP 723 Python scripts</p>
 
 </dd></dl>
 


### PR DESCRIPTION
## Summary

Closes #6542 

## Test Plan

`cargo test`
