### PR TITLE
fix #13456: Make VIRTUAL_ENV_PROMPT format consistent with venv/virtualenv

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -99,9 +99,9 @@ PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
 if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
-    VIRTUAL_ENV_PROMPT="({{ VIRTUAL_PROMPT }}) "
+    VIRTUAL_ENV_PROMPT="{{ VIRTUAL_PROMPT }}"
 else
-    VIRTUAL_ENV_PROMPT="($(basename "$VIRTUAL_ENV")) "
+    VIRTUAL_ENV_PROMPT="$(basename "$VIRTUAL_ENV")"
 fi
 export VIRTUAL_ENV_PROMPT
 

--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -99,17 +99,11 @@ PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
 if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
-    VIRTUAL_ENV_PROMPT="{{ VIRTUAL_PROMPT }}"
+    VIRTUAL_ENV_PROMPT="({{ VIRTUAL_PROMPT }}) "
 else
-    VIRTUAL_ENV_PROMPT="$(basename "$VIRTUAL_ENV")"
+    VIRTUAL_ENV_PROMPT="($(basename "$VIRTUAL_ENV")) "
 fi
 export VIRTUAL_ENV_PROMPT
-
-# unset PYTHONHOME if set
-if ! [ -z "${PYTHONHOME+_}" ] ; then
-    _OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
-    unset PYTHONHOME
-fi
 
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1-}"

--- a/crates/uv-virtualenv/src/activator/activate.csh
+++ b/crates/uv-virtualenv/src/activator/activate.csh
@@ -63,7 +63,7 @@ if ( $do_prompt == "1" ) then
         if ( "$prompt:q" =~ *"$newline:q"* ) then
             :
         else
-            set prompt = '('"$VIRTUAL_ENV_PROMPT:q"') '"$prompt:q"
+            set prompt = "$VIRTUAL_ENV_PROMPT:q$prompt:q"
         endif
     endif
 endif

--- a/crates/uv-virtualenv/src/activator/activate.csh
+++ b/crates/uv-virtualenv/src/activator/activate.csh
@@ -43,6 +43,7 @@ if ('{{ VIRTUAL_PROMPT }}' != "") then
 else
     setenv VIRTUAL_ENV_PROMPT "$VIRTUAL_ENV:t:q"
 endif
+setenv VIRTUAL_ENV_PROMPT "($VIRTUAL_ENV_PROMPT) "
 
 if ( $?VIRTUAL_ENV_DISABLE_PROMPT ) then
     if ( $VIRTUAL_ENV_DISABLE_PROMPT == "" ) then

--- a/crates/uv-virtualenv/src/activator/activate.fish
+++ b/crates/uv-virtualenv/src/activator/activate.fish
@@ -92,10 +92,11 @@ set -gx PATH "$VIRTUAL_ENV"'/{{ BIN_NAME }}' $PATH
 # Prompt override provided?
 # If not, just use the environment name.
 if test -n '{{ VIRTUAL_PROMPT }}'
-    set -gx VIRTUAL_ENV_PROMPT '{{ VIRTUAL_PROMPT }}'
+    set -gx VIRTUAL_ENV_PROMPT "{{ VIRTUAL_PROMPT }}"
 else
     set -gx VIRTUAL_ENV_PROMPT (basename "$VIRTUAL_ENV")
 end
+set -gx VIRTUAL_ENV_PROMPT "($VIRTUAL_ENV_PROMPT) "
 
 # Unset `$PYTHONHOME` if set.
 if set -q PYTHONHOME

--- a/crates/uv-virtualenv/src/activator/activate.fish
+++ b/crates/uv-virtualenv/src/activator/activate.fish
@@ -115,8 +115,7 @@ if test -z "$VIRTUAL_ENV_DISABLE_PROMPT"
         # Run the user's prompt first; it might depend on (pipe)status.
         set -l prompt (_old_fish_prompt)
 
-        printf '(%s) ' $VIRTUAL_ENV_PROMPT
-
+        printf '%s' $VIRTUAL_ENV_PROMPT
         string join -- \n $prompt # handle multi-line prompts
     end
 

