### PR TITLE
Fix `.tgz` parsing to respect true extension

### DIFF
--- a/crates/uv-distribution-filename/src/extension.rs
+++ b/crates/uv-distribution-filename/src/extension.rs
@@ -27,13 +27,18 @@ pub enum DistExtension {
 )]
 #[rkyv(derive(Debug))]
 pub enum SourceDistExtension {
-    Zip,
-    TarGz,
+    Tar,
     TarBz2,
+    TarGz,
+    TarLz,
+    TarLzma,
     TarXz,
     TarZst,
-    TarLzma,
-    Tar,
+    Tbz,
+    Tgz,
+    Tlz,
+    Txz,
+    Zip,
 }
 
 impl DistExtension {
@@ -71,14 +76,15 @@ impl SourceDistExtension {
         match extension {
             "zip" => Ok(Self::Zip),
             "tar" => Ok(Self::Tar),
-            "tgz" => Ok(Self::TarGz),
-            "tbz" => Ok(Self::TarBz2),
-            "txz" => Ok(Self::TarXz),
-            "tlz" => Ok(Self::TarLzma),
+            "tgz" => Ok(Self::Tgz),
+            "tbz" => Ok(Self::Tbz),
+            "txz" => Ok(Self::Txz),
+            "tlz" => Ok(Self::Tlz),
             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
             "bz2" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
             "xz" if is_tar(path.as_ref()) => Ok(Self::TarXz),
-            "lz" | "lzma" if is_tar(path.as_ref()) => Ok(Self::TarLzma),
+            "lz" if is_tar(path.as_ref()) => Ok(Self::TarLz),
+            "lzma" if is_tar(path.as_ref()) => Ok(Self::TarLzma),
             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
             _ => Err(ExtensionError::SourceDist),
         }
@@ -87,13 +93,18 @@ impl SourceDistExtension {
     /// Return the name for the extension.
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Zip => "zip",
-            Self::TarGz => "tar.gz",
+            Self::Tar => "tar",
             Self::TarBz2 => "tar.bz2",
+            Self::TarGz => "tar.gz",
+            Self::TarLz => "tar.lz",
+            Self::TarLzma => "tar.lzma",
             Self::TarXz => "tar.xz",
             Self::TarZst => "tar.zst",
-            Self::TarLzma => "tar.lzma",
-            Self::Tar => "tar",
+            Self::Tbz => "tbz",
+            Self::Tgz => "tgz",
+            Self::Tlz => "tlz",
+            Self::Txz => "txz",
+            Self::Zip => "zip",
         }
     }
 }

--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -58,7 +58,7 @@ impl SourceDistFilename {
                 filename: filename.to_string(),
                 kind: SourceDistFilenameErrorKind::PackageName(err),
             })?;
-        if &actual_package_name != package_name {
+        if actual_package_name != *package_name {
             return Err(SourceDistFilenameError {
                 filename: filename.to_string(),
                 kind: SourceDistFilenameErrorKind::Filename(package_name.clone()),
@@ -191,6 +191,13 @@ mod tests {
             "foo_lib-1.2.3.tar.gz",
             "foo_lib-1.2.3.tar.bz2",
             "foo_lib-1.2.3.tar.zst",
+            "foo_lib-1.2.3.tar.xz",
+            "foo_lib-1.2.3.tar.lz",
+            "foo_lib-1.2.3.tar.lzma",
+            "foo_lib-1.2.3.tgz",
+            "foo_lib-1.2.3.tbz",
+            "foo_lib-1.2.3.tlz",
+            "foo_lib-1.2.3.txz",
         ] {
             let ext = SourceDistExtension::from_path(normalized).unwrap();
             assert_eq!(

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -330,13 +330,17 @@ pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
         SourceDistExtension::Tar => {
             untar(reader, target).await?;
         }
-        SourceDistExtension::TarGz => {
+        SourceDistExtension::Tgz | SourceDistExtension::TarGz => {
             untar_gz(reader, target).await?;
         }
-        SourceDistExtension::TarBz2 => {
+        SourceDistExtension::Tbz | SourceDistExtension::TarBz2 => {
             untar_bz2(reader, target).await?;
         }
-        SourceDistExtension::TarXz | SourceDistExtension::TarLzma => {
+        SourceDistExtension::Txz
+        | SourceDistExtension::TarXz
+        | SourceDistExtension::Tlz
+        | SourceDistExtension::TarLz
+        | SourceDistExtension::TarLzma => {
             untar_xz(reader, target).await?;
         }
         SourceDistExtension::TarZst => {


### PR DESCRIPTION
## Summary

We mapped both `.tgz` and `.tar.gz` to the same enum variant; later, though, we made the assumption that a file marked with that variant ended with exactly `.tar.gz`. Instead, we need to preserve the originating suffix.

Closes https://github.com/astral-sh/uv/issues/13372.
