### PR TITLE
Add `uv add --bounds` to configure the version constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4875,6 +4875,7 @@ dependencies = [
  "uv-torch",
  "uv-version",
  "uv-warnings",
+ "uv-workspace",
 ]
 
 [[package]]
@@ -5736,6 +5737,7 @@ dependencies = [
  "uv-static",
  "uv-torch",
  "uv-warnings",
+ "uv-workspace",
 ]
 
 [[package]]
@@ -5897,6 +5899,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "assert_fs",
+ "clap",
  "fs-err 3.1.0",
  "glob",
  "insta",

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -31,6 +31,7 @@ uv-static = { workspace = true }
 uv-torch = { workspace = true, features = ["clap"] }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
+uv-workspace = { workspace = true }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -22,6 +22,7 @@ use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_resolver::{AnnotationStyle, ExcludeNewer, ForkStrategy, PrereleaseMode, ResolutionMode};
 use uv_static::EnvVars;
 use uv_torch::TorchMode;
+use uv_workspace::pyproject_mut::DependencyBoundDefault;
 
 pub mod comma;
 pub mod compat;
@@ -731,10 +732,6 @@ pub enum ProjectCommand {
     /// If a given dependency exists already, it will be updated to the new version specifier unless
     /// it includes markers that differ from the existing specifier in which case another entry for
     /// the dependency will be added.
-    ///
-    /// If no constraint or URL is provided for a dependency, a lower bound is added equal to the
-    /// latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in
-    /// which case no resolution is performed.
     ///
     /// The lockfile and project environment will be updated to reflect the added dependencies. To
     /// skip updating the lockfile, use `--frozen`. To skip updating the environment, use
@@ -3441,6 +3438,14 @@ pub struct AddArgs {
         conflicts_with = "branch"
     )]
     pub raw_sources: bool,
+
+    /// The kind of version specifier for newly added dependencies.
+    ///
+    /// If no constraint or URL is provided for a dependency, a bound is added based on the
+    /// latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in
+    /// which case no resolution is performed.
+    #[arg(long, value_enum)]
+    pub bounds: Option<DependencyBoundDefault>,
 
     /// Commit to use when adding a dependency from Git.
     #[arg(long, group = "git-ref", action = clap::ArgAction::Set)]

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -32,6 +32,7 @@ uv-resolver = { workspace = true, features = ["schemars", "clap"] }
 uv-static = { workspace = true }
 uv-torch = { workspace = true, features = ["schemars", "clap"] }
 uv-warnings = { workspace = true }
+uv-workspace = { workspace = true, features = ["schemars", "clap"] }
 
 clap = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -13,6 +13,7 @@ use uv_pypi_types::{SchemaConflicts, SupportedEnvironments};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_resolver::{AnnotationStyle, ExcludeNewer, ForkStrategy, PrereleaseMode, ResolutionMode};
 use uv_torch::TorchMode;
+use uv_workspace::pyproject_mut::DependencyBoundDefault;
 
 use crate::{FilesystemOptions, Options, PipOptions};
 
@@ -73,6 +74,7 @@ macro_rules! impl_combine_or {
     };
 }
 
+impl_combine_or!(DependencyBoundDefault);
 impl_combine_or!(AnnotationStyle);
 impl_combine_or!(ExcludeNewer);
 impl_combine_or!(ForkStrategy);

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -20,6 +20,7 @@ use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_resolver::{AnnotationStyle, ExcludeNewer, ForkStrategy, PrereleaseMode, ResolutionMode};
 use uv_static::EnvVars;
 use uv_torch::TorchMode;
+use uv_workspace::pyproject_mut::DependencyBoundDefault;
 
 /// A `pyproject.toml` with an (optional) `[tool.uv]` section.
 #[allow(dead_code)]
