### PR TITLE
Remove `--version` from subcommands

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4062,7 +4062,7 @@ pub enum ToolCommand {
         about = "Run a command provided by a Python package.",
         after_help = "Use `uv help tool run` for more details.",
         after_long_help = "",
-        long_version = crate::version::version()
+        long_version = crate::version::uv_self_version()
     )]
     Uvx(UvxArgs),
     /// Install commands provided by a Python package.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -76,7 +76,6 @@ const STYLES: Styles = Styles::styled()
 #[derive(Parser)]
 #[command(name = "uv", author, long_version = crate::version::uv_self_version())]
 #[command(about = "An extremely fast Python package manager.")]
-#[command(propagate_version = true)]
 #[command(
     after_help = "Use `uv help` for more details.",
     after_long_help = "",
@@ -127,7 +126,7 @@ pub struct TopLevelArgs {
     help: Option<bool>,
 
     /// Display the uv version.
-    #[arg(global = true, short = 'V', long, action = clap::ArgAction::Version, help_heading = "Global options")]
+    #[arg(short = 'V', long, action = clap::ArgAction::Version)]
     version: Option<bool>,
 }
 
@@ -4062,9 +4061,10 @@ pub enum ToolCommand {
         override_usage = "uvx [OPTIONS] [COMMAND]",
         about = "Run a command provided by a Python package.",
         after_help = "Use `uv help tool run` for more details.",
-        after_long_help = ""
+        after_long_help = "",
+        long_version = crate::version::version()
     )]
-    Uvx(ToolRunArgs),
+    Uvx(UvxArgs),
     /// Install commands provided by a Python package.
     ///
     /// Packages are installed into an isolated virtual environment in the uv tools directory. The
