### PR TITLE
Make `uv init` resilient against broken git

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1191,35 +1191,80 @@ fn generate_package_scripts(
     Ok(())
 }
 
+enum GitDiscoveryResult {
+    /// Git is initialized at the path.
+    WorkTree,
+    /// Git is not initialized at the path.
+    NoWorkTree,
+    /// There is no `git[.exe]` binary in PATH.
+    NoGit,
+    /// There is a `git[.exe]` binary in PATH, but it returned an unexpected output.
+    BrokenGit,
+}
+
+/// Checks if there is a Git work tree at the given path.
+fn detect_git_work_tree(path: &Path) -> GitDiscoveryResult {
+    // Determine whether the path is inside a Git work tree.
+    let Ok(git) = GIT.as_ref() else {
+        return GitDiscoveryResult::NoGit;
+    };
+    let Ok(output) = Command::new(git)
+        .arg("rev-parse")
+        .arg("--is-inside-work-tree")
+        .current_dir(path)
+        .output()
+    else {
+        debug!(
+            "`git rev-parse --is-inside-work-tree` failed to launch for `{}`",
+            path.display()
+        );
+        return GitDiscoveryResult::BrokenGit;
+    };
+    if output.status.success() {
+        if std::str::from_utf8(&output.stdout) == Ok("true") {
+            debug!("Found a worktree for `{}`", path.display());
+            GitDiscoveryResult::WorkTree
+        } else {
+            debug!(
+                "`git rev-parse --is-inside-work-tree` succeeded but didn't return `true` for `{}`",
+                path.display()
+            );
+            GitDiscoveryResult::BrokenGit
+        }
+    } else {
+        if std::str::from_utf8(&output.stderr).is_ok_and(|err| err.contains("not a git repository"))
+        {
+            debug!("Not a git repository `{}`", path.display());
+            GitDiscoveryResult::NoWorkTree
+        } else {
+            debug!(
+                "`git rev-parse --is-inside-work-tree` failed but didn't contain `not a git repository` in stderr for `{}`",
+                path.display()
+            );
+            GitDiscoveryResult::BrokenGit
+        }
+    }
+}
+
 /// Initialize the version control system at the given path.
 fn init_vcs(path: &Path, vcs: Option<VersionControlSystem>) -> Result<()> {
-    // Detect any existing version control system.
-    let existing = VersionControlSystem::detect(path);
-
-    let implicit = vcs.is_none();
-
-    let vcs = match (vcs, existing) {
-        // If no version control system was specified, and none was detected, default to Git.
-        (None, None) => VersionControlSystem::default(),
-        // If no version control system was specified, but a VCS was detected, leave it as-is.
-        (None, Some(existing)) => {
-            debug!("Detected existing version control system: {existing}");
-            VersionControlSystem::None
-        }
-        // If the user provides an explicit `--vcs none`,
-        (Some(VersionControlSystem::None), _) => VersionControlSystem::None,
-        // If a version control system was specified, use it.
-        (Some(vcs), None) => vcs,
-        // If a version control system was specified, but a VCS was detected...
-        (Some(vcs), Some(existing)) => {
-            // If they differ, raise an error.
-            if vcs != existing {
-                anyhow::bail!("The project is already in a version control system (`{existing}`); cannot initialize with `--vcs {vcs}`");
+    // vcs is None for an existing repository because we don't want to initialize again.
+    let (vcs, implicit) = match vcs {
+        None => match detect_git_work_tree(path) {
+            GitDiscoveryResult::NoWorkTree => (VersionControlSystem::Git, true),
+            GitDiscoveryResult::WorkTree
+            | GitDiscoveryResult::NoGit
+            | GitDiscoveryResult::BrokenGit => (VersionControlSystem::None, false),
+        },
+        Some(VersionControlSystem::None) => (VersionControlSystem::None, false),
+        Some(VersionControlSystem::Git) => match detect_git_work_tree(path) {
+            GitDiscoveryResult::NoWorkTree | GitDiscoveryResult::BrokenGit => {
+                (VersionControlSystem::Git, true)
             }
-
-            // Otherwise, ignore the specified VCS, since it's already in use.
-            VersionControlSystem::None
-        }
+            GitDiscoveryResult::WorkTree | GitDiscoveryResult::NoGit => {
+                (VersionControlSystem::None, false)
+            }
+        },
     };
 
     // Attempt to initialize the VCS.

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -619,7 +619,7 @@ impl TestContext {
         command
     }
 
-    fn disallow_git_cli(bin_dir: &Path) -> std::io::Result<()> {
+    pub fn disallow_git_cli(bin_dir: &Path) -> std::io::Result<()> {
         let contents = r"#!/bin/sh
     echo 'error: `git` operations are not allowed — are you missing a cfg for the `git` feature?' >&2
     exit 127";

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -3713,3 +3713,64 @@ fn init_without_description() -> Result<()> {
 
     Ok(())
 }
+
+/// Check how `uv init` reacts to working and broken git with different `--vcs` options.
+#[test]
+fn git_states() {
+    let context = TestContext::new("3.12");
+
+    // First, with working git.
+
+    context.init().arg("working").assert().success();
+    assert!(context.temp_dir.child("working/.git").is_dir());
+
+    context
+        .init()
+        .arg("working-no-git")
+        .arg("--vcs")
+        .arg("none")
+        .assert()
+        .success();
+    assert!(!context.temp_dir.child("working-no-git/.git").is_dir());
+
+    context
+        .init()
+        .arg("working-git")
+        .arg("--vcs")
+        .arg("git")
+        .assert()
+        .success();
+    assert!(context.temp_dir.child("working-git/.git").is_dir());
+
+    // The same tests again, but with broken git.
+    TestContext::disallow_git_cli(&context.bin_dir)
+        .expect("Failed to setup disallowed `git` command");
+
+    context.init().arg("broken").assert().success();
+    assert!(!context.temp_dir.child("broken/.git").is_dir());
+
+    context
+        .init()
+        .arg("broken-no-git")
+        .arg("--vcs")
+        .arg("none")
+        .assert()
+        .success();
+    assert!(!context.temp_dir.child("broken-no-git/.git").is_dir());
+
+    uv_snapshot!(context.filters(), context
+        .init()
+        .arg("broken-git")
+        .arg("--vcs")
+        .arg("git"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to initialize Git repository at `[TEMP_DIR]/broken-git`
+    stdout:
+    stderr: error: `git` operations are not allowed — are you missing a cfg for the `git` feature?
+    ");
+    assert!(!context.temp_dir.child("broken-git/.git").is_dir());
+}


### PR DESCRIPTION
Currently, `uv init` works without a `git` executable, and with a working `git` executable, but not with a broken `git`, be it from GitHub Action's Windows CI or from the shim we insert.

`uv init` calls git twice: Once `git rev-parse` to check whether a git repo already exists, and then `git init` (if there is no git repository yet and no `--vcs none`).

By separately handling the cases where git failed during `git rev-parse` doesn't work vs. where the is no repository when checking for an existing repo work tree, we can avoid calling `git init` for broken git and erroring.