### PR TITLE
Cache `which git` in `uv init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4955,12 +4955,12 @@ dependencies = [
  "uv-cache-info",
  "uv-cache-key",
  "uv-distribution-types",
+ "uv-git",
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
  "uv-static",
- "which",
 ]
 
 [[package]]

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -21,6 +21,7 @@ uv-cache = { workspace = true }
 uv-cache-info = { workspace = true }
 uv-cache-key = { workspace = true }
 uv-distribution-types = { workspace = true }
+uv-git = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true, features = ["schemars"] }
@@ -40,7 +41,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-which = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Avoid running `which` multiple times, to be more coherent with the other git code. In preparation of improving the `uv init` git handling.