### PR TITLE
Include pre-release versions in `uv python install --reinstall`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -203,7 +203,11 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Default | PythonRequest::Any => Some(Self::default()),
+            PythonRequest::Any => Some(Self {
+                prereleases: Some(true), // Explicitly allow pre-releases for PythonRequest::Any
+                ..Self::default()
+            }),
+            PythonRequest::Default => Some(Self::default()),
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This change allows for `uv python install --reinstall` to include pre-releases when reinstalling. It does this by explicitly allowing pre-releases to be included within `PythonRequest::Any` if the user does not specify a version to reinstall.

Fixes #13582

## Test Plan

<!-- How was it tested? -->
```bash
uv python install 3.14 3.13 3.10
uv python install --no-config --reinstall
```
