### PR TITLE
Set `LC_ALL=C` for git when checking git worktree

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -24,6 +24,7 @@ use uv_python::{
 use uv_resolver::RequiresPython;
 use uv_scripts::{Pep723Script, ScriptTag};
 use uv_settings::PythonInstallMirrors;
+use uv_static::EnvVars;
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, Workspace, WorkspaceCache, WorkspaceError};
@@ -1235,6 +1236,7 @@ fn detect_git_repository(path: &Path) -> GitDiscoveryResult {
     let Ok(output) = Command::new(git)
         .arg("rev-parse")
         .arg("--is-inside-work-tree")
+        .env(EnvVars::LC_ALL, "C")
         .current_dir(path)
         .output()
     else {


### PR DESCRIPTION
## Summary

Closes #13612

We check if the git error message includes `not a git repository` to figure out if the path isn't a Git repo or if Git's broken. This PR sets `LC_ALL=C` when invoking `git rev-parse --is-inside-work-tree` so that the error message doesn’t change based on the user’s locale settings.
