### PR TITLE
Reference no update command in `uv sync` version mismatch

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -298,7 +298,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         let package_version = uv_pep440::Version::from_str(uv_version::version())?;
         if !required_version.contains(&package_version) {
             return Err(anyhow::anyhow!(
-                "Required uv version `{required_version}` does not match the running version `{package_version}`",
+                "Required uv version `{required_version}` does not match the running version `{package_version}`\nRun `uv self update <version>` to update to <version> (blank for latest)",
             ));
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes: #13253 
## Summary
(Very) small change to refer to update command `uv self update` when the uv version is mismatched. 

I found only this one occurrence where a reference is suitable. Only other contenders are here 
https://github.com/astral-sh/uv/blob/21b9f62dbf0901e6ff453f11afb79a7ab89f1af1/crates/uv/src/commands/project/mod.rs#L81-L85
But I think this would rather convolute the message and they will run into the other message when running `uv sync`. 


## Note 
Happy to also try my look with implementing your feedback on #11869 if that's ok for you, @aarondobbing?
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Local test
<!-- How was it tested? -->
