### PR TITLE
Fix ecosystem checks by pinning Git refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,16 +691,19 @@ jobs:
       matrix:
         include:
           - repo: "prefecthq/prefect"
+            ref: "7f25bbdf45fc81cca6dc23fb6a7377d436b70c83"
             commands:
               - "uv venv"
               - "uv pip install -e '.[dev]'"
             python: "3.9"
           - repo: "pallets/flask"
+            ref: "b78b5a210bde49e7e04b62a2a4f453ca10e0048c"
             commands:
               - "uv venv"
               - "uv pip install -r requirements/dev.txt"
             python: "3.12"
           - repo: "pydantic/pydantic-core"
+            ref: "d03bf4a01ca3b378cc8590bd481f307e82115bc6"
             commands:
               - "uv sync --group all"
               - "uv lock --upgrade"
@@ -710,6 +713,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ matrix.repo }}
+          ref: ${{ matrix.ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:


### PR DESCRIPTION
https://github.com/pallets/flask/pull/5727 broke our ecosystem checks, for now we're pinning the Git refs to unblock CI.