### PR TITLE
Move static feature out of perf features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2250,7 +2250,7 @@ jobs:
           cargo run --bin uv -- pip compile scripts/requirements/airflow.in --universal --exclude-newer 2024-08-08 --cache-dir .cache
 
       - name: "Build benchmarks"
-        run: cargo codspeed build --profile profiling --features "codspeed,performance" -p uv-bench
+        run: cargo codspeed build --profile profiling --features codspeed -p uv-bench
 
       - name: "Run benchmarks"
         uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3.5.0

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -58,6 +58,4 @@ ignored = ["uv-extract"]
 
 [features]
 codspeed = ["codspeed-criterion-compat"]
-performance = [
-  "uv-extract/performance"
-]
+static = ["uv-extract/static"]

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -66,13 +66,10 @@ name = "uv-dev"
 required-features = ["dev"]
 
 [features]
-default = ["performance"]
+default = ["performance", "uv-extract/static"]
 # Actually build the dev CLI.
 dev = []
-performance = [
-  "performance-memory-allocator",
-  "uv-extract/performance"
-]
+performance = ["performance-memory-allocator"]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]
 render = ["poloto", "resvg", "tagu"]
 

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -63,4 +63,4 @@ insta = { version = "1.40.0", features = ["filters", "json", "redactions"] }
 
 [features]
 default = []
-performance = ["uv-extract/performance"]
+static = ["uv-extract/static"]

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -40,6 +40,7 @@ zip = { workspace = true }
 
 [features]
 default = []
+# Avoid a liblzma.so dependency
 static = ["xz2/static"]
 
 [package.metadata.cargo-shear]

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -40,7 +40,7 @@ zip = { workspace = true }
 
 [features]
 default = []
-performance = ["xz2/static"]
+static = ["xz2/static"]
 
 [package.metadata.cargo-shear]
 ignored = ["xz2"]

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -158,7 +158,7 @@ default-tests = [
     "slow-tests",
     "test-ecosystem"
 ]
-# Introduces a dependency on crates.io.
+# Introduces a testing dependency on crates.io.
 crates-io = []
 # Introduces a dependency on Git.
 git = []

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -136,33 +136,44 @@ ignored = [
 ]
 
 [features]
-default = ["python", "python-managed", "pypi", "git", "performance", "crates-io", "slow-tests", "test-ecosystem"]
+default = ["performance", "uv-distribution/static", "default-tests"]
 # Use better memory allocators, etc.
-performance = [
-    "performance-memory-allocator",
-    "uv-distribution/performance",
-]
+performance = ["performance-memory-allocator"]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]
+
+# Adds self-update functionality. This feature is only enabled for uv's cargo-dist installer
+# and should be left unselected when building uv for package managers.
+self-update = ["axoupdater", "uv-cli/self-update"]
+
+# Features for development only.
 tracing-durations-export = ["dep:tracing-durations-export", "uv-resolver/tracing-durations-export"]
 
+# Features that only apply when running tests, no-ops otherwise.
+default-tests = [
+    "crates-io",
+    "git",
+    "pypi",
+    "python",
+    "python-managed",
+    "slow-tests",
+    "test-ecosystem"
+]
+# Introduces a dependency on crates.io.
+crates-io = []
+# Introduces a dependency on Git.
+git = []
+# Introduces a dependency on PyPI.
+pypi = []
 # Introduces a dependency on a local Python installation.
 python = []
 # Introduces a dependency on a local Python installation with specific patch versions.
 python-patch = []
 # Introduces a dependency on managed Python installations.
 python-managed = []
-# Introduces a dependency on PyPI.
-pypi = []
-# Introduces a dependency on Git.
-git = []
-# Introduces a dependency on crates.io.
-crates-io = []
 # Include "slow" test cases.
 slow-tests = []
 # Includes test cases that require ecosystem packages
 test-ecosystem = []
-# Adds self-update functionality.
-self-update = ["axoupdater", "uv-cli/self-update"]
 
 [package.metadata.dist]
 dist = true

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -160,15 +160,15 @@ default-tests = [
 ]
 # Introduces a testing dependency on crates.io.
 crates-io = []
-# Introduces a dependency on Git.
+# Introduces a testing dependency on Git.
 git = []
-# Introduces a dependency on PyPI.
+# Introduces a testing dependency on PyPI.
 pypi = []
-# Introduces a dependency on a local Python installation.
+# Introduces a testing dependency on a local Python installation.
 python = []
-# Introduces a dependency on a local Python installation with specific patch versions.
+# Introduces a testing dependency on a local Python installation with specific patch versions.
 python-patch = []
-# Introduces a dependency on managed Python installations.
+# Introduces a testing dependency on managed Python installations.
 python-managed = []
 # Include "slow" test cases.
 slow-tests = []


### PR DESCRIPTION
#5577 fixed a bug on macos due to dynamically linking lzma/xz through static linking. In #7686, this feature was moved to the performance category.

This PR moves the `xz2/static` back to the general default features, and, inspired by https://github.com/Homebrew/homebrew-core/pull/222211, it structures and documents the feature flags cleaner.

We need to take care that this feature does not accidentally disable features we want.