### PR TITLE
Support using `uv build-backend` in the Python backend

### DIFF
--- a/crates/uv-build/python/uv_build/__init__.py
+++ b/crates/uv-build/python/uv_build/__init__.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence  # noqa:I001
     from typing import Any  # noqa:I001
 
-# Use "uv build-backend" command rather than "uv-build".  This options is provided
-# for downstreams who provide "uv" and wish to avoid building a partially overlapping
-# "uv-build" executable.
+# Use the `uv build-backend` command rather than `uv-build`. This options is provided
+# for downstream distributions who provide `uv` and wish to avoid building a partially
+# overlapping `uv-build` executable.
 USE_UV_EXECUTABLE = False
 
 
@@ -43,10 +43,12 @@ def call(
     import sys
 
     warn_config_settings(config_settings)
+
+    uv_bin_name = "uv" if USE_UV_EXECUTABLE else "uv-build"
     # Unlike `find_uv_bin`, this mechanism must work according to PEP 517
-    uv_bin = shutil.which("uv" if USE_UV_EXECUTABLE else "uv-build")
+    uv_bin = shutil.which(uv_bin_name)
     if uv_bin is None:
-        raise RuntimeError("uv was not properly installed")
+        raise RuntimeError(f"{uv_bin_name} was not properly installed")
     build_backend_args = ["build-backend"] if USE_UV_EXECUTABLE else []
     # Forward stderr, capture stdout for the filename
     result = subprocess.run(
@@ -59,7 +61,10 @@ def call(
     sys.stdout.writelines(stdout[:-1])
     # Fail explicitly instead of an irrelevant stacktrace
     if not stdout:
-        print("uv subprocess did not return a filename on stdout", file=sys.stderr)
+        print(
+            f"{uv_bin_name} subprocess did not return a filename on stdout",
+            file=sys.stderr,
+        )
         sys.exit(1)
     return stdout[-1].strip()
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Provide an in-code switch to permit using the `uv build-backend` command rather than the default `uv-build` in the Python PEP517 backend.  This option is intended to be used by downstream packagers to provide an option of reusing `uv` that was built already instead of having to build a second `uv-build` executable that largely overlaps with `uv`.

Fixes #12389

## Test Plan

The option is intended for downstream consumption only, and it is tested downstream (via attempting to build a package using the `uv_build` backend). The backend itself is covered by tests already.