### PR TITLE
docs: Fix highlight line in explicit index documentation

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -261,7 +261,7 @@ When defining an index, an `explicit` flag can be included to indicate that the 
 be used for packages that explicitly specify it in `tool.uv.sources`. If `explicit` is not set,
 other packages may be resolved from the index, if not found elsewhere.
 
-```toml title="pyproject.toml" hl_lines="3"
+```toml title="pyproject.toml" hl_lines="4"
 [[tool.uv.index]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
## Summary

Fix the highlighted line in [Index Documentation](https://docs.astral.sh/uv/concepts/projects/dependencies/#index) (towards the end of the section) - the `explicit = true` line should be highlighted.

## Test Plan
Docs.
