### PR TITLE
Increase uv publish integration test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1422,7 +1422,7 @@ jobs:
           echo "code_any_changed=${CODE_CHANGED}" >> "${GITHUB_OUTPUT}"
 
   integration-test-publish:
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: integration-test-publish-changed
     name: "integration test | uv publish"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes we have to wait a long time for remote caches to update, see e.g. https://github.com/astral-sh/uv/actions/runs/15252860797/job/42893715464