### PR TITLE
Avoid enumerating sources in errors for path Python requests

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2646,6 +2646,12 @@ impl fmt::Display for PythonNotFound {
             PythonRequest::Default | PythonRequest::Any => {
                 write!(f, "No interpreter found in {sources}")
             }
+            PythonRequest::File(_) => {
+                write!(f, "No interpreter found at {}", self.request)
+            }
+            PythonRequest::Directory(_) => {
+                write!(f, "No interpreter found in {}", self.request)
+            }
             _ => {
                 write!(f, "No interpreter found for {} in {sources}", self.request)
             }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -293,6 +293,19 @@ impl TestContext {
         self
     }
 
+    /// Adds a filter for platform-specific errors when a file is not executable.
+    #[inline]
+    pub fn with_filtered_not_executable(mut self) -> Self {
+        let pattern = if cfg!(unix) {
+            r"Permission denied \(os error 13\)"
+        } else {
+            r"\%1 is not a valid Win32 application. \(os error 193\)"
+        };
+        self.filters
+            .push((pattern.to_string(), "[PERMISSION DENIED]".to_string()));
+        self
+    }
+
     /// Adds a filter that ignores platform information in a Python installation key.
     pub fn with_filtered_python_keys(mut self) -> Self {
         // Filter platform keys

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -17381,7 +17381,7 @@ fn compile_broken_active_venv() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × No interpreter found for path `python3.14159` in managed installations or search path
+      × No interpreter found at path `python3.14159`
     ");
 
     // Simulate a removed Python interpreter

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -1,4 +1,4 @@
-use assert_fs::prelude::PathChild;
+use assert_fs::prelude::{FileTouch, PathChild};
 use assert_fs::{fixture::FileWriteStr, prelude::PathCreateDir};
 use indoc::indoc;
 
@@ -975,5 +975,45 @@ fn python_find_show_version() {
     3.11.[X]
 
     ----- stderr -----
+    ");
+}
+
+#[test]
+fn python_find_path() {
+    let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_not_executable();
+
+    context.temp_dir.child("foo").create_dir_all().unwrap();
+    context.temp_dir.child("bar").touch().unwrap();
+
+    // No interpreter in a directory
+    uv_snapshot!(context.filters(), context.python_find().arg(context.temp_dir.child("foo").as_os_str()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found in directory `foo`
+    ");
+
+    // No interpreter at a file
+    uv_snapshot!(context.filters(), context.python_find().arg(context.temp_dir.child("bar").as_os_str()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to inspect Python interpreter from provided path at `bar`
+      Caused by: Failed to query Python interpreter at `[TEMP_DIR]/bar`
+      Caused by: [PERMISSION DENIED]
+    ");
+
+    // No interpreter at a file that does not exist
+    uv_snapshot!(context.filters(), context.python_find().arg(context.temp_dir.child("foobar").as_os_str()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found at path `foobar`
     ");
 }


### PR DESCRIPTION
e.g., these are misleading cruft in the error message at https://github.com/astral-sh/uv/pull/12168#discussion_r2078204601

```
❯ uv python find /foo/bar
error: No interpreter found for path `/foo/bar` in virtual environments, managed installations, or search path
❯ cargo run -q -- python find /foo/bar
error: No interpreter found at path `/foo/bar`
```