### PR TITLE
Reproducible uv build backend across operating systems

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -444,10 +444,10 @@ mod tests {
         built_by_uv-0.1.0/third-party-licenses
         built_by_uv-0.1.0/third-party-licenses/PEP-401.txt
         "###);
-        assert_snapshot!(format_file_list(source_dist_list_files), @r###"
+        assert_snapshot!(format_file_list(source_dist_list_files), @r"
+        built_by_uv-0.1.0/PKG-INFO (generated)
         built_by_uv-0.1.0/LICENSE-APACHE (LICENSE-APACHE)
         built_by_uv-0.1.0/LICENSE-MIT (LICENSE-MIT)
-        built_by_uv-0.1.0/PKG-INFO (generated)
         built_by_uv-0.1.0/README.md (README.md)
         built_by_uv-0.1.0/assets/data.csv (assets/data.csv)
         built_by_uv-0.1.0/header/built_by_uv.h (header/built_by_uv.h)
@@ -460,7 +460,7 @@ mod tests {
         built_by_uv-0.1.0/src/built_by_uv/build-only.h (src/built_by_uv/build-only.h)
         built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
         built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
-        "###);
+        ");
 
         assert_snapshot!(indirect_wheel_contents.iter().map(|path| path.replace('\\', "/")).join("\n"), @r###"
         built_by_uv-0.1.0.data/data/
@@ -488,22 +488,22 @@ mod tests {
         built_by_uv/cli.py
         "###);
 
-        assert_snapshot!(format_file_list(wheel_list_files), @r###"
-        built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
-        built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
-        built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
-        built_by_uv-0.1.0.dist-info/METADATA (generated)
-        built_by_uv-0.1.0.dist-info/WHEEL (generated)
-        built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
-        built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
-        built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
-        built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
+        assert_snapshot!(format_file_list(wheel_list_files), @r"
         built_by_uv/__init__.py (src/built_by_uv/__init__.py)
         built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
         built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
         built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
         built_by_uv/cli.py (src/built_by_uv/cli.py)
-        "###);
+        built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
+        built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
+        built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
+        built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
+        built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
+        built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
+        built_by_uv-0.1.0.dist-info/WHEEL (generated)
+        built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
+        built_by_uv-0.1.0.dist-info/METADATA (generated)
+        ");
 
         // Check that the wheel is the same for both build paths and reproducible across platforms.
         let wheel_filename = "built_by_uv-0.1.0-py3-none-any.whl";

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -346,7 +346,6 @@ mod tests {
 
         // Build a wheel from the source dist
         let sdist_tree = TempDir::new().unwrap();
-        let source_dist_path = source_dist_dir.path().join("built_by_uv-0.1.0.tar.gz");
         let sdist_reader = BufReader::new(File::open(&source_dist_path).unwrap());
         let mut source_dist = tar::Archive::new(GzDecoder::new(sdist_reader));
         let mut source_dist_contents: Vec<_> = source_dist
@@ -497,7 +496,7 @@ mod tests {
         );
         assert_snapshot!(
             format!("{:x}", sha2::Sha256::digest(&index_wheel_contents)),
-            @"9f662b985a348d5f1561b82b79359d013906955c28b377b41b2f7a7cafb208ee"
+            @"ad9bc0dad97ef3174366e1bd808817a8a89d09695473f309ee835c110f34e8b4"
         );
     }
 

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -410,14 +410,18 @@ impl PyProjectToml {
                         }
                     })?;
 
-                for entry in WalkDir::new(root).into_iter().filter_entry(|entry| {
-                    license_globs.match_directory(
-                        entry
-                            .path()
-                            .strip_prefix(root)
-                            .expect("walkdir starts with root"),
-                    )
-                }) {
+                for entry in WalkDir::new(root)
+                    .sort_by_file_name()
+                    .into_iter()
+                    .filter_entry(|entry| {
+                        license_globs.match_directory(
+                            entry
+                                .path()
+                                .strip_prefix(root)
+                                .expect("walkdir starts with root"),
+                        )
+                    })
+                {
                     let entry = entry.map_err(|err| Error::WalkDir {
                         root: root.to_path_buf(),
                         err,

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -54,8 +54,6 @@ pub fn list_source_dist(
     let mut files = FileList::new();
     let writer = ListWriter::new(&mut files);
     write_source_dist(source_tree, writer, uv_version)?;
-    // Ensure a deterministic order even when file walking changes
-    files.sort_unstable();
     Ok((filename, files))
 }
 

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -87,8 +87,6 @@ pub fn list_wheel(
     let mut files = FileList::new();
     let writer = ListWriter::new(&mut files);
     write_wheel(source_tree, &pyproject_toml, &filename, uv_version, writer)?;
-    // Ensure a deterministic order even when file walking changes
-    files.sort_unstable();
     Ok((filename, files))
 }
 

--- a/crates/uv-globfilter/src/glob_dir_filter.rs
+++ b/crates/uv-globfilter/src/glob_dir_filter.rs
@@ -174,7 +174,8 @@ mod tests {
         let matcher = GlobDirFilter::from_globs(&patterns).unwrap();
 
         // Test the prefix filtering
-        let mut visited: Vec<_> = WalkDir::new(dir.path())
+        let visited: Vec<_> = WalkDir::new(dir.path())
+            .sort_by_file_name()
             .into_iter()
             .filter_entry(|entry| {
                 let relative = entry
@@ -196,7 +197,6 @@ mod tests {
                 relative.replace(MAIN_SEPARATOR, "/")
             })
             .collect();
-        visited.sort();
         assert_eq!(
             visited,
             [
@@ -234,6 +234,7 @@ mod tests {
 
         let walkdir_root = dir.path();
         let mut matches: Vec<_> = WalkDir::new(walkdir_root)
+            .sort_by_file_name()
             .into_iter()
             .filter_entry(|entry| {
                 // TODO(konsti): This should be prettier.

--- a/crates/uv-globfilter/src/main.rs
+++ b/crates/uv-globfilter/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
 
     let walkdir_root = args().next().unwrap();
     for entry in WalkDir::new(&walkdir_root)
+        .sort_by_file_name()
         .into_iter()
         .filter_entry(|entry| {
             // TODO(konsti): This should be prettier.

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -1553,14 +1553,14 @@ fn build_list_files() -> Result<()> {
         .arg(&built_by_uv)
         .arg("--out-dir")
         .arg(context.temp_dir.join("output1"))
-        .arg("--list"), @r###"
+        .arg("--list"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
     Building built_by_uv-0.1.0.tar.gz will include the following files:
+    built_by_uv-0.1.0/PKG-INFO (generated)
     built_by_uv-0.1.0/LICENSE-APACHE (LICENSE-APACHE)
     built_by_uv-0.1.0/LICENSE-MIT (LICENSE-MIT)
-    built_by_uv-0.1.0/PKG-INFO (generated)
     built_by_uv-0.1.0/README.md (README.md)
     built_by_uv-0.1.0/assets/data.csv (assets/data.csv)
     built_by_uv-0.1.0/header/built_by_uv.h (header/built_by_uv.h)
@@ -1574,25 +1574,25 @@ fn build_list_files() -> Result<()> {
     built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
     built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     Building built_by_uv-0.1.0-py3-none-any.whl will include the following files:
-    built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
-    built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
-    built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
-    built_by_uv-0.1.0.dist-info/METADATA (generated)
-    built_by_uv-0.1.0.dist-info/WHEEL (generated)
-    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
-    built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
-    built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
-    built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     built_by_uv/__init__.py (src/built_by_uv/__init__.py)
     built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
     built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
     built_by_uv/cli.py (src/built_by_uv/cli.py)
+    built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
+    built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
+    built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
+    built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
+    built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
+    built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
+    built_by_uv-0.1.0.dist-info/WHEEL (generated)
+    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
+    built_by_uv-0.1.0.dist-info/METADATA (generated)
 
     ----- stderr -----
     Building source distribution (uv build backend)...
     Successfully built output1/built_by_uv-0.1.0.tar.gz
-    "###);
+    ");
     context
         .temp_dir
         .child("output1")
@@ -1611,14 +1611,14 @@ fn build_list_files() -> Result<()> {
         .arg(context.temp_dir.join("output2"))
         .arg("--list")
         .arg("--sdist")
-        .arg("--wheel"), @r###"
+        .arg("--wheel"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
     Building built_by_uv-0.1.0.tar.gz will include the following files:
+    built_by_uv-0.1.0/PKG-INFO (generated)
     built_by_uv-0.1.0/LICENSE-APACHE (LICENSE-APACHE)
     built_by_uv-0.1.0/LICENSE-MIT (LICENSE-MIT)
-    built_by_uv-0.1.0/PKG-INFO (generated)
     built_by_uv-0.1.0/README.md (README.md)
     built_by_uv-0.1.0/assets/data.csv (assets/data.csv)
     built_by_uv-0.1.0/header/built_by_uv.h (header/built_by_uv.h)
@@ -1632,23 +1632,23 @@ fn build_list_files() -> Result<()> {
     built_by_uv-0.1.0/src/built_by_uv/cli.py (src/built_by_uv/cli.py)
     built_by_uv-0.1.0/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     Building built_by_uv-0.1.0-py3-none-any.whl will include the following files:
-    built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
-    built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
-    built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
-    built_by_uv-0.1.0.dist-info/METADATA (generated)
-    built_by_uv-0.1.0.dist-info/WHEEL (generated)
-    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
-    built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
-    built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
-    built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
     built_by_uv/__init__.py (src/built_by_uv/__init__.py)
     built_by_uv/arithmetic/__init__.py (src/built_by_uv/arithmetic/__init__.py)
     built_by_uv/arithmetic/circle.py (src/built_by_uv/arithmetic/circle.py)
     built_by_uv/arithmetic/pi.txt (src/built_by_uv/arithmetic/pi.txt)
     built_by_uv/cli.py (src/built_by_uv/cli.py)
+    built_by_uv-0.1.0.dist-info/licenses/LICENSE-APACHE (LICENSE-APACHE)
+    built_by_uv-0.1.0.dist-info/licenses/LICENSE-MIT (LICENSE-MIT)
+    built_by_uv-0.1.0.dist-info/licenses/third-party-licenses/PEP-401.txt (third-party-licenses/PEP-401.txt)
+    built_by_uv-0.1.0.data/headers/built_by_uv.h (header/built_by_uv.h)
+    built_by_uv-0.1.0.data/scripts/whoami.sh (scripts/whoami.sh)
+    built_by_uv-0.1.0.data/data/data.csv (assets/data.csv)
+    built_by_uv-0.1.0.dist-info/WHEEL (generated)
+    built_by_uv-0.1.0.dist-info/entry_points.txt (generated)
+    built_by_uv-0.1.0.dist-info/METADATA (generated)
 
     ----- stderr -----
-    "###);
+    ");
     context
         .temp_dir
         .child("output2")


### PR DESCRIPTION
The goal of this PR is to support reproducible builds and best-effort platform-independent builds. Previously, while the build backend would build the same source dist and wheel on the same machine, they would look different across different operating systems. This PR fixes the platform-dependent walk dir order by sorting and removes platform-specific permissions from the source dist that had caused those differences.

The reproducibility goal does not extend to platform-dependent filesystem features, such as permissions and links, especially in interaction with Git. Since most users share code across platforms through Git, we're focusing on cross-platform behavior under Git. One of those caveats is intentional: If a file, such as a bash script, has an executable bit, we preserve it. This means that E.g. builds of Git checkout of a repository with an executable shell script in the sources will have different archives on Unix and Windows. Another relevant case are symlinks: By default, Git on Windows replaces symlinks with a file that contains the path to the target file (https://stackoverflow.com/q/5917249/3549270). (This example comes from Cargo, where it means that the package archive is different on Windows when symlinking license from the repository root to a workspace package)

Best reviewed commit-by-commit