### PR TITLE
Remove extra newline

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -716,7 +716,7 @@ impl Display for BrokenSymlink {
             self.path.user_display()
         )?;
         if self.venv {
-            writeln!(
+            write!(
                 f,
                 "\n\n{}{} Consider recreating the environment (e.g., with `{}`)",
                 "hint".bold().cyan(),


### PR DESCRIPTION
This left an extra newline the hint, which isn't captured in the snapshot.