### PR TITLE
Deactivate uv publish codeberg integration test

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -143,11 +143,12 @@ local_targets: dict[str, TargetConfiguration] = {
         "https://gitlab.com/api/v4/projects/61853105/packages/pypi",
         "https://gitlab.com/api/v4/projects/61853105/packages/pypi/simple/",
     ),
-    "codeberg": TargetConfiguration(
-        "astral-test-token",
-        "https://codeberg.org/api/packages/astral-test-user/pypi",
-        "https://codeberg.org/api/packages/astral-test-user/pypi/simple/",
-    ),
+    # Codeberg is deactivated because it times out
+    # "codeberg": TargetConfiguration(
+    #    "astral-test-token",
+    #    "https://codeberg.org/api/packages/astral-test-user/pypi",
+    #    "https://codeberg.org/api/packages/astral-test-user/pypi/simple/",
+    # ),
     "cloudsmith": TargetConfiguration(
         "astral-test-token",
         "https://python.cloudsmith.io/astral-test/astral-test-1/",


### PR DESCRIPTION
The codeberg server times out, failing the uv CI.
