### PR TITLE
Mask `gen` as `r#gen` for the 2024 edition

### DIFF
--- a/crates/uv-distribution-types/src/status_code_strategy.rs
+++ b/crates/uv-distribution-types/src/status_code_strategy.rs
@@ -140,8 +140,8 @@ impl schemars::JsonSchema for SerializableStatusCode {
         "StatusCode".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        let mut schema = gen.subschema_for::<u16>().into_object();
+    fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema = r#gen.subschema_for::<u16>().into_object();
         schema.metadata().description = Some("HTTP status code (100-599)".to_string());
         schema.number().minimum = Some(100.0);
         schema.number().maximum = Some(599.0);


### PR DESCRIPTION
`gen` is a reserved keyword in Rust 2024. This is a requirement to run `cargo fmt` on the Rust 2024 edition.