### PR TITLE
uv export docs: "export" instead of "install"

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3941,7 +3941,7 @@ pub struct ExportArgs {
     #[arg(long, overrides_with("no_header"), hide = true)]
     pub header: bool,
 
-    /// Install any editable dependencies, including the project and any workspace members, as
+    /// Export any editable dependencies, including the project and any workspace members, as
     /// non-editable.
     #[arg(long)]
     pub no_editable: bool,
@@ -3977,7 +3977,7 @@ pub struct ExportArgs {
     /// Do not emit the given package(s).
     ///
     /// By default, all of the project's dependencies are included in the exported requirements
-    /// file. The `--no-install-package` option allows exclusion of specific packages.
+    /// file. The `--no-emit-package` option allows exclusion of specific packages.
     #[arg(long, alias = "no-install-package")]
     pub no_emit_package: Vec<PackageName>,
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2464,11 +2464,11 @@ uv export [OPTIONS]
 
 <p>This option is an alias of <code>--no-group dev</code>. See <code>--no-default-groups</code> to disable all default groups instead.</p>
 
-</dd><dt id="uv-export--no-editable"><a href="#uv-export--no-editable"><code>--no-editable</code></a></dt><dd><p>Install any editable dependencies, including the project and any workspace members, as non-editable</p>
+</dd><dt id="uv-export--no-editable"><a href="#uv-export--no-editable"><code>--no-editable</code></a></dt><dd><p>Export any editable dependencies, including the project and any workspace members, as non-editable</p>
 
 </dd><dt id="uv-export--no-emit-package"><a href="#uv-export--no-emit-package"><code>--no-emit-package</code></a>, <code>--no-install-package</code> <i>no-emit-package</i></dt><dd><p>Do not emit the given package(s).</p>
 
-<p>By default, all of the project&#8217;s dependencies are included in the exported requirements file. The <code>--no-install-package</code> option allows exclusion of specific packages.</p>
+<p>By default, all of the project&#8217;s dependencies are included in the exported requirements file. The <code>--no-emit-package</code> option allows exclusion of specific packages.</p>
 
 </dd><dt id="uv-export--no-emit-project"><a href="#uv-export--no-emit-project"><code>--no-emit-project</code></a>, <code>--no-install-project</code></dt><dd><p>Do not emit the current project.</p>
 


### PR DESCRIPTION
Change the two missing places in the `uv export` docs to say "export" instead of "install".