### PR TITLE
Avoid panic for invalid Python versions

### DIFF
--- a/crates/uv-python/src/python_version.rs
+++ b/crates/uv-python/src/python_version.rs
@@ -31,6 +31,27 @@ impl FromStr for PythonVersion {
         if version.epoch() != 0 {
             return Err(format!("Python version `{s}` has a non-zero epoch"));
         }
+        if let Some(major) = version.release().first() {
+            if u8::try_from(*major).is_err() {
+                return Err(format!(
+                    "Python version `{s}` has an invalid major version ({major})"
+                ));
+            }
+        }
+        if let Some(minor) = version.release().get(1) {
+            if u8::try_from(*minor).is_err() {
+                return Err(format!(
+                    "Python version `{s}` has an invalid minor version ({minor})"
+                ));
+            }
+        }
+        if let Some(patch) = version.release().get(2) {
+            if u8::try_from(*patch).is_err() {
+                return Err(format!(
+                    "Python version `{s}` has an invalid patch version ({patch})"
+                ));
+            }
+        }
 
         Ok(Self(version))
     }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -365,6 +365,26 @@ dependencies = ["flask==1.0.x"]
 }
 
 #[test]
+fn invalid_python_version() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("flask")
+        .arg("--python-version")
+        .arg("311"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: invalid value '311' for '--python-version <PYTHON_VERSION>': Python version `311` has an invalid major version (311)
+
+    For more information, try '--help'.
+    "
+    );
+}
+
+#[test]
 fn missing_pip() {
     uv_snapshot!(Command::new(get_bin()).arg("install"), @r###"
     success: false


### PR DESCRIPTION
## Summary

We unwrap these further on, so we should validate them ahead of time.

Closes https://github.com/astral-sh/uv/issues/13075.
