### PR TITLE
Bugfix relative path glob walking for cache-keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4818,7 +4818,8 @@ name = "uv-cache-info"
 version = "0.0.1"
 dependencies = [
  "fs-err 3.1.0",
- "globwalk",
+ "glob",
+ "pathdiff",
  "schemars",
  "serde",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ fs2 = { version = "0.4.3" }
 futures = { version = "0.3.30" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.15" }
-globwalk = { version = "0.9.1" }
 goblin = { version = "0.9.0", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
 hashbrown = { version = "0.15.1" }
 hex = { version = "0.4.3" }
@@ -129,8 +128,8 @@ nanoid = { version = "0.4.0" }
 nix = { version = "0.29.0", features = ["signal"] }
 once_cell = { version = "1.20.2" }
 owo-colors = { version = "4.1.0" }
+pathdiff = { version = "0.2.3" }
 path-slash = { version = "0.2.1" }
-pathdiff = { version = "0.2.1" }
 percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
 proc-macro2 = { version = "1.0.86" }

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -17,7 +17,8 @@ workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-globwalk = { workspace = true }
+glob = { workspace = true }
+pathdiff = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Description

Being able to specify relative paths for `cache-keys` is useful, but it is currently broken. This PR fixes that.

## Background

### Use Case

Building a python project from maturin on a cargo workspace (i.e. it's not just the local package to trigger rebuilds from). e.g.

```
[tool.uv]
# Rebuild package when any rust files change
cache-keys = [
    { file = "pyproject.toml" },
    { file = "Cargo.toml" },
    { file = ".cargo/config.toml" },
    { file = "**/*.rs" },
    { file = "../sv2_behaviors/**/*.rs" },
    { file = "../sv2_collisions/**/*.rs" },
    ...
]
```

### Why it's broken

The previous tool, `globwalker`, cannot handle relative paths - it just silently passed over them. It's a long standing issue (5+ years) that's not likely to be fixed given that it's in maintenance mode.

* https://github.com/Gilnaa/globwalk/issues/28.

## Solution

Plain old `glob` can handle relative paths. It is obsessed with working from `cwd` though, so this PR provides some assistance to redirect the relative paths to that rather than the directory that the toml file is in though.

## Test Plan

I have a unit test in place to check for the relative path lookups.

----

First time contributing here, please do point out where and how I might better integrate this contribution.