### PR TITLE
Fix patching of `clang` in managed Python sysconfig

### DIFF
--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -68,87 +68,85 @@ impl ReplacementEntry {
 }
 
 /// Mapping for sysconfig keys to lookup and replace with the appropriate entry.
-static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, ReplacementEntry>> =
+static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<ReplacementEntry>>> =
     LazyLock::new(|| {
         BTreeMap::from_iter([
             (
                 "CC".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang".to_string(),
+                vec![
+                    ReplacementEntry {
+                        mode: ReplacementMode::Partial {
+                            from: "clang".to_string(),
+                        },
+                        to: "cc".to_string(),
                     },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "CC".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "/usr/bin/aarch64-linux-gnu-gcc".to_string(),
+                    ReplacementEntry {
+                        mode: ReplacementMode::Partial {
+                            from: "/usr/bin/aarch64-linux-gnu-gcc".to_string(),
+                        },
+                        to: "cc".to_string(),
                     },
-                    to: "cc".to_string(),
-                },
-            ),
-            (
-                "CXX".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "clang++".to_string(),
-                    },
-                    to: "c++".to_string(),
-                },
+                ],
             ),
             (
                 "CXX".to_string(),
-                ReplacementEntry {
-                    mode: ReplacementMode::Partial {
-                        from: "/usr/bin/x86_64-linux-gnu-g++".to_string(),
+                vec![
+                    ReplacementEntry {
+                        mode: ReplacementMode::Partial {
+                            from: "clang++".to_string(),
+                        },
+                        to: "c++".to_string(),
                     },
-                    to: "c++".to_string(),
-                },
+                    ReplacementEntry {
+                        mode: ReplacementMode::Partial {
+                            from: "/usr/bin/x86_64-linux-gnu-g++".to_string(),
+                        },
+                        to: "c++".to_string(),
+                    },
+                ],
             ),
             (
                 "BLDSHARED".to_string(),
-                ReplacementEntry {
+                vec![ReplacementEntry {
                     mode: ReplacementMode::Partial {
                         from: "clang".to_string(),
                     },
                     to: "cc".to_string(),
-                },
+                }],
             ),
             (
                 "LDSHARED".to_string(),
-                ReplacementEntry {
+                vec![ReplacementEntry {
                     mode: ReplacementMode::Partial {
                         from: "clang".to_string(),
                     },
                     to: "cc".to_string(),
-                },
+                }],
             ),
             (
                 "LDCXXSHARED".to_string(),
-                ReplacementEntry {
+                vec![ReplacementEntry {
                     mode: ReplacementMode::Partial {
                         from: "clang++".to_string(),
                     },
                     to: "c++".to_string(),
-                },
+                }],
             ),
             (
                 "LINKCC".to_string(),
-                ReplacementEntry {
+                vec![ReplacementEntry {
                     mode: ReplacementMode::Partial {
                         from: "clang".to_string(),
                     },
                     to: "cc".to_string(),
-                },
+                }],
             ),
             (
                 "AR".to_string(),
-                ReplacementEntry {
+                vec![ReplacementEntry {
                     mode: ReplacementMode::Full,
                     to: "ar".to_string(),
-                },
+                }],
             ),
         ])
     });
@@ -296,8 +294,10 @@ fn patch_sysconfigdata(mut data: SysconfigData, real_prefix: &Path) -> Sysconfig
         let patched = update_prefix(value, real_prefix);
         let mut patched = remove_isysroot(&patched);
 
-        if let Some(replacement_entry) = DEFAULT_VARIABLE_UPDATES.get(key) {
-            patched = replacement_entry.patch(&patched);
+        if let Some(replacement_entries) = DEFAULT_VARIABLE_UPDATES.get(key) {
+            for replacement_entry in replacement_entries {
+                patched = replacement_entry.patch(&patched);
+            }
         }
 
         if *value != patched {
@@ -456,8 +456,8 @@ mod tests {
         # system configuration generated and used by the sysconfig module
         build_time_vars = {
             "AR": "ar",
-            "CC": "clang -pthread",
-            "CXX": "clang++ -pthread",
+            "CC": "cc -pthread",
+            "CXX": "c++ -pthread",
             "PYTHON_BUILD_STANDALONE": 1
         }
         "##);


### PR DESCRIPTION
Regressed in https://github.com/astral-sh/uv/pull/12239/files#r2069106892 because additional entries override the previous one in the mapping. Now, we can apply multiple patches in-order.

Closes #13236 