### PR TITLE
Align supported Config-settings with example in docs

### DIFF
--- a/crates/uv-configuration/src/config_settings.rs
+++ b/crates/uv-configuration/src/config_settings.rs
@@ -29,7 +29,7 @@ impl FromStr for ConfigSettingEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema), schemars(untagged))]
 enum ConfigSettingValue {
     /// The value consists of a single string.
     String(String),

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -645,35 +645,17 @@
       ]
     },
     "ConfigSettingValue": {
-      "oneOf": [
+      "anyOf": [
         {
           "description": "The value consists of a single string.",
-          "type": "object",
-          "required": [
-            "String"
-          ],
-          "properties": {
-            "String": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+          "type": "string"
         },
         {
           "description": "The value consists of a list of strings.",
-          "type": "object",
-          "required": [
-            "List"
-          ],
-          "properties": {
-            "List": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "additionalProperties": false
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       ]
     },


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes #12929
## Summary
Untag the `config-settings` value to support JSON schema according to the [docs](https://docs.astral.sh/uv/reference/settings/#config-settings). 
```toml
[tool.uv]
config-settings = { editable_mode = "compat" }
```
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Verified using the "Even Better TOML" extension with paths to old and new `uv.schema.json`.


## Notes
I could not reproduce the issue with either the `taplo` (on which Even Better Toml is built, afaik) and `check-jsonschema` CLI tools; with both old and new versions of the `uv.schema.json` validated the `pyproject.toml`.

Maybe for these there is some additional regularization going on and that's also how a breaking case ended up in the docs? 
I'm unsure on how to test for this.

After about an hour, the Even better TOML VSCode extension was the only way to reproduce failing validation.

Let me know if I can do something else.

<!-- How was it tested? -->
