### PR TITLE
Forward additional signals to the child process in `uv run`

### DIFF
--- a/crates/uv/src/commands/run.rs
+++ b/crates/uv/src/commands/run.rs
@@ -94,7 +94,7 @@ pub(crate) async fn run_to_completion(mut handle: Child) -> anyhow::Result<ExitS
         let mut sigint_handle = handle_signal(SignalKind::interrupt())?;
         let mut sigint_count = 0;
 
-        // The following signals are terminal by default, but can be have user defined handlers.
+        // The following signals are terminal by default, but can have user defined handlers.
         // Forward them to the child process for handling.
         let mut sigusr1_handle = handle_signal(SignalKind::user_defined1())?;
         let mut sigusr2_handle = handle_signal(SignalKind::user_defined2())?;


### PR DESCRIPTION
As I suspected quite some time ago (https://github.com/astral-sh/uv/pull/6738#issuecomment-2315466033), it's problematic that we don't handle _every_ signal here. This PR adds handling for all of the Unix signals except `SIGCHLD`, `SIGIO`, and `SIGPOLL` which seem incorrect to forward. Also notable, we _cannot_ handle `SIGKILL` so if someone sends that to the PID instead of the PGID, they will leave dangling subprocesses.

Instead, we could use `exec` and avoid this handling. However, we'd lose the ability to add nice error message on failure (e.g., as someone is trying to add in https://github.com/astral-sh/uv/pull/12201) and, more critically, we'd need to figure out how to clean up resources properly (i.e., temporary directories) which currently happens on `Drop`. In the long-term, we'll probably want an option to use `exec` — but we'll need to figure out when to clean up resources or accept that they will dangle. This was last discussed in https://github.com/astral-sh/uv/issues/3095 — discussion on that approach should continue there.

A note on the implementation: I spent time time trying to write the handler using a tokio stream, so we could dynamically iterate over a list of signals instead of copy/pasting the implementation — I couldn't get it to work though and it didn't seem critical.

Closes https://github.com/astral-sh/uv/issues/12830