### PR TITLE
Fix CLI reference with code block

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5662,12 +5662,13 @@ pub struct PublishArgs {
     ///
     /// With these settings, the following two calls are equivalent:
     ///
-    /// ```
+    /// ```shell
     /// uv publish --index pypi
     /// uv publish --publish-url https://upload.pypi.org/legacy/ --check-url https://pypi.org/simple
     /// ```
     #[arg(
         long,
+        verbatim_doc_comment,
         env = EnvVars::UV_PUBLISH_INDEX,
         conflicts_with = "publish_url",
         conflicts_with = "check_url"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8821,9 +8821,17 @@ uv publish [OPTIONS] [FILES]...
 
 <p>The index must have a <code>publish-url</code> setting, for example:</p>
 
-<pre><code class="language-toml [[tool.uv.index]] name = &quot;pypi&quot; url = &quot;https://pypi.org/simple&quot; publish-url = &quot;https://upload.pypi.org/legacy/&quot; ```">The index `url` will be used to check for existing files to skip duplicate uploads.
+<pre><code class="language-toml">[[tool.uv.index]]
+name = &quot;pypi&quot;
+url = &quot;https://pypi.org/simple&quot;
+publish-url = &quot;https://upload.pypi.org/legacy/&quot;</code></pre>
 
-With these settings, the following two calls are equivalent:</code></pre>
+<p>The index <code>url</code> will be used to check for existing files to skip duplicate uploads.</p>
+
+<p>With these settings, the following two calls are equivalent:</p>
+
+<pre><code class="language-shell">uv publish --index pypi
+uv publish --publish-url https://upload.pypi.org/legacy/ --check-url https://pypi.org/simple</code></pre>
 
 <p>May also be set with the <code>UV_PUBLISH_INDEX</code> environment variable.</p>
 </dd><dt id="uv-publish--keyring-provider"><a href="#uv-publish--keyring-provider"><code>--keyring-provider</code></a> <i>keyring-provider</i></dt><dd><p>Attempt to use <code>keyring</code> for authentication for remote requirements files.</p>


### PR DESCRIPTION
Due to https://github.com/clap-rs/clap/issues/5900, clap folds docstring code blocks in a way that breaks the rendering of the `uv publish --index` option to html. As a workaround, `verbatim_doc_comment` prevents this. 


Release:
![image](https://github.com/user-attachments/assets/66d9af51-ac23-47f6-a859-7b20a4f1f4a2)

PR:
![image](https://github.com/user-attachments/assets/6a32a5a6-1dd8-49ff-a853-9df02f0141ad)


Release:
```
      --index <INDEX>
          The name of an index in the configuration to use for publishing.
          
          The index must have a `publish-url` setting, for example:
          
          ```toml [[tool.uv.index]] name = "pypi" url =
          "https://pypi.org/simple" publish-url =
          "https://upload.pypi.org/legacy/" ```
          
          The index `url` will be used to check for existing files to skip
          duplicate uploads.
          
          With these settings, the following two calls are equivalent:
          
          ``` uv publish --index pypi uv publish --publish-url
          https://upload.pypi.org/legacy/ --check-url https://pypi.org/simple
          ```
          
          [env: UV_PUBLISH_INDEX=]
```

PR:
```
      --index <INDEX>
          The name of an index in the configuration to use for publishing.
          
          The index must have a `publish-url` setting, for example:
          
          ```toml
          [[tool.uv.index]]
          name = "pypi"
          url = "https://pypi.org/simple"
          publish-url = "https://upload.pypi.org/legacy/"
          ```
          
          The index `url` will be used to check for existing files to skip
          duplicate uploads.
          
          With these settings, the following two calls are equivalent:
          
          ```shell
          uv publish --index pypi
          uv publish --publish-url https://upload.pypi.org/legacy/
          --check-url https://pypi.org/simple
          ```
          
          [env: UV_PUBLISH_INDEX=]
```	

Fixes #12652