### PR TITLE
[docs] Fix Publishing Packages, Next = "Index"

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -99,7 +99,7 @@ nav:
       - Features: getting-started/features.md
       - Getting help: getting-started/help.md
   - Guides:
-      - guides/index.md
+      - Integration Guides: guides/index.md
       - Installing Python: guides/install-python.md
       - Running scripts: guides/scripts.md
       - Using tools: guides/tools.md


### PR DESCRIPTION
The Next footer tab on the Publishing Packages docs page just says "Index" which is not helpful. The page it links to is headed "Integration guides".

