### PR TITLE
make distability opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,8 @@ inherits = "release"
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.28.4-prerelease.1"
+# make a package being included in our releases opt-in instead of opt-out
+dist = false
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -162,3 +162,6 @@ slow-tests = []
 test-ecosystem = []
 # Adds self-update functionality.
 self-update = ["axoupdater", "uv-cli/self-update"]
+
+[package.metadata.dist]
+dist = true


### PR DESCRIPTION
We have been claiming in our releases that we provide archives/installers for uv-build, but we only upload it as a wheel to pypi. This is because cargo-dist tries to be helpful and find all your apps, but this scales poorly to large workspaces like ours, as stuff like this slips in. So invert the default and make uv the only package dist will see until we say otherwise.

See e.g. https://github.com/astral-sh/uv/releases/tag/0.6.14

Fixes #12883