### PR TITLE
Add `uv-build` and `uv_build` aliases to `uv init --build-backend`

### DIFF
--- a/crates/uv-configuration/src/project_build_backend.rs
+++ b/crates/uv-configuration/src/project_build_backend.rs
@@ -4,7 +4,10 @@
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProjectBuildBackend {
-    #[cfg_attr(feature = "clap", value(hide = true))]
+    #[cfg_attr(
+        feature = "clap",
+        value(alias = "uv-build", alias = "uv_build", hide = true)
+    )]
     #[cfg_attr(feature = "schemars", schemars(skip))]
     /// Use uv as the project build backend.
     Uv,


### PR DESCRIPTION
This matches similar aliases for pdm/pdm-backend and hatch/hatchling.