### PR TITLE
make `uv version` lock and sync

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -577,7 +577,7 @@ pub struct VersionArgs {
     #[arg(long, env = EnvVars::UV_LOCKED, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["frozen", "upgrade"])]
     pub locked: bool,
 
-    /// Remove dependencies without re-locking the project.
+    /// Update the version without re-locking the project.
     ///
     /// The project environment will not be synced.
     #[arg(long, env = EnvVars::UV_FROZEN, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["locked", "upgrade", "no_sources"])]
@@ -592,7 +592,7 @@ pub struct VersionArgs {
     #[command(flatten)]
     pub refresh: RefreshArgs,
 
-    /// Remove the dependencies from a specific package in the workspace.
+    /// Update the version of a specific package in the workspace.
     #[arg(long, conflicts_with = "isolated")]
     pub package: Option<PackageName>,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -493,8 +493,6 @@ pub enum Commands {
     /// Clear the cache, removing all entries or those linked to specific packages.
     #[command(hide = true)]
     Clean(CleanArgs),
-    /// Read or update the project's version.
-    Version(VersionArgs),
     /// Generate shell completion
     #[command(alias = "--generate-shell-completion", hide = true)]
     GenerateShellCompletion(GenerateShellCompletionArgs),
@@ -525,29 +523,91 @@ pub struct HelpArgs {
     pub command: Option<Vec<String>>,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args)]
 #[command(group = clap::ArgGroup::new("operation"))]
+#[allow(clippy::struct_excessive_bools)]
 pub struct VersionArgs {
     /// Set the project version to this value
     ///
     /// To update the project using semantic versioning components instead, use `--bump`.
     #[arg(group = "operation")]
     pub value: Option<String>,
+
     /// Update the project version using the given semantics
     #[arg(group = "operation", long)]
     pub bump: Option<VersionBump>,
+
     /// Don't write a new version to the `pyproject.toml`
     ///
     /// Instead, the version will be displayed.
     #[arg(long)]
     pub dry_run: bool,
+
     /// Only show the version
     ///
     /// By default, uv will show the project name before the version.
     #[arg(long)]
     pub short: bool,
+
+    /// The format of the output
     #[arg(long, value_enum, default_value = "text")]
     pub output_format: VersionFormat,
+
+    /// Avoid syncing the virtual environment after re-locking the project.
+    #[arg(long, env = EnvVars::UV_NO_SYNC, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with = "frozen")]
+    pub no_sync: bool,
+
+    /// Prefer the active virtual environment over the project's virtual environment.
+    ///
+    /// If the project virtual environment is active or no virtual environment is active, this has
+    /// no effect.
+    #[arg(long, overrides_with = "no_active")]
+    pub active: bool,
+
+    /// Prefer project's virtual environment over an active environment.
+    ///
+    /// This is the default behavior.
+    #[arg(long, overrides_with = "active", hide = true)]
+    pub no_active: bool,
+
+    /// Assert that the `uv.lock` will remain unchanged.
+    ///
+    /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
+    /// uv will exit with an error.
+    #[arg(long, env = EnvVars::UV_LOCKED, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["frozen", "upgrade"])]
+    pub locked: bool,
+
+    /// Remove dependencies without re-locking the project.
+    ///
+    /// The project environment will not be synced.
+    #[arg(long, env = EnvVars::UV_FROZEN, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    pub frozen: bool,
+
+    #[command(flatten)]
+    pub installer: ResolverInstallerArgs,
+
+    #[command(flatten)]
+    pub build: BuildOptionsArgs,
+
+    #[command(flatten)]
+    pub refresh: RefreshArgs,
+
+    /// Remove the dependencies from a specific package in the workspace.
+    #[arg(long, conflicts_with = "isolated")]
+    pub package: Option<PackageName>,
+
+    /// The Python interpreter to use for resolving and syncing.
+    ///
+    /// See `uv help python` for details on Python discovery and supported request formats.
+    #[arg(
+        long,
+        short,
+        env = EnvVars::UV_PYTHON,
+        verbatim_doc_comment,
+        help_heading = "Python options",
+        value_parser = parse_maybe_string,
+    )]
+    pub python: Option<Maybe<String>>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, clap::ValueEnum)]
@@ -819,6 +879,8 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Remove(RemoveArgs),
+    /// Read or update the project's version.
+    Version(VersionArgs),
     /// Update the project's environment.
     ///
     /// Syncing ensures that all project dependencies are installed and up-to-date with the

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use project::remove::remove;
 pub(crate) use project::run::{RunCommand, run};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
+pub(crate) use project::version::{project_version, self_version};
 pub(crate) use publish::publish;
 pub(crate) use python::dir::dir as python_dir;
 pub(crate) use python::find::find as python_find;
@@ -56,7 +57,6 @@ use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
 use uv_scripts::Pep723Script;
 pub(crate) use venv::venv;
-pub(crate) use version::{project_version, self_version};
 
 use crate::printer::Printer;
 
@@ -77,7 +77,6 @@ mod run;
 mod self_update;
 mod tool;
 mod venv;
