### PR TITLE
Support more zip compression formats: bzip2, lzma, xz, zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zstd"] }
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.9.1" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["bzip2", "deflate", "lzma", "tokio", "xz", "zstd"] }
 axoupdater = { version = "0.9.0", default-features = false }
 backon = { version = "1.3.0" }
 base64 = { version = "0.22.1" }


### PR DESCRIPTION
Wheels are zip files, and as such can internally be compressed with a number of compression algorithms besides the popular choices, DEFLATE and stored. I added all algorithms supported by async-zip except `deflate64`, which wasn't yet a part of our dependency tree.  All other compression algorithms and crates are already supported and dependencies for their source dist `.tar.<format>` support.

Python 3.13 supports stored, deflate, bzip2 and lzma (https://docs.python.org/3/library/zipfile.html#zipfile.ZIP_STORED), PEP 784 adds zstandard support in 3.14.

Fixes #13192