### PR TITLE
ProgressReporter: align progress bars by largest name length

### DIFF
--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -206,15 +206,15 @@ impl ProgressReporter {
         let max_len = state.max_len;
         for id in 0..state.id {
             if let Some(progress) = state.bars.get_mut(&id) {
+                let template = format!(
+                    "{{msg:{max_len}.dim}} {{bar:30.green/dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}"
+                );
                 progress.set_style(
-                ProgressStyle::with_template(
-                    &format!(
-                        "{{msg:{max_len}.dim}} {{bar:30.green/dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}"
-                    ),
-                )
-                .unwrap()
-                .progress_chars("--"),
-            );
+                    ProgressStyle::with_template(&template)
+                        .unwrap()
+                        .progress_chars("--"),
+                );
+                progress.tick();
             }
         }
 

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -53,6 +53,8 @@ struct BarState {
     /// A map of progress bars, by ID.
     bars: FxHashMap<usize, ProgressBar>,
     /// The download size, if known, by ID.
+    ///
+    /// There are only entries for numerical progress, none for spinners.
     size: FxHashMap<usize, Option<u64>>,
     /// A monotonic counter for bar IDs.
     id: usize,
@@ -205,6 +207,11 @@ impl ProgressReporter {
 
         let max_len = state.max_len;
         for id in 0..state.id {
+            // Ignore spinners, such as for builds.
+            if !state.size.contains_key(&id) {
+                continue;
+            }
+
             if let Some(progress) = state.bars.get_mut(&id) {
                 let template = format!(
                     "{{msg:{max_len}.dim}} {{bar:30.green/dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}"

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -91,7 +91,7 @@ impl Default for BarState {
             id: 0,
             // Avoid resizing the progress bar templates too often by starting with a padding
             // that's wider than most package names.
-            max_len: 5,
+            max_len: 20,
         }
     }
 }


### PR DESCRIPTION
## Summary

Related to https://github.com/astral-sh/uv/issues/12492

This change makes all progress bars vertically aligned. This is still a WIP and so is not complete, in the current design I store `max_len` in `BarState` and update it on every `on_request_start`, however this is problematic since order matters, and if the largest name is not sent first, the alignment is not complete. To mitigate this we'd probably have to update all previous bars by "iterating" through the `bars` field in `BarState` and update all request bars.

Below is an image of what happens when the largest name (`nvidia-cusparselt-cu12`) is not the first (in this case, it was the second to last).

![2025-05-02T10:56:54-03:00](https://github.com/user-attachments/assets/ac6f2205-5f30-4fe3-a2c3-f980e36b7cf7)


## Test Plan

There are currently no tests, and I'm not sure how to design them since from what I gather the `uv_snapshot` facilities record the final output, not the intermediate stages.
