### PR TITLE
Exit early on `self update` if global `--offline` is set

### DIFF
--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -10,6 +10,7 @@ use uv_fs::Simplified;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
+use crate::settings::NetworkSettings;
 
 /// Attempt to update the uv binary.
 pub(crate) async fn self_update(
@@ -17,7 +18,26 @@ pub(crate) async fn self_update(
     token: Option<String>,
     dry_run: bool,
     printer: Printer,
+    network_settings: NetworkSettings,
 ) -> Result<ExitStatus> {
+    if network_settings.connectivity.is_offline() {
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format_args!(
+                concat!(
+                "{}{} Self-update exited because network is disabled.",
+                "\n",
+                "\n",
+                "Hint: Remove --offline to continue self update."
+                ),
+                "error".red().bold(),
+                ":".bold()
+            )
+        )?;
+        return Ok(ExitStatus::Failure);
+    }
+
     let mut updater = AxoUpdater::new_for("uv");
     updater.disable_installer_output();
 

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -26,10 +26,7 @@ pub(crate) async fn self_update(
             "{}",
             format_args!(
                 concat!(
-                    "{}{} Self-update exited because network is disabled.",
-                    "\n",
-                    "\n",
-                    "Hint: Remove --offline to continue self update."
+                    "{}{} Self-update is not possible because network connectivity is disabled (i.e., with `--offline`)"
                 ),
                 "error".red().bold(),
                 ":".bold()

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -26,10 +26,10 @@ pub(crate) async fn self_update(
             "{}",
             format_args!(
                 concat!(
-                "{}{} Self-update exited because network is disabled.",
-                "\n",
-                "\n",
-                "Hint: Remove --offline to continue self update."
+                    "{}{} Self-update exited because network is disabled.",
+                    "\n",
+                    "\n",
+                    "Hint: Remove --offline to continue self update."
                 ),
                 "error".red().bold(),
                 ":".bold()

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1067,7 +1067,16 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     token,
                     dry_run,
                 }),
-        }) => commands::self_update(target_version, token, dry_run, printer).await,
+        }) => {
+            commands::self_update(
+                target_version,
+                token,
+                dry_run,
+                printer,
+                globals.network_settings,
+            )
+            .await
+        }
         Commands::Self_(SelfNamespace {
             command:
                 SelfCommand::Version {

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -878,6 +878,13 @@ impl TestContext {
         command
     }
 
+    pub fn self_update(&self) -> Command {
+        let mut command = self.new_command();
+        command.arg("self").arg("update");
+        self.add_shared_options(&mut command, false);
+        command
+    }
+
     /// Create a `uv publish` command with options shared across scenarios.
     pub fn publish(&self) -> Command {
         let mut command = self.new_command();

--- a/crates/uv/tests/it/self_update.rs
+++ b/crates/uv/tests/it/self_update.rs
@@ -48,14 +48,13 @@ fn test_self_update_offline_error() {
     let context = TestContext::new("3.12");
 
     uv_snapshot!(context.self_update().arg("--offline"),
-    @r###"
-success: false
-exit_code: 1
------ stdout -----
+    @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
 
------ stderr -----
-error: Self-update exited because network is disabled.
+    ----- stderr -----
+    error: Self-update exited because network is disabled.
 
-Hint: Remove --offline to continue self update.
-"###);
+    Hint: Remove --offline to continue self update."#);
 }

--- a/crates/uv/tests/it/self_update.rs
+++ b/crates/uv/tests/it/self_update.rs
@@ -7,7 +7,7 @@ use axoupdater::{
 
 use uv_static::EnvVars;
 
-use crate::common::get_bin;
+use crate::common::{TestContext, get_bin, uv_snapshot};
 
 #[test]
 fn check_self_update() {
@@ -41,4 +41,21 @@ fn check_self_update() {
         .status()
         .expect("failed to run 'uv --version'");
     assert!(status.success(), "'uv --version' returned non-zero");
+}
+
+#[test]
+fn test_self_update_offline_error() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.self_update().arg("--offline"),
+    @r###"
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: Self-update exited because network is disabled.
+
+Hint: Remove --offline to continue self update.
+"###);
 }

--- a/crates/uv/tests/it/self_update.rs
+++ b/crates/uv/tests/it/self_update.rs
@@ -48,13 +48,12 @@ fn test_self_update_offline_error() {
     let context = TestContext::new("3.12");
 
     uv_snapshot!(context.self_update().arg("--offline"),
-    @r#"
+    @r"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Self-update exited because network is disabled.
-
-    Hint: Remove --offline to continue self update."#);
+    error: Self-update is not possible because network connectivity is disabled (i.e., with `--offline`)
+    ");
 }


### PR DESCRIPTION
## Summary
Resolves https://github.com/astral-sh/uv/issues/13580.

`uv self update --offline` should fail and exit early because self-updating requires network connection.

## Test Plan
A snapshot test is added.

