### PR TITLE
Add a brief sleep before sending SIGINT to children

### DIFF
--- a/crates/uv/src/commands/run.rs
+++ b/crates/uv/src/commands/run.rs
@@ -105,7 +105,10 @@ pub(crate) async fn run_to_completion(mut handle: Child) -> anyhow::Result<ExitS
                         continue;
                     }
 
-                    debug!("Received SIGINT, forwarding to child at {child_pid}");
+                    // The shell may still be forwarding these signals, give the child a moment to
+                    // handle that signal before hitting it with another one
+                    debug!("Received SIGINT, forwarding to child at {child_pid} in 200ms");
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                     let _ = signal::kill(child_pid, signal::Signal::SIGINT);
                 },
                 _ = sigterm_handle.recv() => {


### PR DESCRIPTION
In an attempt to avoid interrupting the child if it is in the process of exiting.

This resolves the issue with marimo reported in https://github.com/astral-sh/uv/issues/12108#issuecomment-2745933178 and https://github.com/marimo-team/marimo/issues/4224