### PR TITLE
Prevent uninstalling a Python installation if it is used by a tool

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4773,6 +4773,10 @@ pub struct PythonUninstallArgs {
     /// Uninstall all managed Python versions.
     #[arg(long, conflicts_with("targets"))]
     pub all: bool,
+
+    /// Force uninstall the requested Python version(s), even if they are in use.
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -291,7 +291,7 @@ Error=This Python installation is managed by uv and should not be modified.
 ";
 
 /// A uv-managed Python installation on the current system.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ManagedPythonInstallation {
     /// The path to the top-level directory of the installed Python.
     path: PathBuf,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1337,6 +1337,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.install_dir,
                 args.targets,
                 args.all,
+                args.force,
                 printer,
                 globals.preview,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -956,6 +956,7 @@ pub(crate) struct PythonUninstallSettings {
     pub(crate) install_dir: Option<PathBuf>,
     pub(crate) targets: Vec<String>,
     pub(crate) all: bool,
+    pub(crate) force: bool,
 }
 
 impl PythonUninstallSettings {
@@ -969,12 +970,14 @@ impl PythonUninstallSettings {
             install_dir,
             targets,
             all,
+            force,
         } = args;
 
         Self {
             install_dir,
             targets,
             all,
+            force,
         }
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5473,6 +5473,8 @@ uv python uninstall [OPTIONS] <TARGETS>...
 
 <p>See <code>--project</code> to only change the project root directory.</p>
 
+</dd><dt id="uv-python-uninstall--force"><a href="#uv-python-uninstall--force"><code>--force</code></a></dt><dd><p>Force uninstall the requested Python version(s), even if they are in use</p>
+
 </dd><dt id="uv-python-uninstall--help"><a href="#uv-python-uninstall--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
 </dd><dt id="uv-python-uninstall--install-dir"><a href="#uv-python-uninstall--install-dir"><code>--install-dir</code></a>, <code>-i</code> <i>install-dir</i></dt><dd><p>The directory where the Python was installed</p>


### PR DESCRIPTION
## Summary

This PR adds a check if a managed Python is still being used by any tool before uninstalling it. If it is, we won’t uninstall it unless you use the `--force` flag. This way, we avoid messing up any tools you have installed.

Could this be a breaking change?