@@ -4220,6 +4220,16 @@ pub struct ToolRunArgs {
 
     #[arg(long, hide = true)]
     pub generate_shell_completion: Option<clap_complete_command::Shell>,
+}
+
+#[derive(Args)]
+pub struct UvxArgs {
+    #[command(flatten)]
+    pub tool_run: ToolRunArgs,
+
+    /// Display the uvx version.
+    #[arg(short = 'V', long, action = clap::ArgAction::Version)]
+    pub version: Option<bool>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1067,7 +1067,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             command: run_variant @ (ToolCommand::Uvx(_) | ToolCommand::Run(_)),
         }) => {
             let (args, invocation_source) = match run_variant {
-                ToolCommand::Uvx(args) => (args, ToolRunCommand::Uvx),
+                ToolCommand::Uvx(args) => (args.tool_run, ToolRunCommand::Uvx),
                 ToolCommand::Run(args) => (args, ToolRunCommand::ToolRun),
                 // OK guarded by the outer match statement
                 _ => unreachable!(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1081,15 +1081,15 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     .find_subcommand("uvx")
                     .unwrap()
                     .clone()
-                    // Avoid duplicating the `--help` and `--version` flags from the top-level arguments.
+                    // Avoid duplicating the `--help` and `--version` flags from the top-level
+                    // arguments.
                     .disable_help_flag(true)
-                    .disable_version_flag(true)
-                    .version(env!("CARGO_PKG_VERSION"));
+                    .disable_version_flag(true);
 
-                // Copy the top-level arguments into the `uvx` command. (Like `Args::augment_args`, but
-                // expanded to skip collisions.)
+                // Copy the top-level arguments into the `uvx` command, as in `Args::augment_args`,
+                // but expanded to skip collisions.
                 for arg in TopLevelArgs::command().get_arguments() {
-                    if arg.get_id() != "isolated" {
+                    if arg.get_id() != "isolated" && arg.get_id() != "version" {
                         uvx = uvx.arg(arg);
                     }
                 }

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -438,9 +438,6 @@ fn help_subcommand() {
       -h, --help
               Display the concise help for this command
 
-      -V, --version
-              Display the uv version
-
     Use `uv help python <command>` for more information on a specific command.
 
 
@@ -691,9 +688,6 @@ fn help_subsubcommand() {
       -h, --help
               Display the concise help for this command
 
-      -V, --version
-              Display the uv version
-
 
     ----- stderr -----
     "#);
@@ -755,8 +749,6 @@ fn help_flag_subcommand() {
               Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) [env: UV_NO_CONFIG=]
       -h, --help
               Display the concise help for this command
-      -V, --version
-              Display the uv version
 
     Use `uv help python` for more details.
 
@@ -826,8 +818,6 @@ fn help_flag_subsubcommand() {
               Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) [env: UV_NO_CONFIG=]
       -h, --help
               Display the concise help for this command
-      -V, --version
-              Display the uv version
 
     ----- stderr -----
     "#);
@@ -896,7 +886,7 @@ fn help_unknown_subcommand() {
 fn help_unknown_subsubcommand() {
     let context = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.help().arg("python").arg("foobar"), @r###"
+    uv_snapshot!(context.filters(), context.help().arg("python").arg("foobar"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -909,7 +899,7 @@ fn help_unknown_subsubcommand() {
         pin
         dir
         uninstall
-    "###);
+    ");
 }
 
 #[test]
@@ -1014,14 +1004,20 @@ fn help_with_help() {
 fn help_with_version() {
     let context = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.help().arg("--version"), @r###"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), context.help().arg("--version"), @r"
+    success: false
+    exit_code: 2
     ----- stdout -----
-    uv [VERSION] ([COMMIT] DATE)
 
     ----- stderr -----
-    "###);
+    error: unexpected argument '--version' found
+
+      tip: a similar argument exists: '--verbose'
+
+    Usage: uv help --verbose... [COMMAND]...
+
+    For more information, try '--help'.
+    ");
 }
 
 #[test]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -481,8 +481,6 @@ uv run [OPTIONS] [COMMAND]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-run--version"><a href="#uv-run--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd><dt id="uv-run--with"><a href="#uv-run--with"><code>--with</code></a> <i>with</i></dt><dd><p>Run with the given packages installed.</p>
 
 <p>When used in a project, these dependencies will be layered on top of the project environment in a separate, ephemeral environment. These dependencies are allowed to conflict with those specified by the project.</p>
@@ -730,8 +728,6 @@ uv init [OPTIONS] [PATH]
 </dd><dt id="uv-init--verbose"><a href="#uv-init--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-init--version"><a href="#uv-init--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -1114,8 +1110,6 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-add--version"><a href="#uv-add--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ## uv remove
@@ -1461,8 +1455,6 @@ uv remove [OPTIONS] <PACKAGES>...
 </dd><dt id="uv-remove--verbose"><a href="#uv-remove--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-remove--version"><a href="#uv-remove--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -1888,8 +1880,6 @@ uv sync [OPTIONS]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-sync--version"><a href="#uv-sync--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ## uv lock
@@ -2205,8 +2195,6 @@ uv lock [OPTIONS]
 </dd><dt id="uv-lock--verbose"><a href="#uv-lock--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-lock--version"><a href="#uv-lock--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -2614,8 +2602,6 @@ uv export [OPTIONS]
 </dd><dt id="uv-export--verbose"><a href="#uv-export--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-export--version"><a href="#uv-export--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -3059,8 +3045,6 @@ uv tree [OPTIONS]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tree--version"><a href="#uv-tree--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ## uv tool
@@ -3433,8 +3417,6 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tool-run--version"><a href="#uv-tool-run--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd><dt id="uv-tool-run--with"><a href="#uv-tool-run--with"><code>--with</code></a> <i>with</i></dt><dd><p>Run with the given packages installed</p>
 
 </dd><dt id="uv-tool-run--with-editable"><a href="#uv-tool-run--with-editable"><code>--with-editable</code></a> <i>with-editable</i></dt><dd><p>Run with the given packages installed in editable mode</p>
@@ -3775,8 +3757,6 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tool-install--version"><a href="#uv-tool-install--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd><dt id="uv-tool-install--with"><a href="#uv-tool-install--with"><code>--with</code></a> <i>with</i></dt><dd><p>Include the following extra requirements</p>
 
 </dd><dt id="uv-tool-install--with-editable"><a href="#uv-tool-install--with-editable"><code>--with-editable</code></a> <i>with-editable</i></dt><dd><p>Include the given packages in editable mode</p>
@@ -4084,8 +4064,6 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tool-upgrade--version"><a href="#uv-tool-upgrade--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv tool list
@@ -4199,8 +4177,6 @@ uv tool list [OPTIONS]
 </dd><dt id="uv-tool-list--verbose"><a href="#uv-tool-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-tool-list--version"><a href="#uv-tool-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -4322,8 +4298,6 @@ uv tool uninstall [OPTIONS] <NAME>...
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tool-uninstall--version"><a href="#uv-tool-uninstall--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv tool update-shell
@@ -4441,8 +4415,6 @@ uv tool update-shell [OPTIONS]
 </dd><dt id="uv-tool-update-shell--verbose"><a href="#uv-tool-update-shell--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-tool-update-shell--version"><a href="#uv-tool-update-shell--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -4579,8 +4551,6 @@ uv tool dir [OPTIONS]
 </dd><dt id="uv-tool-dir--verbose"><a href="#uv-tool-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-tool-dir--version"><a href="#uv-tool-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -4810,8 +4780,6 @@ uv python list [OPTIONS] [REQUEST]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-python-list--version"><a href="#uv-python-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv python install
@@ -4983,8 +4951,6 @@ uv python install [OPTIONS] [TARGETS]...
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-python-install--version"><a href="#uv-python-install--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv python find
@@ -5123,8 +5089,6 @@ uv python find [OPTIONS] [REQUEST]
 </dd><dt id="uv-python-find--verbose"><a href="#uv-python-find--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-python-find--version"><a href="#uv-python-find--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -5274,8 +5238,6 @@ uv python pin [OPTIONS] [REQUEST]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-python-pin--version"><a href="#uv-python-pin--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv python dir
@@ -5410,8 +5372,6 @@ uv python dir [OPTIONS]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-python-dir--version"><a href="#uv-python-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv python uninstall
@@ -5536,8 +5496,6 @@ uv python uninstall [OPTIONS] <TARGETS>...
 </dd><dt id="uv-python-uninstall--verbose"><a href="#uv-python-uninstall--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-python-uninstall--version"><a href="#uv-python-uninstall--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -6135,8 +6093,6 @@ uv pip compile [OPTIONS] <SRC_FILE|--group <GROUP>>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-pip-compile--version"><a href="#uv-pip-compile--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv pip sync
@@ -6601,8 +6557,6 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 </dd><dt id="uv-pip-sync--verbose"><a href="#uv-pip-sync--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-pip-sync--version"><a href="#uv-pip-sync--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -7155,8 +7109,6 @@ uv pip install [OPTIONS] <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDIT
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-pip-install--version"><a href="#uv-pip-install--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv pip uninstall
@@ -7316,8 +7268,6 @@ uv pip uninstall [OPTIONS] <PACKAGE|--requirements <REQUIREMENTS>>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-pip-uninstall--version"><a href="#uv-pip-uninstall--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv pip freeze
@@ -7449,8 +7399,6 @@ uv pip freeze [OPTIONS]
 </dd><dt id="uv-pip-freeze--verbose"><a href="#uv-pip-freeze--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-pip-freeze--version"><a href="#uv-pip-freeze--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -7672,8 +7620,6 @@ uv pip list [OPTIONS]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-pip-list--version"><a href="#uv-pip-list--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv pip show
@@ -7809,8 +7755,6 @@ uv pip show [OPTIONS] [PACKAGE]...
 </dd><dt id="uv-pip-show--verbose"><a href="#uv-pip-show--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-pip-show--version"><a href="#uv-pip-show--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -8025,8 +7969,6 @@ uv pip tree [OPTIONS]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-pip-tree--version"><a href="#uv-pip-tree--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv pip check
@@ -8152,8 +8094,6 @@ uv pip check [OPTIONS]
 </dd><dt id="uv-pip-check--verbose"><a href="#uv-pip-check--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-pip-check--version"><a href="#uv-pip-check--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -8416,8 +8356,6 @@ uv venv [OPTIONS] [PATH]
 </dd><dt id="uv-venv--verbose"><a href="#uv-venv--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-venv--version"><a href="#uv-venv--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -8772,8 +8710,6 @@ uv build [OPTIONS] [SRC]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-build--version"><a href="#uv-build--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd><dt id="uv-build--wheel"><a href="#uv-build--wheel"><code>--wheel</code></a></dt><dd><p>Build a binary distribution (&quot;wheel&quot;) from the given directory</p>
 
 </dd></dl>
@@ -8969,8 +8905,6 @@ uv publish --publish-url https://upload.pypi.org/legacy/ --check-url https://pyp
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-publish--version"><a href="#uv-publish--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ## uv cache
@@ -9109,8 +9043,6 @@ uv cache clean [OPTIONS] [PACKAGE]...
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-cache-clean--version"><a href="#uv-cache-clean--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv cache prune
@@ -9228,8 +9160,6 @@ uv cache prune [OPTIONS]
 </dd><dt id="uv-cache-prune--verbose"><a href="#uv-cache-prune--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-cache-prune--version"><a href="#uv-cache-prune--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -9350,8 +9280,6 @@ uv cache dir [OPTIONS]
 </dd><dt id="uv-cache-dir--verbose"><a href="#uv-cache-dir--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-cache-dir--version"><a href="#uv-cache-dir--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -9492,8 +9420,6 @@ uv self update [OPTIONS] [TARGET_VERSION]
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-self-update--version"><a href="#uv-self-update--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
 </dd></dl>
 
 ### uv self version
@@ -9607,8 +9533,6 @@ uv self version [OPTIONS]
 </dd><dt id="uv-self-version--verbose"><a href="#uv-self-version--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-self-version--version"><a href="#uv-self-version--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -9748,8 +9672,6 @@ uv version [OPTIONS] [VALUE]
 </dd><dt id="uv-version--verbose"><a href="#uv-version--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-version--version"><a href="#uv-version--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 
@@ -9924,8 +9846,6 @@ uv help [OPTIONS] [COMMAND]...
 </dd><dt id="uv-help--verbose"><a href="#uv-help--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt id="uv-help--version"><a href="#uv-help--version"><code>--version</code></a>, <code>-V</code></dt><dd><p>Display the uv version</p>
 
 </dd></dl>
 


### PR DESCRIPTION
Supersedes https://github.com/astral-sh/uv/pull/12439 — does not use the Clap macro so we retain control over the messages
Closes #12431 

https://github.com/astral-sh/uv/pull/13108/commits/0077a67b34d22071dcfd42c9281c6929658bb7f9 pulls `uv run` and `uv tool run` test changes from https://github.com/astral-sh/uv/pull/12439