### PR TITLE
Add missing git feature dep to preserve_executable_bit test

### DIFF
--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -216,7 +216,7 @@ fn built_by_uv_editable() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "git"))]
 #[test]
 fn preserve_executable_bit() -> Result<()> {
     use std::io::Write;


### PR DESCRIPTION
## Summary

Without the `git` feature, it fails with:

```
error: Failed to initialize Git repository at `/home/mgorny/.local/share/uv/tests/.tmp01wGGK/temp/preserve_executable_bit`
stdout:
stderr: error: `git` operations are not allowed — are you missing a cfg for the `git` feature?
```

## Test Plan
    cargo test --features python --profile=fast-build --no-default-features