@@ -52,6 +53,9 @@ pub struct Options {
 
     #[serde(flatten)]
     pub publish: PublishOptions,
+
+    #[serde(flatten)]
+    pub edit: EditOptions,
 
     #[option_group]
     pub pip: Option<PipOptions>,
@@ -1818,6 +1822,10 @@ pub struct OptionsWire {
     trusted_publishing: Option<TrustedPublishing>,
     check_url: Option<IndexUrl>,
 
+    // #[serde(flatten)]
+    // edit: EditOptions
+    bounds: Option<DependencyBoundDefault>,
+
     pip: Option<PipOptions>,
     cache_keys: Option<Vec<CacheKey>>,
 
@@ -1906,6 +1914,7 @@ impl From<OptionsWire> for Options {
             dev_dependencies,
             managed,
             package,
+            bounds,
             // Used by the build backend
             build_backend: _,
         } = value;
@@ -1971,6 +1980,7 @@ impl From<OptionsWire> for Options {
                 trusted_publishing,
                 check_url,
             },
+            edit: EditOptions { bounds },
             workspace,
             sources,
             dev_dependencies,
@@ -2031,4 +2041,24 @@ pub struct PublishOptions {
         "#
     )]
     pub check_url: Option<IndexUrl>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, CombineOptions, OptionsMetadata)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct EditOptions {
+    /// The default version specifier when adding a dependency.
+    ///
+    /// If no constraint or URL is provided for a dependency, a bound is added based on the
+    /// latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in
+    /// which case no resolution is performed.
+    #[option(
+        default = "\"lower\"",
+        value_type = "str",
+        example = r#"
+            bounds = "major"
+        "#,
+        possible_values = true
+    )]
+    pub bounds: Option<DependencyBoundDefault>,
 }

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -29,6 +29,7 @@ uv-pypi-types = { workspace = true }
 uv-static = { workspace = true }
 uv-warnings = { workspace = true }
 
+clap = { workspace = true, optional = true }
 fs-err = { workspace = true }
 glob = { workspace = true }
 itertools = { workspace = true }

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1,9 +1,10 @@
 use std::cmp::Ordering;
 use std::path::Path;
 use std::str::FromStr;
-use std::{fmt, mem};
+use std::{fmt, iter, mem};
 
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use toml_edit::{
     Array, ArrayOfTables, DocumentMut, Formatted, Item, RawString, Table, TomlError, Value,
@@ -49,6 +50,8 @@ pub enum Error {
         package_name: PackageName,
         requirements: Vec<Requirement>,
     },
+    #[error("Unknown bound king {0}")]
+    UnknownBoundKind(String),
 }
 
 /// The result of editing an array in a TOML document.
@@ -78,6 +81,76 @@ impl ArrayEdit {
     pub fn index(&self) -> usize {
         match self {
             Self::Update(i) | Self::Add(i) => *i,
+        }
+    }
+}
+
+/// The default version specifier when adding a dependency.
+// There is an implicit assumption that version numbers have three digits. While PEP 440
+// allows an arbitrary number of version digits, most projects stick to two or three digits, which
+// we can treat like a SemVer major.minor.patch.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum DependencyBoundDefault {
+    /// Only a lower bound, e.g., `>=1.2.3`.
+    #[default]
+    Lower,
+    /// Allow the same major version, similar to the semver caret, e.g., `>=1.2.3,<2.0.0`.
+    Major,
+    /// Allow the same minor version, similar to the semver tilde does, `>=1.2.3,<1.3.0`.
+    Minor,
+    /// Pin the exact version, e.g., `==1.2.3`.
+    ///
+    /// This option is not recommended, as uv provides a lockfiles that pins versions.
+    Exact,
+}
+
+impl DependencyBoundDefault {
+    fn specifiers(self, version: Version) -> VersionSpecifiers {
+        match self {
+            DependencyBoundDefault::Lower => {
+                VersionSpecifiers::from(VersionSpecifier::greater_than_equal_version(version))
+            }
+            DependencyBoundDefault::Major => {
+                // Compute the new major version and pad it to the same length:
+                // 1.2.3 -> 2.0.0
+                // 1.2 -> 2.0
+                // 1 -> 2
+                let next_major = version.release()[0] + 1;
+                let upper_bound = Version::new(
+                    iter::once(next_major)
+                        .chain(iter::repeat_n(0, version.release().iter().skip(1).len())),
+                );
+
+                VersionSpecifiers::from_iter([
+                    VersionSpecifier::greater_than_equal_version(version),
+                    VersionSpecifier::less_than_version(upper_bound),
+                ])
+            }
+            DependencyBoundDefault::Minor => {
+                // Compute the new minor version and pad it to the same length where possible:
+                // 1.2.3 -> 1.3.0
+                // 1.2 -> 1.3
+                // 1 -> 1.1
+
+                // If the version has only one digit, say `1`, pad with zeroes.
+                let next_minor = version.release().get(1).copied().unwrap_or(0) + 1;
+                let upper_bound = Version::new(
+                    iter::once(version.release()[0])
+                        .chain(iter::once(next_minor))
+                        .chain(iter::repeat_n(0, version.release().iter().skip(2).len())),
+                );
+
+                VersionSpecifiers::from_iter([
+                    VersionSpecifier::greater_than_equal_version(version),
+                    VersionSpecifier::less_than_version(upper_bound),
+                ])
+            }
+            DependencyBoundDefault::Exact => {
+                VersionSpecifiers::from_iter([VersionSpecifier::equals_version(version)])
+            }
         }
     }
 }
