### PR TITLE
Avoid reinstalling dependency group members with `--all-packages`

### DIFF
--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -91,7 +91,8 @@ pub trait Installable<'lock> {
             }
         }
 
-        // Add the workspace packages to the queue.
+        // Initialize the workspace roots.
+        let mut roots = vec![];
         for root_name in self.roots() {
             let dist = self
                 .lock()
@@ -114,6 +115,12 @@ pub trait Installable<'lock> {
             // Add an edge from the root.
             petgraph.add_edge(root, index, Edge::Prod(MarkerTree::TRUE));
 
+            // Push the package onto the queue.
+            roots.push((dist, index));
+        }
+
+        // Add the workspace dependencies to the queue.
+        for (dist, index) in roots {
             if dev.prod() {
                 // Push its dependencies onto the queue.
                 queue.push_back((dist, None));


### PR DESCRIPTION
## Summary

Right now, if a workspace member is first created by way of being a dev dependency on another member, we end up duplicating it in the graph. Instead, we should create all the roots upfront; all subsequent node creations are robust to existing nodes.

Closes https://github.com/astral-sh/uv/issues/13673#issuecomment-2912196406.
