### PR TITLE
Issue template: Please include the complete error message

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -13,6 +13,8 @@ body:
       description: |
         A clear and concise description of the bug, including [a minimal reproducible example](https://docs.astral.sh/uv/reference/troubleshooting/reproducible-examples/).
         If we cannot reproduce the bug, it is unlikely that we will be able to help you.
+
+        Please include the full output of uv with the complete error message.
     validations:
       required: true
 


### PR DESCRIPTION
We're getting a number of user reports where we could have helped if we were just seeing the full error message. If we're not getting an MRE, we should at least urge users to copy the _full_ error they see on screen.

![image](https://github.com/user-attachments/assets/45c72990-e068-4706-abb6-591962a865c6)