-mod version;
 
 #[derive(Copy, Clone)]
 pub(crate) enum ExitStatus {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -67,6 +67,7 @@ pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod sync;
 pub(crate) mod tree;
+pub(crate) mod version;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ProjectError {

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -1,0 +1,474 @@
+use std::fmt::Write;
+use std::str::FromStr;
+use std::{cmp::Ordering, path::Path};
+
+use anyhow::{anyhow, Context, Result};
+use owo_colors::OwoColorize;
+
+use tracing::debug;
+use uv_cache::Cache;
+use uv_cli::version::VersionInfo;
+use uv_cli::{VersionBump, VersionFormat};
+use uv_configuration::{
+    Concurrency, DependencyGroups, DryRun, EditableMode, ExtrasSpecification, InstallOptions,
+    PreviewMode,
+};
+use uv_fs::Simplified;
+use uv_normalize::DefaultExtras;
+use uv_pep440::Version;
+use uv_pep508::PackageName;
+use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
+use uv_settings::PythonInstallMirrors;
+use uv_warnings::warn_user;
+use uv_workspace::pyproject_mut::Error;
+use uv_workspace::{
+    pyproject_mut::{DependencyTarget, PyProjectTomlMut},
+    DiscoveryOptions, WorkspaceCache,
+};
+use uv_workspace::{VirtualProject, Workspace};
+
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
+use crate::commands::pip::operations::Modifications;
+use crate::commands::project::add::{AddTarget, PythonTarget};
+use crate::commands::project::install_target::InstallTarget;
+use crate::commands::project::lock::LockMode;
+use crate::commands::project::{
+    default_dependency_groups, ProjectEnvironment, ProjectError, ProjectInterpreter, UniversalState,
+};
+use crate::commands::{diagnostics, project, ExitStatus};
+use crate::printer::Printer;
+use crate::settings::{NetworkSettings, ResolverInstallerSettings};
+
+/// Display version information for uv itself (`uv self version`)
+pub(crate) fn self_version(
+    short: bool,
+    output_format: VersionFormat,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    let version_info = uv_cli::version::uv_self_version();
+    print_version(version_info, None, short, output_format, printer)?;
+
+    Ok(ExitStatus::Success)
+}
+
+/// Read or update project version (`uv version`)
+#[allow(clippy::fn_params_excessive_bools)]
+pub(crate) async fn project_version(
+    value: Option<String>,
+    bump: Option<VersionBump>,
+    short: bool,
+    output_format: VersionFormat,
+    strict: bool,
+    project_dir: &Path,
+    package: Option<PackageName>,
+    dry_run: bool,
+    locked: bool,
+    frozen: bool,
+    active: Option<bool>,
+    no_sync: bool,
+    python: Option<String>,
+    install_mirrors: PythonInstallMirrors,
+    settings: ResolverInstallerSettings,
+    network_settings: NetworkSettings,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    installer_metadata: bool,
+    concurrency: Concurrency,
+    no_config: bool,
+    cache: &Cache,
+    printer: Printer,
+    preview: PreviewMode,
+) -> Result<ExitStatus> {
+    // Read the metadata
+    let project = match find_target(project_dir, package.as_ref()).await {
+        Ok(target) => target,
+        Err(err) => {
+            // If strict, hard bail on failing to find the pyproject.toml
+            if strict {
+                return Err(err)?;
+            }
+            // Otherwise, warn and provide fallback to the old `uv version` from before 0.7.0
+            warn_user!("Failed to read project metadata ({err}). Running `{}` for compatibility. This fallback will be removed in the future; pass `--preview` to force an error.", "uv self version".green());
+            return self_version(short, output_format, printer);
+        }
+    };
+
+    let mut toml = PyProjectTomlMut::from_toml(
+        project.pyproject_toml().raw.as_ref(),
+        DependencyTarget::PyProjectToml,
+    )?;
+
+    let pyproject_path = project.root().join("pyproject.toml");
+    let name = project
+        .pyproject_toml()
+        .project
+        .as_ref()
+        .map(|project| project.name.clone());
+    let old_version = toml.version().map_err(|err| match err {
+        Error::MalformedWorkspace => {
+            if toml.has_dynamic_version() {
+                anyhow!(
+                    "We cannot get or set dynamic project versions in: {}",
+                    pyproject_path.user_display()
+                )
+            } else {
+                anyhow!(
+                    "There is no 'project.version' field in: {}",
+                    pyproject_path.user_display()
+                )
+            }
+        }
+        err => {
+            anyhow!("{err}: {}", pyproject_path.user_display())
+        }
+    })?;
+
+    // Figure out new metadata
+    let new_version = if let Some(value) = value {
+        match Version::from_str(&value) {
+            Ok(version) => Some(version),
+            Err(err) => match &*value {
+                "major" | "minor" | "patch" => {
+                    return Err(anyhow!(
+                        "Invalid version `{value}`, did you mean to pass `--bump {value}`?"
+                    ));
+                }
+                _ => {
+                    return Err(err)?;
+                }
+            },
+        }
+    } else if let Some(bump) = bump {
+        Some(bumped_version(&old_version, bump, printer)?)
+    } else {
+        None
+    };
+
+    // Update the toml and lock
+    let status = if dry_run {
+        ExitStatus::Success
+    } else {
+        Box::pin(lock_and_sync(
+            new_version.as_ref(),
+            project,
+            &mut toml,
+            &pyproject_path,
+            project_dir,
+            locked,
+            frozen,
+            active,
+            no_sync,
+            python,
+            install_mirrors,
+            &settings,
+            network_settings,
+            python_preference,
+            python_downloads,
+            installer_metadata,
+            concurrency,
+            no_config,
+            cache,
+            printer,
+            preview,
+        ))
+        .await?
+    };
+
+    // Report the results
+    let old_version = VersionInfo::new(name.as_ref(), &old_version);
+    let new_version = new_version.map(|version| VersionInfo::new(name.as_ref(), &version));
+    print_version(old_version, new_version, short, output_format, printer)?;
+
+    Ok(status)
+}
+
+/// Find the pyproject.toml we're modifying
+///
+/// Note that `uv version` never needs to support PEP723 scripts, as those are unversioned.
+async fn find_target(project_dir: &Path, package: Option<&PackageName>) -> Result<VirtualProject> {
+    // Find the project in the workspace.
+    // No workspace caching since `uv version` changes the workspace definition.
+    let project = if let Some(package) = package {
+        VirtualProject::Project(
+            Workspace::discover(
+                project_dir,
+                &DiscoveryOptions::default(),
+                &WorkspaceCache::default(),
+            )
+            .await?
+            .with_current_project(package.clone())
+            .with_context(|| format!("Package `{package}` not found in workspace"))?,
+        )
+    } else {
+        VirtualProject::discover(
+            project_dir,
+            &DiscoveryOptions::default(),
+            &WorkspaceCache::default(),
+        )
+        .await?
+    };
+    Ok(project)
+}
+
+/// Re-lock and re-sync the project after a series of edits.
+#[allow(clippy::fn_params_excessive_bools)]
+async fn lock_and_sync(
+    new_version: Option<&Version>,
+    project: VirtualProject,
+    toml: &mut PyProjectTomlMut,
+    pyproject_path: &Path,
+    project_dir: &Path,
+    locked: bool,
+    frozen: bool,
+    active: Option<bool>,
+    no_sync: bool,
+    python: Option<String>,
+    install_mirrors: PythonInstallMirrors,
+    settings: &ResolverInstallerSettings,
+    network_settings: NetworkSettings,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    installer_metadata: bool,
+    concurrency: Concurrency,
+    no_config: bool,
+    cache: &Cache,
+    printer: Printer,
+    preview: PreviewMode,
+) -> Result<ExitStatus> {
+    // Apply the new metadata
+    let Some(new_version) = &new_version else {
+        debug!("No changes to version; skipping update");
+        return Ok(ExitStatus::Success);
+    };
+
+    // Save to disk
+    toml.set_version(new_version)?;
+    let content = toml.to_string();
+    fs_err::write(pyproject_path, &content)?;
+
+    // If `--frozen`, exit early. There's no reason to lock and sync, since we don't need a `uv.lock`
+    // to exist at all.
+    if frozen {
+        return Ok(ExitStatus::Success);
+    }
+
+    // Update the `pyproject.toml` in-memory.
+    let project = project
+        .with_pyproject_toml(toml::from_str(&content).map_err(ProjectError::PyprojectTomlParse)?)
+        .ok_or(ProjectError::PyprojectTomlUpdate)?;
+
+    // Convert to an `AddTarget` by attaching the appropriate interpreter or environment.
+    let target = if no_sync {
+        // Discover the interpreter.
+        let interpreter = ProjectInterpreter::discover(
+            project.workspace(),
+            project_dir,
+            python.as_deref().map(PythonRequest::parse),
+            &network_settings,
+            python_preference,
+            python_downloads,
+            &install_mirrors,
+            false,
+            no_config,
+            active,
+            cache,
+            printer,
+        )
+        .await?
+        .into_interpreter();
+
+        AddTarget::Project(project, Box::new(PythonTarget::Interpreter(interpreter)))
+    } else {
+        // Discover or create the virtual environment.
+        let environment = ProjectEnvironment::get_or_init(
+            project.workspace(),
+            python.as_deref().map(PythonRequest::parse),
+            &install_mirrors,
+            &network_settings,
+            python_preference,
+            python_downloads,
+            no_sync,
+            no_config,
+            active,
+            cache,
+            DryRun::Disabled,
+            printer,
+        )
+        .await?
+        .into_environment()?;
+
+        AddTarget::Project(project, Box::new(PythonTarget::Environment(environment)))
+    };
+
+    // Determine the lock mode.
+    let mode = if locked {
+        LockMode::Locked(target.interpreter())
+    } else {
+        LockMode::Write(target.interpreter())
+    };
+
+    // Initialize any shared state.
+    let state = UniversalState::default();
+
+    // Lock and sync the environment, if necessary.
+    let lock = match project::lock::LockOperation::new(
+        mode,
+        &settings.resolver,
+        &network_settings,
+        &state,
+        Box::new(DefaultResolveLogger),
+        concurrency,
+        cache,
+        printer,
+        preview,
+    )
+    .execute((&target).into())
+    .await
+    {
+        Ok(result) => result.into_lock(),
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let AddTarget::Project(project, environment) = target else {
+        // If we're not adding to a project, exit early.
+        return Ok(ExitStatus::Success);
+    };
+
+    let PythonTarget::Environment(venv) = &*environment else {
+        // If we're not syncing, exit early.
+        return Ok(ExitStatus::Success);
+    };
+
+    // Perform a full sync, because we don't know what exactly is affected by the removal.
+    // TODO(ibraheem): Should we accept CLI overrides for this? Should we even sync here?
+    let extras = ExtrasSpecification::from_all_extras();
+    let install_options = InstallOptions::default();
+
+    // Determine the default groups to include.
+    let default_groups = default_dependency_groups(project.pyproject_toml())?;
+
+    // Determine the default extras to include.
+    let default_extras = DefaultExtras::default();
+
+    // Identify the installation target.
+    let target = match &project {
+        VirtualProject::Project(project) => InstallTarget::Project {
+            workspace: project.workspace(),
+            name: project.project_name(),
+            lock: &lock,
+        },
+        VirtualProject::NonProject(workspace) => InstallTarget::NonProjectWorkspace {
+            workspace,
+            lock: &lock,
+        },
+    };
+
+    let state = state.fork();
+
+    match project::sync::do_sync(
+        target,
+        venv,
+        &extras.with_defaults(default_extras),
+        &DependencyGroups::default().with_defaults(default_groups),
+        EditableMode::Editable,
+        install_options,
+        Modifications::Exact,
+        settings.into(),
+        &network_settings,
+        &state,
+        Box::new(DefaultInstallLogger),
+        installer_metadata,
+        concurrency,
+        cache,
+        DryRun::Disabled,
+        printer,
+        preview,
+    )
+    .await
+    {
+        Ok(()) => {}
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+        }
+        Err(err) => return Err(err.into()),
+    }
+
+    Ok(ExitStatus::Success)
+}
+
+fn print_version(
+    old_version: VersionInfo,
+    new_version: Option<VersionInfo>,
+    short: bool,
+    output_format: VersionFormat,
+    printer: Printer,
+) -> Result<()> {
+    match output_format {
+        VersionFormat::Text => {
+            if let Some(name) = &old_version.package_name {
+                if !short {
+                    write!(printer.stdout(), "{name} ")?;
+                }
+            }
+            if let Some(new_version) = new_version {
+                if short {
+                    writeln!(printer.stdout(), "{}", new_version.cyan())?;
+                } else {
+                    writeln!(
+                        printer.stdout(),
+                        "{} => {}",
+                        old_version.cyan(),
+                        new_version.cyan()
+                    )?;
+                }
+            } else {
+                writeln!(printer.stdout(), "{}", old_version.cyan())?;
+            }
+        }
+        VersionFormat::Json => {
+            let final_version = new_version.unwrap_or(old_version);
+            let string = serde_json::to_string_pretty(&final_version)?;
+            writeln!(printer.stdout(), "{string}")?;
+        }
+    }
+    Ok(())
+}
+
+fn bumped_version(from: &Version, bump: VersionBump, printer: Printer) -> Result<Version> {
+    // All prereleasey details "carry to 0" with every currently supported mode of `--bump`
+    // We could go out of our way to preserve epoch information but no one uses those...
+    if from.any_prerelease() || from.is_post() || from.is_local() || from.epoch() > 0 {
+        writeln!(
+            printer.stderr(),
+            "warning: prerelease information will be cleared as part of the version bump"
+        )?;
+    }
+
+    let index = match bump {
+        VersionBump::Major => 0,
+        VersionBump::Minor => 1,
+        VersionBump::Patch => 2,
+    };
+
+    // Use `max` here to try to do 0.2 => 0.3 instead of 0.2 => 0.3.0
+    let old_parts = from.release();
+    let len = old_parts.len().max(index + 1);
+    let new_release_vec = (0..len)
+        .map(|i| match i.cmp(&index) {
+            // Everything before the bumped value is preserved (or is an implicit 0)
+            Ordering::Less => old_parts.get(i).copied().unwrap_or(0),
+            // This is the value to bump (could be implicit 0)
+            Ordering::Equal => old_parts.get(i).copied().unwrap_or(0) + 1,
+            // Everything after the bumped value becomes 0
+            Ordering::Greater => 0,
+        })
+        .collect::<Vec<u64>>();
+    Ok(Version::new(new_release_vec))
+}

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -377,7 +377,7 @@ async fn lock_and_sync(
         &DependencyGroups::default().with_defaults(default_groups),
         EditableMode::Editable,
         install_options,
-        Modifications::Exact,
+        Modifications::Sufficient,
         settings.into(),
         &network_settings,
         &state,

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -99,7 +99,7 @@ pub(crate) async fn project_version(
     let pyproject_path = project.root().join("pyproject.toml");
     let Some(name) = project.project_name().cloned() else {
         return Err(anyhow!(
-            "There is no 'project.name' field in: {}",
+            "Missing `project.name` field in: {}",
             pyproject_path.user_display()
         ));
     };
@@ -215,7 +215,7 @@ pub(crate) async fn project_version(
 
 /// Find the pyproject.toml we're modifying
 ///
-/// Note that `uv version` never needs to support PEP723 scripts, as those are unversioned.
+/// Note that `uv version` never needs to support PEP 723 scripts, as those are unversioned.
 async fn find_target(project_dir: &Path, package: Option<&PackageName>) -> Result<VirtualProject> {
     // Find the project in the workspace.
     // No workspace caching since `uv version` changes the workspace definition.

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -102,11 +102,7 @@ pub(crate) async fn project_version(
     )?;
 
     let pyproject_path = project.root().join("pyproject.toml");
-    let name = project
-        .pyproject_toml()
-        .project
-        .as_ref()
-        .map(|project| project.name.clone());
+    let name = project.project_name().cloned();
 
     // Short-circuit early for a frozen read
     let is_read_only = value.is_none() && bump.is_none();

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 use std::str::FromStr;
 use std::{cmp::Ordering, path::Path};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use owo_colors::OwoColorize;
 
 use tracing::debug;
@@ -22,8 +22,8 @@ use uv_settings::PythonInstallMirrors;
 use uv_warnings::warn_user;
 use uv_workspace::pyproject_mut::Error;
 use uv_workspace::{
-    pyproject_mut::{DependencyTarget, PyProjectTomlMut},
     DiscoveryOptions, WorkspaceCache,
+    pyproject_mut::{DependencyTarget, PyProjectTomlMut},
 };
 use uv_workspace::{VirtualProject, Workspace};
 
@@ -33,9 +33,9 @@ use crate::commands::project::add::{AddTarget, PythonTarget};
 use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::LockMode;
 use crate::commands::project::{
-    default_dependency_groups, ProjectEnvironment, ProjectError, ProjectInterpreter, UniversalState,
+    ProjectEnvironment, ProjectError, ProjectInterpreter, UniversalState, default_dependency_groups,
 };
-use crate::commands::{diagnostics, project, ExitStatus};
+use crate::commands::{ExitStatus, diagnostics, project};
 use crate::printer::Printer;
 use crate::settings::{NetworkSettings, ResolverInstallerSettings};
 
@@ -88,7 +88,10 @@ pub(crate) async fn project_version(
                 return Err(err)?;
             }
             // Otherwise, warn and provide fallback to the old `uv version` from before 0.7.0
-            warn_user!("Failed to read project metadata ({err}). Running `{}` for compatibility. This fallback will be removed in the future; pass `--preview` to force an error.", "uv self version".green());
+            warn_user!(
+                "Failed to read project metadata ({err}). Running `{}` for compatibility. This fallback will be removed in the future; pass `--preview` to force an error.",
+                "uv self version".green()
+            );
             return self_version(short, output_format, printer);
         }
     };
@@ -319,7 +322,7 @@ async fn print_frozen_version(
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
                 .report(err)
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -449,7 +452,7 @@ async fn lock_and_sync(
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
                 .report(err)
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     };
@@ -515,7 +518,7 @@ async fn lock_and_sync(
         Err(ProjectError::Operation(err)) => {
             return diagnostics::OperationDiagnostic::native_tls(network_settings.native_tls)
                 .report(err)
-                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
         Err(err) => return Err(err.into()),
     }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -25,9 +25,9 @@ use uv_cache_info::Timestamp;
 #[cfg(feature = "self-update")]
 use uv_cli::SelfUpdateArgs;
 use uv_cli::{
-    compat::CompatArgs, BuildBackendCommand, CacheCommand, CacheNamespace, Cli, Commands,
-    PipCommand, PipNamespace, ProjectCommand, PythonCommand, PythonNamespace, SelfCommand,
-    SelfNamespace, ToolCommand, ToolNamespace, TopLevelArgs,
+    BuildBackendCommand, CacheCommand, CacheNamespace, Cli, Commands, PipCommand, PipNamespace,
+    ProjectCommand, PythonCommand, PythonNamespace, SelfCommand, SelfNamespace, ToolCommand,
+    ToolNamespace, TopLevelArgs, compat::CompatArgs,
 };
 use uv_configuration::min_stack_size;
 use uv_fs::{CWD, Simplified};

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -20,6 +20,7 @@ fn help() {
       init                       Create a new project
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
+      version                    Read or update the project's version
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format
@@ -32,7 +33,6 @@ fn help() {
       publish                    Upload distributions to an index
       cache                      Manage uv's cache
       self                       Manage the uv executable
-      version                    Read or update the project's version
       generate-shell-completion  Generate shell completion
       help                       Display documentation for a command
 
@@ -100,6 +100,7 @@ fn help_flag() {
       init     Create a new project
       add      Add dependencies to the project
       remove   Remove dependencies from the project
+      version  Read or update the project's version
       sync     Update the project's environment
       lock     Update the project's lockfile
       export   Export the project's lockfile to an alternate format
@@ -112,7 +113,6 @@ fn help_flag() {
       publish  Upload distributions to an index
       cache    Manage uv's cache
       self     Manage the uv executable
-      version  Read or update the project's version
       help     Display documentation for a command
 
     Cache options:
@@ -178,6 +178,7 @@ fn help_short_flag() {
       init     Create a new project
       add      Add dependencies to the project
       remove   Remove dependencies from the project
+      version  Read or update the project's version
       sync     Update the project's environment
       lock     Update the project's lockfile
       export   Export the project's lockfile to an alternate format
@@ -190,7 +191,6 @@ fn help_short_flag() {
       publish  Upload distributions to an index
       cache    Manage uv's cache
       self     Manage the uv executable
-      version  Read or update the project's version
       help     Display documentation for a command
 
     Cache options:
@@ -857,6 +857,7 @@ fn help_unknown_subcommand() {
         init
         add
         remove
+        version
         sync
         lock
         export
@@ -869,7 +870,6 @@ fn help_unknown_subcommand() {
         publish
         cache
         self
-        version
         generate-shell-completion
     ");
 
@@ -884,6 +884,7 @@ fn help_unknown_subcommand() {
         init
         add
         remove
+        version
         sync
         lock
         export
@@ -896,7 +897,6 @@ fn help_unknown_subcommand() {
         publish
         cache
         self
-        version
         generate-shell-completion
     ");
 }
@@ -938,6 +938,7 @@ fn help_with_global_option() {
       init                       Create a new project
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
+      version                    Read or update the project's version
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format
@@ -950,7 +951,6 @@ fn help_with_global_option() {
       publish                    Upload distributions to an index
       cache                      Manage uv's cache
       self                       Manage the uv executable
-      version                    Read or update the project's version
       generate-shell-completion  Generate shell completion
       help                       Display documentation for a command
 
@@ -1059,6 +1059,7 @@ fn help_with_no_pager() {
       init                       Create a new project
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
+      version                    Read or update the project's version
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format
@@ -1071,7 +1072,6 @@ fn help_with_no_pager() {
       publish                    Upload distributions to an index
       cache                      Manage uv's cache
       self                       Manage the uv executable
-      version                    Read or update the project's version
       generate-shell-completion  Generate shell completion
       help                       Display documentation for a command
 

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1,6 +1,7 @@
 use anyhow::{Ok, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
+use indoc::indoc;
 use insta::assert_snapshot;
 
 use crate::common::TestContext;
@@ -1289,6 +1290,569 @@ fn version_get_workspace() -> Result<()> {
 
     ----- stderr -----
     error: There is no 'project.version' field in: pyproject.toml
+    ");
+
+    Ok(())
+}
+
+/// Edit the version of a workspace member
+///
+/// Also check that --locked/--frozen/--no-sync do what they say
+#[test]
+fn version_set_workspace() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let workspace = context.temp_dir.child("pyproject.toml");
+    workspace.write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["child1", "child2"]
+    "#})?;
+
+    let pyproject_toml = context.temp_dir.child("child1/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child1"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "child2",
+        ]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [tool.uv.sources]
+        child2 = { workspace = true }
+    "#})?;
+    context
+        .temp_dir
+        .child("child1")
+        .child("src")
+        .child("child1")
+        .child("__init__.py")
+        .touch()?;
+
+    let pyproject_toml = context.temp_dir.child("child2/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child2"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+    context
+        .temp_dir
+        .child("child2")
+        .child("src")
+        .child("child2")
+        .child("__init__.py")
+        .touch()?;
+
+    // Set one child's version, creating the lock and initial sync
+    let mut version_cmd = context.version();
+    version_cmd
+        .arg("--package")
+        .arg("child2")
+        .arg("1.1.1")
+        .current_dir(&context.temp_dir);
+
+    uv_snapshot!(context.filters(), version_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child2 0.1.0 => 1.1.1
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + child2==1.1.1 (from file://[TEMP_DIR]/child2)
+    ");
+
+    // `uv version` implies a full lock and sync, including development dependencies.
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child1",
+            "child2",
+        ]
+
+        [[package]]
+        name = "child1"
+        version = "0.1.0"
+        source = { editable = "child1" }
+        dependencies = [
+            { name = "child2" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child2", editable = "child2" }]
+
+        [[package]]
+        name = "child2"
+        version = "1.1.1"
+        source = { editable = "child2" }
+        "#
+        );
+    });
+
+    // Set the other child's version, refereshing the lock and sync
+    let mut version_cmd = context.version();
+    version_cmd
+        .arg("--package")
+        .arg("child1")
+        .arg("1.2.3")
+        .current_dir(&context.temp_dir);
+
+    uv_snapshot!(context.filters(), version_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child1 0.1.0 => 1.2.3
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + child1==1.2.3 (from file://[TEMP_DIR]/child1)
+    ");
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child1",
+            "child2",
+        ]
+
+        [[package]]
+        name = "child1"
+        version = "1.2.3"
+        source = { editable = "child1" }
+        dependencies = [
+            { name = "child2" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child2", editable = "child2" }]
+
+        [[package]]
+        name = "child2"
+        version = "1.1.1"
+        source = { editable = "child2" }
+        "#
+        );
+    });
+
+    // Confirm --locked get works fine
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child1")
+        .arg("--locked"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child1 1.2.3
+
+    ----- stderr -----
+    ");
+
+    // Confirm --frozen get works fine
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child2")
+        .arg("--frozen"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child2 1.1.1
+
+    ----- stderr -----
+    ");
+
+    // Confirm --no-sync get works fine
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child1")
+        .arg("--no-sync"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child1 1.2.3
+
+    ----- stderr -----
+    ");
+
+    // Confirm --frozen set does no lock or sync
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child2")
+        .arg("--frozen")
+        .arg("2.0.0"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child2 1.1.1 => 2.0.0
+
+    ----- stderr -----
+    ");
+
+    // Confirm --no-sync set does a lock but no sync
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child1")
+        .arg("--no-sync")
+        .arg("3.0.0"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child1 1.2.3 => 3.0.0
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child1",
+            "child2",
+        ]
+
+        [[package]]
+        name = "child1"
+        version = "3.0.0"
+        source = { editable = "child1" }
+        dependencies = [
+            { name = "child2" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child2", editable = "child2" }]
+
+        [[package]]
+        name = "child2"
+        version = "2.0.0"
+        source = { editable = "child2" }
+        "#
+        );
+    });
+
+    // Confirm --locked set works if it's a noop (can sync)
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child1")
+        .arg("--locked")
+        .arg("3.0.0"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child1 3.0.0 => 3.0.0
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     - child1==1.2.3 (from file://[TEMP_DIR]/child1)
+     + child1==3.0.0 (from file://[TEMP_DIR]/child1)
+     - child2==1.1.1 (from file://[TEMP_DIR]/child2)
+     + child2==2.0.0 (from file://[TEMP_DIR]/child2)
+    ");
+
+    Ok(())
+}
+
+/// Edit the version of a workspace member in a way that breaks a version
+/// constraint, forcing the lockfile to be updated non-trivially.
+///
+/// The idea here is that:
+///
+/// * "myproj" depends on the registry package "anyio"
+/// * "anyio" depends on the registry package "idna"
+/// * our workspace defines "idna", forcing "anyio" to use whatever version we have
+///
+/// The result is that `uv version --package idna x.y.z` can force the re-evaluation
+/// of the version of "anyio" we select. In particular we *shrink* the version of "idna",
+/// forcing "anyio" to massively revert all the way back to before it depended on "idna".
+///
+/// It would be nice to have a case where we still get a package dependency, but
+/// this still demonstrates the non-trivial "hazard" of a version change.
+#[test]
+fn version_set_evil_constraints() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let workspace = context.temp_dir.child("pyproject.toml");
+    workspace.write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["idna", "myproj"]
+    "#})?;
+
+    let pyproject_toml = context.temp_dir.child("idna/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "idna"
+        version = "3.10.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+    context
+        .temp_dir
+        .child("idna")
+        .child("src")
+        .child("idna")
+        .child("__init__.py")
+        .touch()?;
+
+    let pyproject_toml = context.temp_dir.child("myproj/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "myproj"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "anyio",
+        ]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+    context
+        .temp_dir
+        .child("myproj")
+        .child("src")
+        .child("myproj")
+        .child("__init__.py")
+        .touch()?;
+
+    // sync all, creating the lock and initial sync
+    uv_snapshot!(context.filters(),  context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.10.0 (from file://[TEMP_DIR]/idna)
+     + myproj==0.1.0 (from file://[TEMP_DIR]/myproj)
+     + sniffio==1.3.1
+    ");
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "idna",
+            "myproj",
+        ]
+
+        [[package]]
+        name = "anyio"
+        version = "4.3.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6", size = 159642, upload-time = "2024-02-19T08:36:28.641Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8", size = 85584, upload-time = "2024-02-19T08:36:26.842Z" },
+        ]
+
+        [[package]]
+        name = "idna"
+        version = "3.10.0"
+        source = { editable = "idna" }
+
+        [[package]]
+        name = "myproj"
+        version = "0.1.0"
+        source = { editable = "myproj" }
+        dependencies = [
+            { name = "anyio" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "anyio" }]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+        ]
+        "#
+        );
+    });
+
+    // Reduce idna's version, forcing a downgrade of anyio (used by myproj)
+    // This will not appear in the sync, but it will show up in the lock,
+    // because we use "sufficient" sync semantics
+    let mut version_cmd = context.version();
+    version_cmd
+        .arg("--project")
+        .arg("idna")
+        .arg("2.0.0")
+        .current_dir(&context.temp_dir);
+
+    uv_snapshot!(context.filters(), version_cmd, @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    idna 3.10.0 => 2.0.0
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - idna==3.10.0 (from file://[TEMP_DIR]/idna)
+     + idna==2.0.0 (from file://[TEMP_DIR]/idna)
+    ");
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "idna",
+            "myproj",
+        ]
+
+        [[package]]
+        name = "anyio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "async-generator" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/44/eb/c5f29a8c854cf454cb995dc791152c641eb8948b2d71cb30e233eb262c53/anyio-1.3.1.tar.gz", hash = "sha256:a46bb2b7743455434afd9adea848a3c4e0b7321aee3e9d08844b11d348d3b5a0", size = 56763, upload-time = "2020-05-31T11:50:54.61Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ab/c2/17b5c64a1a92c5dbd7ab3fd24c4db4332aa78ebe132e54136d1bc5eb1bd5/anyio-1.3.1-py3-none-any.whl", hash = "sha256:f21b4fafeec1b7db81e09a907e44e374a1e39718d782a488fdfcdcf949c8950c", size = 35056, upload-time = "2020-05-31T11:50:53.646Z" },
+        ]
+
+        [[package]]
+        name = "async-generator"
+        version = "1.10"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/ce/b6/6fa6b3b598a03cba5e80f829e0dadbb49d7645f523d209b2fb7ea0bbb02a/async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144", size = 29870, upload-time = "2018-08-01T03:36:21.69Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/71/52/39d20e03abd0ac9159c162ec24b93fbcaa111e8400308f2465432495ca2b/async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b", size = 18857, upload-time = "2018-08-01T03:36:20.029Z" },
+        ]
+
+        [[package]]
+        name = "idna"
+        version = "2.0.0"
+        source = { editable = "idna" }
+
+        [[package]]
+        name = "myproj"
+        version = "0.1.0"
+        source = { editable = "myproj" }
+        dependencies = [
+            { name = "anyio" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "anyio" }]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+        ]
+        "#
+        );
+    });
+
+    // however once we explicitly sync the change will go into effect
+    uv_snapshot!(context.filters(),  context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 2 packages in [TIME]
+     - anyio==4.3.0
+     + anyio==1.3.1
+     + async-generator==1.10
     ");
 
     Ok(())

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1273,6 +1273,25 @@ fn version_get_workspace() -> Result<()> {
     ----- stderr -----
     ");
 
+    // Check that --directory also works
+    uv_snapshot!(context.filters(), context.version().arg("--directory").arg(context.temp_dir.as_ref()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    myproject 1.10.31
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.version().arg("--directory").arg(context.temp_dir.join("workspace-member")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    workspace-member 0.1.0
+
+    ----- stderr -----
+    ");
+
     pyproject_toml.write_str(
         r#"
         [tool.uv.workspace]

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1510,7 +1510,7 @@ fn version_set_workspace() -> Result<()> {
     ----- stderr -----
     ");
 
-    // Confirm --frozen set does no lock or sync
+    // Confirm --frozen set works
     uv_snapshot!(context.filters(), context.version()
         .arg("--package").arg("child2")
         .arg("--frozen")
@@ -1519,6 +1519,31 @@ fn version_set_workspace() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     child2 1.1.1 => 2.0.0
+
+    ----- stderr -----
+    ");
+
+    // Confirm --frozen --bump works, sees the previous set
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child2")
+        .arg("--frozen")
+        .arg("--bump").arg("patch"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child2 2.0.0 => 2.0.1
+
+    ----- stderr -----
+    ");
+
+    // Confirm --frozen get doesn't see the --frozen set or bump
+    uv_snapshot!(context.filters(), context.version()
+        .arg("--package").arg("child2")
+        .arg("--frozen"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    child2 1.1.1
 
     ----- stderr -----
     ");
@@ -1570,7 +1595,7 @@ fn version_set_workspace() -> Result<()> {
 
         [[package]]
         name = "child2"
-        version = "2.0.0"
+        version = "2.0.1"
         source = { editable = "child2" }
         "#
         );
@@ -1594,9 +1619,8 @@ fn version_set_workspace() -> Result<()> {
      - child1==1.2.3 (from file://[TEMP_DIR]/child1)
      + child1==3.0.0 (from file://[TEMP_DIR]/child1)
      - child2==1.1.1 (from file://[TEMP_DIR]/child2)
-     + child2==2.0.0 (from file://[TEMP_DIR]/child2)
+     + child2==2.0.1 (from file://[TEMP_DIR]/child2)
     ");
-
     Ok(())
 }
 

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1308,7 +1308,7 @@ fn version_get_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: There is no 'project.name' field in: pyproject.toml
+    error: Missing `project.name` field in: pyproject.toml
     ");
 
     Ok(())

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -147,6 +147,8 @@ requires-python = ">=3.12"
     myproject 1.10.31 => 1.1.1
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -187,6 +189,8 @@ requires-python = ">=3.12"
     1.1.1
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -226,6 +230,8 @@ requires-python = ">=3.12"
     myproject 1.10.31 => 1.10.32
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -265,6 +271,8 @@ requires-python = ">=3.12"
     1.10.32
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -303,6 +311,8 @@ requires-python = ">=3.12"
     myproject 1.10.31 => 1.11.0
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -341,6 +351,8 @@ requires-python = ">=3.12"
     myproject 1.10.31 => 2.0.0
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -379,6 +391,8 @@ requires-python = ">=3.12"
     myproject 0.1 => 0.1.1
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -417,6 +431,8 @@ requires-python = ">=3.12"
     myproject 0.1 => 0.2
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -455,6 +471,8 @@ requires-python = ">=3.12"
     myproject 0.1 => 1.0
 
     ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -494,6 +512,8 @@ requires-python = ">=3.12"
 
     ----- stderr -----
     warning: prerelease information will be cleared as part of the version bump
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -533,6 +553,8 @@ requires-python = ">=3.12"
 
     ----- stderr -----
     warning: prerelease information will be cleared as part of the version bump
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -572,6 +594,8 @@ requires-python = ">=3.12"
 
     ----- stderr -----
     warning: prerelease information will be cleared as part of the version bump
+    Resolved 1 package in [TIME]
+    Audited in [TIME]
     ");
 
     let pyproject = fs_err::read_to_string(&pyproject_toml)?;
@@ -1264,7 +1288,7 @@ fn version_get_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No `project` table found in: `[TEMP_DIR]/pyproject.toml`
+    error: There is no 'project.version' field in: pyproject.toml
     ");
 
     Ok(())

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1308,7 +1308,7 @@ fn version_get_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: There is no 'project.version' field in: pyproject.toml
+    error: There is no 'project.name' field in: pyproject.toml
     ");
 
     Ok(())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1590,7 +1590,7 @@ uv version [OPTIONS] [VALUE]
 
 <li><code>requires-python</code>:  Optimize for selecting latest supported version of each package, for each supported Python version</li>
 </ul>
-</dd><dt id="uv-version--frozen"><a href="#uv-version--frozen"><code>--frozen</code></a></dt><dd><p>Remove dependencies without re-locking the project.</p>
+</dd><dt id="uv-version--frozen"><a href="#uv-version--frozen"><code>--frozen</code></a></dt><dd><p>Update the version without re-locking the project.</p>
 
 <p>The project environment will not be synced.</p>
 
@@ -1739,7 +1739,7 @@ uv version [OPTIONS] [VALUE]
 
 <li><code>json</code>:  Display the version as JSON</li>
 </ul>
-</dd><dt id="uv-version--package"><a href="#uv-version--package"><code>--package</code></a> <i>package</i></dt><dd><p>Remove the dependencies from a specific package in the workspace</p>
+</dd><dt id="uv-version--package"><a href="#uv-version--package"><code>--package</code></a> <i>package</i></dt><dd><p>Update the version of a specific package in the workspace</p>
 
 </dd><dt id="uv-version--prerelease"><a href="#uv-version--prerelease"><code>--prerelease</code></a> <i>prerelease</i></dt><dd><p>The strategy to use when considering pre-release versions.</p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,8 @@ uv [OPTIONS] <COMMAND>
 </dd>
 <dt><a href="#uv-remove"><code>uv remove</code></a></dt><dd><p>Remove dependencies from the project</p>
 </dd>
+<dt><a href="#uv-version"><code>uv version</code></a></dt><dd><p>Read or update the project&#8217;s version</p>
+</dd>
 <dt><a href="#uv-sync"><code>uv sync</code></a></dt><dd><p>Update the project&#8217;s environment</p>
 </dd>
 <dt><a href="#uv-lock"><code>uv lock</code></a></dt><dd><p>Update the project&#8217;s lockfile</p>
@@ -43,8 +45,6 @@ uv [OPTIONS] <COMMAND>
 <dt><a href="#uv-cache"><code>uv cache</code></a></dt><dd><p>Manage uv&#8217;s cache</p>
 </dd>
 <dt><a href="#uv-self"><code>uv self</code></a></dt><dd><p>Manage the uv executable</p>
-</dd>
-<dt><a href="#uv-version"><code>uv version</code></a></dt><dd><p>Read or update the project&#8217;s version</p>
 </dd>
 <dt><a href="#uv-help"><code>uv help</code></a></dt><dd><p>Display documentation for a command</p>
 </dd>
@@ -1457,6 +1457,359 @@ uv remove [OPTIONS] <PACKAGES>...
 </dd><dt id="uv-remove--upgrade-package"><a href="#uv-remove--upgrade-package"><code>--upgrade-package</code></a>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt id="uv-remove--verbose"><a href="#uv-remove--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
+
+<p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
+
+</dd></dl>
+
+## uv version
+
+Read or update the project's version
+
+<h3 class="cli-reference">Usage</h3>
+
+```
+uv version [OPTIONS] [VALUE]
+```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="uv-version--value"><a href="#uv-version--value"<code>VALUE</code></a></dt><dd><p>Set the project version to this value</p>
+
+<p>To update the project using semantic versioning components instead, use <code>--bump</code>.</p>
+
+</dd></dl>
+
+<h3 class="cli-reference">Options</h3>
+
+<dl class="cli-reference"><dt id="uv-version--active"><a href="#uv-version--active"><code>--active</code></a></dt><dd><p>Prefer the active virtual environment over the project&#8217;s virtual environment.</p>
+
+<p>If the project virtual environment is active or no virtual environment is active, this has no effect.</p>
+
+</dd><dt id="uv-version--allow-insecure-host"><a href="#uv-version--allow-insecure-host"><code>--allow-insecure-host</code></a>, <code>--trusted-host</code> <i>allow-insecure-host</i></dt><dd><p>Allow insecure connections to a host.</p>
+
+<p>Can be provided multiple times.</p>
+
+<p>Expects to receive either a hostname (e.g., <code>localhost</code>), a host-port pair (e.g., <code>localhost:8080</code>), or a URL (e.g., <code>https://localhost</code>).</p>
+
+<p>WARNING: Hosts included in this list will not be verified against the system&#8217;s certificate store. Only use <code>--allow-insecure-host</code> in a secure network with verified sources, as it bypasses SSL verification and could expose you to MITM attacks.</p>
+
+<p>May also be set with the <code>UV_INSECURE_HOST</code> environment variable.</p>
+</dd><dt id="uv-version--bump"><a href="#uv-version--bump"><code>--bump</code></a> <i>bump</i></dt><dd><p>Update the project version using the given semantics</p>
+
+<p>Possible values:</p>
+
+<ul>
+<li><code>major</code>:  Increase the major version (1.2.3 =&gt; 2.0.0)</li>
+
+<li><code>minor</code>:  Increase the minor version (1.2.3 =&gt; 1.3.0)</li>
+
+<li><code>patch</code>:  Increase the patch version (1.2.3 =&gt; 1.2.4)</li>
+</ul>
+</dd><dt id="uv-version--cache-dir"><a href="#uv-version--cache-dir"><code>--cache-dir</code></a> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
+
+<p>Defaults to <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on macOS and Linux, and <code>%LOCALAPPDATA%\uv\cache</code> on Windows.</p>
+
+<p>To view the location of the cache directory, run <code>uv cache dir</code>.</p>
+
+<p>May also be set with the <code>UV_CACHE_DIR</code> environment variable.</p>
+</dd><dt id="uv-version--color"><a href="#uv-version--color"><code>--color</code></a> <i>color-choice</i></dt><dd><p>Control the use of color in output.</p>
+
+<p>By default, uv will automatically detect support for colors when writing to a terminal.</p>
+
+<p>Possible values:</p>
+
+<ul>
+<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
+
+<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
+
+<li><code>never</code>:  Disables colored output</li>
+</ul>
+</dd><dt id="uv-version--compile-bytecode"><a href="#uv-version--compile-bytecode"><code>--compile-bytecode</code></a>, <code>--compile</code></dt><dd><p>Compile Python files to bytecode after installation.</p>
+
+<p>By default, uv does not compile Python (<code>.py</code>) files to bytecode (<code>__pycache__/*.pyc</code>); instead, compilation is performed lazily the first time a module is imported. For use-cases in which start time is critical, such as CLI applications and Docker containers, this option can be enabled to trade longer installation times for faster start times.</p>
+
+<p>When enabled, uv will process the entire site-packages directory (including packages that are not being modified by the current operation) for consistency. Like pip, it will also ignore errors.</p>
+
+<p>May also be set with the <code>UV_COMPILE_BYTECODE</code> environment variable.</p>
+</dd><dt id="uv-version--config-file"><a href="#uv-version--config-file"><code>--config-file</code></a> <i>config-file</i></dt><dd><p>The path to a <code>uv.toml</code> file to use for configuration.</p>
+
+<p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
+
+<p>May also be set with the <code>UV_CONFIG_FILE</code> environment variable.</p>
+</dd><dt id="uv-version--config-setting"><a href="#uv-version--config-setting"><code>--config-setting</code></a>, <code>--config-settings</code>, <code>-C</code> <i>config-setting</i></dt><dd><p>Settings to pass to the PEP 517 build backend, specified as <code>KEY=VALUE</code> pairs</p>
+
+</dd><dt id="uv-version--default-index"><a href="#uv-version--default-index"><code>--default-index</code></a> <i>default-index</i></dt><dd><p>The URL of the default package index (by default: &lt;https://pypi.org/simple&gt;).</p>
+
+<p>Accepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.</p>
+
+<p>The index given by this flag is given lower priority than all other indexes specified via the <code>--index</code> flag.</p>
+
+<p>May also be set with the <code>UV_DEFAULT_INDEX</code> environment variable.</p>
+</dd><dt id="uv-version--directory"><a href="#uv-version--directory"><code>--directory</code></a> <i>directory</i></dt><dd><p>Change to the given directory prior to running the command.</p>
+
+<p>Relative paths are resolved with the given directory as the base.</p>
+
+<p>See <code>--project</code> to only change the project root directory.</p>
+
+</dd><dt id="uv-version--dry-run"><a href="#uv-version--dry-run"><code>--dry-run</code></a></dt><dd><p>Don&#8217;t write a new version to the <code>pyproject.toml</code></p>
+
+<p>Instead, the version will be displayed.</p>
+
+</dd><dt id="uv-version--exclude-newer"><a href="#uv-version--exclude-newer"><code>--exclude-newer</code></a> <i>exclude-newer</i></dt><dd><p>Limit candidate packages to those that were uploaded prior to the given date.</p>
+
+<p>Accepts both RFC 3339 timestamps (e.g., <code>2006-12-02T02:07:43Z</code>) and local dates in the same format (e.g., <code>2006-12-02</code>) in your system&#8217;s configured time zone.</p>
+
+<p>May also be set with the <code>UV_EXCLUDE_NEWER</code> environment variable.</p>
+</dd><dt id="uv-version--extra-index-url"><a href="#uv-version--extra-index-url"><code>--extra-index-url</code></a> <i>extra-index-url</i></dt><dd><p>(Deprecated: use <code>--index</code> instead) Extra URLs of package indexes to use, in addition to <code>--index-url</code>.</p>
+
+<p>Accepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.</p>
+
+<p>All indexes provided via this flag take priority over the index specified by <code>--index-url</code> (which defaults to PyPI). When multiple <code>--extra-index-url</code> flags are provided, earlier values take priority.</p>
+
+<p>May also be set with the <code>UV_EXTRA_INDEX_URL</code> environment variable.</p>
+</dd><dt id="uv-version--find-links"><a href="#uv-version--find-links"><code>--find-links</code></a>, <code>-f</code> <i>find-links</i></dt><dd><p>Locations to search for candidate distributions, in addition to those found in the registry indexes.</p>
+
+<p>If a path, the target must be a directory that contains packages as wheel files (<code>.whl</code>) or source distributions (e.g., <code>.tar.gz</code> or <code>.zip</code>) at the top level.</p>
+
+<p>If a URL, the page must contain a flat list of links to package files adhering to the formats described above.</p>
+
+<p>May also be set with the <code>UV_FIND_LINKS</code> environment variable.</p>
+</dd><dt id="uv-version--fork-strategy"><a href="#uv-version--fork-strategy"><code>--fork-strategy</code></a> <i>fork-strategy</i></dt><dd><p>The strategy to use when selecting multiple versions of a given package across Python versions and platforms.</p>
+
+<p>By default, uv will optimize for selecting the latest version of each package for each supported Python version (<code>requires-python</code>), while minimizing the number of selected versions across platforms.</p>
+
+<p>Under <code>fewest</code>, uv will minimize the number of selected versions for each package, preferring older versions that are compatible with a wider range of supported Python versions or platforms.</p>
+
+<p>May also be set with the <code>UV_FORK_STRATEGY</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>fewest</code>:  Optimize for selecting the fewest number of versions for each package. Older versions may be preferred if they are compatible with a wider range of supported Python versions or platforms</li>
+
+<li><code>requires-python</code>:  Optimize for selecting latest supported version of each package, for each supported Python version</li>
+</ul>
+</dd><dt id="uv-version--frozen"><a href="#uv-version--frozen"><code>--frozen</code></a></dt><dd><p>Remove dependencies without re-locking the project.</p>
+
+<p>The project environment will not be synced.</p>
+
+<p>May also be set with the <code>UV_FROZEN</code> environment variable.</p>
+</dd><dt id="uv-version--help"><a href="#uv-version--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
+
+</dd><dt id="uv-version--index"><a href="#uv-version--index"><code>--index</code></a> <i>index</i></dt><dd><p>The URLs to use when resolving dependencies, in addition to the default index.</p>
+
+<p>Accepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.</p>
+
+<p>All indexes provided via this flag take priority over the index specified by <code>--default-index</code> (which defaults to PyPI). When multiple <code>--index</code> flags are provided, earlier values take priority.</p>
+
+<p>May also be set with the <code>UV_INDEX</code> environment variable.</p>
+</dd><dt id="uv-version--index-strategy"><a href="#uv-version--index-strategy"><code>--index-strategy</code></a> <i>index-strategy</i></dt><dd><p>The strategy to use when resolving against multiple index URLs.</p>
+
+<p>By default, uv will stop at the first index on which a given package is available, and limit resolutions to those present on that first index (<code>first-index</code>). This prevents &quot;dependency confusion&quot; attacks, whereby an attacker can upload a malicious package under the same name to an alternate index.</p>
+
+<p>May also be set with the <code>UV_INDEX_STRATEGY</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>first-index</code>:  Only use results from the first index that returns a match for a given package name</li>
+
+<li><code>unsafe-first-match</code>:  Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next</li>
+
+<li><code>unsafe-best-match</code>:  Search for every package name across all indexes, preferring the &quot;best&quot; version found. If a package version is in multiple indexes, only look at the entry for the first index</li>
+</ul>
+</dd><dt id="uv-version--index-url"><a href="#uv-version--index-url"><code>--index-url</code></a>, <code>-i</code> <i>index-url</i></dt><dd><p>(Deprecated: use <code>--default-index</code> instead) The URL of the Python package index (by default: &lt;https://pypi.org/simple&gt;).</p>
+
+<p>Accepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.</p>
+
+<p>The index given by this flag is given lower priority than all other indexes specified via the <code>--extra-index-url</code> flag.</p>
+
+<p>May also be set with the <code>UV_INDEX_URL</code> environment variable.</p>
+</dd><dt id="uv-version--keyring-provider"><a href="#uv-version--keyring-provider"><code>--keyring-provider</code></a> <i>keyring-provider</i></dt><dd><p>Attempt to use <code>keyring</code> for authentication for index URLs.</p>
+
+<p>At present, only <code>--keyring-provider subprocess</code> is supported, which configures uv to use the <code>keyring</code> CLI to handle authentication.</p>
+
+<p>Defaults to <code>disabled</code>.</p>
+
+<p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>disabled</code>:  Do not use keyring for credential lookup</li>
+
+<li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
+</ul>
+</dd><dt id="uv-version--link-mode"><a href="#uv-version--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
+
+<p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
+
+<p>May also be set with the <code>UV_LINK_MODE</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>clone</code>:  Clone (i.e., copy-on-write) packages from the wheel into the <code>site-packages</code> directory</li>
+
+<li><code>copy</code>:  Copy packages from the wheel into the <code>site-packages</code> directory</li>
+
+<li><code>hardlink</code>:  Hard link packages from the wheel into the <code>site-packages</code> directory</li>
+
+<li><code>symlink</code>:  Symbolically link packages from the wheel into the <code>site-packages</code> directory</li>
+</ul>
+</dd><dt id="uv-version--locked"><a href="#uv-version--locked"><code>--locked</code></a></dt><dd><p>Assert that the <code>uv.lock</code> will remain unchanged.</p>
+
+<p>Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated, uv will exit with an error.</p>
+
+<p>May also be set with the <code>UV_LOCKED</code> environment variable.</p>
+</dd><dt id="uv-version--managed-python"><a href="#uv-version--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
+
+<p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
+
+<p>May also be set with the <code>UV_MANAGED_PYTHON</code> environment variable.</p>
+</dd><dt id="uv-version--native-tls"><a href="#uv-version--native-tls"><code>--native-tls</code></a></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>
+
+<p>By default, uv loads certificates from the bundled <code>webpki-roots</code> crate. The <code>webpki-roots</code> are a reliable set of trust roots from Mozilla, and including them in uv improves portability and performance (especially on macOS).</p>
+
+<p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
+
+<p>May also be set with the <code>UV_NATIVE_TLS</code> environment variable.</p>
+</dd><dt id="uv-version--no-binary"><a href="#uv-version--no-binary"><code>--no-binary</code></a></dt><dd><p>Don&#8217;t install pre-built wheels.</p>
+
+<p>The given packages will be built and installed from source. The resolver will still use pre-built wheels to extract package metadata, if available.</p>
+
+<p>May also be set with the <code>UV_NO_BINARY</code> environment variable.</p>
+</dd><dt id="uv-version--no-binary-package"><a href="#uv-version--no-binary-package"><code>--no-binary-package</code></a> <i>no-binary-package</i></dt><dd><p>Don&#8217;t install pre-built wheels for a specific package</p>
+
+<p>May also be set with the <code>UV_NO_BINARY_PACKAGE</code> environment variable.</p>
+</dd><dt id="uv-version--no-build"><a href="#uv-version--no-build"><code>--no-build</code></a></dt><dd><p>Don&#8217;t build source distributions.</p>
+
+<p>When enabled, resolving will not run arbitrary Python code. The cached wheels of already-built source distributions will be reused, but operations that require building distributions will exit with an error.</p>
+
+<p>May also be set with the <code>UV_NO_BUILD</code> environment variable.</p>
+</dd><dt id="uv-version--no-build-isolation"><a href="#uv-version--no-build-isolation"><code>--no-build-isolation</code></a></dt><dd><p>Disable isolation when building source distributions.</p>
+
+<p>Assumes that build dependencies specified by PEP 518 are already installed.</p>
+
+<p>May also be set with the <code>UV_NO_BUILD_ISOLATION</code> environment variable.</p>
+</dd><dt id="uv-version--no-build-isolation-package"><a href="#uv-version--no-build-isolation-package"><code>--no-build-isolation-package</code></a> <i>no-build-isolation-package</i></dt><dd><p>Disable isolation when building source distributions for a specific package.</p>
+
+<p>Assumes that the packages&#8217; build dependencies specified by PEP 518 are already installed.</p>
+
+</dd><dt id="uv-version--no-build-package"><a href="#uv-version--no-build-package"><code>--no-build-package</code></a> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
+
+<p>May also be set with the <code>UV_NO_BUILD_PACKAGE</code> environment variable.</p>
+</dd><dt id="uv-version--no-cache"><a href="#uv-version--no-cache"><code>--no-cache</code></a>, <code>--no-cache-dir</code>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
+
+<p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
+</dd><dt id="uv-version--no-config"><a href="#uv-version--no-config"><code>--no-config</code></a></dt><dd><p>Avoid discovering configuration files (<code>pyproject.toml</code>, <code>uv.toml</code>).</p>
+
+<p>Normally, configuration files are discovered in the current directory, parent directories, or user configuration directories.</p>
+
+<p>May also be set with the <code>UV_NO_CONFIG</code> environment variable.</p>
+</dd><dt id="uv-version--no-index"><a href="#uv-version--no-index"><code>--no-index</code></a></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
+
+</dd><dt id="uv-version--no-managed-python"><a href="#uv-version--no-managed-python"><code>--no-managed-python</code></a></dt><dd><p>Disable use of uv-managed Python versions.</p>
+
+<p>Instead, uv will search for a suitable Python version on the system.</p>
+
+<p>May also be set with the <code>UV_NO_MANAGED_PYTHON</code> environment variable.</p>
+</dd><dt id="uv-version--no-progress"><a href="#uv-version--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
+
+<p>For example, spinners or progress bars.</p>
+
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
+</dd><dt id="uv-version--no-python-downloads"><a href="#uv-version--no-python-downloads"><code>--no-python-downloads</code></a></dt><dd><p>Disable automatic downloads of Python.</p>
+
+</dd><dt id="uv-version--no-sources"><a href="#uv-version--no-sources"><code>--no-sources</code></a></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any workspace, Git, URL, or local path sources</p>
+
+</dd><dt id="uv-version--no-sync"><a href="#uv-version--no-sync"><code>--no-sync</code></a></dt><dd><p>Avoid syncing the virtual environment after re-locking the project</p>
+
+<p>May also be set with the <code>UV_NO_SYNC</code> environment variable.</p>
+</dd><dt id="uv-version--offline"><a href="#uv-version--offline"><code>--offline</code></a></dt><dd><p>Disable network access.</p>
+
+<p>When disabled, uv will only use locally cached data and locally available files.</p>
+
+<p>May also be set with the <code>UV_OFFLINE</code> environment variable.</p>
+</dd><dt id="uv-version--output-format"><a href="#uv-version--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dd><p>The format of the output</p>
+
+<p>[default: text]</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>text</code>:  Display the version as plain text</li>
+
+<li><code>json</code>:  Display the version as JSON</li>
+</ul>
+</dd><dt id="uv-version--package"><a href="#uv-version--package"><code>--package</code></a> <i>package</i></dt><dd><p>Remove the dependencies from a specific package in the workspace</p>
+
+</dd><dt id="uv-version--prerelease"><a href="#uv-version--prerelease"><code>--prerelease</code></a> <i>prerelease</i></dt><dd><p>The strategy to use when considering pre-release versions.</p>
+
+<p>By default, uv will accept pre-releases for packages that <em>only</em> publish pre-releases, along with first-party requirements that contain an explicit pre-release marker in the declared specifiers (<code>if-necessary-or-explicit</code>).</p>
+
+<p>May also be set with the <code>UV_PRERELEASE</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>disallow</code>:  Disallow all pre-release versions</li>
+
+<li><code>allow</code>:  Allow all pre-release versions</li>
+
+<li><code>if-necessary</code>:  Allow pre-release versions if all versions of a package are pre-release</li>
+
+<li><code>explicit</code>:  Allow pre-release versions for first-party packages with explicit pre-release markers in their version requirements</li>
+
+<li><code>if-necessary-or-explicit</code>:  Allow pre-release versions if all versions of a package are pre-release, or if the package has an explicit pre-release marker in its version requirements</li>
+</ul>
+</dd><dt id="uv-version--project"><a href="#uv-version--project"><code>--project</code></a> <i>project</i></dt><dd><p>Run the command within the given project directory.</p>
+
+<p>All <code>pyproject.toml</code>, <code>uv.toml</code>, and <code>.python-version</code> files will be discovered by walking up the directory tree from the project root, as will the project&#8217;s virtual environment (<code>.venv</code>).</p>
+
+<p>Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.</p>
+
+<p>See <code>--directory</code> to change the working directory entirely.</p>
+
+<p>This setting has no effect when used in the <code>uv pip</code> interface.</p>
+
+<p>May also be set with the <code>UV_PROJECT</code> environment variable.</p>
+</dd><dt id="uv-version--python"><a href="#uv-version--python"><code>--python</code></a>, <code>-p</code> <i>python</i></dt><dd><p>The Python interpreter to use for resolving and syncing.</p>
+
+<p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
+
+<p>May also be set with the <code>UV_PYTHON</code> environment variable.</p>
+</dd><dt id="uv-version--quiet"><a href="#uv-version--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
+
+<p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
+
+</dd><dt id="uv-version--refresh"><a href="#uv-version--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
+
+</dd><dt id="uv-version--refresh-package"><a href="#uv-version--refresh-package"><code>--refresh-package</code></a> <i>refresh-package</i></dt><dd><p>Refresh cached data for a specific package</p>
+
+</dd><dt id="uv-version--reinstall"><a href="#uv-version--reinstall"><code>--reinstall</code></a>, <code>--force-reinstall</code></dt><dd><p>Reinstall all packages, regardless of whether they&#8217;re already installed. Implies <code>--refresh</code></p>
+
+</dd><dt id="uv-version--reinstall-package"><a href="#uv-version--reinstall-package"><code>--reinstall-package</code></a> <i>reinstall-package</i></dt><dd><p>Reinstall a specific package, regardless of whether it&#8217;s already installed. Implies <code>--refresh-package</code></p>
+
+</dd><dt id="uv-version--resolution"><a href="#uv-version--resolution"><code>--resolution</code></a> <i>resolution</i></dt><dd><p>The strategy to use when selecting between the different compatible versions for a given package requirement.</p>
+
+<p>By default, uv will use the latest compatible version of each package (<code>highest</code>).</p>
+
+<p>May also be set with the <code>UV_RESOLUTION</code> environment variable.</p>
+<p>Possible values:</p>
+
+<ul>
+<li><code>highest</code>:  Resolve the highest compatible version of each package</li>
+
+<li><code>lowest</code>:  Resolve the lowest compatible version of each package</li>
+
+<li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
+</ul>
+</dd><dt id="uv-version--short"><a href="#uv-version--short"><code>--short</code></a></dt><dd><p>Only show the version</p>
+
+<p>By default, uv will show the project name before the version.</p>
+
+</dd><dt id="uv-version--upgrade"><a href="#uv-version--upgrade"><code>--upgrade</code></a>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
+
+</dd><dt id="uv-version--upgrade-package"><a href="#uv-version--upgrade-package"><code>--upgrade-package</code></a>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
+
+</dd><dt id="uv-version--verbose"><a href="#uv-version--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
@@ -9549,145 +9902,6 @@ uv self version [OPTIONS]
 </dd><dt id="uv-self-version--short"><a href="#uv-self-version--short"><code>--short</code></a></dt><dd><p>Only print the version</p>
 
 </dd><dt id="uv-self-version--verbose"><a href="#uv-self-version--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
-
-<p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd></dl>
-
-## uv version
-
-Read or update the project's version
-
-<h3 class="cli-reference">Usage</h3>
-
-```
-uv version [OPTIONS] [VALUE]
-```
-
-<h3 class="cli-reference">Arguments</h3>
-
-<dl class="cli-reference"><dt id="uv-version--value"><a href="#uv-version--value"<code>VALUE</code></a></dt><dd><p>Set the project version to this value</p>
-
-<p>To update the project using semantic versioning components instead, use <code>--bump</code>.</p>
-
-</dd></dl>
-
-<h3 class="cli-reference">Options</h3>
-
-<dl class="cli-reference"><dt id="uv-version--allow-insecure-host"><a href="#uv-version--allow-insecure-host"><code>--allow-insecure-host</code></a>, <code>--trusted-host</code> <i>allow-insecure-host</i></dt><dd><p>Allow insecure connections to a host.</p>
-
-<p>Can be provided multiple times.</p>
-
-<p>Expects to receive either a hostname (e.g., <code>localhost</code>), a host-port pair (e.g., <code>localhost:8080</code>), or a URL (e.g., <code>https://localhost</code>).</p>
-
-<p>WARNING: Hosts included in this list will not be verified against the system&#8217;s certificate store. Only use <code>--allow-insecure-host</code> in a secure network with verified sources, as it bypasses SSL verification and could expose you to MITM attacks.</p>
-
-<p>May also be set with the <code>UV_INSECURE_HOST</code> environment variable.</p>
-</dd><dt id="uv-version--bump"><a href="#uv-version--bump"><code>--bump</code></a> <i>bump</i></dt><dd><p>Update the project version using the given semantics</p>
-
-<p>Possible values:</p>
-
-<ul>
-<li><code>major</code>:  Increase the major version (1.2.3 =&gt; 2.0.0)</li>
-
-<li><code>minor</code>:  Increase the minor version (1.2.3 =&gt; 1.3.0)</li>
-
-<li><code>patch</code>:  Increase the patch version (1.2.3 =&gt; 1.2.4)</li>
-</ul>
-</dd><dt id="uv-version--cache-dir"><a href="#uv-version--cache-dir"><code>--cache-dir</code></a> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
-
-<p>Defaults to <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on macOS and Linux, and <code>%LOCALAPPDATA%\uv\cache</code> on Windows.</p>
-
-<p>To view the location of the cache directory, run <code>uv cache dir</code>.</p>
-
-<p>May also be set with the <code>UV_CACHE_DIR</code> environment variable.</p>
-</dd><dt id="uv-version--color"><a href="#uv-version--color"><code>--color</code></a> <i>color-choice</i></dt><dd><p>Control the use of color in output.</p>
-
-<p>By default, uv will automatically detect support for colors when writing to a terminal.</p>
-
-<p>Possible values:</p>
-
-<ul>
-<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
-
-<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
-
-<li><code>never</code>:  Disables colored output</li>
-</ul>
-</dd><dt id="uv-version--config-file"><a href="#uv-version--config-file"><code>--config-file</code></a> <i>config-file</i></dt><dd><p>The path to a <code>uv.toml</code> file to use for configuration.</p>
-
-<p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
-
-<p>May also be set with the <code>UV_CONFIG_FILE</code> environment variable.</p>
-</dd><dt id="uv-version--directory"><a href="#uv-version--directory"><code>--directory</code></a> <i>directory</i></dt><dd><p>Change to the given directory prior to running the command.</p>
-
-<p>Relative paths are resolved with the given directory as the base.</p>
-
-<p>See <code>--project</code> to only change the project root directory.</p>
-
-</dd><dt id="uv-version--dry-run"><a href="#uv-version--dry-run"><code>--dry-run</code></a></dt><dd><p>Don&#8217;t write a new version to the <code>pyproject.toml</code></p>
-
-<p>Instead, the version will be displayed.</p>
-
-</dd><dt id="uv-version--help"><a href="#uv-version--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
-
-</dd><dt id="uv-version--managed-python"><a href="#uv-version--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
-
-<p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
-
-<p>May also be set with the <code>UV_MANAGED_PYTHON</code> environment variable.</p>
-</dd><dt id="uv-version--native-tls"><a href="#uv-version--native-tls"><code>--native-tls</code></a></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>
-
-<p>By default, uv loads certificates from the bundled <code>webpki-roots</code> crate. The <code>webpki-roots</code> are a reliable set of trust roots from Mozilla, and including them in uv improves portability and performance (especially on macOS).</p>
-
-<p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
-
-<p>May also be set with the <code>UV_NATIVE_TLS</code> environment variable.</p>
-</dd><dt id="uv-version--no-cache"><a href="#uv-version--no-cache"><code>--no-cache</code></a>, <code>--no-cache-dir</code>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
-
-<p>May also be set with the <code>UV_NO_CACHE</code> environment variable.</p>
-</dd><dt id="uv-version--no-config"><a href="#uv-version--no-config"><code>--no-config</code></a></dt><dd><p>Avoid discovering configuration files (<code>pyproject.toml</code>, <code>uv.toml</code>).</p>
-
-<p>Normally, configuration files are discovered in the current directory, parent directories, or user configuration directories.</p>
-
-<p>May also be set with the <code>UV_NO_CONFIG</code> environment variable.</p>
-</dd><dt id="uv-version--no-managed-python"><a href="#uv-version--no-managed-python"><code>--no-managed-python</code></a></dt><dd><p>Disable use of uv-managed Python versions.</p>
-
-<p>Instead, uv will search for a suitable Python version on the system.</p>
-
-<p>May also be set with the <code>UV_NO_MANAGED_PYTHON</code> environment variable.</p>
-</dd><dt id="uv-version--no-progress"><a href="#uv-version--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>
-
-<p>For example, spinners or progress bars.</p>
-
-<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
-</dd><dt id="uv-version--no-python-downloads"><a href="#uv-version--no-python-downloads"><code>--no-python-downloads</code></a></dt><dd><p>Disable automatic downloads of Python.</p>
-
-</dd><dt id="uv-version--offline"><a href="#uv-version--offline"><code>--offline</code></a></dt><dd><p>Disable network access.</p>
-
-<p>When disabled, uv will only use locally cached data and locally available files.</p>
-
-<p>May also be set with the <code>UV_OFFLINE</code> environment variable.</p>
-</dd><dt id="uv-version--output-format"><a href="#uv-version--output-format"><code>--output-format</code></a> <i>output-format</i></dt><dt id="uv-version--project"><a href="#uv-version--project"><code>--project</code></a> <i>project</i></dt><dd><p>Run the command within the given project directory.</p>
-
-<p>All <code>pyproject.toml</code>, <code>uv.toml</code>, and <code>.python-version</code> files will be discovered by walking up the directory tree from the project root, as will the project&#8217;s virtual environment (<code>.venv</code>).</p>
-
-<p>Other command-line arguments (such as relative paths) will be resolved relative to the current working directory.</p>
-
-<p>See <code>--directory</code> to change the working directory entirely.</p>
-
-<p>This setting has no effect when used in the <code>uv pip</code> interface.</p>
-
-<p>May also be set with the <code>UV_PROJECT</code> environment variable.</p>
-</dd><dt id="uv-version--quiet"><a href="#uv-version--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
-
-<p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
-
-</dd><dt id="uv-version--short"><a href="#uv-version--short"><code>--short</code></a></dt><dd><p>Only show the version</p>
-
-<p>By default, uv will show the project name before the version.</p>
-
-</dd><dt id="uv-version--verbose"><a href="#uv-version--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 


### PR DESCRIPTION
This adopts the logic from `uv remove` for locking and syncing, as the scope of the changes made are ultimately similar. Unlike `uv remove` there is no support for modifying PEP723 scripts, as these are not versioned.

In doing this the `version` command gains a truckload of args for configuring lock/sync behaviour. Presumably most of these are passed via settings or env files, and not of particular concern. 

The most interesting additions are:

* `--frozen`: makes `uv version` work ~exactly as it did before this PR
* `--locked`: errors if the lockfile is out of date
* `--no-sync`: updates the lockfile, but doesn't run the equivalent of `uv sync`
* `--package name`: a convenience for referring to a package in the workspace

Note that the existing `--dry-run` flag effectively implies `--frozen`.

Fixes #13254
Fixes #13548