### PR TITLE
Follow links when cache-key is a glob

### DIFF
--- a/crates/uv-cache-info/src/cache_info.rs
+++ b/crates/uv-cache-info/src/cache_info.rs
@@ -215,6 +215,7 @@ impl CacheInfo {
         // If we have any globs, process them in a single pass.
         if !globs.is_empty() {
             let walker = globwalk::GlobWalkerBuilder::from_patterns(directory, &globs)
+                .follow_links(true)
                 .file_type(globwalk::FileType::FILE | globwalk::FileType::SYMLINK)
                 .build()?;
             for entry in walker {


### PR DESCRIPTION
## Summary

There's some inconsistent behaviour in handling symlinks when `cache-key` is a glob or a file path. This PR attempts to address that.

- When cache-key is a path, [`Path::metadata()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.metadata) is used to check if it's a file or not. According to the docs:
  > This function will traverse symbolic links to query information about the destination file.

  So, if the target file is a symlink, it will be resolved and the metadata will be queried for the underlying file.

- When cache-key is a glob, `globwalk` is used, specifically allowing for symlinks:

  ```rust
  .file_type(globwalk::FileType::FILE | globwalk::FileType::SYMLINK)
  ```

- However, without enabling link following, `DirEntry::metadata()` will return an equivalent of `Path::symlink_metadata()` (and not `Path::metadata()`), which will have a file type that looks like

   ```rust
   FileType {
       is_file: false,
       is_dir: false,
       is_symlink: true,
      ..
    }
    ```

- Then, there's a check for `metadata.is_file()` which fails and complains that the target entry "is a directory when file was expected".

- TLDR: glob cache-keys don't work with symlinks.

## Solutions

Option 1 (current PR): follow symlinks.

Option 2 (also doable): don't follow symlinks, but resolve the resulting target entry manually in case its file type is a symlink. However, this would be a little weird and unobvious in that we resolve files but not directories for some reason.

## Test Plan

This has been tested manually:

```rust
fn main() {
    for follow_links in [false, true] {
        let walker = globwalk::GlobWalkerBuilder::from_patterns(".", &["a/*"])
            .file_type(globwalk::FileType::FILE | globwalk::FileType::SYMLINK)
            .follow_links(follow_links)
            .build()
            .unwrap();
        let entry = walker.into_iter().next().unwrap().unwrap();
        dbg!(&entry);
        dbg!(entry.file_type());
        dbg!(entry.path_is_symlink());
        dbg!(entry.path());
        let meta = entry.metadata().unwrap();
        dbg!(meta.is_file());
    }

    let path = std::path::PathBuf::from("./a/b");
    dbg!(path.metadata().unwrap().file_type());
    dbg!(path.symlink_metadata().unwrap().file_type());
}
```

Current behaviour (glob cache-key, don't follow links):
```
[src/main.rs:9:9] &entry = DirEntry("./a/b")
[src/main.rs:10:9] entry.file_type() = FileType {
    is_file: false,
    is_dir: false,
    is_symlink: true,
    ..
}
[src/main.rs:11:9] entry.path_is_symlink() = true
[src/main.rs:12:9] entry.path() = "./a/b"
[src/main.rs:14:9] meta.is_file() = false
```

Glob cache-key, follow links:
```
[src/main.rs:9:9] &entry = DirEntry("./a/b")
[src/main.rs:10:9] entry.file_type() = FileType {
    is_file: true,
    is_dir: false,
    is_symlink: false,
    ..
}
[src/main.rs:11:9] entry.path_is_symlink() = true
[src/main.rs:12:9] entry.path() = "./a/b"
[src/main.rs:14:9] meta.is_file() = true
```

Using `path.metadata()` for a non-glob cache key:
```
[src/main.rs:18:5] path.metadata().unwrap().file_type() = FileType {
    is_file: true,
    is_dir: false,
    is_symlink: false,
    ..
}
[src/main.rs:19:5] path.symlink_metadata().unwrap().file_type() = FileType {
    is_file: false,
    is_dir: false,
    is_symlink: true,
    ..
}
```