### PR TITLE
Generate artifact attestations for release binaries, too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@
 name: Release
 permissions:
   "contents": "write"
+  "attestations": "write" # needed to push artifact attestations to the Github attestation store
+  "id-token": "write" # needed for signing the artifacts with GitHub OIDC Token
 
 # This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -193,6 +195,10 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2
+        with:
+          subject-path: target/distrib/*
       # This is a harmless no-op for GitHub Releases, hosting for that happens in "announce"
       - id: host
         shell: bash


### PR DESCRIPTION

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Motivation for this is to have ability to verify the artifacts downloaded from GH release, just like it is already possible for container images.

Tools such as [aqua](https://aquaproj.github.io) and [mise](https://mise.jdx.dev) ([likely, later](https://github.com/jdx/mise/discussions/4531)) can make use of these and verify downloads automatically.

## Test Plan

<!-- How was it tested? -->

This is untested by me. The CI setup is quite elaborate, not sure if I could get it to run properly in my fork with reasonable effort. But I suppose this _could_ Just Work anyway :)