### PR TITLE
Add `--locked` to `uv sync` in GitHub Actions guide

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -190,7 +190,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --locked --all-extras --dev
 
       - name: Run tests
         # For example, using `pytest`


### PR DESCRIPTION
## Summary

Closes #10793

As requested by @konstin in

- https://github.com/astral-sh/uv/issues/10793#issuecomment-2603869549