### PR TITLE
Windows paths are valid URLs

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -554,13 +554,16 @@ impl ManagedPythonDownload {
             let json_downloads: HashMap<String, JsonPythonDownload> = if let Some(json_source) =
                 python_downloads_json_url
             {
-                if Url::parse(json_source).is_ok() {
-                    return Err(Error::RemoteJSONNotSupported());
-                }
-
                 let file = match fs_err::File::open(json_source) {
                     Ok(file) => file,
-                    Err(e) => { Err(Error::Io(e)) }?,
+                    Err(e) => {
+                        // Windows paths can also be valid URLs
+                        if Url::parse(json_source).is_ok() {
+                            return Err(Error::RemoteJSONNotSupported());
+                        } else {
+                            Err(Error::Io(e))
+                        }
+                    }?,
                 };
 
                 serde_json::from_reader(file)


### PR DESCRIPTION
Currently, it is not possible to set a custom Python downloads JSON on Windows, as Windows paths can be valid URLs.

```rust
use url::Url;

fn main() {
    dbg!(Url::parse(r"C:\Users\Ferris\download.json"));
}
```

Tested by https://github.com/astral-sh/uv/pull/13585 (where it is currently failing CI).