### PR TITLE
Provide new unsafe-first-index strategy

### DIFF
--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -323,6 +323,13 @@ pub enum IndexStrategy {
     #[default]
     #[cfg_attr(feature = "clap", clap(alias = "first-match"))]
     FirstIndex,
+    /// Only use results from the first index that returns a match for a given package name,
+    /// but ignore any authentication failures.
+    ///
+    /// This is more secure than pip's behavior but is still vulnerable to dependency confusion
+    /// if we encounter an authentication failure at an earlier index.
+    #[cfg_attr(feature = "clap", clap(alias = "unsafe-first-index"))]
+    UnsafeFirstIndex,
     /// Search for every package name across all indexes, exhausting the versions from the first
     /// index before moving on to the next.
     ///

--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -327,7 +327,7 @@ pub enum IndexStrategy {
     /// but ignore any authentication failures.
     ///
     /// This is more secure than pip's behavior but is still vulnerable to dependency confusion
-    /// if we encounter an authentication failure at an earlier index.
+    /// if we encounter an authentication failure at a higher-priority index.
     #[cfg_attr(feature = "clap", clap(alias = "unsafe-first-index"))]
     UnsafeFirstIndex,
     /// Search for every package name across all indexes, exhausting the versions from the first

--- a/crates/uv-distribution-types/src/status_code_strategy.rs
+++ b/crates/uv-distribution-types/src/status_code_strategy.rs
@@ -65,17 +65,20 @@ impl IndexStatusCodeStrategy {
         index_url: &IndexUrl,
         capabilities: &IndexCapabilities,
     ) -> IndexStatusCodeDecision {
+        match status_code {
+            StatusCode::UNAUTHORIZED => {
+                capabilities.set_unauthorized(index_url.clone());
+            }
+            StatusCode::FORBIDDEN => {
+                capabilities.set_forbidden(index_url.clone());
+            }
+            _ => {}
+        }
         match self {
             IndexStatusCodeStrategy::Default => match status_code {
                 StatusCode::NOT_FOUND => IndexStatusCodeDecision::Ignore,
-                StatusCode::UNAUTHORIZED => {
-                    capabilities.set_unauthorized(index_url.clone());
-                    IndexStatusCodeDecision::Fail(status_code)
-                }
-                StatusCode::FORBIDDEN => {
-                    capabilities.set_forbidden(index_url.clone());
-                    IndexStatusCodeDecision::Fail(status_code)
-                }
+                StatusCode::UNAUTHORIZED => IndexStatusCodeDecision::Fail(status_code),
+                StatusCode::FORBIDDEN => IndexStatusCodeDecision::Fail(status_code),
                 _ => IndexStatusCodeDecision::Fail(status_code),
             },
             IndexStatusCodeStrategy::IgnoreErrorCodes { status_codes } => {

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -894,7 +894,10 @@ impl PubGrubReportFormatter<'_> {
 
         // Add hints due to the package being available on an index, but not at the correct version,
         // with subsequent indexes that were _not_ queried.
-        if matches!(selector.index_strategy(), IndexStrategy::FirstIndex) {
+        if matches!(
+            selector.index_strategy(),
+            IndexStrategy::FirstIndex | IndexStrategy::UnsafeFirstIndex
+        ) {
             // Do not include the hint if the set is "all versions". This is an unusual but valid
             // case in which a package returns a 200 response, but without any versions or
             // distributions for the package.

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -127,6 +127,9 @@ To opt in to alternate index behaviors, use the`--index-strategy` command-line o
 
 - `first-index` (default): Search for each package across all indexes, limiting the candidate
   versions to those present in the first index that contains the package.
+- `unsafe-first-index`: Search for each package across all indexes, limiting the candidate versions
+  to those present in the first index that contains the package. But treat authentication failures
+  as package not found.
 - `unsafe-first-match`: Search for each package across all indexes, but prefer the first index with
   a compatible version, even if newer versions are available on other indexes.
 - `unsafe-best-match`: Search for each package across all indexes, and select the best version from
@@ -231,6 +234,9 @@ ignore-error-codes = [403]
 
 uv will always continue searching across indexes when it encounters a `404 Not Found`. This cannot
 be overridden.
+
+It is also possible to use the [unsafe-first-index strategy](#searching-across-multiple-indexes).
+But because this approach is less fine-grained, it is more vulnerable to dependency confusion.
 
 ### Disabling authentication
 

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -111,6 +111,10 @@ supports the following values:
 - `first-index` (default): Search for each package across all indexes, limiting the candidate
   versions to those present in the first index that contains the package, prioritizing the
   `--extra-index-url` indexes over the default index URL.
+- `unsafe-first-index`: Search for each package across all indexes, limiting the candidate versions
+  to those present in the first index that contains the package, prioritizing the
+  `--extra-index-url` indexes over the default index URL. But treat authentication failures as
+  package not found.
 - `unsafe-first-match`: Search for each package across all indexes, but prefer the first index with
   a compatible version, even if newer versions are available on other indexes.
 - `unsafe-best-match`: Search for each package across all indexes, and select the best version from

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -230,6 +230,8 @@ uv run [OPTIONS] [COMMAND]
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -905,6 +907,8 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -1266,6 +1270,8 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -1638,6 +1644,8 @@ uv sync [OPTIONS]
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -2017,6 +2025,8 @@ uv lock [OPTIONS]
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -2358,6 +2368,8 @@ uv export [OPTIONS]
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -2735,6 +2747,8 @@ uv tree [OPTIONS]
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -3232,6 +3246,8 @@ uv tool run [OPTIONS] [COMMAND]
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -3577,6 +3593,8 @@ uv tool install [OPTIONS] <PACKAGE>
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -3898,6 +3916,8 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -5733,6 +5753,8 @@ uv pip compile [OPTIONS] <SRC_FILE|--group <GROUP>>
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -6248,6 +6270,8 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -6738,6 +6762,8 @@ uv pip install [OPTIONS] <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDIT
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -7529,6 +7555,8 @@ uv pip list [OPTIONS]
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -7869,6 +7897,8 @@ uv pip tree [OPTIONS]
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
@@ -8230,6 +8260,8 @@ uv venv [OPTIONS] [PATH]
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
 
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
+
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 
 <li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
@@ -8514,6 +8546,8 @@ uv build [OPTIONS] [SRC]
 
 <ul>
 <li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-index</code>:  Only use results from the first index that returns a match for a given package name, but ignore any authentication failures</li>
 
 <li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1114,6 +1114,7 @@ same name to an alternate index.
 **Possible values**:
 
 - `"first-index"`: Only use results from the first index that returns a match for a given package name
+- `"unsafe-first-index"`: Only use results from the first index that returns a match for a given package name, but ignore any authentication failures
 - `"unsafe-first-match"`: Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next
 - `"unsafe-best-match"`: Search for every package name across all indexes, preferring the "best" version found. If a package version is in multiple indexes, only look at the entry for the first index
 
@@ -2551,6 +2552,7 @@ same name to an alternate index.
 **Possible values**:
 
 - `"first-index"`: Only use results from the first index that returns a match for a given package name
+- `"unsafe-first-index"`: Only use results from the first index that returns a match for a given package name, but ignore any authentication failures
 - `"unsafe-first-match"`: Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next
 - `"unsafe-best-match"`: Search for every package name across all indexes, preferring the "best" version found. If a package version is in multiple indexes, only look at the entry for the first index
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -949,7 +949,7 @@
           ]
         },
         {
-          "description": "Only use results from the first index that returns a match for a given package name, but ignore any authentication failures.\n\nThis is more secure than pip's behavior but is still vulnerable to dependency confusion if we encounter an authentication failure at an earlier index.",
+          "description": "Only use results from the first index that returns a match for a given package name, but ignore any authentication failures.\n\nThis is more secure than pip's behavior but is still vulnerable to dependency confusion if we encounter an authentication failure at a higher-priority index.",
           "type": "string",
           "enum": [
             "unsafe-first-index"

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -949,6 +949,13 @@
           ]
         },
         {
+          "description": "Only use results from the first index that returns a match for a given package name, but ignore any authentication failures.\n\nThis is more secure than pip's behavior but is still vulnerable to dependency confusion if we encounter an authentication failure at an earlier index.",
+          "type": "string",
+          "enum": [
+            "unsafe-first-index"
+          ]
+        },
+        {
           "description": "Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next.\n\nIn this strategy, we look for every package across all indexes. When resolving, we attempt to use versions from the indexes in order, such that we exhaust all available versions from the first index before moving on to the next. Further, if a version is found to be incompatible in the first index, we do not reconsider that version in subsequent indexes, even if the secondary index might contain compatible versions (e.g., variants of the same versions with different ABI tags or Python version constraints).\n\nSee: <https://peps.python.org/pep-0708/>",
           "type": "string",
           "enum": [


### PR DESCRIPTION
This PR adds a new index strategy called `unsafe-first-index`. This is the same as the default `first-index` strategy except that it continues searching indexes when encountering authentication failures. This provides a way to ignore these failures without configuring an index in `pyproject.toml`, but also makes clear that it is more insecure than our default.

Usage example:
```
uv add anyio --extra-index-url private.index.url --index-strategy unsafe-first-index
``` 

I'm not certain this should be an option, but since it was straightforward to add I've created this PR for discussion. It's a little confusing that `unsafe-first-index` and the existing `unsafe-first-match` sound similar, but this is just the `first-index` strategy with ignored authentication errors.

