### PR TITLE
Add .env to default .gitignore template  

### DIFF
--- a/crates/uv-configuration/src/vcs.rs
+++ b/crates/uv-configuration/src/vcs.rs
@@ -93,4 +93,7 @@ wheels/
 
 # Virtual environments
 .venv
+
+# Environment variables
+.env
 ";

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2617,7 +2617,7 @@ fn init_git() -> Result<()> {
         filters => context.filters(),
     }, {
         assert_snapshot!(
-            gitignore, @r###"
+            gitignore, @r"
         # Python-generated files
         __pycache__/
         *.py[oc]
@@ -2628,7 +2628,10 @@ fn init_git() -> Result<()> {
 
         # Virtual environments
         .venv
-        "###
+
+        # Environment variables
+        .env
+        "
         );
     });
 


### PR DESCRIPTION
This PR adds `.env` files to the default `.gitignore` template that's generated when initializing a new uv project.
  
## Motivation  
`.env` files typically contain environment-specific configuration and secrets that shouldn't be committed to version control. The uv project already has support for `.env` files in the `uv run` command, so adding this to the default `.gitignore` aligns with best practices and the existing functionality.  
  
## Changes  
- Added `.env` to the `GITIGNORE` constant in `crates/uv-configuration/src/vcs.rs`