### PR TITLE
Skip packages with mismatched names in Simple API

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1105,10 +1105,14 @@ impl SimpleMetadata {
                 warn!("Skipping file for {package_name}: {}", file.filename);
                 continue;
             };
-            let version = match filename {
-                DistFilename::SourceDistFilename(ref inner) => &inner.version,
-                DistFilename::WheelFilename(ref inner) => &inner.version,
-            };
+            if filename.name() != package_name {
+                warn!(
+                    "Skipping file with mismatched package name: `{}` vs. `{}`",
+                    filename.name(),
+                    package_name
+                );
+                continue;
+            }
             let file = match File::try_from(file, &base) {
                 Ok(file) => file,
                 Err(err) => {
@@ -1117,7 +1121,7 @@ impl SimpleMetadata {
                     continue;
                 }
             };
-            match map.entry(version.clone()) {
+            match map.entry(filename.version().clone()) {
                 std::collections::btree_map::Entry::Occupied(mut entry) => {
                     entry.get_mut().push(filename, file);
                 }


### PR DESCRIPTION
## Summary

Given:

```
> cargo run pip install paddlepaddle-gpu==3.0.0 --index https://www.paddlepaddle.org.cn/packages/stable/cu126/ -v
...
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
WARN Skipping file with mismatched package name: `paddlepaddle` vs. `paddlepaddle-gpu`
...
```