### PR TITLE
fix(ui): update version formatting to use cyan color

### DIFF
--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -96,11 +96,11 @@ pub(crate) async fn self_update(
             let version_information = if let Some(old_version) = result.old_version {
                 format!(
                     "from {} to {}",
-                    format!("v{old_version}").bold().white(),
-                    format!("v{}", result.new_version).bold().white(),
+                    format!("v{old_version}").bold().cyan(),
+                    format!("v{}", result.new_version).bold().cyan(),
                 )
             } else {
-                format!("to {}", format!("v{}", result.new_version).bold().white())
+                format!("to {}", format!("v{}", result.new_version).bold().cyan())
             };
 
             writeln!(
@@ -127,7 +127,7 @@ pub(crate) async fn self_update(
                     "{}{} You're on the latest version of uv ({})",
                     "success".green().bold(),
                     ":".bold(),
-                    format!("v{}", env!("CARGO_PKG_VERSION")).bold().white()
+                    format!("v{}", env!("CARGO_PKG_VERSION")).bold().cyan()
                 )
             )?;
         }


### PR DESCRIPTION
## Summary

This PR simplifies the version formatting by replacing `.white()` with `.cyan()` styling for consistency.

Resolves #12940 

## Test Plan

I manually recreated the code and tested it with this patch:

```diff
diff --git i/crates/uv/src/lib.rs w/crates/uv/src/lib.rs
index b9c01b002..cf051351f 100644
--- i/crates/uv/src/lib.rs
+++ w/crates/uv/src/lib.rs
@@ -1019,6 +1019,20 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }) => commands::self_update(target_version, token, printer).await,
         #[cfg(not(feature = "self-update"))]
         Commands::Self_(_) => {
+            eprintln!("{}: {}", "error".cyan().bold(), "fake error message");
+
+            let version_information = format!(
+                "from {} to {}",
+                "v0.1.1".bold().cyan(),
+                "v0.1.2".bold().cyan(),
+            );
+            eprintln!(
+                "{}{} Upgraded uv {}! {}",
+                "success".green().bold(),
+                ":".bold(),
+                version_information,
+                format!("https://github.com/astral-sh/uv/releases/tag/{}", "v0.1.2").cyan()
+            );
             anyhow::bail!(
                 "uv was installed through an external package manager, and self-update \
                 is not available. Please use your package manager to update uv."
```

In a light terminal, this is what it looks like:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/dc0d283c-e845-41fb-9821-80b0a3f1c4fe" />
