### PR TITLE
Fix VIRTUAL_ENV_PROMPT value in activator/activate

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate
+++ b/crates/uv-virtualenv/src/activator/activate
@@ -99,9 +99,9 @@ PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
 if [ "x{{ VIRTUAL_PROMPT }}" != x ] ; then
-    VIRTUAL_ENV_PROMPT="({{ VIRTUAL_PROMPT }}) "
+    VIRTUAL_ENV_PROMPT="{{ VIRTUAL_PROMPT }}"
 else
-    VIRTUAL_ENV_PROMPT="($(basename "$VIRTUAL_ENV")) "
+    VIRTUAL_ENV_PROMPT=$(basename "$VIRTUAL_ENV")
 fi
 export VIRTUAL_ENV_PROMPT
 
@@ -113,7 +113,7 @@ fi
 
 if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT-}" ] ; then
     _OLD_VIRTUAL_PS1="${PS1-}"
-    PS1="${VIRTUAL_ENV_PROMPT}${PS1-}"
+    PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1-}"
     export PS1
 fi
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
I've compared all the activator scripts here with the original ones in https://github.com/pypa/virtualenv/tree/main/src/virtualenv/activation and only the bash/POSIX script here was yielding a VIRTUAL_ENV_PROMPT value with parenthesis and a trailing space, which should be part of the shell prompt (PS1 for bash/POSIX) but not of the VIRTUAL_ENV_PROMPT value itself. This fixes that small inconsistency. Fixes #13456

This reverts commit 0ec2d4e434878c6f99f7fea77b5236292a35093a

## Test Plan

<!-- How was it tested? -->
I didn't test this locally.
