### PR TITLE
Refactor environment validity check into separate function

### DIFF
--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15748,7 +15748,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG No Python version file found in workspace: [TEMP_DIR]/
     DEBUG Using Python request `>=3.12` from `requires-python` metadata
     DEBUG Checking for Python environment at `.venv`
-    DEBUG The virtual environment's Python version satisfies `>=3.12`
+    DEBUG The virtual environment's Python version satisfies the request: `Python >=3.12`
     DEBUG Using request timeout of [TIME]
     DEBUG Found static `pyproject.toml` for: project @ file://[TEMP_DIR]/
     DEBUG No workspace root found, using project root


### PR DESCRIPTION
Now, we can use early returns! Pulled out of https://github.com/astral-sh/uv/pull/7934, where we're adding more logic here.