### PR TITLE
Omit `license-file` key for Metadata 2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5469,6 +5469,7 @@ dependencies = [
  "uv-extract",
  "uv-fs",
  "uv-metadata",
+ "uv-pep440",
  "uv-pypi-types",
  "uv-static",
  "uv-warnings",

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -22,6 +22,7 @@ uv-distribution-types = { workspace = true }
 uv-extract = { workspace = true }
 uv-fs = { workspace = true }
 uv-metadata = { workspace = true }
+uv-pep440 = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-static = { workspace = true }
 uv-warnings = { workspace = true }


### PR DESCRIPTION
## Summary

Some versions of `setuptools` added this key despite using Metadata 2.1. It seems like `setuptools` now writes Metadata 2.4? But this is a challenging error if you have existing wheels that you want to upload.

See: https://github.com/pypa/setuptools/issues/4759

Closes #9513