### PR TITLE
make the error message clearer when running distroless containers

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -222,7 +222,12 @@ pub enum Error {
         PythonSource,
     ),
 
-    /// An error was encountered when interacting with a managed Python installation.
+    /// An error was encountered while trying to find a managed Python installation matching the
+    /// current platform.
+    #[error("Failed to find a managed Python installation matching the current platform")]
+    FindMatchingError(#[source] crate::managed::Error),
+
+    /// Some other error was encountered when interacting with a managed Python installation.
     #[error(transparent)]
     ManagedPython(#[from] crate::managed::Error),
 
@@ -317,7 +322,9 @@ fn python_executables_from_installed<'a>(
                     "Searching for managed installations at `{}`",
                     installed_installations.root().user_display()
                 );
-                let installations = installed_installations.find_matching_current_platform()?;
+                let installations = installed_installations
+                    .find_matching_current_platform()
+                    .map_err(Error::FindMatchingError)?;
                 // Check that the Python version satisfies the request to avoid unnecessary interpreter queries later
                 Ok(installations
                     .into_iter()

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -224,7 +224,7 @@ pub enum Error {
 
     /// An error was encountered while trying to find a managed Python installation matching the
     /// current platform.
-    #[error("Failed to find a managed Python installation matching the current platform")]
+    #[error("Failed to find a managed Python installation")]
     FindMatchingError(#[source] crate::managed::Error),
 
     /// Some other error was encountered when interacting with a managed Python installation.

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -224,7 +224,7 @@ pub enum Error {
 
     /// An error was encountered while trying to find a managed Python installation matching the
     /// current platform.
-    #[error("Failed to find a managed Python installation matching the current platform")]
+    #[error("Failed to discover managed Python installations")]
     ManagedPython(#[from] crate::managed::Error),
 
     /// An error was encountered when inspecting a virtual environment.

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -224,11 +224,7 @@ pub enum Error {
 
     /// An error was encountered while trying to find a managed Python installation matching the
     /// current platform.
-    #[error("Failed to find a managed Python installation")]
-    FindMatchingError(#[source] crate::managed::Error),
-
-    /// Some other error was encountered when interacting with a managed Python installation.
-    #[error(transparent)]
+    #[error("Failed to find a managed Python installation matching the current platform")]
     ManagedPython(#[from] crate::managed::Error),
 
     /// An error was encountered when inspecting a virtual environment.
@@ -322,9 +318,7 @@ fn python_executables_from_installed<'a>(
                     "Searching for managed installations at `{}`",
                     installed_installations.root().user_display()
                 );
-                let installations = installed_installations
-                    .find_matching_current_platform()
-                    .map_err(Error::FindMatchingError)?;
+                let installations = installed_installations.find_matching_current_platform()?;
                 // Check that the Python version satisfies the request to avoid unnecessary interpreter queries later
                 Ok(installations
                     .into_iter()

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -90,7 +90,7 @@ pub enum Error {
     NoDownloadFound(PythonDownloadRequest),
     #[error("A mirror was provided via `{0}`, but the URL does not match the expected format: {0}")]
     Mirror(&'static str, &'static str),
-    #[error(transparent)]
+    #[error("Failed to determine the current platform")]
     LibcDetection(#[from] LibcDetectionError),
     #[error(
         "Remote python downloads JSON is not yet supported, please use a local path (without `file://` prefix)"

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -90,7 +90,7 @@ pub enum Error {
     NoDownloadFound(PythonDownloadRequest),
     #[error("A mirror was provided via `{0}`, but the URL does not match the expected format: {0}")]
     Mirror(&'static str, &'static str),
-    #[error("Failed to determine the current platform")]
+    #[error("Failed to determine the libc used on the current platform")]
     LibcDetection(#[from] LibcDetectionError),
     #[error(
         "Remote python downloads JSON is not yet supported, please use a local path (without `file://` prefix)"

--- a/crates/uv-python/src/libc.rs
+++ b/crates/uv-python/src/libc.rs
@@ -37,7 +37,7 @@ pub enum LibcDetectionError {
     InvalidLdSoOutputMusl(PathBuf),
     #[error("Could not read ELF interpreter from any of the following paths: {0}")]
     CoreBinaryParsing(String),
-    #[error("Failed to find any common binaries ({0})")]
+    #[error("Failed to find any common binaries to determine libc from: {0}")]
     NoCommonBinariesFound(String),
     #[error("Failed to determine libc")]
     Io(#[from] io::Error),

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -87,7 +87,7 @@ pub enum Error {
     AbsolutePath(PathBuf, #[source] io::Error),
     #[error(transparent)]
     NameParseError(#[from] installation::PythonInstallationKeyError),
-    #[error(transparent)]
+    #[error("Failed to determine the current platform")]
     LibcDetection(#[from] LibcDetectionError),
     #[error(transparent)]
     MacOsDylib(#[from] macos_dylib::Error),

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -87,7 +87,7 @@ pub enum Error {
     AbsolutePath(PathBuf, #[source] io::Error),
     #[error(transparent)]
     NameParseError(#[from] installation::PythonInstallationKeyError),
-    #[error("Failed to determine the current platform")]
+    #[error("Failed to determine the libc used on the current platform")]
     LibcDetection(#[from] LibcDetectionError),
     #[error(transparent)]
     MacOsDylib(#[from] macos_dylib::Error),


### PR DESCRIPTION
Previously you could generate a confusing warning like this:

```
$ dr ghcr.io/astral-sh/uv run python
error: Could not read ELF interpreter from any of the following paths: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
```

Now the error message is better (updated):

```
error: Failed to discover managed Python installations
  Caused by: Failed to determine the libc used on the current platform
  Caused by: Failed to find any common binaries to determine libc from: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
```

See https://github.com/astral-sh/uv/issues/8635.