### PR TITLE
Add `pylock.toml` to `uv pip install` and `uv pip sync`

### DIFF
--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -19,7 +19,7 @@ pub struct Resolution {
 }
 
 impl Resolution {
-    /// Create a new resolution from the given pinned packages.
+    /// Create a [`Resolution`] from the given pinned packages.
     pub fn new(graph: petgraph::graph::DiGraph<Node, Edge>) -> Self {
         Self {
             graph,
@@ -206,17 +206,6 @@ pub enum Edge {
     Prod(MarkerTree),
     Optional(ExtraName, MarkerTree),
     Dev(GroupName, MarkerTree),
-}
-
-impl Edge {
-    /// Return the [`MarkerTree`] for this edge.
-    pub fn marker(&self) -> &MarkerTree {
-        match self {
-            Self::Prod(marker) => marker,
-            Self::Optional(_, marker) => marker,
-            Self::Dev(_, marker) => marker,
-        }
-    }
 }
 
 impl From<&ResolvedDist> for RequirementSource {

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -61,6 +61,8 @@ pub struct RequirementsSpecification {
     pub constraints: Vec<NameRequirementSpecification>,
     /// The overrides for the project.
     pub overrides: Vec<UnresolvedRequirementSpecification>,
+    /// The `pylock.toml` file from which to extract the resolution.
+    pub pylock: Option<PathBuf>,
     /// The source trees from which to extract requirements.
     pub source_trees: Vec<PathBuf>,
     /// The groups to use for `source_trees`
@@ -190,6 +192,16 @@ impl RequirementsSpecification {
                     ..Self::default()
                 }
             }
+            RequirementsSource::PylockToml(path) => {
+                if !path.is_file() {
+                    return Err(anyhow::anyhow!("File not found: `{}`", path.user_display()));
+                }
+
+                Self {
+                    pylock: Some(path.clone()),
+                    ..Self::default()
+                }
+            }
             RequirementsSource::SourceTree(path) => {
                 if !path.is_dir() {
                     return Err(anyhow::anyhow!(
@@ -231,7 +243,66 @@ impl RequirementsSpecification {
     ) -> Result<Self> {
         let mut spec = Self::default();
 
-        // Resolve sources into specifications so we know their `source_tree`s∂
+        // Disallow `pylock.toml` files as constraints.
+        if let Some(pylock_toml) = constraints.iter().find_map(|source| {
+            if let RequirementsSource::PylockToml(path) = source {
+                Some(path)
+            } else {
+                None
+            }
+        }) {
+            return Err(anyhow::anyhow!(
+                "Cannot use `{}` as a constraint file",
+                pylock_toml.user_display()
+            ));
+        }
+
+        // Disallow `pylock.toml` files as overrides.
+        if let Some(pylock_toml) = overrides.iter().find_map(|source| {
+            if let RequirementsSource::PylockToml(path) = source {
+                Some(path)
+            } else {
+                None
+            }
+        }) {
+            return Err(anyhow::anyhow!(
+                "Cannot use `{}` as an override file",
+                pylock_toml.user_display()
+            ));
+        }
+
+        // If we have a `pylock.toml`, don't allow additional requirements, constraints, or
+        // overrides.
+        if requirements
+            .iter()
+            .any(|source| matches!(source, RequirementsSource::PylockToml(..)))
+        {
+            if requirements
+                .iter()
+                .any(|source| !matches!(source, RequirementsSource::PylockToml(..)))
+            {
+                return Err(anyhow::anyhow!(
+                    "Cannot specify additional requirements alongside a `pylock.toml` file",
+                ));
+            }
+            if !constraints.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Cannot specify additional requirements with a `pylock.toml` file"
+                ));
+            }
+            if !overrides.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Cannot specify constraints with a `pylock.toml` file"
+                ));
+            }
+            if !groups.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Cannot specify groups with a `pylock.toml` file"
+                ));
+            }
+        }
+
+        // Resolve sources into specifications so we know their `source_tree`.
         let mut requirement_sources = Vec::new();
         for source in requirements {
             let source = Self::from_source(source, client_builder).await?;
@@ -300,6 +371,18 @@ impl RequirementsSpecification {
             spec.overrides.extend(source.overrides);
             spec.extras.extend(source.extras);
             spec.source_trees.extend(source.source_trees);
+
+            // Allow at most one `pylock.toml`.
+            if let Some(pylock) = source.pylock {
+                if let Some(existing) = spec.pylock {
+                    return Err(anyhow::anyhow!(
+                        "Multiple `pylock.toml` files specified: `{}` vs. `{}`",
+                        existing.user_display(),
+                        pylock.user_display()
+                    ));
+                }
+                spec.pylock = Some(pylock);
+            }
 
             // Use the first project name discovered.
             if spec.project.is_none() {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2202,7 +2202,7 @@ impl Package {
                         let wheels = self
                             .wheels
                             .iter()
-                            .map(|wheel| wheel.to_registry_dist(source, workspace_root))
+                            .map(|wheel| wheel.to_registry_wheel(source, workspace_root))
                             .collect::<Result<_, LockError>>()?;
                         let reg_built_dist = RegistryBuiltDist {
                             wheels,
@@ -4183,7 +4183,7 @@ impl Wheel {
         }
     }
 
-    pub(crate) fn to_registry_dist(
+    pub(crate) fn to_registry_wheel(
         &self,
         source: &RegistrySource,
         root: &Path,

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -171,6 +171,7 @@ pub(crate) async fn pip_compile(
         requirements,
         constraints,
         overrides,
+        pylock,
         source_trees,
         groups,
         extras: used_extras,
@@ -188,6 +189,13 @@ pub(crate) async fn pip_compile(
         &client_builder,
     )
     .await?;
+
+    // Reject `pylock.toml` files, which are valid outputs but not inputs.
+    if pylock.is_some() {
+        return Err(anyhow!(
+            "`pylock.toml` is not a supported input format for `uv pip compile`"
+        ));
+    }
 
     let constraints = constraints
         .iter()

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -32,8 +32,8 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
-    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PythonRequirement,
-    ResolutionMode, ResolverEnvironment,
+    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PylockToml,
+    PythonRequirement, ResolutionMode, ResolverEnvironment,
 };
 use uv_torch::{TorchMode, TorchStrategy};
 use uv_types::{BuildIsolation, HashStrategy};
@@ -111,6 +111,7 @@ pub(crate) async fn pip_install(
         requirements,
         constraints,
         overrides,
+        pylock,
         source_trees,
         groups,
         index_url,
@@ -129,6 +130,12 @@ pub(crate) async fn pip_install(
         &client_builder,
     )
     .await?;
+
+    if pylock.is_some() {
+        if preview.is_disabled() {
+            warn_user!("The `--pylock` setting is experimental and may change without warning. Pass `--preview` to disable this warning.");
+        }
+    }
 
     let constraints: Vec<NameRequirementSpecification> = constraints
         .iter()
@@ -245,6 +252,7 @@ pub(crate) async fn pip_install(
     if reinstall.is_none()
         && upgrade.is_none()
         && source_trees.is_empty()
+        && pylock.is_none()
         && matches!(modifications, Modifications::Sufficient)
     {
         match site_packages.satisfies_spec(&requirements, &constraints, &overrides, &marker_env)? {
@@ -304,9 +312,6 @@ pub(crate) async fn pip_install(
     } else {
         HashStrategy::None
     };
-
-    // When resolving, don't take any external preferences into account.
-    let preferences = Vec::default();
 
     // Incorporate any index locations from the provided sources.
     let index_locations = index_locations.combine(
@@ -429,51 +434,69 @@ pub(crate) async fn pip_install(
         preview,
     );
 
-    let options = OptionsBuilder::new()
-        .resolution_mode(resolution_mode)
-        .prerelease_mode(prerelease_mode)
-        .dependency_mode(dependency_mode)
-        .exclude_newer(exclude_newer)
-        .index_strategy(index_strategy)
-        .build_options(build_options.clone())
-        .build();
+    let (resolution, hasher) = if let Some(pylock) = pylock {
+        // Read the `pylock.toml` from disk, and deserialize it from TOML.
+        let install_path = std::path::absolute(&pylock)?;
+        let install_path = install_path.parent().unwrap();
+        let content = fs_err::tokio::read_to_string(&pylock).await?;
+        let lock = toml::from_str::<PylockToml>(&content)?;
 
-    // Resolve the requirements.
-    let resolution = match operations::resolve(
-        requirements,
-        constraints,
-        overrides,
-        source_trees,
-        project,
-        BTreeSet::default(),
-        extras,
-        &groups,
-        preferences,
-        site_packages.clone(),
-        &hasher,
-        &reinstall,
-        &upgrade,
-        Some(&tags),
-        ResolverEnvironment::specific(marker_env.clone()),
-        python_requirement,
-        Conflicts::empty(),
-        &client,
-        &flat_index,
-        state.index(),
-        &build_dispatch,
-        concurrency,
-        options,
-        Box::new(DefaultResolveLogger),
-        printer,
-    )
-    .await
-    {
-        Ok(graph) => Resolution::from(graph),
-        Err(err) => {
-            return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
-                .report(err)
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
-        }
+        let resolution = lock.to_resolution(install_path, marker_env.markers(), &tags)?;
+        let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
+
+        (resolution, hasher)
+    } else {
+        // When resolving, don't take any external preferences into account.
+        let preferences = Vec::default();
+
+        let options = OptionsBuilder::new()
+            .resolution_mode(resolution_mode)
+            .prerelease_mode(prerelease_mode)
+            .dependency_mode(dependency_mode)
+            .exclude_newer(exclude_newer)
+            .index_strategy(index_strategy)
+            .build_options(build_options.clone())
+            .build();
+
+        // Resolve the requirements.
+        let resolution = match operations::resolve(
+            requirements,
+            constraints,
+            overrides,
+            source_trees,
+            project,
+            BTreeSet::default(),
+            extras,
+            &groups,
+            preferences,
+            site_packages.clone(),
+            &hasher,
+            &reinstall,
+            &upgrade,
+            Some(&tags),
+            ResolverEnvironment::specific(marker_env.clone()),
+            python_requirement,
+            Conflicts::empty(),
+            &client,
+            &flat_index,
+            state.index(),
+            &build_dispatch,
+            concurrency,
+            options,
+            Box::new(DefaultResolveLogger),
+            printer,
+        )
+        .await
+        {
+            Ok(graph) => Resolution::from(graph),
+            Err(err) => {
+                return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
+                    .report(err)
+                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+            }
+        };
+
+        (resolution, hasher)
     };
 
     // Sync the environment.
@@ -502,7 +525,7 @@ pub(crate) async fn pip_install(
     )
     .await
     {
-        Ok(_) => {}
+        Ok(..) => {}
         Err(err) => {
             return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
                 .report(err)


### PR DESCRIPTION
## Summary

We accept `pylock.toml` as a requirements file (e.g., `uv sync pylock.toml` or `uv pip install -r pylock.toml`). When you provide a `pylock.toml` file, we don't allow you to provide other requirements, or constraints, etc. And you can only provide one `pylock.toml` file, not multiple.

We might want to remove this from `uv pip install` for now, since `pip` may end up with a different interface (whereas `uv pip sync` is already specific to uv), and most of the arguments aren't applicable (like `--resolution`, etc.). Regardless, it's behind `--preview` for both commands.
