### PR TITLE
Show PyPy downloads during `uv python list`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -206,10 +206,7 @@ impl PythonDownloadRequest {
     /// Fill empty entries with default values.
     ///
     /// Platform information is pulled from the environment.
-    pub fn fill(mut self) -> Result<Self, Error> {
-        if self.implementation.is_none() {
-            self.implementation = Some(ImplementationName::CPython);
-        }
+    pub fn fill_platform(mut self) -> Result<Self, Error> {
         if self.arch.is_none() {
             self.arch = Some(Arch::from_env());
         }
@@ -219,6 +216,14 @@ impl PythonDownloadRequest {
         if self.libc.is_none() {
             self.libc = Some(Libc::from_env()?);
         }
+        Ok(self)
+    }
+
+    pub fn fill(mut self) -> Result<Self, Error> {
+        if self.implementation.is_none() {
+            self.implementation = Some(ImplementationName::CPython);
+        }
+        self = self.fill_platform()?;
         Ok(self)
     }
 

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -79,16 +79,16 @@ pub(crate) async fn list(
             PythonListKinds::Downloads => Some(if all_platforms {
                 base_download_request
             } else {
-                base_download_request.fill()?
+                base_download_request.fill_platform()?
             }),
             PythonListKinds::Default => {
                 if python_downloads.is_automatic() {
                     Some(if all_platforms {
                         base_download_request
                     } else if all_arches {
-                        base_download_request.fill()?.with_any_arch()
+                        base_download_request.fill_platform()?.with_any_arch()
                     } else {
-                        base_download_request.fill()?
+                        base_download_request.fill_platform()?
                     })
                 } else {
                     // If fetching is not automatic, then don't show downloads as available by default


### PR DESCRIPTION
Fixes #12914.
When `PythonDownloadRequest` does not have the `implementation` set, do not set it to CPython when calling `fill`, otherwise only CPython interpreters are shown when listing interpreters available for download, with `uv python list`.