### PR TITLE
Collapse whitespace in python_list tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -319,6 +319,13 @@ impl TestContext {
         self
     }
 
+    /// Add a filter that collapses duplicate whitespace.
+    #[must_use]
+    pub fn with_collapsed_whitespace(mut self) -> Self {
+        self.filters.push((r"[ \t]+".to_string(), " ".to_string()));
+        self
+    }
+
     /// Add extra directories and configuration for managed Python installations.
     #[must_use]
     pub fn with_managed_python_dirs(mut self) -> Self {

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -7,7 +7,8 @@ use crate::common::{uv_snapshot, TestContext};
 fn python_list() {
     let mut context: TestContext = TestContext::new_with_versions(&["3.11", "3.12"])
         .with_filtered_python_symlinks()
-        .with_filtered_python_keys();
+        .with_filtered_python_keys()
+        .with_collapsed_whitespace();
 
     uv_snapshot!(context.filters(), context.python_list().env(EnvVars::UV_TEST_PYTHON_PATH, ""), @r"
     success: true
@@ -22,8 +23,8 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -33,7 +34,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]    [PYTHON-3.12]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
 
     ----- stderr -----
     ");
@@ -43,7 +44,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -53,8 +54,8 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -64,7 +65,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]    [PYTHON-3.12]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
 
     ----- stderr -----
     ");
@@ -74,7 +75,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]    [PYTHON-3.12]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
 
     ----- stderr -----
     ");
@@ -87,7 +88,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]    [PYTHON-3.12]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
 
     ----- stderr -----
     ");
@@ -108,8 +109,8 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -119,7 +120,7 @@ fn python_list() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -129,7 +130,8 @@ fn python_list() {
 fn python_list_pin() {
     let context: TestContext = TestContext::new_with_versions(&["3.11", "3.12"])
         .with_filtered_python_symlinks()
-        .with_filtered_python_keys();
+        .with_filtered_python_keys()
+        .with_collapsed_whitespace();
 
     // Pin to a version
     uv_snapshot!(context.filters(), context.python_pin().arg("3.12"), @r###"
@@ -146,8 +148,8 @@ fn python_list_pin() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -157,8 +159,8 @@ fn python_list_pin() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -171,7 +173,8 @@ fn python_list_venv() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_python_names()
-        .with_filtered_virtualenv_bin();
+        .with_filtered_virtualenv_bin()
+        .with_collapsed_whitespace();
 
     // Create a virtual environment
     uv_snapshot!(context.filters(), context.venv().arg("--python").arg("3.12").arg("-q"), @r###"
@@ -187,8 +190,8 @@ fn python_list_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -198,8 +201,8 @@ fn python_list_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -285,7 +288,8 @@ fn python_list_unsupported_version() {
 fn python_list_duplicate_path_entries() {
     let context: TestContext = TestContext::new_with_versions(&["3.11", "3.12"])
         .with_filtered_python_symlinks()
-        .with_filtered_python_keys();
+        .with_filtered_python_keys()
+        .with_collapsed_whitespace();
 
     // Construct a `PATH` with all entries duplicated
     let path = std::env::join_paths(
@@ -298,8 +302,8 @@ fn python_list_duplicate_path_entries() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-    cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+    cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+    cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
     ----- stderr -----
     ");
@@ -320,8 +324,8 @@ fn python_list_duplicate_path_entries() {
             success: true
             exit_code: 0
             ----- stdout -----
-            cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]
-            cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]
+            cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]
+            cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]
 
             ----- stderr -----
             ");
@@ -341,8 +345,8 @@ fn python_list_duplicate_path_entries() {
         success: true
         exit_code: 0
         ----- stdout -----
-        cpython-3.12.[X]-[PLATFORM]     [PYTHON-3.12]-link/python3
-        cpython-3.11.[X]-[PLATFORM]    [PYTHON-3.11]-link/python3
+        cpython-3.12.[X]-[PLATFORM] [PYTHON-3.12]-link/python3
+        cpython-3.11.[X]-[PLATFORM] [PYTHON-3.11]-link/python3
 
         ----- stderr -----
         ");


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Collapse whitespace into a single space in python_list tests, in order to make them agnostic of padding, and therefore pass both with Python 3.12.9 and Python 3.12.10.

Fixes #12799

## Test Plan
    cargo test --features python --profile=fast-build --no-default-features

