### PR TITLE
roll back toolchain bump

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87"
+channel = "1.86"


### PR DESCRIPTION
1.87 seems to be busted for s390x?