### PR TITLE
Update issue templates to use `uv self version` command

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -27,7 +27,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of uv are you using? (see `uv version`)
+      description: What version of uv are you using? (see `uv self version`)
       placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -25,7 +25,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of uv are you using? (see `uv version`)
+      description: What version of uv are you using? (see `uv self version`)
       placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
     validations:
       required: false


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR updates the issue templates to recommend using the `uv self version` command instead of `uv version` for retrieving uv's own version information. The `uv version` command is intended to show the current project's version (from pyproject.toml), not the uv tool version, which leads to confusion when users try to report issues.

## Test Plan

<!-- How was it tested? -->
n/a
