### PR TITLE
Accept `musllinux_1_0` as a valid platform tag

### DIFF
--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -466,8 +466,7 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
         }
         (Os::Musllinux { major, minor }, _) => {
             let mut platform_tags = vec![PlatformTag::Linux { arch }];
-            // musl 1.1 is the lowest supported version in musllinux
-            platform_tags.extend((1..=*minor).map(|minor| PlatformTag::Musllinux {
+            platform_tags.extend((0..=*minor).map(|minor| PlatformTag::Musllinux {
                 major: *major,
                 minor,
                 arch,


### PR DESCRIPTION
## Summary

This seems to match `packaging`:

https://github.com/pypa/packaging/blob/d0d5ad8687f666bea942d1ab4ee2feb5fa019d04/src/packaging/_musllinux.py#L71C1-L72C62

Closes https://github.com/astral-sh/uv/issues/13045.
