### PR TITLE
Add `crates/uv-publish/src/lib.rs` to version patch files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ version_files = [
   "crates/uv-version/Cargo.toml",
   "crates/uv-build/Cargo.toml",
   "crates/uv-build/pyproject.toml",
+  "crates/uv-publish/src/lib.rs",
   "docs/getting-started/installation.md",
   "docs/guides/integration/docker.md",
   "docs/guides/integration/pre-commit.md",


### PR DESCRIPTION
See https://github.com/astral-sh/uv/actions/runs/14583501775/job/40904734786?pr=13034

cc @jtfmumm I'm not sure why this changed in https://github.com/astral-sh/uv/pull/12920 but please be careful of snapshots with the uv version. We might want to filter that out.

cc @konstin regarding if there are less brittle ways snapshot here.