### PR TITLE
Fix display name for `uvx --version`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4062,6 +4062,7 @@ pub enum ToolCommand {
         about = "Run a command provided by a Python package.",
         after_help = "Use `uv help tool run` for more details.",
         after_long_help = "",
+        display_name = "uvx",
         long_version = crate::version::uv_self_version()
     )]
     Uvx(UvxArgs),


### PR DESCRIPTION
Based on #13108 because I don't want to deal with rebasing conflicts across `main` and `release/070`.

```
# Before
❯ .uvx --version
uv-tool-uvx 0.6.16+23 (33b8b7340 2025-04-25)

# After
❯ uvx --version
uvx 0.6.16+23 (33b8b7340 2025-04-25)
```

For posterity, chased this down via https://github.com/clap-rs/clap/pull/3693 and https://github.com/clap-rs/clap/issues/1382