### PR TITLE
Avoid rendering info log level

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -347,9 +347,9 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
 
     // Configure the `tracing` crate, which controls internal logging.
     #[cfg(feature = "tracing-durations-export")]
-    let (duration_layer, _duration_guard) = logging::setup_duration()?;
+    let (durations_layer, _duration_guard) = logging::setup_durations()?;
     #[cfg(not(feature = "tracing-durations-export"))]
-    let duration_layer = None::<tracing_subscriber::layer::Identity>;
+    let durations_layer = None::<tracing_subscriber::layer::Identity>;
     logging::setup_logging(
         match globals.verbose {
             0 => logging::Level::Off,
@@ -357,7 +357,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             2 => logging::Level::TraceUv,
             3.. => logging::Level::TraceAll,
         },
-        duration_layer,
+        durations_layer,
         globals.color,
     )?;
 


### PR DESCRIPTION
We were previously rendering messages for the info level, carrying overhead in pubgrub which using `log::info!`. We avoid this by only configuring `LevelFilter::INFO` if the durations layer exists.

I've confirmed that the default `Subscriber::max_level_hint` goes from `INFO` to `OFF` and the profile skips `Incompatibility::display`.