### PR TITLE
Fix tests on non-English Windows

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -68,11 +68,6 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
         r"uv(-.*)? \d+\.\d+\.\d+(\+\d+)?( \(.*\))?",
         r"uv [VERSION] ([COMMIT] DATE)",
     ),
-    // The exact message is host language dependent
-    (
-        r"Caused by: .* \(os error 2\)",
-        "Caused by: No such file or directory (os error 2)",
-    ),
     // Trim end-of-line whitespaces, to allow removing them on save.
     (r"([^\s])[ \t]+(\r?\n)", "$1$2"),
 ];
@@ -155,13 +150,18 @@ impl TestContext {
 
     /// Add extra standard filtering for Windows-compatible missing file errors.
     pub fn with_filtered_missing_file_error(mut self) -> Self {
+        // The exact message string depends on the system language, so we remove it.
+        // We want to only remove the phrase after `Caused by:`
         self.filters.push((
-            regex::escape("The system cannot find the file specified. (os error 2)"),
-            "[OS ERROR 2]".to_string(),
+            r"[^:\n]* \(os error 2\)".to_string(),
+            " [OS ERROR 2]".to_string(),
         ));
+        // Replace the Windows "The system cannot find the path specified. (os error 3)"
+        // with the Unix "No such file or directory (os error 2)"
+        // and mask the language-dependent message.
         self.filters.push((
-            regex::escape("No such file or directory (os error 2)"),
-            "[OS ERROR 2]".to_string(),
+            r"[^:\n]* \(os error 3\)".to_string(),
+            " [OS ERROR 2]".to_string(),
         ));
         self
     }

--- a/crates/uv/tests/it/ecosystem.rs
+++ b/crates/uv/tests/it/ecosystem.rs
@@ -45,6 +45,7 @@ fn home_assistant_core() -> Result<()> {
 
 // Source: https://github.com/konstin/transformers/blob/da3c00433d93e43bf1e7360b1057e8c160e7978e/pyproject.toml
 #[test]
+#[cfg(unix)] // deepspeed fails on windows due to missing torch
 fn transformers() -> Result<()> {
     // Takes too long on non-Linux in CI.
     if !cfg!(target_os = "linux") && std::env::var_os(EnvVars::CI).is_some() {

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -83,21 +83,11 @@ fn missing_pyproject_toml() {
 
 #[test]
 fn missing_find_links() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_missing_file_error();
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str("flask")?;
 
-    let error = regex::escape("The system cannot find the path specified. (os error 3)");
-    let filters = context
-        .filters()
-        .into_iter()
-        .chain(std::iter::once((
-            error.as_str(),
-            "No such file or directory (os error 2)",
-        )))
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, context.pip_install()
+    uv_snapshot!(context.filters(), context.pip_install()
         .arg("-r")
         .arg("requirements.txt")
         .arg("--find-links")
@@ -109,7 +99,7 @@ fn missing_find_links() -> Result<()> {
 
     ----- stderr -----
     error: Failed to read `--find-links` directory: [TEMP_DIR]/missing
-      Caused by: No such file or directory (os error 2)
+      Caused by: [OS ERROR 2]
     "###
     );
 

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -230,6 +230,7 @@ fn install_hardlink() -> Result<()> {
 
 /// Install a package into a virtual environment using symlink semantics.
 #[test]
+#[cfg(unix)] // Windows does not allow symlinks by default
 fn install_symlink() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2303,7 +2303,8 @@ fn run_editable() -> Result<()> {
 #[test]
 fn run_from_directory() -> Result<()> {
     // Default to 3.11 so that the `.python-version` is meaningful.
-    let context = TestContext::new_with_versions(&["3.10", "3.11", "3.12"]);
+    let context = TestContext::new_with_versions(&["3.10", "3.11", "3.12"])
+        .with_filtered_missing_file_error();
 
     let project_dir = context.temp_dir.child("project");
     project_dir
@@ -2340,7 +2341,6 @@ fn run_from_directory() -> Result<()> {
         .into_iter()
         .map(|pattern| (pattern, "[PROJECT_VENV]/".to_string()))
         .collect::<Vec<_>>();
-    let error = regex::escape("The system cannot find the path specified. (os error 3)");
     let filters = context
         .filters()
         .into_iter()
@@ -2349,10 +2349,6 @@ fn run_from_directory() -> Result<()> {
                 .iter()
                 .map(|(pattern, replacement)| (pattern.as_str(), replacement.as_str())),
         )
-        .chain(std::iter::once((
-            error.as_str(),
-            "No such file or directory (os error 2)",
-        )))
         .collect::<Vec<_>>();
 
     // Use `--project`, which resolves configuration relative to the provided directory, but paths
@@ -2434,7 +2430,7 @@ fn run_from_directory() -> Result<()> {
     Installed 1 package in [TIME]
      + foo==1.0.0 (from file://[TEMP_DIR]/project)
     error: Failed to spawn: `./project/main.py`
-      Caused by: No such file or directory (os error 2)
+      Caused by: [OS ERROR 2]
     "###);
 
     // Even if we write a `.python-version` file in the current directory, we should prefer the


### PR DESCRIPTION
By default, unlike on CI, a Windows machine does not allow creating symlinks, so we have to unix-gate tests that assume symlinks.

We can't install the transformers ecosystem test on Windows due to missing torch, so it is also unix-gated.

Windows translates error messages, so we have to filter the "File not found" message, since it can also be a "Datei nicht gefunden".