### PR TITLE
Clarify adding SSH Git dependencies

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -270,13 +270,18 @@ explicit = true
 
 ### Git
 
-To add a Git dependency source, prefix a Git-compatible URL (i.e., that you would use with
-`git clone`) with `git+`.
+To add a Git dependency source, prefix a Git-compatible URL with `git+`.
 
-For example:
+For example for a dependency available over HTTP(S):
 
 ```console
 $ uv add git+https://github.com/encode/httpx
+```
+
+For a dependency available over SSH:
+
+```console
+$ uv add git+ssh://git@github.com/encode/httpx
 ```
 
 ```toml title="pyproject.toml" hl_lines="5"

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -272,15 +272,13 @@ explicit = true
 
 To add a Git dependency source, prefix a Git-compatible URL with `git+`.
 
-For example for a dependency available over HTTP(S):
+For example:
 
 ```console
+$ # Install over HTTP(S).
 $ uv add git+https://github.com/encode/httpx
-```
 
-For a dependency available over SSH:
-
-```console
+$ # Install over SSH.
 $ uv add git+ssh://git@github.com/encode/httpx
 ```
 


### PR DESCRIPTION
The current instructions say 

> prefix a Git-compatible URL (i.e., that you would use with git clone) with git+.

But this does not work with the URL that Github gives you when you choose Clone -> SSH via the UI, which is of the form `git@github.com:astral-sh/uv.git`. If you prefix this with `git+`, i.e.

`git+git@github.com:astral-sh/uv.git`

it does not work.
