### PR TITLE
Avoid panics for cannot-be-a-base URLs

### DIFF
--- a/crates/uv-cache-key/src/canonical_url.rs
+++ b/crates/uv-cache-key/src/canonical_url.rs
@@ -65,6 +65,8 @@ impl CanonicalUrl {
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("git"));
             if needs_chopping {
                 let last = {
+                    // Unwrap safety: We checked `url.cannot_be_a_base()`, and `url.path()` having
+                    // an extension implies at least one segment.
                     let last = url.path_segments().unwrap().next_back().unwrap();
                     last[..last.len() - 4].to_owned()
                 };
@@ -74,6 +76,7 @@ impl CanonicalUrl {
 
         // Decode any percent-encoded characters in the path.
         if memchr::memchr(b'%', url.path().as_bytes()).is_some() {
+            // Unwrap safety: We checked `url.cannot_be_a_base()`.
             let decoded = url
                 .path_segments()
                 .unwrap()

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -66,6 +66,8 @@ pub enum Error {
     },
     #[error("Invalid download URL")]
     InvalidUrl(#[from] url::ParseError),
+    #[error("Invalid download URL: {0}")]
+    InvalidUrlFormat(Url),
     #[error("Invalid path in file URL: `{0}`")]
     InvalidFileUrl(String),
     #[error("Failed to create download directory")]
@@ -643,9 +645,9 @@ impl ManagedPythonDownload {
         // decodes to.
         let filename = url
             .path_segments()
-            .unwrap()
+            .ok_or_else(|| Error::InvalidUrlFormat(url.clone()))?
             .next_back()
-            .unwrap()
+            .ok_or_else(|| Error::InvalidUrlFormat(url.clone()))?
             .replace("%2B", "-");
         debug_assert!(
             filename


### PR DESCRIPTION
Following #13376, avoid `.unwrap()` on `Url::path_segments()`.

I also added some unwrap-safety comments.