### PR TITLE
Temporarily remove bogus redirect test

### DIFF
--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -11107,37 +11107,3 @@ fn pep_751_multiple_sources() -> Result<()> {
 
     Ok(())
 }
-
-/// Test that uv doesn't hang if an index returns a distribution for the wrong package.
-#[tokio::test]
-async fn bogus_redirect() -> Result<()> {
-    let context = TestContext::new("3.12");
-
-    let redirect_server = MockServer::start().await;
-
-    // Configure a bogus redirect where for all packages, anyio is returned.
-    Mock::given(method("GET"))
-        .respond_with(
-            ResponseTemplate::new(302).insert_header("Location", "https://pypi.org/simple/anyio/"),
-        )
-        .mount(&redirect_server)
-        .await;
-
-    uv_snapshot!(
-        context
-            .pip_install()
-            .arg("--default-index")
-            .arg(redirect_server.uri())
-            .arg("sniffio"),
-        @r"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: The index returned metadata for the wrong package: expected distribution for sniffio, got distribution for anyio
-    "
-    );
-
-    Ok(())
-}


### PR DESCRIPTION
## Summary

This needs to be made more reliable.