### PR TITLE
Improve messages for `FirstIndex` authentication failures

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock, RwLock};
 
-use http::StatusCode;
 use itertools::Either;
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
@@ -588,20 +587,6 @@ impl IndexCapabilities {
             .entry(index_url)
             .or_insert(Flags::empty())
             .insert(Flags::NO_RANGE_REQUESTS);
-    }
-
-    /// Mark an [`IndexUrl`] as returning a status code if it is either a
-    /// `401 Unauthorized` or a `403 Forbidden`.
-    pub fn set_by_status_code(&self, status_code: StatusCode, index_url: &IndexUrl) {
-        match status_code {
-            StatusCode::UNAUTHORIZED => {
-                self.set_unauthorized(index_url.clone());
-            }
-            StatusCode::FORBIDDEN => {
-                self.set_forbidden(index_url.clone());
-            }
-            _ => {}
-        }
     }
 
     /// Returns `true` if the given [`IndexUrl`] returns a `401 Unauthorized` status code.

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -930,12 +930,6 @@ impl PubGrubReportFormatter<'_> {
                 });
             }
             if index_capabilities.forbidden(&index.url) {
-                // If the index is a PyTorch index (e.g., `https://download.pytorch.org/whl/cu118`),
-                // avoid noting the lack of credentials. PyTorch returns a 403 (Forbidden) status
-                // code for any package that does not exist.
-                if index.url.url().host_str() == Some("download.pytorch.org") {
-                    continue;
-                }
                 hints.insert(PubGrubHint::ForbiddenIndex {
                     index: index.url.clone(),
                 });

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -10304,14 +10304,17 @@ fn add_full_url_in_keyring() -> Result<()> {
         .env(EnvVars::KEYRING_TEST_CREDENTIALS, r#"{"https://pypi-proxy.fly.dev/basic-auth/simple/anyio": {"public": "heron"}}"#)
         .env(EnvVars::PATH, venv_bin_path(&keyring_context.venv)), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Keyring request for public@https://pypi-proxy.fly.dev/basic-auth/simple
     Keyring request for public@pypi-proxy.fly.dev
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/anyio/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/anyio/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "
     );
     Ok(())
@@ -10338,12 +10341,15 @@ fn add_stop_index_search_early_on_auth_failure() -> Result<()> {
 
     uv_snapshot!(context.add().arg("anyio"), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/anyio/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/anyio/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "
     );
     Ok(())
@@ -10416,12 +10422,15 @@ fn add_empty_ignore_error_codes() -> Result<()> {
     // by the empty ignore-error-codes list.
     uv_snapshot!(context.add().arg("flask"), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `https://download.pytorch.org/whl/cpu/flask/`
-      Caused by: HTTP status client error (403 Forbidden) for url (https://download.pytorch.org/whl/cpu/flask/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because flask was not found in the package registry and your project depends on flask, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://download.pytorch.org/whl/cpu) could not be queried due to a lack of valid authentication credentials (403 Forbidden).
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "
     );
     Ok(())
@@ -10657,12 +10666,15 @@ fn add_auth_policy_never_with_env_var_credentials() -> Result<()> {
         .env("UV_INDEX_MY_INDEX_USERNAME", "public")
         .env("UV_INDEX_MY_INDEX_PASSWORD", "heron"), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/anyio/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/anyio/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
+      help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "
     );
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7519,12 +7519,13 @@ fn lock_index_workspace_member() -> Result<()> {
     // Locking without the necessary credentials should fail.
     uv_snapshot!(context.filters(), context.lock(), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because iniconfig was not found in the package registry and child depends on iniconfig>=2, we can conclude that child's requirements are unsatisfiable.
+          And because your workspace requires child, we can conclude that your workspace's requirements are unsatisfiable.
     ");
 
     uv_snapshot!(context.filters(), context.lock()
@@ -8460,12 +8461,14 @@ fn lock_env_credentials() -> Result<()> {
     // Without credentials, the resolution should fail.
     uv_snapshot!(context.filters(), context.lock(), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
     ");
 
     // Provide credentials via environment variables.
@@ -18906,14 +18909,16 @@ fn lock_keyring_explicit_always() -> Result<()> {
         .env(EnvVars::KEYRING_TEST_CREDENTIALS, r#"{"pypi-proxy.fly.dev": {"public": "frog"}}"#)
         .env(EnvVars::PATH, venv_bin_path(&keyring_context.venv)), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Keyring request for https://pypi-proxy.fly.dev/basic-auth/simple
     Keyring request for pypi-proxy.fly.dev
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/iniconfig/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because iniconfig was not found in the package registry and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
     ");
 
     // With valid credentials, we should succeed

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -5384,14 +5384,16 @@ fn install_package_basic_auth_from_keyring_wrong_password() {
         .env(EnvVars::KEYRING_TEST_CREDENTIALS, r#"{"pypi-proxy.fly.dev": {"public": "foobar"}}"#)
         .env(EnvVars::PATH, venv_bin_path(&context.venv)), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Keyring request for public@https://pypi-proxy.fly.dev/basic-auth/simple
     Keyring request for public@pypi-proxy.fly.dev
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/anyio/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/anyio/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
     "
     );
 }
@@ -5425,14 +5427,16 @@ fn install_package_basic_auth_from_keyring_wrong_username() {
         .env(EnvVars::KEYRING_TEST_CREDENTIALS, r#"{"pypi-proxy.fly.dev": {"other": "heron"}}"#)
         .env(EnvVars::PATH, venv_bin_path(&context.venv)), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Keyring request for public@https://pypi-proxy.fly.dev/basic-auth/simple
     Keyring request for public@pypi-proxy.fly.dev
-    error: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/simple/anyio/`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/simple/anyio/)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
+
+          hint: An index URL (https://pypi-proxy.fly.dev/basic-auth/simple) could not be queried due to a lack of valid authentication credentials (401 Unauthorized).
     "
     );
 }


### PR DESCRIPTION
Stop exiting early on authentication failures so we can benefit from more detailed reporting.
