### PR TITLE
Fix discovery of pre-release managed Python versions in range requests

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2177,7 +2177,7 @@ impl VersionRequest {
                 (version.major(), version.minor(), version.patch())
                     == (*major, *minor, Some(*patch))
             }
-            Self::Range(specifiers, _) => specifiers.contains(&version.version),
+            Self::Range(specifiers, _) => specifiers.contains(&version.version.only_release()),
             Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
                 (version.major(), version.minor(), version.pre())
                     == (*major, *minor, Some(*prerelease))

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1248,12 +1248,12 @@ fn python_install_314() {
 
     // This also applies to `>=` requests, even though pre-releases aren't technically in the range
     uv_snapshot!(context.filters(), context.python_find().arg(">=3.14"), @r"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
+    [TEMP_DIR]/managed/cpython-3.14.0a6-[PLATFORM]/[INSTALL-BIN]/python
 
     ----- stderr -----
-    error: No interpreter found for Python >=3.14 in virtual environments, managed installations, or search path
     ");
 
     uv_snapshot!(context.filters(), context.python_find().arg("3"), @r"

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1246,6 +1246,16 @@ fn python_install_314() {
     ----- stderr -----
     ");
 
+    // This also applies to `>=` requests, even though pre-releases aren't technically in the range
+    uv_snapshot!(context.filters(), context.python_find().arg(">=3.14"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for Python >=3.14 in virtual environments, managed installations, or search path
+    ");
+
     uv_snapshot!(context.filters(), context.python_find().arg("3"), @r"
     success: true
     exit_code: 0


### PR DESCRIPTION
We have test coverage for this elsewhere, but managed Python versions are a distinct case because we know the _full_ version before querying the interpreter (whereas, when we find them on the `PATH`, we usually only know `X.y` from the file name).

This pre-filter logic now matches our subsequent logic at

https://github.com/astral-sh/uv/blob/060be9cef197d83e5546fb1be10e8e8373a1cfc6/crates/uv-python/src/discovery.rs#L2146-L2149


https://github.com/astral-sh/uv/pull/13330/commits/060be9cef197d83e5546fb1be10e8e8373a1cfc6 shows the snapshot change.