### PR TITLE
Obfuscate username in tracing URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,6 +4686,7 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+ "tracing-test",
  "url",
  "uv-once-map",
  "uv-small-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ toml_edit = { version = "0.22.21", features = ["serde"] }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.3.0", features = ["plot"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"] }
+tracing-test = { version = "0.2.5" }
 tracing-tree = { version = "0.4.0" }
 unicode-width = { version = "0.2.0" }
 unscanny = { version = "0.1.0" }

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -36,4 +36,5 @@ insta = { version = "1.40.0" }
 tempfile = { workspace = true }
 test-log = { version = "0.2.16", features = ["trace"], default-features = false }
 tokio = { workspace = true }
+tracing-test = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -72,6 +72,10 @@ impl From<Option<String>> for Username {
 pub struct Password(String);
 
 impl Password {
+    pub fn new(password: String) -> Self {
+        Self(password)
+    }
+
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -506,32 +506,29 @@ impl AuthMiddleware {
 }
 
 fn tracing_url(request: &Request, credentials: Option<&Credentials>) -> String {
-    if tracing::enabled!(tracing::Level::DEBUG) {
-        let mut url = request.url().clone();
-        if credentials
-            .as_ref()
-            .and_then(|credentials| credentials.username())
-            .is_some()
-        {
+    if !tracing::enabled!(tracing::Level::DEBUG) {
+        return request.url().to_string();
+    }
+
+    let mut url = request.url().clone();
+    if let Some(creds) = credentials {
+        if creds.password().is_some() {
+            if let Some(username) = creds.username() {
+                let _ = url.set_username(username);
+            }
+            let _ = url.set_password(Some("****"));
+        } else if creds.username().is_some() {
             let _ = url.set_username("****");
         }
-        if credentials
-            .as_ref()
-            .and_then(|credentials| credentials.password())
-            .is_some()
-        {
-            let _ = url.set_password(Some("****"));
-        }
-        url.to_string()
-    } else {
-        request.url().to_string()
     }
+    url.to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::Write;
 
+    use http::Method;
     use reqwest::Client;
     use tempfile::NamedTempFile;
     use test_log::test;
@@ -1844,5 +1841,42 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    #[tracing_test::traced_test(level = "debug")]
+    fn test_tracing_url() {
+        // No credentials
+        let req = create_request("https://pypi-proxy.fly.dev/basic-auth/simple");
+        assert_eq!(
+            tracing_url(&req, None),
+            "https://pypi-proxy.fly.dev/basic-auth/simple"
+        );
+
+        // Mask username if there is a username but no password
+        let creds = Credentials::Basic {
+            username: Username::new(Some(String::from("user"))),
+            password: None,
+        };
+        let req = create_request("https://pypi-proxy.fly.dev/basic-auth/simple");
+        assert_eq!(
+            tracing_url(&req, Some(&creds)),
+            "https://****@pypi-proxy.fly.dev/basic-auth/simple"
+        );
+
+        // Log username but mask password if a password is present
+        let creds = Credentials::Basic {
+            username: Username::new(Some(String::from("user"))),
+            password: Some(String::from("password")),
+        };
+        let req = create_request("https://pypi-proxy.fly.dev/basic-auth/simple");
+        assert_eq!(
+            tracing_url(&req, Some(&creds)),
+            "https://user:****@pypi-proxy.fly.dev/basic-auth/simple"
+        );
+    }
+
+    fn create_request(url: &str) -> Request {
+        Request::new(Method::GET, Url::parse(url).unwrap())
     }
 }

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -517,6 +517,7 @@ fn tracing_url(request: &Request, credentials: Option<&Credentials>) -> String {
                 let _ = url.set_username(username);
             }
             let _ = url.set_password(Some("****"));
+        // A username on its own might be a secret token.
         } else if creds.username().is_some() {
             let _ = url.set_username("****");
         }

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -508,11 +508,12 @@ impl AuthMiddleware {
 fn tracing_url(request: &Request, credentials: Option<&Credentials>) -> String {
     if tracing::enabled!(tracing::Level::DEBUG) {
         let mut url = request.url().clone();
-        if let Some(username) = credentials
+        if credentials
             .as_ref()
             .and_then(|credentials| credentials.username())
+            .is_some()
         {
-            let _ = url.set_username(username);
+            let _ = url.set_username("****");
         }
         if credentials
             .as_ref()

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -538,6 +538,8 @@ mod tests {
     use wiremock::matchers::{basic_auth, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use crate::credentials::Password;
+
     use super::*;
 
     type Error = Box<dyn std::error::Error>;
@@ -1868,7 +1870,7 @@ mod tests {
         // Log username but mask password if a password is present
         let creds = Credentials::Basic {
             username: Username::new(Some(String::from("user"))),
-            password: Some(String::from("password")),
+            password: Some(Password::new(String::from("password"))),
         };
         let req = create_request("https://pypi-proxy.fly.dev/basic-auth/simple");
         assert_eq!(


### PR DESCRIPTION
A URL username can be a secret token, so we should avoid logging it.