### PR TITLE
Ensure virtual environment is compatible with interpreter on sync

### DIFF
--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -355,4 +355,12 @@ impl PythonEnvironment {
                 .unwrap_or(false)
         }
     }
+
+    /// Returns true if the virtual environment has the same `pyvenv.cfg` version
+    /// as the interpreter Python version. Also returns true if there is no
+    /// `pyvenv.cfg` file.
+    pub fn matches_interpreter(&self, interpreter: &Interpreter) -> bool {
+        let Ok(cfg) = self.cfg() else { return true };
+        cfg.matches_interpreter(interpreter)
+    }
 }

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -356,9 +356,9 @@ impl PythonEnvironment {
         }
     }
 
-    /// Returns true if the virtual environment has the same `pyvenv.cfg` version
-    /// as the interpreter Python version. Also returns true if there is no
-    /// `pyvenv.cfg` file.
+    /// Returns true if the virtual environment has the same `pyvenv.cfg`
+    /// version as the interpreter Python version. Also returns true if
+    /// there is no `pyvenv.cfg` file.
     pub fn matches_interpreter(&self, interpreter: &Interpreter) -> bool {
         let Ok(cfg) = self.cfg() else { return true };
         cfg.matches_interpreter(interpreter)

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -356,9 +356,10 @@ impl PythonEnvironment {
         }
     }
 
-    /// Returns true if the virtual environment has the same `pyvenv.cfg`
-    /// version as the interpreter Python version. Also returns true if
-    /// there is no `pyvenv.cfg` file.
+    /// If this is a virtual environment (indicated by the presence of
+    /// a `pyvenv.cfg` file), this returns true if the `pyvenv.cfg` version
+    /// is the same as the interpreter Python version. Also returns true
+    /// if this is not a virtual environment.
     pub fn matches_interpreter(&self, interpreter: &Interpreter) -> bool {
         let Ok(cfg) = self.cfg() else { return true };
         cfg.matches_interpreter(interpreter)

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -661,7 +661,6 @@ impl ScriptInterpreter {
         } = ScriptPython::from_request(python_request, workspace, script, no_config).await?;
 
         let root = Self::root(script, active, cache);
-
         match PythonEnvironment::from_root(&root, cache) {
             Ok(venv) => {
                 if python_request.as_ref().is_none_or(|request| {
@@ -804,21 +803,23 @@ impl ProjectInterpreter {
         let venv = workspace.venv(active);
         match PythonEnvironment::from_root(&venv, cache) {
             Ok(venv) => {
-                if python_request.as_ref().is_none_or(|request| {
-                    if request.satisfied(venv.interpreter(), cache) {
-                        debug!(
-                            "The virtual environment's Python version satisfies `{}`",
-                            request.to_canonical_string()
-                        );
-                        true
-                    } else {
-                        debug!(
-                            "The virtual environment's Python version does not satisfy `{}`",
-                            request.to_canonical_string()
-                        );
-                        false
-                    }
-                }) {
+                if venv.matches_interpreter(venv.interpreter())
+                    && python_request.as_ref().is_none_or(|request| {
+                        if request.satisfied(venv.interpreter(), cache) {
+                            debug!(
+                                "The virtual environment's Python version satisfies `{}`",
+                                request.to_canonical_string()
+                            );
+                            true
+                        } else {
+                            debug!(
+                                "The virtual environment's Python version does not satisfy `{}`",
+                                request.to_canonical_string()
+                            );
+                            false
+                        }
+                    })
+                {
                     if let Some(requires_python) = requires_python.as_ref() {
                         if requires_python.contains(venv.interpreter().python_version()) {
                             return Ok(Self::Environment(venv));

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -803,7 +803,11 @@ impl ProjectInterpreter {
         let venv = workspace.venv(active);
         match PythonEnvironment::from_root(&venv, cache) {
             Ok(venv) => {
-                if venv.matches_interpreter(venv.interpreter())
+                let venv_matches_interpreter = venv.matches_interpreter(venv.interpreter());
+                if !venv_matches_interpreter {
+                    debug!("The virtual environment's interpreter version does not match the version it was created from.");
+                }
+                if venv_matches_interpreter
                     && python_request.as_ref().is_none_or(|request| {
                         if request.satisfied(venv.interpreter(), cache) {
                             debug!(

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -9172,6 +9172,7 @@ fn sync_build_constraints() -> Result<()> {
 // Test that we recreate a virtual environment when `pyvenv.cfg` version
 // is incompatible with the interpreter version.
 #[test]
+#[cfg(feature = "git")]
 fn sync_when_virtual_environment_incompatible_with_interpreter() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -9172,11 +9172,19 @@ fn sync_build_constraints() -> Result<()> {
 // Test that we recreate a virtual environment when `pyvenv.cfg` version
 // is incompatible with the interpreter version.
 #[test]
-#[cfg(feature = "git")]
 fn sync_when_virtual_environment_incompatible_with_interpreter() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    context.init().assert().success();
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        dependencies = []
+        "#,
+    )?;
 
     // Create a virtual environment at `.venv`.
     context

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -9168,3 +9168,105 @@ fn sync_build_constraints() -> Result<()> {
 
     Ok(())
 }
+
+// Test that we recreate a virtual environment when `pyvenv.cfg` version
+// is incompatible with the interpreter version.
+#[test]
+fn sync_when_virtual_environment_incompatible_with_interpreter() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    context.init().assert().success();
+
+    // Create a virtual environment at `.venv`.
+    context
+        .venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12")
+        .assert()
+        .success();
+
+    // Simulate an incompatible `pyvenv.cfg:version` value created
+    // by the venv module.
+    let pyvenv_cfg = context.venv.child("pyvenv.cfg");
+    let contents = fs_err::read_to_string(&pyvenv_cfg)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("version") {
+                "version = 3.11.0".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs_err::write(&pyvenv_cfg, contents)?;
+
+    // We should also be able to read from the lockfile.
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Removed virtual environment at: .venv
+    Creating virtual environment at: .venv
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        let contents = fs_err::read_to_string(&pyvenv_cfg).unwrap();
+        let lines: Vec<&str> = contents.split('\n').collect();
+        assert_snapshot!(lines[3], @r###"
+        version_info = 3.12.[X]
+        "###);
+    });
+
+    // Simulate an incompatible `pyvenv.cfg:version_info` value created
+    // by uv or virtualenv.
+    let pyvenv_cfg = context.venv.child("pyvenv.cfg");
+    let contents = fs_err::read_to_string(&pyvenv_cfg)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("version") {
+                "version_info = 3.11.0".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs_err::write(&pyvenv_cfg, contents)?;
+
+    // We should also be able to read from the lockfile.
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Removed virtual environment at: .venv
+    Creating virtual environment at: .venv
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
+    ");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        let contents = fs_err::read_to_string(&pyvenv_cfg).unwrap();
+        let lines: Vec<&str> = contents.split('\n').collect();
+        assert_snapshot!(lines[3], @r###"
+        version_info = 3.12.[X]
+        "###);
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
It was possible that a virtual environment became out of sync with the interpreter it pointed to (for example, if a symlink was changed to an updated Python version). In such a case, `pyvenv.cfg` and `activate_this.py` would no longer be correct. This PR detects when the `version` (`venv` module) or `version_info` (uv and `virtualenv`) field in `pyvenv.cfg` is out of sync with the interpreter. In such a case, uv recreates the virtual environment.

Closes #12461
