### PR TITLE
Reject non-PEP 751 filenames in `uv pip compile` and `uv export`

### DIFF
--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -16258,6 +16258,32 @@ fn compile_invalid_output_file() -> Result<()> {
 }
 
 #[test]
+fn pep_751_filename() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("iniconfig")?;
+
+    uv_snapshot!(context.filters(), context
+        .pip_compile()
+        .arg("requirements.txt")
+        .arg("--universal")
+        .arg("--format")
+        .arg("pylock.toml")
+        .arg("-o")
+        .arg("test.toml"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Expected the output filename to start with `pylock.` and end with `.toml` (e.g., `pylock.toml`, `pylock.dev.toml`); `test.toml` won't be recognized as a `pylock.toml` file in subsequent commands
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn pep_751_compile_registry_wheel() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
## Summary

We shouldn't let users create files that won't work in subsequent commands.

Closes https://github.com/astral-sh/uv/issues/13117.
