### PR TITLE
Write the path of the parent environment to an `extends-environment` key in the `pyvenv.cfg` file of an ephemeral environment

### DIFF
--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -1,9 +1,12 @@
+use std::path::Path;
+
 use tracing::debug;
 
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::{cache_digest, hash_digest};
 use uv_configuration::{Concurrency, Constraints, PreviewMode};
 use uv_distribution_types::{Name, Resolution};
+use uv_fs::PythonExt;
 use uv_python::{Interpreter, PythonEnvironment};
 
 use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
@@ -165,6 +168,30 @@ impl CachedEnvironment {
     pub(crate) fn clear_system_site_packages(&self) -> Result<(), ProjectError> {
         self.0
             .set_pyvenv_cfg("include-system-site-packages", "false")?;
+        Ok(())
+    }
+
+    /// Set the `extends-environment` key in the `pyvenv.cfg` file to the given path.
+    ///
+    /// Ephemeral environments created by `uv run --with` extend a parent (virtual or system)
+    /// environment by adding a `.pth` file to the ephemeral environment's `site-packages`
+    /// directory. The `pth` file contains Python code to dynamically add the parent
+    /// environment's `site-packages` directory to Python's import search paths in addition to
+    /// the ephemeral environment's `site-packages` directory. This works well at runtime, but
+    /// is too dynamic for static analysis tools like ty to understand. As such, we
+    /// additionally write the `sys.prefix` of the parent environment to to the
+    /// `extends-environment` key of the ephemeral environment's `pyvenv.cfg` file, making it
+    /// easier for these tools to statically and reliably understand the relationship between
+    /// the two environments.
+    #[allow(clippy::result_large_err)]
+    pub(crate) fn set_parent_environment(
+        &self,
+        parent_environment_sys_prefix: &Path,
+    ) -> Result<(), ProjectError> {
+        self.0.set_pyvenv_cfg(
+            "extends-environment",
+            &parent_environment_sys_prefix.escape_for_python(),
+        )?;
         Ok(())
     }
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -991,6 +991,16 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             site_packages.escape_for_python()
         ))?;
 
+        // Write the `sys.prefix` of the parent environment to the `extends-environment` key of the `pyvenv.cfg`
+        // file. This helps out static-analysis tools such as ty (see docs on
+        // `CachedEnvironment::set_parent_environment`).
+        //
+        // Note that we do this even if the parent environment is not a virtual environment.
+        // For ephemeral environments created by `uv run --with`, the parent environment's
+        // `site-packages` directory is added to `sys.path` even if the parent environment is not
+        // a virtual environment and even if `--system-site-packages` was not explicitly selected.
+        ephemeral_env.set_parent_environment(base_interpreter.sys_prefix())?;
+
         // If `--system-site-packages` is enabled, add the system site packages to the ephemeral
         // environment.
         if base_interpreter.is_virtualenv()

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -243,23 +243,27 @@ impl TestContext {
         self
     }
 
-    /// Filtering for the `home = foo/bar/baz/python3.X.X/bin` key in a `pyvenv.cfg` file
+    /// Filtering for various keys in a `pyvenv.cfg` file that will vary
+    /// depending on the specific machine used:
+    /// - `home = foo/bar/baz/python3.X.X/bin`
+    /// - `uv = X.Y.Z`
+    /// - `extends-environment = <path/to/parent/venv>`
     #[must_use]
