### PR TITLE
Remove unused source tree variant

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -23,8 +23,6 @@ pub enum RequirementsSource {
     SetupPy(PathBuf),
     /// Dependencies were provided via a `setup.cfg` file (e.g., `pip-compile setup.cfg`).
     SetupCfg(PathBuf),
-    /// Dependencies were provided via a path to a source tree (e.g., `pip install .`).
-    SourceTree(PathBuf),
     /// Dependencies were provided via an unsupported Conda `environment.yml` file (e.g., `pip install -r environment.yml`).
     EnvironmentYml(PathBuf),
 }
@@ -271,12 +269,6 @@ impl RequirementsSource {
         Ok(Self::Package(requirement))
     }
 
-    /// Parse a [`RequirementsSource`] from a user-provided string, assumed to be a path to a source
-    /// tree.
-    pub fn from_source_tree(path: PathBuf) -> Self {
-        Self::SourceTree(path)
-    }
-
     /// Returns `true` if the source allows extras to be specified.
     pub fn allows_extras(&self) -> bool {
         matches!(
@@ -301,8 +293,7 @@ impl std::fmt::Display for RequirementsSource {
             | Self::PyprojectToml(path)
             | Self::SetupPy(path)
             | Self::SetupCfg(path)
-            | Self::EnvironmentYml(path)
-            | Self::SourceTree(path) => {
+            | Self::EnvironmentYml(path) => {
                 write!(f, "{}", path.simplified_display())
             }
         }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -33,6 +33,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use rustc_hash::FxHashSet;
 use tracing::instrument;
+
 use uv_cache_key::CanonicalUrl;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{DependencyGroups, NoBinary, NoBuild};
@@ -43,8 +44,6 @@ use uv_distribution_types::{
 };
 use uv_fs::{Simplified, CWD};
 use uv_normalize::{ExtraName, GroupName, PackageName};
-use uv_pep508::{MarkerTree, UnnamedRequirement, UnnamedRequirementUrl};
-use uv_pypi_types::VerbatimParsedUrl;
 use uv_requirements_txt::{RequirementsTxt, RequirementsTxtRequirement};
 use uv_warnings::warn_user;
 use uv_workspace::pyproject::PyProjectToml;
@@ -199,28 +198,6 @@ impl RequirementsSpecification {
 
                 Self {
                     pylock: Some(path.clone()),
-                    ..Self::default()
-                }
-            }
-            RequirementsSource::SourceTree(path) => {
-                if !path.is_dir() {
-                    return Err(anyhow::anyhow!(
-                        "Directory not found: `{}`",
-                        path.user_display()
-                    ));
-                }
-
-                Self {
-                    project: None,
-                    requirements: vec![UnresolvedRequirementSpecification {
-                        requirement: UnresolvedRequirement::Unnamed(UnnamedRequirement {
-                            url: VerbatimParsedUrl::parse_absolute_path(path)?,
-                            extras: Box::new([]),
-                            marker: MarkerTree::TRUE,
-                            origin: None,
-                        }),
-                        hashes: vec![],
-                    }],
                     ..Self::default()
                 }
             }

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -60,12 +60,10 @@ pub(crate) async fn read_requirements(
     // If the user requests `extras` but does not provide a valid source (e.g., a `pyproject.toml`),
     // return an error.
     if !extras.is_empty() && !requirements.iter().any(RequirementsSource::allows_extras) {
-        let hint = if requirements.iter().any(|source| {
-            matches!(
-                source,
-                RequirementsSource::Editable(_) | RequirementsSource::SourceTree(_)
-            )
-        }) {
+        let hint = if requirements
+            .iter()
+            .any(|source| matches!(source, RequirementsSource::Editable(_)))
+        {
             "Use `<dir>[extra]` syntax or `-r <file>` instead."
         } else {
             "Use `package[extra]` syntax instead."

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -110,8 +110,7 @@ pub(crate) async fn add(
             RequirementsSource::Package(_)
             | RequirementsSource::Editable(_)
             | RequirementsSource::RequirementsTxt(_)
-            | RequirementsSource::EnvironmentYml(_)
-            | RequirementsSource::SourceTree(_) => {}
+            | RequirementsSource::EnvironmentYml(_) => {}
         }
     }
 


### PR DESCRIPTION
## Summary

Perhaps this disappeared when we added support for unnamed requirements?