### PR TITLE
Bump simple cache bucket to v16

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -986,7 +986,7 @@ impl CacheBucket {
             Self::Interpreter => "interpreter-v4",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/it/cache_clean.rs`.
-            Self::Simple => "simple-v15",
+            Self::Simple => "simple-v16",
             // Note that when bumping this, you'll also need to bump it
             // in `crates/uv/tests/it/cache_prune.rs`.
             Self::Wheels => "wheels-v5",

--- a/crates/uv/tests/it/cache_clean.rs
+++ b/crates/uv/tests/it/cache_clean.rs
@@ -51,7 +51,7 @@ fn clean_package_pypi() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v15")
+        .child("simple-v16")
         .child("pypi")
         .child("iniconfig.rkyv");
     assert!(
@@ -125,7 +125,7 @@ fn clean_package_index() -> Result<()> {
     // Assert that the `.rkyv` file is created for `iniconfig`.
     let rkyv = context
         .cache_dir
-        .child("simple-v15")
+        .child("simple-v16")
         .child("index")
         .child("e8208120cae3ba69")
         .child("iniconfig.rkyv");


### PR DESCRIPTION
We broke the rkyv deserialization in https://github.com/astral-sh/uv/commit/e70cf25ea72c94502d08637474e9e4ad576bf342#diff-348b24d7a84672ab2873833988156191995ff467619a77f548adbd9808549999L30-R41 by placing `.tar.bz2` in the position of `.tar.gz`. We need to invalidate the cache bucket.

Fixes #13492
