### PR TITLE
Fix PowerShell code blocks

### DIFF
--- a/docs/configuration/installer.md
+++ b/docs/configuration/installer.md
@@ -16,8 +16,8 @@ To change the installation path, use `UV_INSTALL_DIR`:
 
 === "Windows"
 
-    ```powershell
-    powershell -ExecutionPolicy ByPass -c {$env:UV_INSTALL_DIR = "C:\Custom\Path";irm https://astral.sh/uv/install.ps1 | iex}
+    ```pwsh-session
+    PS> powershell -ExecutionPolicy ByPass -c {$env:UV_INSTALL_DIR = "C:\Custom\Path";irm https://astral.sh/uv/install.ps1 | iex}
     ```
 
 ## Disabling shell modifications

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,16 +32,16 @@ uv provides a standalone installer to download and install uv:
 
     Use `irm` to download the script and execute it with `iex`:
 
-    ```console
-    $ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    ```pwsh-session
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
 
     Changing the [execution policy](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.4#powershell-execution-policies) allows running a script from the internet.
 
     Request a specific version by including it in the URL:
 
-    ```console
-    $ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.7.5/install.ps1 | iex"
+    ```pwsh-session
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.7.5/install.ps1 | iex"
     ```
 
 !!! tip
@@ -56,8 +56,8 @@ uv provides a standalone installer to download and install uv:
 
     === "Windows"
 
-        ```console
-        $ powershell -c "irm https://astral.sh/uv/install.ps1 | more"
+        ```pwsh-session
+        PS> powershell -c "irm https://astral.sh/uv/install.ps1 | more"
         ```
 
     Alternatively, the installer or binaries can be downloaded directly from [GitHub](#github-releases).
@@ -260,9 +260,9 @@ If you need to remove uv from your system, follow these steps:
 
     === "Windows"
 
-        ```powershell
-        $ rm $HOME\.local\bin\uv.exe
-        $ rm $HOME\.local\bin\uvx.exe
+        ```pwsh-session
+        PS> rm $HOME\.local\bin\uv.exe
+        PS> rm $HOME\.local\bin\uvx.exe
         ```
 
     !!! note

--- a/docs/guides/integration/jupyter.md
+++ b/docs/guides/integration/jupyter.md
@@ -117,11 +117,11 @@ so by adding Jupyter to the environment directly. For example:
 
 === "Windows"
 
-    ```powershell
-    uv venv --seed
-    uv pip install pydantic
-    uv pip install jupyterlab
-    .venv\Scripts\jupyter lab
+    ```pwsh-session
+    PS> uv venv --seed
+    PS> uv pip install pydantic
+    PS> uv pip install jupyterlab
+    PS> .venv\Scripts\jupyter lab
     ```
 
 From here, `import pydantic` will work within the notebook, and you can install additional packages

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -203,11 +203,11 @@ executing a command:
 
 === "Windows"
 
-    ```powershell
-    uv sync
-    source .venv\Scripts\activate
-    flask run -p 3000
-    python example.py
+    ```pwsh-session
+    PS> uv sync
+    PS> .venv\Scripts\activate
+    PS> flask run -p 3000
+    PS> python example.py
     ```
 
 !!! note

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,8 +47,8 @@ Install uv with our official standalone installer:
 
 === "Windows"
 
-    ```console
-    $ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+    ```pwsh-session
+    PS> powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
 
 Then, check out the [first steps](./getting-started/first-steps.md) or read on for a brief overview.

--- a/docs/pip/environments.md
+++ b/docs/pip/environments.md
@@ -53,8 +53,8 @@ The virtual environment can be "activated" to make its packages available:
 
 === "Windows"
 
-    ```console
-    $ .venv\Scripts\activate
+    ```pwsh-session
+    PS> .venv\Scripts\activate
     ```
 
 !!! note


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The PowerShell prompt is not `$`, so it is not detected as a `Generic.Prompt` token by Pygments lexers. Therefore, the JavaScript code does not strip the prompt when copying from PowerShell code blocks, such as [here](https://docs.astral.sh/uv/getting-started/installation/#__tabbed_5_2).

Other places in the docs have removed the prompt completely to address this issue:
* https://docs.astral.sh/uv/guides/projects/#__tabbed_1_2
* https://docs.astral.sh/uv/guides/integration/jupyter/#__tabbed_1_2

This PR updates the PowerShell prompt to `PS>` and changes the code fence language to `pwsh-session` to match the lexer name from [Pygments](https://pygments.org/docs/lexers/#pygments.lexers.shell.PowerShellSessionLexer). This allows the prompt to be correctly detected as a `Generic.Prompt` token and is stripped during copy.

Related: https://github.com/astral-sh/uv/pull/12520

