### PR TITLE
Suggest `uv self update` if required version is newer

### DIFF
--- a/crates/uv-configuration/src/required_version.rs
+++ b/crates/uv-configuration/src/required_version.rs
@@ -14,7 +14,7 @@ impl RequiredVersion {
     }
 
     /// Returns the underlying [`VersionSpecifiers`].
-    pub fn version_sepcifiers(&self) -> &VersionSpecifiers {
+    pub fn specifiers(&self) -> &VersionSpecifiers {
         &self.0
     }
 }

--- a/crates/uv-configuration/src/required_version.rs
+++ b/crates/uv-configuration/src/required_version.rs
@@ -12,6 +12,11 @@ impl RequiredVersion {
     pub fn contains(&self, version: &Version) -> bool {
         self.0.contains(version)
     }
+
+    /// Returns the underlying [`VersionSpecifiers`].
+    pub fn version_sepcifiers(&self) -> &VersionSpecifiers {
+        &self.0
+    }
 }
 
 impl FromStr for RequiredVersion {


### PR DESCRIPTION
## Summary

Closes #13253 

## Test Plan

```sh
❯ cat pyproject.toml | rg required
required-version = ">=0.7.3, <0.8"
❯ cargo run -q --features self-update --manifest-path ~/uv/Cargo.toml add black
error: Required uv version `>=0.7.3, <0.8` does not match the running version `0.7.2`.
hint: Update `uv` by running `uv self update`.
❯ cat pyproject.toml | rg required
required-version = ">=0.7.3"
❯ cargo run -q --features self-update --manifest-path ~/uv/Cargo.toml add black
error: Required uv version `>=0.7.3` does not match the running version `0.7.2`. 
hint: Update `uv` by running `uv self update`.
❯ cat pyproject.toml | rg required
required-version = "<0.7"
❯ cargo run -q --features self-update --manifest-path ~/uv/Cargo.toml add black
error: Required uv version `<0.7` does not match the running version `0.7.2`.
❯ cat pyproject.toml | rg required
required-version = ">=0.4,<0.7"
❯ cargo run -q --features self-update --manifest-path ~/uv/Cargo.toml add black
error: Required uv version `>=0.4, <0.7` does not match the running version `0.7.2`.
```
