### PR TITLE
uv-workspace: provide hint when pyproject.toml is missing

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -43,7 +43,7 @@ pub struct WorkspaceCache(Arc<Mutex<FxHashMap<WorkspaceCacheKey, WorkspaceMember
 #[derive(thiserror::Error, Debug)]
 pub enum WorkspaceError {
     // Workspace structure errors.
-    #[error("No `pyproject.toml` found in current directory or any parent directory")]
+    #[error("No `pyproject.toml` found in current directory or any parent directory\nhint: To create one run `uv init`")]
     MissingPyprojectToml,
     #[error("Workspace member `{}` is missing a `pyproject.toml` (matches: `{}`)", _0.simplified_display(), _1)]
     MissingPyprojectTomlMember(PathBuf, String),

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -662,6 +662,7 @@ fn build_workspace() -> Result<()> {
     ----- stderr -----
     error: `--package` was provided, but no workspace was found
       Caused by: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     // Fail when `--all` is provided without a workspace.
@@ -673,6 +674,7 @@ fn build_workspace() -> Result<()> {
     ----- stderr -----
     error: `--all-packages` was provided, but no workspace was found
       Caused by: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     // Fail when `--package` is a non-existent member without a workspace.

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7463,6 +7463,7 @@ fn lock_peer_member() -> Result<()> {
 
     ----- stderr -----
     error: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     Ok(())
@@ -7779,6 +7780,7 @@ fn lock_dev_transitive() -> Result<()> {
 
     ----- stderr -----
     error: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -3289,6 +3289,7 @@ fn no_install_project() -> Result<()> {
 
     ----- stderr -----
     error: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     Ok(())
@@ -3429,6 +3430,7 @@ fn no_install_workspace() -> Result<()> {
 
     ----- stderr -----
     error: No `pyproject.toml` found in current directory or any parent directory
+    hint: To create one run `uv init`
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

When `pyproject.toml` is missing, add a hint in the error message that tells the user to run `uv init`. We don't link to the documentation since it's not versioned and thus not guaranteed to be stable.

## Test Plan

Since the change is pretty simple, all I did was update snapshot tests that had the old error message with `cargo insta review`.

## Related

Closes https://github.com/astral-sh/uv/issues/12988
