### PR TITLE
Improve formatting for `"all"` `default-groups` setting documentation

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -343,7 +343,7 @@ pub struct ToolUv {
 
     /// The list of `dependency-groups` to install by default.
     ///
-    /// Can also be the literal "all" to default enable all groups.
+    /// Can also be the literal `"all"` to default enable all groups.
     #[option(
         default = r#"["dev"]"#,
         value_type = r#"str | list[str]"#,

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -112,7 +112,7 @@ constraint-dependencies = ["grpcio<1.65"]
 
 The list of `dependency-groups` to install by default.
 
-Can also be the literal "all" to default enable all groups.
+Can also be the literal `"all"` to default enable all groups.
 
 **Default value**: `["dev"]`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -119,7 +119,7 @@
       }
     },
     "default-groups": {
-      "description": "The list of `dependency-groups` to install by default.\n\nCan also be the literal \"all\" to default enable all groups.",
+      "description": "The list of `dependency-groups` to install by default.\n\nCan also be the literal `\"all\"` to default enable all groups.",
       "anyOf": [
         {
           "$ref": "#/definitions/DefaultGroups"


### PR DESCRIPTION
## Summary

Make the documentation for `"all"` `defauilt-groups` a little easier to read by monospacing the literal.
