### PR TITLE
Avoid querying GitHub on repeated install invocations

### DIFF
--- a/crates/uv-git-types/src/oid.rs
+++ b/crates/uv-git-types/src/oid.rs
@@ -20,7 +20,7 @@ impl GitOid {
 
     /// Return a truncated representation, i.e., the first 16 characters of the SHA.
     pub fn as_short_str(&self) -> &str {
-        &self.as_str()[..16]
+        self.as_str().get(..16).unwrap_or(self.as_str())
     }
 }
 

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -56,6 +56,11 @@ impl GitResolver {
     ) -> Result<Option<GitOid>, GitResolverError> {
         let reference = RepositoryReference::from(url);
 
+        // If the URL is already precise, return it.
+        if let Some(precise) = url.precise() {
+            return Ok(Some(precise));
+        }
+
         // If we know the precise commit already, return it.
         if let Some(precise) = self.get(&reference) {
             return Ok(Some(*precise));
@@ -72,7 +77,7 @@ impl GitResolver {
 
         let url = format!("https://api.github.com/repos/{owner}/{repo}/commits/{rev}");
 
-        debug!("Attempting GitHub fast path for: {url}");
+        debug!("Querying GitHub for commit at: {url}");
         let mut request = client.get(&url);
         request = request.header("Accept", "application/vnd.github.3.sha");
         request = request.header(


### PR DESCRIPTION
## Summary

If you run `cargo run pip install "pip-test-package @ git+https://github.com/pypa/pip-test-package@5547fa909e83df8bd743d3978d6667497983a4b7"` repeatedly, then every time, we'll take the "GitHub fast path" every time, even if the package is already cached. This PR adds logic to skip the fast path if the reference looks like a commit that we've already checked out.

Closes https://github.com/astral-sh/uv/issues/12760.
