### PR TITLE
Refactor `ExtraSpecification` to support `default-extras`

### DIFF
--- a/crates/uv-configuration/src/extras.rs
+++ b/crates/uv-configuration/src/extras.rs
@@ -1,174 +1,318 @@
-use rustc_hash::FxHashSet;
-use uv_normalize::ExtraName;
+use std::{borrow::Cow, sync::Arc};
 
+use uv_normalize::{DefaultExtras, ExtraName};
+
+/// Manager of all extra decisions and settings history.
+///
+/// This is an Arc mostly just to avoid size bloat on things that contain these.
 #[derive(Debug, Default, Clone)]
-pub enum ExtrasSpecification {
-    #[default]
-    None,
-    All,
-    Some(Vec<ExtraName>),
-    Exclude(FxHashSet<ExtraName>),
+pub struct ExtrasSpecification(Arc<ExtrasSpecificationInner>);
+
+/// Manager of all dependency-group decisions and settings history.
+#[derive(Debug, Default, Clone)]
+pub struct ExtrasSpecificationInner {
+    /// Extras to include.
+    include: IncludeExtras,
+    /// Extras to exclude (always wins over include).
+    exclude: Vec<ExtraName>,
+    /// Whether an `--only` flag was passed.
+    ///
+    /// If true, users of this API should refrain from looking at packages
+    /// that *aren't* specified by the extras. This is exposed
+    /// via [`ExtrasSpecificationInner::prod`][].
+    only_extras: bool,
+    /// The "raw" flags/settings we were passed for diagnostics.
+    history: ExtrasSpecificationHistory,
 }
 
 impl ExtrasSpecification {
-    /// Determine the extras specification to use based on the command-line arguments.
-    pub fn from_args(
-        all_extras: bool,
-        no_extra: Vec<ExtraName>,
-        mut extra: Vec<ExtraName>,
-    ) -> Self {
-        if all_extras && !no_extra.is_empty() {
-            ExtrasSpecification::Exclude(FxHashSet::from_iter(no_extra))
-        } else if all_extras {
-            ExtrasSpecification::All
-        } else if extra.is_empty() {
-            ExtrasSpecification::None
+    /// Create from history.
+    ///
+    /// This is the "real" constructor, it's basically taking raw CLI flags but in
+    /// a way that's a bit nicer for other constructors to use.
+    fn from_history(history: ExtrasSpecificationHistory) -> Self {
+        let ExtrasSpecificationHistory {
+            mut extra,
+            mut only_extra,
+            no_extra,
+            all_extras,
+            no_default_extras,
+            mut defaults,
+        } = history.clone();
+
+        // `extra` and `only_extra` actually have the same meanings: packages to include.
+        // But if `only_extra` is non-empty then *other* packages should be excluded.
+        // So we just record whether it was and then treat the two lists as equivalent.
+        let only_extras = !only_extra.is_empty();
+        // --only flags imply --no-default-extras
+        let default_extras = !no_default_extras && !only_extras;
+
+        let include = if all_extras {
+            // If this is set we can ignore extra/only_extra/defaults as irrelevant.
+            IncludeExtras::All
         } else {
-            // If a package is included in both `no_extra` and `extra`, it should be excluded.
-            extra.retain(|name| !no_extra.contains(name));
-            ExtrasSpecification::Some(extra)
-        }
-    }
-
-    /// Returns true if a name is included in the extra specification.
-    pub fn contains(&self, name: &ExtraName) -> bool {
-        match self {
-            ExtrasSpecification::All => true,
-            ExtrasSpecification::None => false,
-            ExtrasSpecification::Some(extras) => extras.contains(name),
-            ExtrasSpecification::Exclude(excluded) => !excluded.contains(name),
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        matches!(self, ExtrasSpecification::None)
-    }
-
-    pub fn extra_names<'a, Names>(&'a self, all_names: Names) -> ExtrasIter<'a, Names>
-    where
-        Names: Iterator<Item = &'a ExtraName>,
-    {
-        match self {
-            ExtrasSpecification::All => ExtrasIter::All(all_names),
-            ExtrasSpecification::None => ExtrasIter::None,
-            ExtrasSpecification::Some(extras) => ExtrasIter::Some(extras.iter()),
-            ExtrasSpecification::Exclude(excluded) => ExtrasIter::Exclude(all_names, excluded),
-        }
-    }
-}
-
-/// An iterator over the extra names to include.
-#[derive(Debug)]
-pub enum ExtrasIter<'a, Names: Iterator<Item = &'a ExtraName>> {
-    None,
-    All(Names),
-    Some(std::slice::Iter<'a, ExtraName>),
-    Exclude(Names, &'a FxHashSet<ExtraName>),
-}
-
-impl<'a, Names: Iterator<Item = &'a ExtraName>> Iterator for ExtrasIter<'a, Names> {
-    type Item = &'a ExtraName;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Self::All(names) => names.next(),
-            Self::None => None,
-            Self::Some(extras) => extras.next(),
-            Self::Exclude(names, excluded) => {
-                for name in names.by_ref() {
-                    if !excluded.contains(name) {
-                        return Some(name);
+            // Merge all these lists, they're equivalent now
+            extra.append(&mut only_extra);
+            // Resolve default extras potentially also setting All
+            if default_extras {
+                match &mut defaults {
+                    DefaultExtras::All => IncludeExtras::All,
+                    DefaultExtras::List(defaults) => {
+                        extra.append(defaults);
+                        IncludeExtras::Some(extra)
                     }
                 }
-                None
+            } else {
+                IncludeExtras::Some(extra)
             }
+        };
+
+        Self(Arc::new(ExtrasSpecificationInner {
+            include,
+            exclude: no_extra,
+            only_extras,
+            history,
+        }))
+    }
+
+    /// Create from raw CLI args
+    #[allow(clippy::fn_params_excessive_bools)]
+    pub fn from_args(
+        extra: Vec<ExtraName>,
+        no_extra: Vec<ExtraName>,
+        no_default_extras: bool,
+        only_extra: Vec<ExtraName>,
+        all_extras: bool,
+    ) -> Self {
+        Self::from_history(ExtrasSpecificationHistory {
+            extra,
+            only_extra,
+            no_extra,
+            all_extras,
+            no_default_extras,
+            // This is unknown at CLI-time, use `.with_defaults(...)` to apply this later!
+            defaults: DefaultExtras::default(),
+        })
+    }
+
+    /// Helper to make a spec from just a --extra
+    pub fn from_extra(extra: Vec<ExtraName>) -> Self {
+        Self::from_history(ExtrasSpecificationHistory {
+            extra,
+            ..Default::default()
+        })
+    }
+
+    /// Helper to make a spec from just --all-extras
+    pub fn from_all_extras() -> Self {
+        Self::from_history(ExtrasSpecificationHistory {
+            all_extras: true,
+            ..Default::default()
+        })
+    }
+
+    /// Apply defaults to a base [`ExtrasSpecification`].
+    pub fn with_defaults(&self, defaults: DefaultExtras) -> ExtrasSpecificationWithDefaults {
+        // Explicitly clone the inner history and set the defaults, then remake the result.
+        let mut history = self.0.history.clone();
+        history.defaults = defaults;
+
+        ExtrasSpecificationWithDefaults {
+            cur: Self::from_history(history),
+            prev: self.clone(),
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl std::ops::Deref for ExtrasSpecification {
+    type Target = ExtrasSpecificationInner;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
-    macro_rules! extras {
-        () => (
-            Vec::new()
-        );
-        ($($x:expr),+ $(,)?) => (
-            vec![$(ExtraName::from_owned($x.into()).unwrap()),+]
-        )
+impl ExtrasSpecificationInner {
+    /// Returns `true` if packages other than the ones referenced by these
+    /// extras should be considered.
+    ///
+    /// That is, if I tell you to install a project and this is false,
+    /// you should ignore the project itself and all its dependencies,
+    /// and instead just install the extras.
+    ///
+    /// (This is really just asking if an --only flag was passed.)
+    pub fn prod(&self) -> bool {
+        !self.only_extras
     }
 
-    #[test]
-    fn test_no_extra_full() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras!["dev", "docs", "extra-1", "extra-2"];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras![]);
+    /// Returns `true` if the specification includes the given extra.
+    pub fn contains(&self, extra: &ExtraName) -> bool {
+        // exclude always trumps include
+        !self.exclude.contains(extra) && self.include.contains(extra)
     }
 
-    #[test]
-    fn test_no_extra_partial() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras!["extra-1", "extra-2"];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras!["dev", "docs"]);
+    /// Iterate over all extras that we think should exist.
+    pub fn desugarred_names(&self) -> impl Iterator<Item = &ExtraName> {
+        self.include.names().chain(&self.exclude)
     }
 
-    #[test]
-    fn test_no_extra_empty() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras![];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras!["dev", "docs", "extra-1", "extra-2"]);
+    /// Returns `true` if the specification includes the given extra.
+    pub fn extra_names<'a, Names>(
+        &'a self,
+        all_names: Names,
+    ) -> impl Iterator<Item = &'a ExtraName> + 'a
+    where
+        Names: Iterator<Item = &'a ExtraName> + 'a,
+    {
+        all_names.filter(move |name| self.contains(name))
     }
 
-    #[test]
-    fn test_no_extra_excessive() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras!["does-not-exists"];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras!["dev", "docs", "extra-1", "extra-2"]);
+    /// Iterate over all groups the user explicitly asked for on the CLI
+    pub fn explicit_names(&self) -> impl Iterator<Item = &ExtraName> {
+        let ExtrasSpecificationHistory {
+            extra,
+            only_extra,
+            no_extra,
+            // These reference no extras explicitly
+            all_extras: _,
+            no_default_extras: _,
+            defaults: _,
+        } = self.history();
+
+        extra.iter().chain(no_extra).chain(only_extra)
     }
 
-    #[test]
-    fn test_no_extra_without_all_extras() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras!["extra-1", "extra-2"];
-        let spec = ExtrasSpecification::from_args(false, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras![]);
+    /// Returns `true` if the specification will have no effect.
+    pub fn is_empty(&self) -> bool {
+        self.prod() && self.exclude.is_empty() && self.include.is_empty()
     }
 
-    #[test]
-    fn test_no_extra_without_package_extras() {
-        let pkg_extras = extras![];
-        let no_extra = extras!["extra-1", "extra-2"];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras![]);
+    /// Get the raw history for diagnostics
+    pub fn history(&self) -> &ExtrasSpecificationHistory {
+        &self.history
+    }
+}
+
+/// Context about a [`ExtrasSpecification`][] that we've preserved for diagnostics
+#[derive(Debug, Default, Clone)]
+pub struct ExtrasSpecificationHistory {
+    pub extra: Vec<ExtraName>,
+    pub only_extra: Vec<ExtraName>,
+    pub no_extra: Vec<ExtraName>,
+    pub all_extras: bool,
+    pub no_default_extras: bool,
+    pub defaults: DefaultExtras,
+}
+
+impl ExtrasSpecificationHistory {
+    /// Returns all the CLI flags that this represents.
+    ///
+    /// If a flag was provided multiple times (e.g. `--extra A --extra B`) this will
+    /// elide the arguments and just show the flag once (e.g. just yield "--extra").
+    ///
+    /// Conceptually this being an empty list should be equivalent to
+    /// [`ExtrasSpecification::is_empty`][] when there aren't any defaults set.
+    /// When there are defaults the two will disagree, and rightfully so!
+    pub fn as_flags_pretty(&self) -> Vec<Cow<str>> {
+        let ExtrasSpecificationHistory {
+            extra,
+            no_extra,
+            all_extras,
+            only_extra,
+            no_default_extras,
+            // defaults aren't CLI flags!
+            defaults: _,
+        } = self;
+
+        let mut flags = vec![];
+        if *all_extras {
+            flags.push(Cow::Borrowed("--all-extras"));
+        }
+        if *no_default_extras {
+            flags.push(Cow::Borrowed("--no-default-extras"));
+        }
+        match &**extra {
+            [] => {}
+            [extra] => flags.push(Cow::Owned(format!("--extra {extra}"))),
+            [..] => flags.push(Cow::Borrowed("--extra")),
+        }
+        match &**only_extra {
+            [] => {}
+            [extra] => flags.push(Cow::Owned(format!("--only-extra {extra}"))),
+            [..] => flags.push(Cow::Borrowed("--only-extra")),
+        }
+        match &**no_extra {
+            [] => {}
+            [extra] => flags.push(Cow::Owned(format!("--no-extra {extra}"))),
+            [..] => flags.push(Cow::Borrowed("--no-extra")),
+        }
+        flags
+    }
+}
+
+/// A trivial newtype wrapped around [`ExtrasSpecification`][] that signifies "defaults applied"
+///
+/// It includes a copy of the previous semantics to provide info on if
+/// the group being a default actually affected it being enabled, because it's obviously "correct".
+/// (These are Arcs so it's ~free to hold onto the previous semantics)
+#[derive(Debug, Clone)]
+pub struct ExtrasSpecificationWithDefaults {
+    /// The active semantics
+    cur: ExtrasSpecification,
+    /// The semantics before defaults were applied
+    prev: ExtrasSpecification,
+}
+
+impl ExtrasSpecificationWithDefaults {
+    /// Returns `true` if the specification was enabled, and *only* because it was a default
+    pub fn contains_because_default(&self, extra: &ExtraName) -> bool {
+        self.cur.contains(extra) && !self.prev.contains(extra)
+    }
+}
+impl std::ops::Deref for ExtrasSpecificationWithDefaults {
+    type Target = ExtrasSpecification;
+    fn deref(&self) -> &Self::Target {
+        &self.cur
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum IncludeExtras {
+    /// Include dependencies from the specified extras.
+    Some(Vec<ExtraName>),
+    /// A marker indicates including dependencies from all extras.
+    All,
+}
+
+impl IncludeExtras {
+    /// Returns `true` if the specification includes the given extra.
+    pub fn contains(&self, extra: &ExtraName) -> bool {
+        match self {
+            IncludeExtras::Some(extras) => extras.contains(extra),
+            IncludeExtras::All => true,
+        }
     }
 
-    #[test]
-    fn test_no_extra_duplicates() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-1", "extra-2"];
-        let no_extra = extras!["extra-1", "extra-2"];
-        let spec = ExtrasSpecification::from_args(true, no_extra, vec![]);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras!["dev", "docs"]);
+    /// Returns `true` if the specification will have no effect.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            IncludeExtras::Some(extras) => extras.is_empty(),
+            // Although technically this is a noop if they have no extras,
+            // conceptually they're *trying* to have an effect, so treat it as one.
+            IncludeExtras::All => false,
+        }
     }
 
-    #[test]
-    fn test_no_extra_extra() {
-        let pkg_extras = extras!["dev", "docs", "extra-1", "extra-2"];
-        let no_extra = extras!["extra-1", "extra-2"];
-        let extra = extras!["extra-1", "extra-2", "docs"];
-        let spec = ExtrasSpecification::from_args(false, no_extra, extra);
-        let result: Vec<_> = spec.extra_names(pkg_extras.iter()).cloned().collect();
-        assert_eq!(result, extras!["docs"]);
+    /// Iterate over all extras referenced in the [`IncludeExtras`].
+    pub fn names(&self) -> std::slice::Iter<ExtraName> {
+        match self {
+            IncludeExtras::Some(extras) => extras.iter(),
+            IncludeExtras::All => [].iter(),
+        }
+    }
+}
+
+impl Default for IncludeExtras {
+    fn default() -> Self {
+        Self::Some(Vec::new())
     }
 }

--- a/crates/uv-normalize/src/extra_name.rs
+++ b/crates/uv-normalize/src/extra_name.rs
@@ -2,11 +2,92 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
+use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use uv_small_str::SmallString;
 
 use crate::{validate_and_normalize_ref, InvalidNameError};
+
+/// Either the literal "all" or a list of extras
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum DefaultExtras {
+    /// All extras are defaulted
+    All,
+    /// A list of extras
+    List(Vec<ExtraName>),
+}
+
+/// Serialize a [`DefaultExtras`] struct into a list of marker strings.
+impl serde::Serialize for DefaultExtras {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            DefaultExtras::All => serializer.serialize_str("all"),
+            DefaultExtras::List(extras) => {
+                let mut seq = serializer.serialize_seq(Some(extras.len()))?;
+                for extra in extras {
+                    seq.serialize_element(&extra)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+/// Deserialize a "all" or list of [`ExtraName`] into a [`DefaultExtras`] enum.
+impl<'de> serde::Deserialize<'de> for DefaultExtras {
+    fn deserialize<D>(deserializer: D) -> Result<DefaultExtras, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct StringOrVecVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for StringOrVecVisitor {
+            type Value = DefaultExtras;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(r#"the string "all" or a list of strings"#)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value != "all" {
+                    return Err(serde::de::Error::custom(
+                        r#"default-extras must be "all" or a ["list", "of", "extras"]"#,
+                    ));
+                }
+                Ok(DefaultExtras::All)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut extras = Vec::new();
+
+                while let Some(elem) = seq.next_element::<ExtraName>()? {
+                    extras.push(elem);
+                }
+
+                Ok(DefaultExtras::List(extras))
+            }
+        }
+
+        deserializer.deserialize_any(StringOrVecVisitor)
+    }
+}
+
+impl Default for DefaultExtras {
+    fn default() -> Self {
+        DefaultExtras::List(Vec::new())
+    }
+}
 
 /// The normalized name of an extra dependency.
 ///

--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 pub use dist_info_name::DistInfoName;
-pub use extra_name::ExtraName;
+pub use extra_name::{DefaultExtras, ExtraName};
 pub use group_name::{DefaultGroups, GroupName, PipGroupName, DEV_DEPENDENCIES};
 pub use package_name::PackageName;
 

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -8,7 +8,9 @@ use petgraph::visit::IntoNodeReferences;
 use petgraph::{Direction, Graph};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use uv_configuration::{DependencyGroupsWithDefaults, ExtrasSpecification, InstallOptions};
+use uv_configuration::{
+    DependencyGroupsWithDefaults, ExtrasSpecificationWithDefaults, InstallOptions,
+};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ConflictItem;
@@ -43,7 +45,7 @@ impl<'lock> ExportableRequirements<'lock> {
     fn from_lock(
         target: &impl Installable<'lock>,
         prune: &[PackageName],
-        extras: &ExtrasSpecification,
+        extras: &ExtrasSpecificationWithDefaults,
         dev: &DependencyGroupsWithDefaults,
         annotate: bool,
         install_options: &'lock InstallOptions,

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use uv_cache_key::RepositoryUrl;
 use uv_configuration::{
-    BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification, InstallOptions,
+    BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecificationWithDefaults, InstallOptions,
 };
 use uv_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, SourceDistFilename,
@@ -584,7 +584,7 @@ impl<'lock> PylockToml {
     pub fn from_lock(
         target: &impl Installable<'lock>,
         prune: &[PackageName],
-        extras: &ExtrasSpecification,
+        extras: &ExtrasSpecificationWithDefaults,
         dev: &DependencyGroupsWithDefaults,
         annotate: bool,
         install_options: &'lock InstallOptions,

--- a/crates/uv-resolver/src/lock/export/requirements_txt.rs
+++ b/crates/uv-resolver/src/lock/export/requirements_txt.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 use url::Url;
 
 use uv_configuration::{
-    DependencyGroupsWithDefaults, EditableMode, ExtrasSpecification, InstallOptions,
+    DependencyGroupsWithDefaults, EditableMode, ExtrasSpecificationWithDefaults, InstallOptions,
 };
 use uv_distribution_filename::{DistExtension, SourceDistExtension};
 use uv_fs::Simplified;
@@ -30,7 +30,7 @@ impl<'lock> RequirementsTxtExport<'lock> {
     pub fn from_lock(
         target: &impl Installable<'lock>,
         prune: &[PackageName],
-        extras: &ExtrasSpecification,
+        extras: &ExtrasSpecificationWithDefaults,
         dev: &DependencyGroupsWithDefaults,
         annotate: bool,
         editable: EditableMode,

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -9,9 +9,8 @@ use itertools::Itertools;
 use petgraph::Graph;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
-use uv_configuration::{
-    BuildOptions, DependencyGroupsWithDefaults, ExtrasSpecification, InstallOptions,
-};
+use uv_configuration::ExtrasSpecificationWithDefaults;
+use uv_configuration::{BuildOptions, DependencyGroupsWithDefaults, InstallOptions};
 use uv_distribution_types::{Edge, Node, Resolution, ResolvedDist};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerTree;
@@ -39,7 +38,7 @@ pub trait Installable<'lock> {
         &self,
         marker_env: &ResolverMarkerEnvironment,
         tags: &Tags,
-        extras: &ExtrasSpecification,
+        extras: &ExtrasSpecificationWithDefaults,
         dev: &DependencyGroupsWithDefaults,
         build_options: &BuildOptions,
         install_options: &InstallOptions,

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -238,20 +238,18 @@ pub(crate) async fn pip_compile(
     // If all the metadata could be statically resolved, validate that every extra was used. If we
     // need to resolve metadata via PEP 517, we don't know which extras are used until much later.
     if source_trees.is_empty() {
-        if let ExtrasSpecification::Some(extras) = &extras {
-            let mut unused_extras = extras
-                .iter()
-                .filter(|extra| !used_extras.contains(extra))
-                .collect::<Vec<_>>();
-            if !unused_extras.is_empty() {
-                unused_extras.sort_unstable();
-                unused_extras.dedup();
-                let s = if unused_extras.len() == 1 { "" } else { "s" };
-                return Err(anyhow!(
-                    "Requested extra{s} not found: {}",
-                    unused_extras.iter().join(", ")
-                ));
-            }
+        let mut unused_extras = extras
+            .explicit_names()
+            .filter(|extra| !used_extras.contains(extra))
+            .collect::<Vec<_>>();
+        if !unused_extras.is_empty() {
+            unused_extras.sort_unstable();
+            unused_extras.dedup();
+            let s = if unused_extras.len() == 1 { "" } else { "s" };
+            return Err(anyhow!(
+                "Requested extra{s} not found: {}",
+                unused_extras.iter().join(", ")
+            ));
         }
     }
 

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -185,25 +185,23 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             });
 
             // If any of the extras were unused, surface a warning.
-            if let ExtrasSpecification::Some(extras) = extras {
-                let mut unused_extras = extras
-                    .iter()
-                    .filter(|extra| {
-                        !resolutions
-                            .iter()
-                            .any(|resolution| resolution.extras.contains(extra))
-                    })
-                    .collect::<Vec<_>>();
-                if !unused_extras.is_empty() {
-                    unused_extras.sort_unstable();
-                    unused_extras.dedup();
-                    let s = if unused_extras.len() == 1 { "" } else { "s" };
-                    return Err(anyhow!(
-                        "Requested extra{s} not found: {}",
-                        unused_extras.iter().join(", ")
-                    )
-                    .into());
-                }
+            let mut unused_extras = extras
+                .explicit_names()
+                .filter(|extra| {
+                    !resolutions
+                        .iter()
+                        .any(|resolution| resolution.extras.contains(extra))
+                })
+                .collect::<Vec<_>>();
+            if !unused_extras.is_empty() {
+                unused_extras.sort_unstable();
+                unused_extras.dedup();
+                let s = if unused_extras.len() == 1 { "" } else { "s" };
+                return Err(anyhow!(
+                    "Requested extra{s} not found: {}",
+                    unused_extras.iter().join(", ")
+                )
+                .into());
             }
 
             // Extend the requirements with the resolved source trees.

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -11,7 +11,7 @@ use uv_configuration::{
     Concurrency, DependencyGroups, EditableMode, ExportFormat, ExtrasSpecification, InstallOptions,
     PreviewMode,
 };
-use uv_normalize::{DefaultGroups, PackageName};
+use uv_normalize::{DefaultExtras, DefaultGroups, PackageName};
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
 use uv_requirements::is_pylock_toml;
 use uv_resolver::{PylockToml, RequirementsTxtExport};
@@ -111,11 +111,19 @@ pub(crate) async fn export(
     };
 
     // Determine the default groups to include.
-    let defaults = match &target {
+    let default_groups = match &target {
         ExportTarget::Project(project) => default_dependency_groups(project.pyproject_toml())?,
         ExportTarget::Script(_) => DefaultGroups::default(),
     };
-    let dev = dev.with_defaults(defaults);
+
+    // Determine the default extras to include.
+    let default_extras = match &target {
+        ExportTarget::Project(_project) => DefaultExtras::default(),
+        ExportTarget::Script(_) => DefaultExtras::default(),
+    };
+
+    let dev = dev.with_defaults(default_groups);
+    let extras = extras.with_defaults(default_extras);
 
     // Find an interpreter for the project, unless `--frozen` is set.
     let interpreter = if frozen {

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -243,22 +243,9 @@ impl<'lock> InstallTarget<'lock> {
     /// Validate the extras requested by the [`ExtrasSpecification`].
     #[allow(clippy::result_large_err)]
     pub(crate) fn validate_extras(self, extras: &ExtrasSpecification) -> Result<(), ProjectError> {
-        let extras = match extras {
-            ExtrasSpecification::Some(extras) => {
-                if extras.is_empty() {
-                    return Ok(());
-                }
-                Either::Left(extras.iter())
-            }
-            ExtrasSpecification::Exclude(extras) => {
-                if extras.is_empty() {
-                    return Ok(());
-                }
-                Either::Right(extras.iter())
-            }
-            _ => return Ok(()),
-        };
-
+        if extras.is_empty() {
+            return Ok(());
+        }
         match self {
             Self::Project { lock, .. }
             | Self::Workspace { lock, .. }
@@ -280,7 +267,7 @@ impl<'lock> InstallTarget<'lock> {
                     .flat_map(|package| package.provides_extras().iter())
                     .collect::<FxHashSet<_>>();
 
-                for extra in extras {
+                for extra in extras.explicit_names() {
                     if !known_extras.contains(extra) {
                         return match self {
                             Self::Project { .. } => {
@@ -293,7 +280,11 @@ impl<'lock> InstallTarget<'lock> {
             }
             Self::Script { .. } => {
                 // We shouldn't get here if the list is empty so we can assume it isn't
-                let extra = extras.into_iter().next().expect("non-empty extras").clone();
+                let extra = extras
+                    .explicit_names()
+                    .next()
+                    .expect("non-empty extras")
+                    .clone();
                 return Err(ProjectError::MissingExtraScript(extra));
             }
         }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -12,7 +12,8 @@ use uv_cache::Cache;
 use uv_client::{FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults, DryRun, EditableMode,
-    ExtrasSpecification, HashCheckingMode, InstallOptions, PreviewMode,
+    ExtrasSpecification, ExtrasSpecificationWithDefaults, HashCheckingMode, InstallOptions,
+    PreviewMode,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution_types::{
@@ -20,7 +21,7 @@ use uv_distribution_types::{
 };
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
-use uv_normalize::{DefaultGroups, PackageName};
+use uv_normalize::{DefaultExtras, DefaultGroups, PackageName};
 use uv_pep508::{MarkerTree, VersionOrUrl};
 use uv_pypi_types::{ParsedArchiveUrl, ParsedGitUrl, ParsedUrl};
 use uv_python::{PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
@@ -115,9 +116,15 @@ pub(crate) async fn sync(
     };
 
     // Determine the default groups to include.
-    let defaults = match &target {
+    let default_groups = match &target {
         SyncTarget::Project(project) => default_dependency_groups(project.pyproject_toml())?,
         SyncTarget::Script(..) => DefaultGroups::default(),
+    };
+
+    // Determine the default extras to include.
+    let default_extras = match &target {
+        SyncTarget::Project(_project) => DefaultExtras::default(),
+        SyncTarget::Script(..) => DefaultExtras::default(),
     };
 
     // Discover or create the virtual environment.
@@ -425,8 +432,8 @@ pub(crate) async fn sync(
     match do_sync(
         sync_target,
         &environment,
-        &extras,
-        &dev.with_defaults(defaults),
+        &extras.with_defaults(default_extras),
+        &dev.with_defaults(default_groups),
         editable,
         install_options,
         modifications,
@@ -559,7 +566,7 @@ impl Deref for SyncEnvironment {
 pub(super) async fn do_sync(
     target: InstallTarget<'_>,
     venv: &PythonEnvironment,
-    extras: &ExtrasSpecification,
+    extras: &ExtrasSpecificationWithDefaults,
     dev: &DependencyGroupsWithDefaults,
     editable: EditableMode,
     install_options: InstallOptions,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -395,9 +395,13 @@ impl RunSettings {
             locked,
             frozen,
             extras: ExtrasSpecification::from_args(
-                flag(all_extras, no_all_extras).unwrap_or_default(),
-                no_extra,
                 extra.unwrap_or_default(),
+                no_extra,
+                // TODO(blueraft): support no_default_extras
+                false,
+                // TODO(blueraft): support only_extra
+                vec![],
+                flag(all_extras, no_all_extras).unwrap_or_default(),
             ),
             dev: DependencyGroups::from_args(
                 dev,
@@ -1126,9 +1130,13 @@ impl SyncSettings {
             script,
             active: flag(active, no_active),
             extras: ExtrasSpecification::from_args(
-                flag(all_extras, no_all_extras).unwrap_or_default(),
-                no_extra,
                 extra.unwrap_or_default(),
+                no_extra,
+                // TODO(blueraft): support no_default_extras
+                false,
+                // TODO(blueraft): support only_extra
+                vec![],
+                flag(all_extras, no_all_extras).unwrap_or_default(),
             ),
             dev: DependencyGroups::from_args(
                 dev,
@@ -1599,9 +1607,13 @@ impl ExportSettings {
             package,
             prune,
             extras: ExtrasSpecification::from_args(
-                flag(all_extras, no_all_extras).unwrap_or_default(),
-                no_extra,
                 extra.unwrap_or_default(),
+                no_extra,
+                // TODO(blueraft): support no_default_extras
+                false,
+                // TODO(blueraft): support only_extra
+                vec![],
+                flag(all_extras, no_all_extras).unwrap_or_default(),
             ),
             dev: DependencyGroups::from_args(
                 dev,
@@ -2857,10 +2869,15 @@ impl PipSettings {
                 args.no_index.combine(no_index).unwrap_or_default(),
             ),
             extras: ExtrasSpecification::from_args(
-                args.all_extras.combine(all_extras).unwrap_or_default(),
-                args.no_extra.combine(no_extra).unwrap_or_default(),
                 args.extra.combine(extra).unwrap_or_default(),
+                args.no_extra.combine(no_extra).unwrap_or_default(),
+                // TODO(blueraft): support no_default_extras
+                false,
+                // TODO(blueraft): support only_extra
+                vec![],
+                args.all_extras.combine(all_extras).unwrap_or_default(),
             ),
+
             groups: args.group.combine(group).unwrap_or_default(),
             dependency_mode: if args.no_deps.combine(no_deps).unwrap_or_default() {
                 DependencyMode::Direct

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -149,7 +149,25 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -310,7 +328,25 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -472,7 +508,25 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -666,7 +720,25 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -797,7 +869,25 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -970,7 +1060,25 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -1189,7 +1297,25 @@ fn resolve_index_url() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -1416,7 +1542,25 @@ fn resolve_index_url() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -1602,7 +1746,25 @@ fn resolve_find_links() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -1755,7 +1917,25 @@ fn resolve_top_level() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -1964,7 +2144,25 @@ fn resolve_top_level() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -2156,7 +2354,25 @@ fn resolve_top_level() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -2308,7 +2524,25 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -2444,7 +2678,25 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -2580,7 +2832,25 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -2718,7 +2988,25 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -3039,7 +3327,25 @@ fn resolve_poetry_toml() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -3235,7 +3541,25 @@ fn resolve_both() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -3521,7 +3845,25 @@ fn resolve_config_file() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -3751,7 +4093,25 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -3890,7 +4250,25 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -4048,7 +4426,25 @@ fn allow_insecure_host() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -4263,7 +4659,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -4457,7 +4871,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -4657,7 +5089,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -4852,7 +5302,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5054,7 +5522,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5249,7 +5735,25 @@ fn index_priority() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5392,7 +5896,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5521,7 +6043,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5648,7 +6188,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5777,7 +6335,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -5904,7 +6480,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,
@@ -6032,7 +6626,25 @@ fn verify_hashes() -> anyhow::Result<()> {
                 pypy_install_mirror: None,
             },
             system: false,
-            extras: None,
+            extras: ExtrasSpecification(
+                ExtrasSpecificationInner {
+                    include: Some(
+                        [],
+                    ),
+                    exclude: [],
+                    only_extras: false,
+                    history: ExtrasSpecificationHistory {
+                        extra: [],
+                        only_extra: [],
+                        no_extra: [],
+                        all_extras: false,
+                        no_default_extras: false,
+                        defaults: List(
+                            [],
+                        ),
+                    },
+                },
+            ),
             groups: [],
             break_system_packages: false,
             target: None,


### PR DESCRIPTION
## Summary

Part of #8607. This is a pure refactor aimed at paving the way for supporting the `default-extras` configuration in the `pyproject.toml` file.

The `ExtraSpecification` struct has been refactored to align more closely with the [`DependencyGroups`](https://github.com/astral-sh/uv/blob/256b100a9e1980c75f205362c8aac95c036a96ba/crates/uv-configuration/src/dependency_groups.rs#L9) struct.

## Test Plan

Existing tests.