-    pub fn with_filtered_python_home_key(mut self) -> Self {
-        self.filters.push((
-            r"\nhome = .+\n".to_string(),
-            "\nhome = [PYTHON_HOME]\n".to_string(),
-        ));
-        self
-    }
-
-    /// Filtering for the `uv = X.Y.Z` key in a `pyvenv.cfg` file
-    #[must_use]
-    pub fn with_filtered_uv_version(mut self) -> Self {
-        self.filters.push((
-            r"\nuv = \d.\d.\d\n".to_string(),
-            "\nuv = [UV_VERSION]\n".to_string(),
-        ));
+    pub fn with_pyvenv_cfg_filters(mut self) -> Self {
+        let added_filters = [
+            (r"home = .+".to_string(), "home = [PYTHON_HOME]".to_string()),
+            (
+                r"uv = \d+\.\d+\.\d+".to_string(),
+                "uv = [UV_VERSION]".to_string(),
+            ),
+            (
+                r"extends-environment = .+".to_string(),
+                "extends-environment = [PARENT_VENV]".to_string(),
+            ),
+        ];
+        for filter in added_filters {
+            self.filters.insert(0, filter);
+        }
         self
     }
 

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -243,6 +243,26 @@ impl TestContext {
         self
     }
 
+    /// Filtering for the `home = foo/bar/baz/python3.X.X/bin` key in a `pyvenv.cfg` file
+    #[must_use]
+    pub fn with_filtered_python_home_key(mut self) -> Self {
+        self.filters.push((
+            r"\nhome = .+\n".to_string(),
+            "\nhome = [PYTHON_HOME]\n".to_string(),
+        ));
+        self
+    }
+
+    /// Filtering for the `uv = X.Y.Z` key in a `pyvenv.cfg` file
+    #[must_use]
+    pub fn with_filtered_uv_version(mut self) -> Self {
+        self.filters.push((
+            r"\nuv = \d.\d.\d\n".to_string(),
+            "\nuv = [UV_VERSION]\n".to_string(),
+        ));
+        self
+    }
+
     /// Add extra filtering for ` -> <PATH>` symlink display for Python versions in the test
     /// context, e.g., for use in `uv python list`.
     #[must_use]

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -1269,9 +1269,7 @@ fn run_with() -> Result<()> {
 /// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
-    let context = TestContext::new("3.12")
-        .with_filtered_python_home_key()
-        .with_filtered_uv_version();
+    let context = TestContext::new("3.12").with_pyvenv_cfg_filters();
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -1279,7 +1277,6 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
         name = "foo"
         version = "1.0.0"
         requires-python = ">=3.8"
-        dependencies = ["sniffio==1.3.0"]
 
         [build-system]
         requires = ["setuptools>=42"]
@@ -1306,15 +1303,14 @@ fn run_with_pyvenv_cfg_file() -> Result<()> {
     version_info = 3.12.[X]
     include-system-site-packages = false
     relocatable = true
-    extends-environment = [VENV]/
+    extends-environment = [PARENT_VENV]
 
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Prepared 2 packages in [TIME]
-    Installed 2 packages in [TIME]
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
      + foo==1.0.0 (from file://[TEMP_DIR]/)
-     + sniffio==1.3.0
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -1264,9 +1264,9 @@ fn run_with() -> Result<()> {
     Ok(())
 }
 
-// Tests that an ephemeral environment writes the path of its parent environment to the `extends-environment` key
-// of its `pyvenv.cfg` file. This feature makes it easier for static-analysis tools like ty to resolve which import
-// search paths are available in these ephemeral environments.
+/// Test that an ephemeral environment writes the path of its parent environment to the `extends-environment` key
+/// of its `pyvenv.cfg` file. This feature makes it easier for static-analysis tools like ty to resolve which import
+/// search paths are available in these ephemeral environments.
 #[test]
 fn run_with_pyvenv_cfg_file() -> Result<()> {
     let context = TestContext::new("3.12")


### PR DESCRIPTION
## Summary

Ephemeral environments created by `uv run --with` extend a parent (virtual or system) environment by adding a `.pth` file to the ephemeral environment's `site-packages` directory. The `pth` file contains Python code to dynamically add the parent environment's `site-packages` directory to Python's import search paths in addition to the ephemeral environment's `site-packages` directory. This works well at runtime, but is not currently understood by static analysis tools like ty.

As discussed in https://github.com/astral-sh/ty/issues/320, ty _could_ implement support for these virtual environments by attempting to parse the Python code uv is writing into these `.pth` files. This has many disadvantages however:
- It seems somewhat error-prone. The specific Python code uv is writing into the `.pth` files could change at any time -- and if another tool implements a similar ephemeral-environment feature, it could use different Python idioms.
- It would not be particularly efficient for ty to have to attempt to parse Python snippets in every `.pth` file in the `site-packages` directory (it could hurt our ability to effectively implement a persistent cache even if it doesn't cost that much in wall time, since we need to know the import search paths very early on).
- Philosophically, it feels out of spirit with the kind of analysis a static type checker should be expected to do.

Instead, this PR implements a feature where uv additionally writes the `sys.prefix` of the parent environment to a new `extends-environment` key of the ephemeral environment's `pyvenv.cfg` file. This should make it much easier for ty -- and potentially other static-analysis tools -- to statically and reliably understand the relationship between the two environments. If ty sees that a `pyvenv.cfg` file has a `uv` key in it and also has a `extends-environment` key in it, it will be able to easily add the `site-packages` directory of the parent environment to its resolved search paths as well as the `site-packages` directory of the ephemeral child environment.

A question was raised in https://github.com/astral-sh/ty/issues/320#issuecomment-2877865480 about whether it was standards-compliant to add new keys to `pyvenv.cfg` files created by uv. I think it is. `pyvenv.cfg` files are in general very under-specified: only a small handful of keys are currently consistent between virtual-environment creation tools. Different tools already often add bespoke keys to their `pyvenv.cfg` files -- see https://github.com/astral-sh/ty/issues/320#issuecomment-2877881334 for some comparisons between uv, the virtualenv Python library, and the standard-library `venv` module.

## Test Plan

I added a test that demonstrates that the `extends-environment` key is written with the correct value to the `pyvenv.cfg` file of an ephemeral environment.