### PR TITLE
Respect default extras in uv remove

### DIFF
--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -312,11 +312,6 @@ pub(crate) async fn remove(
         return Ok(ExitStatus::Success);
     };
 
-    // Perform a full sync, because we don't know what exactly is affected by the removal.
-    // TODO(ibraheem): Should we accept CLI overrides for this? Should we even sync here?
-    let extras = ExtrasSpecification::from_all_extras();
-    let install_options = InstallOptions::default();
-
     // Determine the default groups to include.
     let default_groups = default_dependency_groups(project.pyproject_toml())?;
 
@@ -341,10 +336,10 @@ pub(crate) async fn remove(
     match project::sync::do_sync(
         target,
         venv,
-        &extras.with_defaults(default_extras),
+        &ExtrasSpecification::default().with_defaults(default_extras),
         &DependencyGroups::default().with_defaults(default_groups),
         EditableMode::Editable,
-        install_options,
+        InstallOptions::default(),
         Modifications::Exact,
         (&settings).into(),
         &network_settings,

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1404,12 +1404,7 @@ fn add_remove_inline_optional() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Prepared 3 packages in [TIME]
     Uninstalled 1 package in [TIME]
-    Installed 3 packages in [TIME]
-     + anyio==3.7.0
-     + idna==3.6
-     + sniffio==1.3.1
      - typing-extensions==4.10.0
     ");
 
@@ -11675,8 +11670,12 @@ fn add_optional_normalize() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Uninstalled 1 package in [TIME]
+    Uninstalled 5 packages in [TIME]
+     - anyio==3.7.0
+     - idna==3.6
      - iniconfig==2.0.0
+     - sniffio==1.3.1
+     - typing-extensions==4.10.0
     ");
 
     let pyproject_toml = context.read("pyproject.toml");
@@ -11704,8 +11703,7 @@ fn add_optional_normalize() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Uninstalled 1 package in [TIME]
-     - typing-extensions==4.10.0
+    Audited in [TIME]
     ");
 
     let pyproject_toml = context.read("pyproject.toml");


### PR DESCRIPTION
## Summary

Using "all extras" in `uv remove` will cause errors for projects with conflicting extras. Now that we have a concept of "default extras", it seems better to respect those defaults like we do for dependency groups.

Closes https://github.com/astral-sh/uv/issues/12770.
