### PR TITLE
 Build backend: Case sensitive module discovery

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -138,6 +138,7 @@ impl DirectoryWriter for ListWriter<'_> {
         self.files.push((path.to_string(), None));
         Ok(())
     }
+
     fn write_file(&mut self, path: &str, file: &Path) -> Result<(), Error> {
         self.files
             .push((path.to_string(), Some(file.to_path_buf())));
@@ -204,11 +205,12 @@ fn find_roots(
     relative_module_root: &Path,
     module_name: Option<&Identifier>,
 ) -> Result<(PathBuf, PathBuf), Error> {
-    let src_root = source_tree.join(uv_fs::normalize_path(relative_module_root));
+    let relative_module_root = uv_fs::normalize_path(relative_module_root);
+    let src_root = source_tree.join(&relative_module_root);
     if !src_root.starts_with(source_tree) {
         return Err(Error::InvalidModuleRoot(relative_module_root.to_path_buf()));
     }
-    let src_root = source_tree.join(relative_module_root);
+    let src_root = source_tree.join(&relative_module_root);
     let module_root = find_module_root(&src_root, module_name, pyproject_toml.name())?;
     Ok((src_root, module_root))
 }

--- a/crates/uv-globfilter/src/portable_glob.rs
+++ b/crates/uv-globfilter/src/portable_glob.rs
@@ -94,8 +94,6 @@ impl PortableGlobParser {
         self.check(glob)?;
         Ok(GlobBuilder::new(glob)
             .literal_separator(true)
-            // We support case-insensitive file systems.
-            .case_insensitive(true)
             // No need to support Windows-style paths, so the backslash can be used a escape.
             .backslash_escape(self.backslash_escape())
             .build()?)

--- a/crates/uv-globfilter/src/portable_glob.rs
+++ b/crates/uv-globfilter/src/portable_glob.rs
@@ -94,6 +94,9 @@ impl PortableGlobParser {
         self.check(glob)?;
         Ok(GlobBuilder::new(glob)
             .literal_separator(true)
+            // We support case-insensitive file systems.
+            .case_insensitive(true)
+            // No need to support Windows-style paths, so the backslash can be used a escape.
             .backslash_escape(self.backslash_escape())
             .build()?)
     }

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -451,6 +451,9 @@ fn build_module_name_normalization() -> Result<()> {
         [build-system]
         requires = ["uv_build>=0.5,<0.8"]
         build-backend = "uv_build"
+
+        [tool.uv.build-backend]
+        module-name = "Django_plugin"
     "#})?;
     fs_err::create_dir_all(context.temp_dir.join("src"))?;
 
@@ -458,28 +461,28 @@ fn build_module_name_normalization() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-wheel")
-        .arg(&wheel_dir), @r###"
+        .arg(&wheel_dir), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module directory at: `src/django_plugin`
-    "###);
+    error: Missing module directory for `Django_plugin` in `src`. Found: ``
+    ");
 
     fs_err::create_dir_all(context.temp_dir.join("src/Django_plugin"))?;
     // Error case 2: A matching module, but no `__init__.py`.
     uv_snapshot!(context
         .build_backend()
         .arg("build-wheel")
-        .arg(&wheel_dir), @r###"
+        .arg(&wheel_dir), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected an `__init__.py` at: `src/Django_plugin/__init__.py`
-    "###);
+    error: Expected a Python module directory at: `src/Django_plugin/__init__.py`
+    ");
 
     // Use `Django_plugin` instead of `django_plugin`
     context
@@ -521,7 +524,7 @@ fn build_module_name_normalization() -> Result<()> {
     ----- stderr -----
     ");
 
-    // Error case 3: Multiple modules a matching name.
+    // Former error case 3, now accepted: Multiple modules a matching name.
     // Requires a case-sensitive filesystem.
     #[cfg(target_os = "linux")]
     {
@@ -534,14 +537,12 @@ fn build_module_name_normalization() -> Result<()> {
             .build_backend()
             .arg("build-wheel")
             .arg(&wheel_dir), @r"
-        success: false
-        exit_code: 2
+        success: true
+        exit_code: 0
         ----- stdout -----
+        django_plugin-1.0.0-py3-none-any.whl
 
         ----- stderr -----
-        error: Expected an `__init__.py` at `django_plugin`, found multiple:
-        * `src/Django_plugin`
-        * `src/django_plugin`
         ");
     }
 
@@ -635,7 +636,7 @@ fn sdist_error_without_module() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module directory at: `src/foo`
+    error: Missing module directory for `foo` in `src`. Found: ``
     ");
 
     Ok(())

--- a/docs/configuration/build-backend.md
+++ b/docs/configuration/build-backend.md
@@ -40,6 +40,20 @@ command includes a copy of the build backend, so when running `uv build`, the sa
 used for the build backend as for the uv process. Other build frontends, such as `python -m build`,
 will choose the latest compatible `uv_build` version.
 
+## Modules
+
+The default module name is the package name in lower case with dots and dashes replaced by
+underscores, and the default module location is under the `src` directory, i.e., the build backend
+expects to find `src/<package_name>/__init__.py`. These defaults can be changed with the
+`module-name` and `module-root` setting. The example below expects a module in the project root with
+`PIL/__init__.py` instead:
+
+```toml
+[tool.uv.build-backend]
+module-name = "PIL"
+module-root = ""
+```
+
 ## Include and exclude configuration
 
 To select which files to include in the source distribution, uv first adds the included files and


### PR DESCRIPTION
We may run on case-sensitive file systems (Linux, generally) or on case-insensitive file systems (Windows, generally), while modules in Python may be lower or upper case. For robustness over filesystem casing, we require an explicit module name for modules with upper case letters.

Fixes #13419