@@ -519,20 +592,19 @@ impl PyProjectTomlMut {
     }
 
     /// Set the minimum version for an existing dependency.
-    pub fn set_dependency_minimum_version(
+    pub fn set_dependency_bound(
         &mut self,
         dependency_type: &DependencyType,
         index: usize,
         version: Version,
+        bound_kind: &DependencyBoundDefault,
     ) -> Result<(), Error> {
         let group = match dependency_type {
-            DependencyType::Production => self.set_project_dependency_minimum_version()?,
-            DependencyType::Dev => self.set_dev_dependency_minimum_version()?,
-            DependencyType::Optional(ref extra) => {
-                self.set_optional_dependency_minimum_version(extra)?
-            }
+            DependencyType::Production => self.set_project_dependency_bound()?,
+            DependencyType::Dev => self.set_dev_dependency_bound()?,
+            DependencyType::Optional(ref extra) => self.set_optional_dependency_bound(extra)?,
             DependencyType::Group(ref group) => {
-                self.set_dependency_group_requirement_minimum_version(group)?
+                self.set_dependency_group_requirement_bound(group)?
             }
         };
 
@@ -544,16 +616,16 @@ impl PyProjectTomlMut {
             .as_str()
             .and_then(try_parse_requirement)
             .ok_or(Error::MalformedDependencies)?;
-        req.version_or_url = Some(VersionOrUrl::VersionSpecifier(VersionSpecifiers::from(
-            VersionSpecifier::greater_than_equal_version(version),
-        )));
+        req.version_or_url = Some(VersionOrUrl::VersionSpecifier(
+            bound_kind.specifiers(version),
+        ));
         group.replace(index, req.to_string());
 
         Ok(())
     }
 
     /// Set the minimum version for an existing dependency in `project.dependencies`.
-    fn set_project_dependency_minimum_version(&mut self) -> Result<&mut Array, Error> {
+    fn set_project_dependency_bound(&mut self) -> Result<&mut Array, Error> {
         // Get or create `project.dependencies`.
         let dependencies = self
             .project()?
@@ -566,7 +638,7 @@ impl PyProjectTomlMut {
     }
 
     /// Set the minimum version for an existing dependency in `tool.uv.dev-dependencies`.
-    fn set_dev_dependency_minimum_version(&mut self) -> Result<&mut Array, Error> {
+    fn set_dev_dependency_bound(&mut self) -> Result<&mut Array, Error> {
         // Get or create `tool.uv.dev-dependencies`.
         let dev_dependencies = self
             .doc
@@ -587,10 +659,7 @@ impl PyProjectTomlMut {
     }
 
     /// Set the minimum version for an existing dependency in `project.optional-dependencies`.
-    fn set_optional_dependency_minimum_version(
-        &mut self,
-        group: &ExtraName,
-    ) -> Result<&mut Array, Error> {
+    fn set_optional_dependency_bound(&mut self, group: &ExtraName) -> Result<&mut Array, Error> {
         // Get or create `project.optional-dependencies`.
         let optional_dependencies = self
             .project()?
@@ -619,7 +688,7 @@ impl PyProjectTomlMut {
     }
 
     /// Set the minimum version for an existing dependency in `dependency-groups`.
-    fn set_dependency_group_requirement_minimum_version(
+    fn set_dependency_group_requirement_bound(
         &mut self,
         group: &GroupName,
     ) -> Result<&mut Array, Error> {
@@ -1421,7 +1490,9 @@ fn split_specifiers(req: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod test {
-    use super::split_specifiers;
+    use super::{split_specifiers, DependencyBoundDefault};
+    use std::str::FromStr;
+    use uv_pep440::Version;
 
     #[test]
     fn split() {
@@ -1433,5 +1504,66 @@ mod test {
         );
         assert_eq!(split_specifiers("flask[dotenv]"), ("flask[dotenv]", ""));
         assert_eq!(split_specifiers("flask @ https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl"), ("flask", "@ https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl"));
+    }
+
+    #[test]
+    fn bound_kind_to_specifiers() {
+        let tests = [
+            (DependencyBoundDefault::Exact, "1", "==1"),
+            (DependencyBoundDefault::Exact, "1.0.0", "==1.0.0"),
+            (DependencyBoundDefault::Exact, "1.2", "==1.2"),
+            (DependencyBoundDefault::Exact, "1.2.3", "==1.2.3"),
+            (DependencyBoundDefault::Exact, "1.2.3.4", "==1.2.3.4"),
+            (
+                DependencyBoundDefault::Exact,
+                "1.2.3.4a1.post1",
+                "==1.2.3.4a1.post1",
+            ),
+            (DependencyBoundDefault::Lower, "1", ">=1"),
+            (DependencyBoundDefault::Lower, "1.0.0", ">=1.0.0"),
+            (DependencyBoundDefault::Lower, "1.2", ">=1.2"),
+            (DependencyBoundDefault::Lower, "1.2.3", ">=1.2.3"),
+            (DependencyBoundDefault::Lower, "1.2.3.4", ">=1.2.3.4"),
+            (
+                DependencyBoundDefault::Lower,
+                "1.2.3.4a1.post1",
+                ">=1.2.3.4a1.post1",
+            ),
+            (DependencyBoundDefault::Major, "1", ">=1, <2"),
+            (DependencyBoundDefault::Major, "1.0.0", ">=1.0.0, <2.0.0"),
+            (DependencyBoundDefault::Major, "1.2", ">=1.2, <2.0"),
+            (DependencyBoundDefault::Major, "1.2.3", ">=1.2.3, <2.0.0"),
+            (
+                DependencyBoundDefault::Major,
+                "1.2.3.4",
+                ">=1.2.3.4, <2.0.0.0",
+            ),
+            (
+                DependencyBoundDefault::Major,
+                "1.2.3.4a1.post1",
+                ">=1.2.3.4a1.post1, <2.0.0.0",
+            ),
+            (DependencyBoundDefault::Minor, "1", ">=1, <1.1"),
+            (DependencyBoundDefault::Minor, "1.0.0", ">=1.0.0, <1.1.0"),
+            (DependencyBoundDefault::Minor, "1.2", ">=1.2, <1.3"),
+            (DependencyBoundDefault::Minor, "1.2.3", ">=1.2.3, <1.3.0"),
+            (
+                DependencyBoundDefault::Minor,
+                "1.2.3.4",
+                ">=1.2.3.4, <1.3.0.0",
+            ),
+            (
+                DependencyBoundDefault::Minor,
+                "1.2.3.4a1.post1",
+                ">=1.2.3.4a1.post1, <1.3.0.0",
+            ),
+        ];
+
+        for (kind, version, expected) in tests {
+            let actual = kind
+                .specifiers(Version::from_str(version).unwrap())
+                .to_string();
+            assert_eq!(actual, expected);
+        }
     }
 }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -57,7 +57,7 @@ uv-types = { workspace = true }
 uv-version = { workspace = true }
 uv-virtualenv = { workspace = true }
 uv-warnings = { workspace = true }
-uv-workspace = { workspace = true }
+uv-workspace = { workspace = true, features = ["clap"] }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -41,7 +41,9 @@ use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::{DependencyType, Source, SourceError};
-use uv_workspace::pyproject_mut::{ArrayEdit, DependencyTarget, PyProjectTomlMut};
+use uv_workspace::pyproject_mut::{
+    ArrayEdit, DependencyBoundDefault, DependencyTarget, PyProjectTomlMut,
+};
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::pip::loggers::{
@@ -74,6 +76,7 @@ pub(crate) async fn add(
     editable: Option<bool>,
     dependency_type: DependencyType,
     raw_sources: bool,
+    build_kind: DependencyBoundDefault,
     indexes: Vec<Index>,
     rev: Option<String>,
     tag: Option<String>,
@@ -519,6 +522,7 @@ pub(crate) async fn add(
         locked,
         &dependency_type,
         raw_sources,
+        &build_kind,
         constraints,
         &settings,
         &network_settings,
@@ -732,6 +736,7 @@ async fn lock_and_sync(
     locked: bool,
     dependency_type: &DependencyType,
     raw_sources: bool,
+    bound_kind: &DependencyBoundDefault,
     constraints: Vec<NameRequirementSpecification>,
     settings: &ResolverInstallerSettings,
     network_settings: &NetworkSettings,
@@ -819,7 +824,7 @@ async fn lock_and_sync(
             // For example, convert `1.2.3+local` to `1.2.3`.
             let minimum = (*minimum).clone().without_local();
 
-            toml.set_dependency_minimum_version(&edit.dependency_type, *index, minimum)?;
+            toml.set_dependency_bound(&edit.dependency_type, *index, minimum, bound_kind)?;
 
             modified = true;
         }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1794,6 +1794,7 @@ async fn run_project(
                 args.editable,
                 args.dependency_type,
                 args.raw_sources,
+                args.bounds,
                 args.indexes,
                 args.rev,
                 args.tag,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -45,6 +45,7 @@ use uv_static::EnvVars;
 use uv_torch::TorchMode;
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::DependencyType;
+use uv_workspace::pyproject_mut::DependencyBoundDefault;
 
 use crate::commands::ToolRunCommand;
 use crate::commands::{pip::operations::Modifications, InitKind, InitProjectKind};
@@ -1224,6 +1225,7 @@ pub(crate) struct AddSettings {
     pub(crate) editable: Option<bool>,
     pub(crate) extras: Vec<ExtraName>,
     pub(crate) raw_sources: bool,
+    pub(crate) bounds: DependencyBoundDefault,
     pub(crate) rev: Option<String>,
     pub(crate) tag: Option<String>,
     pub(crate) branch: Option<String>,
@@ -1252,6 +1254,7 @@ impl AddSettings {
             no_editable,
             extra,
             raw_sources,
+            bounds,
             rev,
             tag,
             branch,
@@ -1325,8 +1328,12 @@ impl AddSettings {
         }
 
         let install_mirrors = filesystem
-            .clone()
+            .as_ref()
             .map(|fs| fs.install_mirrors.clone())
+            .unwrap_or_default();
+
+        let bounds = bounds
+            .or(filesystem.as_ref().and_then(|fs| fs.edit.bounds))
             .unwrap_or_default();
 
         Self {
@@ -1343,6 +1350,7 @@ impl AddSettings {
             marker,
             dependency_type,
             raw_sources,
+            bounds,
             rev,
             tag,
             branch,

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -10777,3 +10777,120 @@ fn add_optional_normalize() -> Result<()> {
 
     Ok(())
 }
+
+/// Add a PyPI requirement with the given bounds.
+#[test]
+fn add_bounds() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Set bounds in `uv.toml`
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(indoc! {r#"
+        bounds = "exact"
+    "#})?;
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("idna"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + idna==3.6
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+    assert_snapshot!(
+        pyproject_toml, @r#"
+    [project]
+    name = "project"
+    version = "0.1.0"
+    requires-python = ">=3.12"
+    dependencies = [
+        "idna==3.6",
+    ]
+    "#
+    );
+
+    fs_err::remove_file(uv_toml)?;
+
+    // Set bounds in `pyproject.toml`
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [tool.uv]
+        bounds = "major"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + anyio==4.3.0
+     + sniffio==1.3.1
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+    assert_snapshot!(
+        pyproject_toml, @r#"
+    [project]
+    name = "project"
+    version = "0.1.0"
+    requires-python = ">=3.12"
+    dependencies = [
+        "anyio>=4.3.0,<5.0.0",
+    ]
+
+    [tool.uv]
+    bounds = "major"
+    "#
+    );
+
+    // Set bounds on the CLI
+    uv_snapshot!(context.filters(), context.add().arg("sniffio").arg("--bounds").arg("minor"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Audited 3 packages in [TIME]
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+    assert_snapshot!(
+        pyproject_toml, @r#"
+    [project]
+    name = "project"
+    version = "0.1.0"
+    requires-python = ">=3.12"
+    dependencies = [
+        "anyio>=4.3.0,<5.0.0",
+        "sniffio>=1.3.1,<1.4.0",
+    ]
+
+    [tool.uv]
+    bounds = "major"
+    "#
+    );
+
+    Ok(())
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -743,8 +743,6 @@ Dependencies are added to the project's `pyproject.toml` file.
 
 If a given dependency exists already, it will be updated to the new version specifier unless it includes markers that differ from the existing specifier in which case another entry for the dependency will be added.
 
-If no constraint or URL is provided for a dependency, a lower bound is added equal to the latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in which case no resolution is performed.
-
 The lockfile and project environment will be updated to reflect the added dependencies. To skip updating the lockfile, use `--frozen`. To skip updating the environment, use `--no-sync`.
 
 If any of the requested dependencies cannot be found, uv will exit with an error, unless the `--frozen` flag is provided, in which case uv will add the dependencies verbatim without checking that they exist or are compatible with the project.
@@ -778,6 +776,21 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 <p>WARNING: Hosts included in this list will not be verified against the system&#8217;s certificate store. Only use <code>--allow-insecure-host</code> in a secure network with verified sources, as it bypasses SSL verification and could expose you to MITM attacks.</p>
 
 <p>May also be set with the <code>UV_INSECURE_HOST</code> environment variable.</p>
+</dd><dt id="uv-add--bounds"><a href="#uv-add--bounds"><code>--bounds</code></a> <i>bounds</i></dt><dd><p>The kind of version specifier for newly added dependencies.</p>
+
+<p>If no constraint or URL is provided for a dependency, a bound is added based on the latest compatible version of the package, e.g., <code>&gt;=1.2.3</code>, unless <code>--frozen</code> is provided, in which case no resolution is performed.</p>
+
+<p>Possible values:</p>
+
+<ul>
+<li><code>lower</code>:  Only a lower bound, e.g., <code>&gt;=1.2.3</code></li>
+
+<li><code>major</code>:  Allow the same major version, similar to the semver caret, e.g., <code>&gt;=1.2.3,&lt;2.0.0</code></li>
+
+<li><code>minor</code>:  Allow the same minor version, similar to the semver tilde does, <code>&gt;=1.2.3,&lt;1.3.0</code></li>
+
+<li><code>exact</code>:  Pin the exact version, e.g., <code>==1.2.3</code></li>
+</ul>
 </dd><dt id="uv-add--branch"><a href="#uv-add--branch"><code>--branch</code></a> <i>branch</i></dt><dd><p>Branch to use when adding a dependency from Git</p>
 
 </dd><dt id="uv-add--cache-dir"><a href="#uv-add--cache-dir"><code>--cache-dir</code></a> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -446,6 +446,39 @@ bypasses SSL verification and could expose you to MITM attacks.
 
 ---
 
+### [`bounds`](#bounds) {: #bounds }
+
+The default version specifier when adding a dependency.
+
+If no constraint or URL is provided for a dependency, a bound is added based on the
+latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in
+which case no resolution is performed.
+
+**Default value**: `"lower"`
+
+**Possible values**:
+
+- `"lower"`: Only a lower bound, e.g., `>=1.2.3`
+- `"major"`: Allow the same major version, similar to the semver caret, e.g., `>=1.2.3,<2.0.0`
+- `"minor"`: Allow the same minor version, similar to the semver tilde does, `>=1.2.3,<1.3.0`
+- `"exact"`: Pin the exact version, e.g., `==1.2.3`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.uv]
+    bounds = "major"
+    ```
+=== "uv.toml"
+
+    ```toml
+    bounds = "major"
+    ```
+
+---
+
 ### [`cache-dir`](#cache-dir) {: #cache-dir }
 
 Path to the cache directory.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -14,6 +14,17 @@
         "$ref": "#/definitions/TrustedHost"
       }
     },
+    "bounds": {
+      "description": "The default version specifier when adding a dependency.\n\nIf no constraint or URL is provided for a dependency, a bound is added based on the latest compatible version of the package, e.g., `>=1.2.3`, unless `--frozen` is provided, in which case no resolution is performed.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DependencyBoundDefault"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "build-constraint-dependencies": {
       "description": "PEP 508-style requirements, e.g., `ruff==0.5.0`, or `ruff @ https://...`.",
       "type": [
@@ -709,6 +720,39 @@
             }
           },
           "additionalProperties": false
+        }
+      ]
+    },
+    "DependencyBoundDefault": {
+      "description": "The default version specifier when adding a dependency.",
+      "oneOf": [
+        {
+          "description": "Only a lower bound, e.g., `>=1.2.3`.",
+          "type": "string",
+          "enum": [
+            "lower"
+          ]
+        },
+        {
+          "description": "Allow the same major version, similar to the semver caret, e.g., `>=1.2.3,<2.0.0`.",
+          "type": "string",
+          "enum": [
+            "major"
+          ]
+        },
+        {
+          "description": "Allow the same minor version, similar to the semver tilde does, `>=1.2.3,<1.3.0`.",
+          "type": "string",
+          "enum": [
+            "minor"
+          ]
+        },
+        {
+          "description": "Pin the exact version, e.g., `==1.2.3`.\n\nThis option is not recommended, as uv provides a lockfiles that pins versions.",
+          "type": "string",
+          "enum": [
+            "exact"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Add support for configuring the kind of version constraint that `uv add` uses.

By default, uv uses only a lower bound. We add two options that add an upper bound on the constraint, one for SemVer (`>=1.2.3,<2.0.0`, modeled after the SemVer caret) and another one for project that make breaking changes in minor version (`>=1.2.3,<1.3.0`, modeled after the SemVer tilde). There is also an exact bounds option (`==1.2.3`), though generally we recommend setting a bound and using the lockfile for pinning.

The bound can be configured in `uv.toml`, as a user preference, in `pyproject.toml`, as a project preference, or on the CLI, when adding a specific project.

TODO: 0.x version semantics

The names of the bounds and the name of the flag is up for bikeshedding. Currently the option is call `tool.uv.bounds`, but we could also move it under `tool.uv.edit.bounds`, where it would be the first/only entry.

Fixes #6783