### PR TITLE
Accept `requirements.txt` (verbatim) as a format on the CLI

### DIFF
--- a/crates/uv-configuration/src/export_format.rs
+++ b/crates/uv-configuration/src/export_format.rs
@@ -2,9 +2,13 @@
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ExportFormat {
     /// Export in `requirements.txt` format.
     #[default]
+    #[serde(rename = "requirements.txt", alias = "requirements-txt")]
+    #[cfg_attr(
+        feature = "clap",
+        clap(name = "requirements.txt", alias = "requirements-txt")
+    )]
     RequirementsTxt,
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2332,11 +2332,11 @@ uv export [OPTIONS]
 
 <p>At present, only <code>requirements-txt</code> is supported.</p>
 
-<p>[default: requirements-txt]</p>
+<p>[default: requirements.txt]</p>
 <p>Possible values:</p>
 
 <ul>
-<li><code>requirements-txt</code>:  Export in <code>requirements.txt</code> format</li>
+<li><code>requirements.txt</code>:  Export in <code>requirements.txt</code> format</li>
 </ul>
 </dd><dt id="uv-export--frozen"><a href="#uv-export--frozen"><code>--frozen</code></a></dt><dd><p>Do not update the <code>uv.lock</code> before exporting.</p>
 


### PR DESCRIPTION
## Summary

Right now, you have to do `--format requirements-txt`, which seems confusing? We now accept both `requirements.txt` and `requirements-txt`.
