### PR TITLE
Update projects.md hello-world main file name

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -32,14 +32,14 @@ uv will create the following files:
 .
 ├── .python-version
 ├── README.md
-├── main.py
+├── hello.py
 └── pyproject.toml
 ```
 
-The `main.py` file contains a simple "Hello world" program. Try it out with `uv run`:
+The `hello.py` file contains a simple "Hello world" program. Try it out with `uv run`:
 
 ```console
-$ uv run main.py
+$ uv run hello.py
 Hello from hello-world!
 ```
 
@@ -60,7 +60,7 @@ A complete listing would look like:
 │   └── pyvenv.cfg
 ├── .python-version
 ├── README.md
-├── main.py
+├── hello.py
 ├── pyproject.toml
 └── uv.lock
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

with the latest version of uv, I run the hello-world example but the main file name is now hello.py, not main.py as per the doc.

## Test Plan

Below logs of the steps to create the project:

```bash
me@macos git % uv init uv-hello-world
Initialized project `uv-hello-world` at `/Users/me/Documents/git/uv-hello-world`
me@macos git % cd uv-hello-world
me@macos uv-hello-world % ls
hello.py	pyproject.toml	README.md

me@macos uv-hello-world % uv init
error: Project is already initialized in `/Users/me/Documents/git/uv-hello-world` (`pyproject.toml` file exists)

me@macos uv-hello-world % uv run main.py
Using CPython 3.12.6 interpreter at: /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
Creating virtual environment at: .venv
error: Failed to spawn: `main.py`
  Caused by: No such file or directory (os error 2)

me@macos uv-hello-world % uv run hello.py
Hello from uv-hello-world!
```