### PR TITLE
Add brew installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 ```bash
+# On macOS, using [brew](https://brew.sh/).
+brew install uv
+```
+
+```bash
 # On Windows.
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```


### PR DESCRIPTION
Brew is a popular MacOS package manager, and as I write this, `brew install uv` installs the most recent `uv` version 0.7.5.