### PR TITLE
Fix display of HTTP responses in trace logs for retry of errors

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -484,11 +484,7 @@ pub fn is_extended_transient_error(err: &dyn Error) -> bool {
     if let Some((Some(status), Some(url))) = find_source::<crate::WrappedReqwestError>(&err)
         .map(|request_err| (request_err.status(), request_err.url()))
     {
-        let status = status
-            .canonical_reason()
-            .map(|reason| format!(" HTTP {status} {reason} "))
-            .unwrap_or_else(|| format!(" HTTP {status} "));
-        trace!("Considering retry of {status} for {url}");
+        trace!("Considering retry of response HTTP {status} for {url}");
     } else {
         trace!("Considering retry of error: {err:?}");
     }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -481,7 +481,7 @@ impl RetryableStrategy for UvRetryableStrategy {
 /// These cases should be safe to retry with [`Retryable::Transient`].
 pub fn is_extended_transient_error(err: &dyn Error) -> bool {
     // First, try to show a nice trace log
-    if let Some((Some(status), Some(url))) = find_source::<reqwest::Error>(&err)
+    if let Some((Some(status), Some(url))) = find_source::<crate::WrappedReqwestError>(&err)
         .map(|request_err| (request_err.status(), request_err.url()))
     {
         let status = status


### PR DESCRIPTION
Follows https://github.com/astral-sh/uv/pull/13228

Closes https://github.com/astral-sh/uv/issues/13338

I recall some discussion (maybe around https://github.com/astral-sh/uv/pull/4725) about how finding the source may not work properly? I can't find it though.

Now, I tested this, e.g.:

```
❯ cargo run -q -- pip install anyio -vv --index-url https://download.pytorch.org/whl/torch/ --no-cache --reinstall
...
TRACE Considering retry of response HTTP 403 Forbidden for https://download.pytorch.org/whl/torch/anyio/
```

I lament that I didn't think of that as a testing method in the first place :)