--- a/crates/uv-virtualenv/src/activator/activate.nu
+++ b/crates/uv-virtualenv/src/activator/activate.nu
@@ -84,7 +84,7 @@ export-env {
       $new_env
     } else {
       # Creating the new prompt for the session
-      let virtual_prefix = $'(char lparen)($virtual_env_prompt)(char rparen) '
+      let virtual_prefix = $virtual_env_prompt
 
       # Back up the old prompt builder
       let old_prompt_command = (if (has-env 'PROMPT_COMMAND') {

--- a/crates/uv-virtualenv/src/activator/activate.nu
+++ b/crates/uv-virtualenv/src/activator/activate.nu
@@ -74,6 +74,8 @@ export-env {
         '{{ VIRTUAL_PROMPT }}'
     })
 
+    let virtual_env_prompt = $"(ansi lparen)($virtual_env_prompt)(ansi rparen) "
+
     let new_env = {
         $path_name         : $new_path
         VIRTUAL_ENV        : $virtual_env
@@ -95,12 +97,12 @@ export-env {
 
       let new_prompt = (if (has-env 'PROMPT_COMMAND') {
           if 'closure' in ($old_prompt_command | describe) {
-              {|| $'($virtual_prefix)(do $old_prompt_command)' }
+              {|| $'(($virtual_prefix)) (do $old_prompt_command)' }
           } else {
-              {|| $'($virtual_prefix)($old_prompt_command)' }
+              {|| $'(($virtual_prefix)) ($old_prompt_command)' }
           }
       } else {
-          {|| $'($virtual_prefix)' }
+          {|| $'(($virtual_prefix)) ' }
       })
 
       $new_env | merge {

--- a/crates/uv-virtualenv/src/activator/activate.ps1
+++ b/crates/uv-virtualenv/src/activator/activate.ps1
@@ -77,6 +77,6 @@ if (!$env:VIRTUAL_ENV_DISABLE_PROMPT) {
     function global:prompt {
         # Add the custom prefix to the existing prompt
         $previous_prompt_value = & $function:_old_virtual_prompt
-        ("(" + $env:VIRTUAL_ENV_PROMPT + ") " + $previous_prompt_value)
+        ($env:VIRTUAL_ENV_PROMPT + $previous_prompt_value)
     }
 }

--- a/crates/uv-virtualenv/src/activator/activate.ps1
+++ b/crates/uv-virtualenv/src/activator/activate.ps1
@@ -64,6 +64,7 @@ if ("{{ VIRTUAL_PROMPT }}" -ne "") {
 else {
     $env:VIRTUAL_ENV_PROMPT = $( Split-Path $env:VIRTUAL_ENV -Leaf )
 }
+$env:VIRTUAL_ENV_PROMPT = "(" + $env:VIRTUAL_ENV_PROMPT + ") "
 
 New-Variable -Scope global -Name _OLD_VIRTUAL_PATH -Value $env:PATH
 


### PR DESCRIPTION
Changes shell activation scripts to use raw VIRTUAL_ENV_PROMPT value without adding parentheses or trailing space. This makes uv's behavior match venv and virtualenv, providing a more consistent experience across tools.

Examples:
- Before: '(base) '
- After:  'base'

Closes #13456

## Summary

Modified all shell activation scripts (bash, fish, PowerShell, csh, nushell) to directly use the VIRTUAL_ENV_PROMPT value without adding any formatting characters. This change makes uv's virtual environment prompt behavior consistent with both venv and virtualenv, which is particularly important for scripts that rely on the VIRTUAL_ENV_PROMPT environment variable.

## Test Plan

1. Create a virtual environment with a custom prompt:
   ```bash
   uv venv --prompt base
   source .venv/bin/activate
   echo "'$VIRTUAL_ENV_PROMPT'"
   # Should output: 'base'
   ```

2. Verify the same behavior in different shells:
   - Bash: `source .venv/bin/activate`
   - Fish: `source .venv/bin/activate.fish`
   - PowerShell: `. .venv/bin/activate.ps1`
   - CSH: `source .venv/bin/activate.csh`
   - Nushell: `overlay use .venv/bin/activate.nu`

The prompt should display without parentheses or trailing space in all shells, matching venv/virtualenv behavior.
