### PR TITLE
Add `--show-with` to `uv tool list` to list packages included by `--with`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4334,9 +4334,9 @@ pub struct ToolListArgs {
     #[arg(long)]
     pub show_version_specifiers: bool,
 
-    /// Whether to display the extra package(s) installed with each tool.
+    /// Whether to display the extra requirements(s) installed with each tool.
     #[arg(long)]
-    pub show_extras: bool,
+    pub show_with: bool,
 
     // Hide unused global Python options.
     #[arg(long, hide = true)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4246,11 +4246,11 @@ pub struct ToolInstallArgs {
     #[arg(long, hide = true)]
     pub from: Option<String>,
 
-    /// Include the following extra requirements.
+    /// Include the following additional requirements.
     #[arg(long)]
     pub with: Vec<comma::CommaSeparatedRequirements>,
 
-    /// Run all requirements listed in the given `requirements.txt` files.
+    /// Include all requirements listed in the given `requirements.txt` files.
     #[arg(long, value_delimiter = ',', value_parser = parse_maybe_file_path)]
     pub with_requirements: Vec<Maybe<PathBuf>>,
 
@@ -4334,7 +4334,7 @@ pub struct ToolListArgs {
     #[arg(long)]
     pub show_version_specifiers: bool,
 
-    /// Whether to display the extra requirements(s) installed with each tool.
+    /// Whether to display the additional requirements installed with each tool.
     #[arg(long)]
     pub show_with: bool,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4334,6 +4334,10 @@ pub struct ToolListArgs {
     #[arg(long)]
     pub show_version_specifiers: bool,
 
+    /// Whether to display the extra package(s) installed with each tool.
+    #[arg(long)]
+    pub show_extras: bool,
+
     // Hide unused global Python options.
     #[arg(long, hide = true)]
     pub python_preference: Option<PythonPreference>,

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -81,8 +81,8 @@ pub(crate) async fn list(
             String::new()
         };
 
-        let extra_requirements = if show_with {
-            let extra_requirements = tool
+        let with_requirements = if show_with {
+            let with_requirements = tool
                 .requirements()
                 .iter()
                 .filter(|req| req.name != name)
@@ -95,10 +95,10 @@ pub(crate) async fn list(
                 })
                 .filter(|s| !s.is_empty())
                 .join(", ");
-            if extra_requirements.is_empty() {
+            if with_requirements.is_empty() {
                 String::new()
             } else {
-                format!(" [with: {extra_requirements}]")
+                format!(" [with: {with_requirements}]")
             }
         } else {
             String::new()
@@ -108,14 +108,14 @@ pub(crate) async fn list(
             writeln!(
                 printer.stdout(),
                 "{} ({})",
-                format!("{name} v{version}{version_specifier}{extra_requirements}").bold(),
+                format!("{name} v{version}{version_specifier}{with_requirements}").bold(),
                 installed_tools.tool_dir(&name).simplified_display().cyan(),
             )?;
         } else {
             writeln!(
                 printer.stdout(),
                 "{}",
-                format!("{name} v{version}{version_specifier}{extra_requirements}").bold()
+                format!("{name} v{version}{version_specifier}{with_requirements}").bold()
             )?;
         }
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -16,7 +16,7 @@ use crate::printer::Printer;
 pub(crate) async fn list(
     show_paths: bool,
     show_version_specifiers: bool,
-    show_extras: bool,
+    show_with: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -81,8 +81,8 @@ pub(crate) async fn list(
             String::new()
         };
 
-        let extras = if show_extras {
-            let extras = tool
+        let extra_requirements = if show_with {
+            let extra_requirements = tool
                 .requirements()
                 .iter()
                 .filter(|req| req.name != name)
@@ -95,10 +95,10 @@ pub(crate) async fn list(
                 })
                 .filter(|s| !s.is_empty())
                 .join(", ");
-            if extras.is_empty() {
+            if extra_requirements.is_empty() {
                 String::new()
             } else {
-                format!(" [extras: {extras}]")
+                format!(" [with: {extra_requirements}]")
             }
         } else {
             String::new()
@@ -108,14 +108,14 @@ pub(crate) async fn list(
             writeln!(
                 printer.stdout(),
                 "{} ({})",
-                format!("{name} v{version}{version_specifier}{extras}").bold(),
+                format!("{name} v{version}{version_specifier}{extra_requirements}").bold(),
                 installed_tools.tool_dir(&name).simplified_display().cyan(),
             )?;
         } else {
             writeln!(
                 printer.stdout(),
                 "{}",
-                format!("{name} v{version}{version_specifier}{extras}").bold()
+                format!("{name} v{version}{version_specifier}{extra_requirements}").bold()
             )?;
         }
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -87,12 +87,11 @@ pub(crate) async fn list(
                 .iter()
                 .filter(|req| req.name != name)
                 .map(|req| {
-                    let spec = if !req.source.to_string().is_empty() {
+                    if !req.source.to_string().is_empty() {
                         format!("{}{}", req.name, req.source)
                     } else {
                         req.name.to_string()
-                    };
-                    spec
+                    }
                 })
                 .filter(|s| !s.is_empty())
                 .join(", ");

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -86,11 +86,14 @@ pub(crate) async fn list(
                 let requirements = tool
                     .requirements()
                     .iter()
-                    // Exclude the package itself
                     .filter(|req| req.name != name)
                     .map(|req| format!("{}{}", req.name, req.source))
                     .join(", ");
-                format!(" [with: {requirements}]")
+                if requirements.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [with: {requirements}]")
+                }
             })
             .unwrap_or_default();
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -81,28 +81,18 @@ pub(crate) async fn list(
             String::new()
         };
 
-        let with_requirements = if show_with {
-            let with_requirements = tool
-                .requirements()
-                .iter()
-                .filter(|req| req.name != name)
-                .map(|req| {
-                    if !req.source.to_string().is_empty() {
-                        format!("{}{}", req.name, req.source)
-                    } else {
-                        req.name.to_string()
-                    }
-                })
-                .filter(|s| !s.is_empty())
-                .join(", ");
-            if with_requirements.is_empty() {
-                String::new()
-            } else {
-                format!(" [with: {with_requirements}]")
-            }
-        } else {
-            String::new()
-        };
+        let with_requirements = (show_with && !tool.requirements().is_empty())
+            .then(|| {
+                let requirements = tool
+                    .requirements()
+                    .iter()
+                    // Exclude the package itself
+                    .filter(|req| req.name != name)
+                    .map(|req| format!("{}{}", req.name, req.source))
+                    .join(", ");
+                format!(" [with: {requirements}]")
+            })
+            .unwrap_or_default();
 
         if show_paths {
             writeln!(

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1258,6 +1258,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             commands::tool_list(
                 args.show_paths,
                 args.show_version_specifiers,
+                args.show_extras,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1258,7 +1258,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             commands::tool_list(
                 args.show_paths,
                 args.show_version_specifiers,
-                args.show_extras,
+                args.show_with,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -772,7 +772,7 @@ impl ToolUpgradeSettings {
 pub(crate) struct ToolListSettings {
     pub(crate) show_paths: bool,
     pub(crate) show_version_specifiers: bool,
-    pub(crate) show_extras: bool,
+    pub(crate) show_with: bool,
 }
 
 impl ToolListSettings {
@@ -782,7 +782,7 @@ impl ToolListSettings {
         let ToolListArgs {
             show_paths,
             show_version_specifiers,
-            show_extras,
+            show_with,
             python_preference: _,
             no_python_downloads: _,
         } = args;
@@ -790,7 +790,7 @@ impl ToolListSettings {
         Self {
             show_paths,
             show_version_specifiers,
-            show_extras,
+            show_with,
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -772,6 +772,7 @@ impl ToolUpgradeSettings {
 pub(crate) struct ToolListSettings {
     pub(crate) show_paths: bool,
     pub(crate) show_version_specifiers: bool,
+    pub(crate) show_extras: bool,
 }
 
 impl ToolListSettings {
@@ -781,6 +782,7 @@ impl ToolListSettings {
         let ToolListArgs {
             show_paths,
             show_version_specifiers,
+            show_extras,
             python_preference: _,
             no_python_downloads: _,
         } = args;
@@ -788,6 +790,7 @@ impl ToolListSettings {
         Self {
             show_paths,
             show_version_specifiers,
+            show_extras
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -790,7 +790,7 @@ impl ToolListSettings {
         Self {
             show_paths,
             show_version_specifiers,
-            show_extras
+            show_extras,
         }
     }
 }

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1711,7 +1711,7 @@ fn tool_install_uninstallable() {
           We are sorry, but this package is not installable with pip.
 
           Please read the installation instructions at:
-
+     
           https://github.com/pyenv/pyenv#installation
           #
 

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1711,7 +1711,7 @@ fn tool_install_uninstallable() {
           We are sorry, but this package is not installable with pip.
 
           Please read the installation instructions at:
-     
+
           https://github.com/pyenv/pyenv#installation
           #
 
@@ -2021,7 +2021,7 @@ fn tool_install_unnamed_with() {
     "###);
 }
 
-/// Test installing a tool with extra requirements from a `requirements.txt` file.
+/// Test installing a tool with additional requirements from a `requirements.txt` file.
 #[test]
 fn tool_install_requirements_txt() {
     let context = TestContext::new("3.12")

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -344,7 +344,7 @@ fn tool_list_show_with() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Install `black` without extra requirements
+    // Install `black` without additional requirements
     context
         .tool_install()
         .arg("black==24.2.0")
@@ -353,7 +353,7 @@ fn tool_list_show_with() {
         .assert()
         .success();
 
-    // Install `flask` with extra requirements
+    // Install `flask` with additional requirements
     context
         .tool_install()
         .arg("flask")
@@ -366,7 +366,7 @@ fn tool_list_show_with() {
         .assert()
         .success();
 
-    // Install `ruff` with version specifier and extra requirements
+    // Install `ruff` with version specifier and additional requirements
     context
         .tool_install()
         .arg("ruff==0.3.4")

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -339,12 +339,12 @@ fn tool_list_show_version_specifiers() {
 }
 
 #[test]
-fn tool_list_show_extras() {
+fn tool_list_show_with() {
     let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Install `flask` with extras
+    // Install `flask` with extra requirements
     context
         .tool_install()
         .arg("flask")
@@ -357,7 +357,7 @@ fn tool_list_show_extras() {
         .assert()
         .success();
 
-    // Install `black` without extras
+    // Install `black` without extra requirements
     context
         .tool_install()
         .arg("black==24.2.0")
@@ -366,8 +366,8 @@ fn tool_list_show_extras() {
         .assert()
         .success();
 
-    // Test with --show-extras
-    uv_snapshot!(context.filters(), context.tool_list().arg("--show-extras")
+    // Test with --show-with
+    uv_snapshot!(context.filters(), context.tool_list().arg("--show-with")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
     .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
     success: true
@@ -376,14 +376,14 @@ fn tool_list_show_extras() {
     black v24.2.0
     - black
     - blackd
-    flask v3.0.2 [extras: requests, black==24.2.0]
+    flask v3.0.2 [with: requests, black==24.2.0]
     - flask
 
     ----- stderr -----
     "###);
 
-    // Test with both --show-extras and --show-paths
-    uv_snapshot!(context.filters(), context.tool_list().arg("--show-extras").arg("--show-paths")
+    // Test with both --show-with and --show-paths
+    uv_snapshot!(context.filters(), context.tool_list().arg("--show-with").arg("--show-paths")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
     .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
     success: true
@@ -392,14 +392,14 @@ fn tool_list_show_extras() {
     black v24.2.0 ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [extras: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
 
     ----- stderr -----
     "###);
 
-    // Test with both --show-extras and --show-version-specifiers
-    uv_snapshot!(context.filters(), context.tool_list().arg("--show-extras").arg("--show-version-specifiers")
+    // Test with both --show-with and --show-version-specifiers
+    uv_snapshot!(context.filters(), context.tool_list().arg("--show-with").arg("--show-version-specifiers")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
     .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @r###"
     success: true
@@ -408,7 +408,7 @@ fn tool_list_show_extras() {
     black v24.2.0 [required: ==24.2.0]
     - black
     - blackd
-    flask v3.0.2 [extras: requests, black==24.2.0]
+    flask v3.0.2 [with: requests, black==24.2.0]
     - flask
 
     ----- stderr -----
@@ -416,7 +416,7 @@ fn tool_list_show_extras() {
 
     // Test with all flags
     uv_snapshot!(context.filters(), context.tool_list()
-    .arg("--show-extras")
+    .arg("--show-with")
     .arg("--show-version-specifiers")
     .arg("--show-paths")
     .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
@@ -427,7 +427,7 @@ fn tool_list_show_extras() {
     black v24.2.0 [required: ==24.2.0] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
-    flask v3.0.2 [extras: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
+    flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
 
     ----- stderr -----

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -361,6 +361,8 @@ fn tool_list_show_with() {
     context
         .tool_install()
         .arg("black==24.2.0")
+        .arg("--with")
+        .arg("requests")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .assert()
@@ -373,7 +375,7 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0
+    black v24.2.0 [with: requests]
     - black
     - blackd
     flask v3.0.2 [with: requests, black==24.2.0]
@@ -389,7 +391,7 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 ([TEMP_DIR]/tools/black)
+    black v24.2.0 [with: requests] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
     flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
@@ -405,7 +407,7 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [required: ==24.2.0]
+    black v24.2.0 [required: ==24.2.0] [with: requests]
     - black
     - blackd
     flask v3.0.2 [with: requests, black==24.2.0]
@@ -424,7 +426,7 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [required: ==24.2.0] ([TEMP_DIR]/tools/black)
+    black v24.2.0 [required: ==24.2.0] [with: requests] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
     flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)

--- a/crates/uv/tests/it/tool_list.rs
+++ b/crates/uv/tests/it/tool_list.rs
@@ -344,6 +344,15 @@ fn tool_list_show_with() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
+    // Install `black` without extra requirements
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
     // Install `flask` with extra requirements
     context
         .tool_install()
@@ -357,10 +366,10 @@ fn tool_list_show_with() {
         .assert()
         .success();
 
-    // Install `black` without extra requirements
+    // Install `ruff` with version specifier and extra requirements
     context
         .tool_install()
-        .arg("black==24.2.0")
+        .arg("ruff==0.3.4")
         .arg("--with")
         .arg("requests")
         .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
@@ -375,11 +384,13 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [with: requests]
+    black v24.2.0
     - black
     - blackd
     flask v3.0.2 [with: requests, black==24.2.0]
     - flask
+    ruff v0.3.4 [with: requests]
+    - ruff
 
     ----- stderr -----
     "###);
@@ -391,11 +402,13 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [with: requests] ([TEMP_DIR]/tools/black)
+    black v24.2.0 ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
     flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
+    ruff v0.3.4 [with: requests] ([TEMP_DIR]/tools/ruff)
+    - ruff ([TEMP_DIR]/bin/ruff)
 
     ----- stderr -----
     "###);
@@ -407,11 +420,13 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [required: ==24.2.0] [with: requests]
+    black v24.2.0 [required: ==24.2.0]
     - black
     - blackd
     flask v3.0.2 [with: requests, black==24.2.0]
     - flask
+    ruff v0.3.4 [required: ==0.3.4] [with: requests]
+    - ruff
 
     ----- stderr -----
     "###);
@@ -426,11 +441,13 @@ fn tool_list_show_with() {
     success: true
     exit_code: 0
     ----- stdout -----
-    black v24.2.0 [required: ==24.2.0] [with: requests] ([TEMP_DIR]/tools/black)
+    black v24.2.0 [required: ==24.2.0] ([TEMP_DIR]/tools/black)
     - black ([TEMP_DIR]/bin/black)
     - blackd ([TEMP_DIR]/bin/blackd)
     flask v3.0.2 [with: requests, black==24.2.0] ([TEMP_DIR]/tools/flask)
     - flask ([TEMP_DIR]/bin/flask)
+    ruff v0.3.4 [required: ==0.3.4] [with: requests] ([TEMP_DIR]/tools/ruff)
+    - ruff ([TEMP_DIR]/bin/ruff)
 
     ----- stderr -----
     "###);

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3759,11 +3759,11 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
-</dd><dt id="uv-tool-install--with"><a href="#uv-tool-install--with"><code>--with</code></a> <i>with</i></dt><dd><p>Include the following extra requirements</p>
+</dd><dt id="uv-tool-install--with"><a href="#uv-tool-install--with"><code>--with</code></a> <i>with</i></dt><dd><p>Include the following additional requirements</p>
 
 </dd><dt id="uv-tool-install--with-editable"><a href="#uv-tool-install--with-editable"><code>--with-editable</code></a> <i>with-editable</i></dt><dd><p>Include the given packages in editable mode</p>
 
-</dd><dt id="uv-tool-install--with-requirements"><a href="#uv-tool-install--with-requirements"><code>--with-requirements</code></a> <i>with-requirements</i></dt><dd><p>Run all requirements listed in the given <code>requirements.txt</code> files</p>
+</dd><dt id="uv-tool-install--with-requirements"><a href="#uv-tool-install--with-requirements"><code>--with-requirements</code></a> <i>with-requirements</i></dt><dd><p>Include all requirements listed in the given <code>requirements.txt</code> files</p>
 
 </dd></dl>
 
@@ -4176,7 +4176,7 @@ uv tool list [OPTIONS]
 
 </dd><dt id="uv-tool-list--show-version-specifiers"><a href="#uv-tool-list--show-version-specifiers"><code>--show-version-specifiers</code></a></dt><dd><p>Whether to display the version specifier(s) used to install each tool</p>
 
-</dd><dt id="uv-tool-list--show-with"><a href="#uv-tool-list--show-with"><code>--show-with</code></a></dt><dd><p>Whether to display the extra requirements(s) installed with each tool</p>
+</dd><dt id="uv-tool-list--show-with"><a href="#uv-tool-list--show-with"><code>--show-with</code></a></dt><dd><p>Whether to display the additional requirements installed with each tool</p>
 
 </dd><dt id="uv-tool-list--verbose"><a href="#uv-tool-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4172,11 +4172,11 @@ uv tool list [OPTIONS]
 
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 
+</dd><dt id="uv-tool-list--show-extras"><a href="#uv-tool-list--show-extras"><code>--show-extras</code></a></dt><dd><p>Whether to display the extra package(s) installed with each tool</p>
+
 </dd><dt id="uv-tool-list--show-paths"><a href="#uv-tool-list--show-paths"><code>--show-paths</code></a></dt><dd><p>Whether to display the path to each tool environment and installed executable</p>
 
 </dd><dt id="uv-tool-list--show-version-specifiers"><a href="#uv-tool-list--show-version-specifiers"><code>--show-version-specifiers</code></a></dt><dd><p>Whether to display the version specifier(s) used to install each tool</p>
-
-</dd><dt id="uv-tool-list--show-extras"><a href="#uv-tool-list--show-extras"><code>--show-extras</code></a></dt><dd><p>Whether to display the extra package(s) installed with each tool.</p>
 
 </dd><dt id="uv-tool-list--verbose"><a href="#uv-tool-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4172,11 +4172,11 @@ uv tool list [OPTIONS]
 
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 
-</dd><dt id="uv-tool-list--show-extras"><a href="#uv-tool-list--show-extras"><code>--show-extras</code></a></dt><dd><p>Whether to display the extra package(s) installed with each tool</p>
-
 </dd><dt id="uv-tool-list--show-paths"><a href="#uv-tool-list--show-paths"><code>--show-paths</code></a></dt><dd><p>Whether to display the path to each tool environment and installed executable</p>
 
 </dd><dt id="uv-tool-list--show-version-specifiers"><a href="#uv-tool-list--show-version-specifiers"><code>--show-version-specifiers</code></a></dt><dd><p>Whether to display the version specifier(s) used to install each tool</p>
+
+</dd><dt id="uv-tool-list--show-with"><a href="#uv-tool-list--show-with"><code>--show-with</code></a></dt><dd><p>Whether to display the extra requirements(s) installed with each tool</p>
 
 </dd><dt id="uv-tool-list--verbose"><a href="#uv-tool-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4176,6 +4176,8 @@ uv tool list [OPTIONS]
 
 </dd><dt id="uv-tool-list--show-version-specifiers"><a href="#uv-tool-list--show-version-specifiers"><code>--show-version-specifiers</code></a></dt><dd><p>Whether to display the version specifier(s) used to install each tool</p>
 
+</dd><dt id="uv-tool-list--show-extras"><a href="#uv-tool-list--show-extras"><code>--show-extras</code></a></dt><dd><p>Whether to display the extra package(s) installed with each tool.</p>
+
 </dd><dt id="uv-tool-list--verbose"><a href="#uv-tool-list--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>


### PR DESCRIPTION
## Summary

Add a `--show-extras` argument to the `uv tool list` cli, to show which extra dependencies were installed with the tool.

i.e.

```bash
$ uv tool install fastapi --with requests --with typer==0.14
```

```bash
$ uv tool list --show-extras
fastapi v0.115.12 [extras: requests, typer==0.14]
- fastapi
```

## Test Plan

Added a new test function based on the others in the same file, with the other arguments tested with the new argument as well.