### PR TITLE
Check for mismatched package and distribution names on resolver thread

### DIFF
--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -844,6 +844,28 @@ impl Name for Dist {
     }
 }
 
+impl Name for CompatibleDist<'_> {
+    fn name(&self) -> &PackageName {
+        match self {
+            CompatibleDist::InstalledDist(dist) => dist.name(),
+            CompatibleDist::SourceDist {
+                sdist,
+                prioritized: _,
+            } => sdist.name(),
+            CompatibleDist::CompatibleWheel {
+                wheel,
+                priority: _,
+                prioritized: _,
+            } => wheel.name(),
+            CompatibleDist::IncompatibleWheel {
+                sdist,
+                wheel: _,
+                prioritized: _,
+            } => sdist.name(),
+        }
+    }
+}
+
 impl DistributionMetadata for RegistryBuiltWheel {
     fn version_or_url(&self) -> VersionOrUrlRef {
         VersionOrUrlRef::Version(&self.filename.version)


### PR DESCRIPTION
This PR restores the `bogus_redirect` test that was non-deterministically hanging (reverting #13076). 

Mismatched package and distribution names were causing uv to hang prior to #12917 (which added the `bogus_redirect` test). But with that fix, uv was only checking for mismatched package names on the main thread (and not the resolver thread). This allowed for a race condition which would prevent uv from ever doing the check, triggering the original hang condition. This PR adds the check to the resolver thread to prevent this race condition.
