### PR TITLE
Only rebuild download JSON on change

### DIFF
--- a/crates/uv-python/build.rs
+++ b/crates/uv-python/build.rs
@@ -21,7 +21,8 @@ fn process_json(data: &serde_json::Value) -> serde_json::Value {
 }
 
 fn main() {
-    let version_metadata = Path::new("download-metadata.json");
+    let version_metadata = "download-metadata.json";
+    println!("cargo::rerun-if-changed={version_metadata}");
     let target = Path::new("src/download-metadata-minified.json");
 
     let json_data: serde_json::Value = serde_json::from_str(


### PR DESCRIPTION
By default, Cargo runs the build script if any file in the package changes (https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection). In our case, we only need to rerun it if `download-metadata.json` changed.