### PR TITLE
Add virtualenv feature specific to Python 3.14

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -170,6 +170,9 @@ pub(crate) fn create(
                 interpreter.python_minor(),
             )),
         )?;
+        if interpreter.python_major() == 3 && interpreter.python_minor() == 14 {
+            uv_fs::replace_symlink("python", scripts.join("𝜋thon"))?;
+        }
 
         if interpreter.markers().implementation_name() == "pypy" {
             uv_fs::replace_symlink(


### PR DESCRIPTION
## Summary

Python 3.14, which is now in [feature freeze](https://peps.python.org/pep-0745/), introduced a [change](https://github.com/python/cpython/issues/119535) (note: the name has been renamed in the second PR of this ticket) in the `venv` module.

More precisely, the interpreter is available in the `$PATH` once the venv is activated with yet another name.

This change is only for non-`nt` operating systems, and only for Python version 3.14 specifically.

I'm no rust developer, so I may have made mistakes when porting the code to rust. Please review accordingly!

_I use a vague commit message to avoid spoiling the fun 🐇🥚_

## Test Plan

I ran `uv venv` under a linux machien and checked the content of the `.venv/bin` directory:
- With Python 3.13, it was as before the PR
- With Python 3.14b1, a new symlink is created