### PR TITLE
feat: Error on dependency object specifier

### DIFF
--- a/crates/uv-workspace/src/dependency_groups.rs
+++ b/crates/uv-workspace/src/dependency_groups.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use thiserror::Error;
-use tracing::warn;
+use tracing::error;
 
 use uv_normalize::{GroupName, DEV_DEPENDENCIES};
 use uv_pep508::Pep508Error;
@@ -73,10 +73,10 @@ impl FlatDependencyGroups {
                         requirements
                             .extend(resolved.get(include_group).into_iter().flatten().cloned());
                     }
-                    DependencyGroupSpecifier::Object(map) => {
-                        warn!(
-                            "Ignoring Dependency Object Specifier referenced by `{name}`: {map:?}"
-                        );
+                    DependencyGroupSpecifier::Object(_map) => {
+                        return Err(DependencyGroupError::DependencyObjectSpecifierNotSupported(
+                            name.clone(),
+                        ));
                     }
                 }
             }
@@ -154,6 +154,8 @@ pub enum DependencyGroupError {
     DevGroupInclude(GroupName),
     #[error("Detected a cycle in `dependency-groups`: {0}")]
     DependencyGroupCycle(Cycle),
+    #[error("Group `{0}` contains a Dependency Object Specifier, which is not supported by uv")]
+    DependencyObjectSpecifierNotSupported(GroupName),
 }
 
 impl DependencyGroupError {

--- a/crates/uv-workspace/src/dependency_groups.rs
+++ b/crates/uv-workspace/src/dependency_groups.rs
@@ -73,9 +73,10 @@ impl FlatDependencyGroups {
                         requirements
                             .extend(resolved.get(include_group).into_iter().flatten().cloned());
                     }
-                    DependencyGroupSpecifier::Object(_map) => {
+                    DependencyGroupSpecifier::Object(map) => {
                         return Err(DependencyGroupError::DependencyObjectSpecifierNotSupported(
                             name.clone(),
+                            map.clone(),
                         ));
                     }
                 }
@@ -154,8 +155,8 @@ pub enum DependencyGroupError {
     DevGroupInclude(GroupName),
     #[error("Detected a cycle in `dependency-groups`: {0}")]
     DependencyGroupCycle(Cycle),
-    #[error("Group `{0}` contains a Dependency Object Specifier, which is not supported by uv")]
-    DependencyObjectSpecifierNotSupported(GroupName),
+    #[error("Group `{0}` contains an unknown dependency object specifier: {1:?}")]
+    DependencyObjectSpecifierNotSupported(GroupName, BTreeMap<String, String>),
 }
 
 impl DependencyGroupError {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -20832,14 +20832,15 @@ fn lock_group_invalid_entry_table() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.lock(), @r###"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), context.lock(), @r"
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
-    "###);
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ╰─▶ Group `foo` contains a Dependency Object Specifier, which is not supported by uv
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -20832,15 +20832,15 @@ fn lock_group_invalid_entry_table() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.lock(), @r"
+    uv_snapshot!(context.filters(), context.lock(), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
       × Failed to build `project @ file://[TEMP_DIR]/`
-      ╰─▶ Group `foo` contains a Dependency Object Specifier, which is not supported by uv
-    ");
+      ╰─▶ Group `foo` contains an unknown dependency object specifier: {"bar": "unknown"}
+    "#);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR errors out when an Unknown Dependency Object Specifier is used in dependency groups.


Fixes #12638 

## Test Plan

The current behaviour is as follows:

```bash
➜  example git:(12638/dependency-object-specifier) ✗ cargo run -- sync
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `/home/luna/Documents/uv/target/debug/uv sync`
error: Failed to generate package metadata for `example==0.1.0 @ virtual+.`
  Caused by: Group `bar` contains a Dependency Object Specifier, which is not supported by uv
  ```


And the pyproject.toml to produce this is:

```toml
[project]
name = "example"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.13.2"
dependencies = []

[dependency-groups]
foo = ["pyparsing"]
bar = [{set-phasers-to = "stun"}]
```
  
  