### PR TITLE
Check dist name to handle bogus redirect

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -124,7 +124,7 @@ pub enum ResolveError {
         #[source]
         name_error: InvalidNameError,
     },
-    #[error("The index returned metadata for the wrong package: Expected {request} for {expected}, got {request} for {actual}")]
+    #[error("The index returned metadata for the wrong package: expected {request} for {expected}, got {request} for {actual}")]
     MismatchedPackageName {
         request: &'static str,
         expected: PackageName,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -124,6 +124,12 @@ pub enum ResolveError {
         #[source]
         name_error: InvalidNameError,
     },
+    #[error("Expected {request} for {expected}, got {request} for {actual}")]
+    MismatchedPackageName {
+        request: &'static str,
+        expected: PackageName,
+        actual: PackageName,
+    },
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -124,7 +124,7 @@ pub enum ResolveError {
         #[source]
         name_error: InvalidNameError,
     },
-    #[error("Expected {request} for {expected}, got {request} for {actual}")]
+    #[error("The index returned metadata for the wrong package: Expected {request} for {expected}, got {request} for {actual}")]
     MismatchedPackageName {
         request: &'static str,
         expected: PackageName,

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -11139,7 +11139,7 @@ async fn bogus_redirect() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected distribution for sniffio, got distribution for anyio
+    error: The index returned metadata for the wrong package: Expected distribution for sniffio, got distribution for anyio
     "
     );
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -1,9 +1,6 @@
 use std::io::Cursor;
 use std::process::Command;
 
-#[cfg(feature = "git")]
-use crate::common::{self, decode_token};
-
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
@@ -20,7 +17,6 @@ use wiremock::{
 
 #[cfg(feature = "git")]
 use crate::common::{self, decode_token};
-
 use crate::common::{
     build_vendor_links_url, download_to_disk, get_bin, uv_snapshot, venv_bin_path,
     venv_to_interpreter, TestContext,

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -11139,7 +11139,7 @@ async fn bogus_redirect() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: The index returned metadata for the wrong package: Expected distribution for sniffio, got distribution for anyio
+    error: The index returned metadata for the wrong package: expected distribution for sniffio, got distribution for anyio
     "
     );
 


### PR DESCRIPTION
When an index performs a bogus redirect or otherwise returns a different distribution name than expected, uv currently hangs.

In the example case, requesting the simple index page for any package returns the page for anyio. This mean querying the sniffio version map returns only anyio entries, and the version maps resolves to an anyio version. When the resolver makes a query for sniffio and waits for it to resolve, the main thread finds an anyio and resolves only that in the wait map, causing the hang.

We fix this by checking the name of the returned distribution against the name of the requested distribution. For good measure, we add the same check in `Request::Dist` and `Request::Installed`. For performance and complexity reasons, we don't perform this check in the version map itself, but only after a candidate distribution has been selected.