### PR TITLE
Revert "[docs] Fix Publishing Packages, Next = "Index""

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -99,7 +99,7 @@ nav:
       - Features: getting-started/features.md
       - Getting help: getting-started/help.md
   - Guides:
-      - Integration Guides: guides/index.md
+      - guides/index.md
       - Installing Python: guides/install-python.md
       - Running scripts: guides/scripts.md
       - Using tools: guides/tools.md


### PR DESCRIPTION
Reverts astral-sh/uv#13533. I think this isn't quite right. AFAICT, this is actually solved by upgrading our Material version.