### PR TITLE
cli: adjust grammar in “script not supported” error

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -169,7 +169,7 @@ pub(crate) async fn run(
         if has_python_script_ext(Path::new(from)) {
             let package_name = PackageName::from_str(from)?;
             return Err(anyhow::anyhow!(
-                "It looks you provided a Python script to `--from`, which is not supported\n\n{}{} If you meant to run a command from the `{}` package, use the normalized package name instead to disambiguate, e.g., `{}`",
+                "It looks like you provided a Python script to `--from`, which is not supported\n\n{}{} If you meant to run a command from the `{}` package, use the normalized package name instead to disambiguate, e.g., `{}`",
                 "hint".bold().cyan(),
                 ":".bold(),
                 package_name.cyan(),
@@ -183,7 +183,7 @@ pub(crate) async fn run(
         if has_python_script_ext(target_path) {
             return if target_path.try_exists()? {
                 Err(anyhow::anyhow!(
-                    "It looks you tried to run a Python script at `{}`, which is not supported by `{}`\n\n{}{} Use `{}` instead",
+                    "It looks like you tried to run a Python script at `{}`, which is not supported by `{}`\n\n{}{} Use `{}` instead",
                     target_path.user_display(),
                     invocation_source,
                     "hint".bold().cyan(),
@@ -193,7 +193,7 @@ pub(crate) async fn run(
             } else {
                 let package_name = PackageName::from_str(target)?;
                 Err(anyhow::anyhow!(
-                    "It looks you provided a Python script to run, which is not supported supported by `{}`\n\n{}{} We did not find a script at the requested path. If you meant to run a command from the `{}` package, pass the normalized package name to `--from` to disambiguate, e.g., `{}`",
+                    "It looks like you provided a Python script to run, which is not supported supported by `{}`\n\n{}{} We did not find a script at the requested path. If you meant to run a command from the `{}` package, pass the normalized package name to `--from` to disambiguate, e.g., `{}`",
                     invocation_source,
                     "hint".bold().cyan(),
                     ":".bold(),

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2243,7 +2243,7 @@ fn tool_run_with_existing_py_script() -> anyhow::Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you tried to run a Python script at `script.py`, which is not supported by `uv tool run`
+    error: It looks like you tried to run a Python script at `script.py`, which is not supported by `uv tool run`
 
     hint: Use `uv run script.py` instead
     ");
@@ -2263,7 +2263,7 @@ fn tool_run_with_existing_pyw_script() -> anyhow::Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you tried to run a Python script at `script.pyw`, which is not supported by `uv tool run`
+    error: It looks like you tried to run a Python script at `script.pyw`, which is not supported by `uv tool run`
 
     hint: Use `uv run script.pyw` instead
     ");
@@ -2282,7 +2282,7 @@ fn tool_run_with_nonexistent_py_script() {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you provided a Python script to run, which is not supported supported by `uv tool run`
+    error: It looks like you provided a Python script to run, which is not supported supported by `uv tool run`
 
     hint: We did not find a script at the requested path. If you meant to run a command from the `script-py` package, pass the normalized package name to `--from` to disambiguate, e.g., `uv tool run --from script-py script.py`
     ");
@@ -2300,7 +2300,7 @@ fn tool_run_with_nonexistent_pyw_script() {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you provided a Python script to run, which is not supported supported by `uv tool run`
+    error: It looks like you provided a Python script to run, which is not supported supported by `uv tool run`
 
     hint: We did not find a script at the requested path. If you meant to run a command from the `script-pyw` package, pass the normalized package name to `--from` to disambiguate, e.g., `uv tool run --from script-pyw script.pyw`
     ");
@@ -2320,7 +2320,7 @@ fn tool_run_with_from_script() {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you provided a Python script to `--from`, which is not supported
+    error: It looks like you provided a Python script to `--from`, which is not supported
 
     hint: If you meant to run a command from the `script-py` package, use the normalized package name instead to disambiguate, e.g., `uv tool run --from script-py ruff`
     ");
@@ -2340,7 +2340,7 @@ fn tool_run_with_script_and_from_script() {
     ----- stdout -----
 
     ----- stderr -----
-    error: It looks you provided a Python script to `--from`, which is not supported
+    error: It looks like you provided a Python script to `--from`, which is not supported
 
     hint: If you meant to run a command from the `script-py` package, use the normalized package name instead to disambiguate, e.g., `uv tool run --from script-py other-script.py`
     ");


### PR DESCRIPTION
Love this tooling! Small adjustment to help on error messaging 🙏 

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The previous message was missing the word **“like,”** which made it read a tad awkwardly.  
This PR inserts the missing word so the error reads naturally:
**After:**
```
$ uvx ch1.py 
error: It looks like you tried to run a Python script at `ch1.py`, which is not supported by `uvx`

hint: Use `uv run ch1.py` instead
```

**Before:**
```
$ uvx ch1.py 
error: It looks you tried to run a Python script at `ch1.py`, which is not supported by `uvx`

hint: Use `uv run ch1.py` instead
```

## Test Plan

<!-- How was it tested? -->
- `cargo run -- uvx examples/ch1.py` shows the updated message (see “After” above).
- `cargo test` passes.
