### PR TITLE
Fis ISSUE and QUESTION github template to correctly suggest to user on how to get the uv version

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -29,7 +29,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of uv are you using? (see `uv self version`)
+      description: What version of uv are you using? (see `uv --version`)
       placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_question.yaml
+++ b/.github/ISSUE_TEMPLATE/3_question.yaml
@@ -25,7 +25,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: What version of uv are you using? (see `uv self version`)
+      description: What version of uv are you using? (see `uv --version`)
       placeholder: e.g., uv 0.5.20 (1c17662b3 2025-01-15)
     validations:
       required: false


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

There's no command `uv self version` 
There's a `uv self --version`, but I thought the `uv --version` might be more useful. Let me know if I got it wrong

```bash
uv self version  
error: unrecognized subcommand 'version'

Usage: uv self [OPTIONS] <COMMAND>

For more information, try '--help'.
```

## Test Plan

N/A
