### PR TITLE
Add `uv sync --format json`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3203,7 +3203,7 @@ pub struct SyncArgs {
 
     /// Select the output format.
     /// **Note:** This option is only available when `--dry-run` is enabled.
-    #[arg(long, value_enum, requires = "dry_run", default_value_t = SyncFormat::default())]
+    #[arg(long, value_enum, default_value_t = SyncFormat::default())]
     pub format: SyncFormat,
     /// Include all optional dependencies.
     ///

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -53,6 +53,11 @@ pub enum SyncFormat {
     /// Display as json
     Json,
 }
+impl SyncFormat {
+    pub fn is_json(&self) -> bool {
+        matches!(self, SyncFormat::Json)
+    }
+}
 
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum ListFormat {
@@ -3197,7 +3202,7 @@ pub struct SyncArgs {
     pub extra: Option<Vec<ExtraName>>,
 
     /// Select the output format.
-    #[arg(long, value_enum, default_value_t = SyncFormat::default())]
+    #[arg(long, value_enum, requires = "dry_run", default_value_t = SyncFormat::default())]
     pub format: SyncFormat,
     /// Include all optional dependencies.
     ///

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -46,6 +46,15 @@ pub enum PythonListFormat {
 }
 
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
+pub enum SyncFormat {
+    /// Display as a text
+    #[default]
+    Text,
+    /// Display as json
+    Json,
+}
+
+#[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum ListFormat {
     /// Display the list of packages in a human-readable table.
     #[default]
@@ -3187,6 +3196,9 @@ pub struct SyncArgs {
     #[arg(long, conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
     pub extra: Option<Vec<ExtraName>>,
 
+    /// Select the output format.
+    #[arg(long, value_enum, default_value_t = SyncFormat::default())]
+    pub format: SyncFormat,
     /// Include all optional dependencies.
     ///
     /// When two or more extras are declared as conflicting in `tool.uv.conflicts`, using this flag

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -50,21 +50,12 @@ pub enum SyncFormat {
     /// Display the result in a human-readable format.
     #[default]
     Text,
-    /// Display the result in a machine-readable JSON format.
+    /// Display the result in JSON format.
     Json,
-
-    /// Output the result in a pretty-printed, human-readable JSON format.
-    PrettyJson,
 }
 impl SyncFormat {
     pub fn is_json(&self) -> bool {
-        matches!(self, SyncFormat::Json | SyncFormat::PrettyJson)
-    }
-    pub fn is_raw_json(&self) -> bool {
         matches!(self, SyncFormat::Json)
-    }
-    pub fn is_pretty(&self) -> bool {
-        matches!(self, SyncFormat::PrettyJson)
     }
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -47,15 +47,24 @@ pub enum PythonListFormat {
 
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum SyncFormat {
-    /// Display as a text
+    /// Display the result in a human-readable format.
     #[default]
     Text,
-    /// Display as json
+    /// Display the result in a machine-readable JSON format.
     Json,
+
+    /// Output the result in a pretty-printed, human-readable JSON format.
+    PrettyJson,
 }
 impl SyncFormat {
     pub fn is_json(&self) -> bool {
+        matches!(self, SyncFormat::Json | SyncFormat::PrettyJson)
+    }
+    pub fn is_raw_json(&self) -> bool {
         matches!(self, SyncFormat::Json)
+    }
+    pub fn is_pretty(&self) -> bool {
+        matches!(self, SyncFormat::PrettyJson)
     }
 }
 
@@ -3202,6 +3211,7 @@ pub struct SyncArgs {
     pub extra: Option<Vec<ExtraName>>,
 
     /// Select the output format.
+    /// **Note:** This option is only available when `--dry-run` is enabled.
     #[arg(long, value_enum, requires = "dry_run", default_value_t = SyncFormat::default())]
     pub format: SyncFormat,
     /// Include all optional dependencies.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use serde::Serialize;
 
 use uv_cache::Cache;
+use uv_cli::SyncFormat;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DependencyGroups, DependencyGroupsWithDefaults, DryRun, EditableMode,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -375,7 +375,7 @@ pub(crate) async fn sync(
         _ => {}
     }
 
-    // Pretty-print JSON for better readability and write it to stdout
+    // Print JSON for better readability and write it to stdout
     if format.is_json() {
         writeln!(printer.stdout(), "{}", sync_json.as_json()?)?;
     }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -62,8 +62,6 @@ enum DryRunAction {
     DiscoveredExisting,
     ReplacingExistingVenv,
     CreatingVenv,
-    UsingScriptEnv,
-    RecreatingScriptEnv,
     ReplacingExistingScriptVenv,
     CreatingScriptEnv,
     /// No action is being taken(should this ever happen?).
@@ -230,7 +228,7 @@ pub(crate) async fn sync(
         SyncEnvironment::Project(ProjectEnvironment::Existing(environment))
             if dry_run.enabled() =>
         {
-            // if
+            // formatting
             if format.is_json() {
                 sync_json.set_env_path(
                     environment.root().to_owned(),
@@ -362,8 +360,10 @@ pub(crate) async fn sync(
     }
 
     // Pretty-print JSON for better readability and write it to stdout
-    if format.is_json() {
-        writeln!(printer.stdout(), "{}", sync_json.as_json()?);
+    if format.is_raw_json() {
+        writeln!(printer.stdout(), "{}", sync_json.as_json()?)?;
+    } else if format.is_pretty() {
+        writeln!(printer.stdout(), "{}", sync_json.as_pretty_json()?)?;
     }
 
     // Notify the user of any environment changes.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -52,10 +52,22 @@ struct SyncEntry {
     project_dir: PathBuf,
     environment: Environment,
 }
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "snake_case")]
+enum DryRunAction {
+    DiscoveredExisting,
+    ReplacingExistingVenv,
+    CreatingVenv,
+    UsingScriptEnv,
+    RecreatingScriptEnv,
+    ReplacingExistingScriptVenv,
+    CreatingScriptEnv,
+}
 #[derive(Serialize, Debug)]
 struct Environment {
     path: PathBuf,
-    action: String,
+    action: DryRunAction,
 }
 
 /// Sync the project environment.
@@ -294,7 +306,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: environment.root().to_owned(),
-                        action: "Discovered".to_string(),
+                        action: DryRunAction::DiscoveredExisting,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -305,8 +317,8 @@ pub(crate) async fn sync(
                 let sync_json = SyncEntry {
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
-                        path: environment.root().to_owned(),
-                        action: "Replace".to_string(),
+                        path: root.to_owned(),
+                        action: DryRunAction::ReplacingExistingVenv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -318,7 +330,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: root.to_owned(),
-                        action: "Replace".to_string(),
+                        action: DryRunAction::CreatingVenv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -329,7 +341,7 @@ pub(crate) async fn sync(
                         project_dir: project_dir.to_owned(),
                         environment: Environment {
                             path: environment.root().to_owned(),
-                            action: "Discovered".to_string(),
+                            action: DryRunAction::DiscoveredExisting,
                         },
                     };
                     writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -338,7 +350,7 @@ pub(crate) async fn sync(
                         project_dir: project_dir.to_owned(),
                         environment: Environment {
                             path: environment.root().to_owned(),
-                            action: "Using".to_string(),
+                            action: DryRunAction::UsingScriptEnv,
                         },
                     };
                     writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -351,7 +363,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: environment.root().to_owned(),
-                        action: "Recreating".to_string(),
+                        action: DryRunAction::RecreatingScriptEnv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -363,7 +375,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: environment.root().to_owned(),
-                        action: "Creating".to_string(),
+                        action: DryRunAction::CreatingScriptEnv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -375,7 +387,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: root.to_owned(),
-                        action: "Replace_existing".to_string(),
+                        action: DryRunAction::ReplacingExistingScriptVenv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
@@ -387,7 +399,7 @@ pub(crate) async fn sync(
                     project_dir: project_dir.to_owned(),
                     environment: Environment {
                         path: root.to_owned(),
-                        action: "Create".to_string(),
+                        action: DryRunAction::CreatingScriptEnv,
                     },
                 };
                 writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -74,6 +74,10 @@ struct Environment {
     path: PathBuf,
     /// The action taken for the environment.
     action: DryRunAction,
+    // Python executable path
+    python_executable: PathBuf,
+    // Python full version
+    python_version: String,
 }
 
 impl SyncEntry {
@@ -84,6 +88,8 @@ impl SyncEntry {
             environment: Environment {
                 path: PathBuf::new(),
                 action: DryRunAction::None,
+                python_executable: PathBuf::new(),
+                python_version: String::new(),
             },
         }
     }
@@ -91,6 +97,12 @@ impl SyncEntry {
     fn set_env_path(&mut self, path: PathBuf, action: DryRunAction) {
         self.environment.path = path;
         self.environment.action = action;
+    }
+
+    /// Sets python executable path and full version.
+    fn set_python(&mut self, executable: PathBuf, version: String) {
+        self.environment.python_executable = executable;
+        self.environment.python_version = version;
     }
 
     /// Serializes the `SyncEntry` into a JSON string.
@@ -221,6 +233,13 @@ pub(crate) async fn sync(
     };
 
     let mut sync_json = SyncEntry::new(project_dir);
+    // set python version and executable path
+    sync_json.set_python(
+        environment.python_executable().to_owned(),
+        environment.interpreter().python_full_version().to_string(),
+    );
+
+    // Notify the user of any environment changes.
     match &environment {
         SyncEnvironment::Project(ProjectEnvironment::Existing(environment))
             if dry_run.enabled() =>

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -97,9 +97,6 @@ impl SyncEntry {
     fn as_json(&self) -> Result<String, serde_json::Error> {
         serde_json::to_string(self)
     }
-    fn as_pretty_json(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string_pretty(self)
-    }
 }
 
 /// Sync the project environment.
@@ -360,12 +357,9 @@ pub(crate) async fn sync(
     }
 
     // Pretty-print JSON for better readability and write it to stdout
-    if format.is_raw_json() {
+    if format.is_json() {
         writeln!(printer.stdout(), "{}", sync_json.as_json()?)?;
-    } else if format.is_pretty() {
-        writeln!(printer.stdout(), "{}", sync_json.as_pretty_json()?)?;
     }
-
     // Notify the user of any environment changes.
 
     // Special-case: we're syncing a script that doesn't have an associated lockfile. In that case,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 use std::ops::Deref;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -46,6 +46,18 @@ use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
 use crate::settings::{InstallerSettingsRef, NetworkSettings, ResolverInstallerSettings};
 
+/// JSON.
+#[derive(Debug, Serialize)]
+struct SyncEntry {
+    project_dir: PathBuf,
+    environment: Environment,
+}
+#[derive(Serialize, Debug)]
+struct Environment {
+    path: PathBuf,
+    action: String,
+}
+
 /// Sync the project environment.
 #[allow(clippy::fn_params_excessive_bools)]
 pub(crate) async fn sync(
@@ -74,6 +86,7 @@ pub(crate) async fn sync(
     cache: &Cache,
     printer: Printer,
     preview: PreviewMode,
+    format: SyncFormat,
 ) -> Result<ExitStatus> {
     // Identify the target.
     let workspace_cache = WorkspaceCache::default();
@@ -166,49 +179,11 @@ pub(crate) async fn sync(
         ),
     };
 
-    // Notify the user of any environment changes.
-    match &environment {
-        SyncEnvironment::Project(ProjectEnvironment::Existing(environment))
-            if dry_run.enabled() =>
-        {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                format!(
-                    "Discovered existing environment at: {}",
-                    environment.root().user_display().bold()
-                )
-                .dimmed()
-            )?;
-        }
-        SyncEnvironment::Project(ProjectEnvironment::WouldReplace(root, ..))
-            if dry_run.enabled() =>
-        {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                format!(
-                    "Would replace existing virtual environment at: {}",
-                    root.user_display().bold()
-                )
-                .dimmed()
-            )?;
-        }
-        SyncEnvironment::Project(ProjectEnvironment::WouldCreate(root, ..))
-            if dry_run.enabled() =>
-        {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                format!(
-                    "Would create virtual environment at: {}",
-                    root.user_display().bold()
-                )
-                .dimmed()
-            )?;
-        }
-        SyncEnvironment::Script(ScriptEnvironment::Existing(environment)) => {
-            if dry_run.enabled() {
+    match format {
+        SyncFormat::Text => match &environment {
+            SyncEnvironment::Project(ProjectEnvironment::Existing(environment))
+                if dry_run.enabled() =>
+            {
                 writeln!(
                     printer.stderr(),
                     "{}",
@@ -218,52 +193,209 @@ pub(crate) async fn sync(
                     )
                     .dimmed()
                 )?;
-            } else {
+            }
+            SyncEnvironment::Project(ProjectEnvironment::WouldReplace(root, ..))
+                if dry_run.enabled() =>
+            {
                 writeln!(
                     printer.stderr(),
-                    "Using script environment at: {}",
+                    "{}",
+                    format!(
+                        "Would replace existing virtual environment at: {}",
+                        root.user_display().bold()
+                    )
+                    .dimmed()
+                )?;
+            }
+            SyncEnvironment::Project(ProjectEnvironment::WouldCreate(root, ..))
+                if dry_run.enabled() =>
+            {
+                writeln!(
+                    printer.stderr(),
+                    "{}",
+                    format!(
+                        "Would create virtual environment at: {}",
+                        root.user_display().bold()
+                    )
+                    .dimmed()
+                )?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::Existing(environment)) => {
+                if dry_run.enabled() {
+                    writeln!(
+                        printer.stderr(),
+                        "{}",
+                        format!(
+                            "Discovered existing environment at: {}",
+                            environment.root().user_display().bold()
+                        )
+                        .dimmed()
+                    )?;
+                } else {
+                    writeln!(
+                        printer.stderr(),
+                        "Using script environment at: {}",
+                        environment.root().user_display().cyan()
+                    )?;
+                }
+            }
+            SyncEnvironment::Script(ScriptEnvironment::Replaced(environment))
+                if !dry_run.enabled() =>
+            {
+                writeln!(
+                    printer.stderr(),
+                    "Recreating script environment at: {}",
                     environment.root().user_display().cyan()
                 )?;
             }
-        }
-        SyncEnvironment::Script(ScriptEnvironment::Replaced(environment)) if !dry_run.enabled() => {
-            writeln!(
-                printer.stderr(),
-                "Recreating script environment at: {}",
-                environment.root().user_display().cyan()
-            )?;
-        }
-        SyncEnvironment::Script(ScriptEnvironment::Created(environment)) if !dry_run.enabled() => {
-            writeln!(
-                printer.stderr(),
-                "Creating script environment at: {}",
-                environment.root().user_display().cyan()
-            )?;
-        }
-        SyncEnvironment::Script(ScriptEnvironment::WouldReplace(root, ..)) if dry_run.enabled() => {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                format!(
-                    "Would replace existing script environment at: {}",
-                    root.user_display().bold()
-                )
-                .dimmed()
-            )?;
-        }
-        SyncEnvironment::Script(ScriptEnvironment::WouldCreate(root, ..)) if dry_run.enabled() => {
-            writeln!(
-                printer.stderr(),
-                "{}",
-                format!(
-                    "Would create script environment at: {}",
-                    root.user_display().bold()
-                )
-                .dimmed()
-            )?;
-        }
-        _ => {}
+            SyncEnvironment::Script(ScriptEnvironment::Created(environment))
+                if !dry_run.enabled() =>
+            {
+                writeln!(
+                    printer.stderr(),
+                    "Creating script environment at: {}",
+                    environment.root().user_display().cyan()
+                )?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::WouldReplace(root, ..))
+                if dry_run.enabled() =>
+            {
+                writeln!(
+                    printer.stderr(),
+                    "{}",
+                    format!(
+                        "Would replace existing script environment at: {}",
+                        root.user_display().bold()
+                    )
+                    .dimmed()
+                )?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::WouldCreate(root, ..))
+                if dry_run.enabled() =>
+            {
+                writeln!(
+                    printer.stderr(),
+                    "{}",
+                    format!(
+                        "Would create script environment at: {}",
+                        root.user_display().bold()
+                    )
+                    .dimmed()
+                )?;
+            }
+            _ => {}
+        },
+
+        SyncFormat::Json => match &environment {
+            SyncEnvironment::Project(ProjectEnvironment::Existing(environment))
+                if dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: environment.root().to_owned(),
+                        action: "Discovered".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Project(ProjectEnvironment::WouldReplace(root, ..))
+                if dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: environment.root().to_owned(),
+                        action: "Replace".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Project(ProjectEnvironment::WouldCreate(root, ..))
+                if dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: root.to_owned(),
+                        action: "Replace".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::Existing(environment)) => {
+                if dry_run.enabled() {
+                    let sync_json = SyncEntry {
+                        project_dir: project_dir.to_owned(),
+                        environment: Environment {
+                            path: environment.root().to_owned(),
+                            action: "Discovered".to_string(),
+                        },
+                    };
+                    writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+                } else {
+                    let sync_json = SyncEntry {
+                        project_dir: project_dir.to_owned(),
+                        environment: Environment {
+                            path: environment.root().to_owned(),
+                            action: "Using".to_string(),
+                        },
+                    };
+                    writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+                }
+            }
+            SyncEnvironment::Script(ScriptEnvironment::Replaced(environment))
+                if !dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: environment.root().to_owned(),
+                        action: "Recreating".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::Created(environment))
+                if !dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: environment.root().to_owned(),
+                        action: "Creating".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::WouldReplace(root, ..))
+                if dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: root.to_owned(),
+                        action: "Replace_existing".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            SyncEnvironment::Script(ScriptEnvironment::WouldCreate(root, ..))
+                if dry_run.enabled() =>
+            {
+                let sync_json = SyncEntry {
+                    project_dir: project_dir.to_owned(),
+                    environment: Environment {
+                        path: root.to_owned(),
+                        action: "Create".to_string(),
+                    },
+                };
+                writeln!(printer.stderr(), "{}", serde_json::to_string(&sync_json)?)?;
+            }
+            _ => {}
+        },
     }
+    // Notify the user of any environment changes.
 
     // Special-case: we're syncing a script that doesn't have an associated lockfile. In that case,
     // we don't create a lockfile, so the resolve-and-install semantics are different.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1764,6 +1764,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
+                args.format,
             ))
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1095,6 +1095,7 @@ pub(crate) struct SyncSettings {
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) refresh: Refresh,
     pub(crate) settings: ResolverInstallerSettings,
+    pub(crate) format: SyncFormat,
 }
 
 impl SyncSettings {
@@ -1134,6 +1135,7 @@ impl SyncSettings {
             python,
             check,
             no_check,
+            format,
         } = args;
         let install_mirrors = filesystem
             .clone()
@@ -1153,6 +1155,7 @@ impl SyncSettings {
         };
 
         Self {
+            format,
             locked,
             frozen,
             dry_run,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -11,8 +11,8 @@ use uv_cli::{
     PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
     PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
     PythonListFormat, PythonPinArgs, PythonUninstallArgs, RemoveArgs, RunArgs, SyncArgs,
-    ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs,
-    VersionArgs, VersionBump, VersionFormat,
+    SyncFormat, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs,
+    TreeArgs, VenvArgs, VersionArgs, VersionBump, VersionFormat,
 };
 use uv_cli::{
     AuthorFrom, BuildArgs, ExportArgs, PublishArgs, PythonDirArgs, ResolverInstallerArgs,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1005,6 +1005,12 @@ uv sync [OPTIONS]
 <ul>
 <li><code>fewest</code>:  Optimize for selecting the fewest number of versions for each package. Older versions may be preferred if they are compatible with a wider range of supported Python versions or platforms</li>
 <li><code>requires-python</code>:  Optimize for selecting latest supported version of each package, for each supported Python version</li>
+</ul></dd><dt id="uv-sync--format"><a href="#uv-sync--format"><code>--format</code></a> <i>format</i></dt><dd><p>Select the output format. <strong>Note:</strong> This option is only available when <code>--dry-run</code> is enabled</p>
+<p>[default: text]</p><p>Possible values:</p>
+<ul>
+<li><code>text</code>:  Display the result in a human-readable format</li>
+<li><code>json</code>:  Display the result in a machine-readable JSON format</li>
+<li><code>pretty-json</code>:  Output the result in a pretty-printed, human-readable JSON format</li>
 </ul></dd><dt id="uv-sync--frozen"><a href="#uv-sync--frozen"><code>--frozen</code></a></dt><dd><p>Sync without updating the <code>uv.lock</code> file.</p>
 <p>Instead of checking if the lockfile is up-to-date, uses the versions in the lockfile as the source of truth. If the lockfile is missing, uv will exit with an error. If the <code>pyproject.toml</code> includes changes to dependencies that have not been included in the lockfile yet, they will not be present in the environment.</p>
 <p>May also be set with the <code>UV_FROZEN</code> environment variable.</p></dd><dt id="uv-sync--group"><a href="#uv-sync--group"><code>--group</code></a> <i>group</i></dt><dd><p>Include dependencies from the specified dependency group.</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1009,8 +1009,7 @@ uv sync [OPTIONS]
 <p>[default: text]</p><p>Possible values:</p>
 <ul>
 <li><code>text</code>:  Display the result in a human-readable format</li>
-<li><code>json</code>:  Display the result in a machine-readable JSON format</li>
-<li><code>pretty-json</code>:  Output the result in a pretty-printed, human-readable JSON format</li>
+<li><code>json</code>:  Display the result in JSON format</li>
 </ul></dd><dt id="uv-sync--frozen"><a href="#uv-sync--frozen"><code>--frozen</code></a></dt><dd><p>Sync without updating the <code>uv.lock</code> file.</p>
 <p>Instead of checking if the lockfile is up-to-date, uses the versions in the lockfile as the source of truth. If the lockfile is missing, uv will exit with an error. If the <code>pyproject.toml</code> includes changes to dependencies that have not been included in the lockfile yet, they will not be present in the environment.</p>
 <p>May also be set with the <code>UV_FROZEN</code> environment variable.</p></dd><dt id="uv-sync--group"><a href="#uv-sync--group"><code>--group</code></a> <i>group</i></dt><dd><p>Include dependencies from the specified dependency group.</p>


### PR DESCRIPTION
This is a continuation of the work in 

* #12405 

I have moved to an architecture where the human output is derived from the json structs to centralize more of the printing state/logic. I've also cleaned up some of the names/types, and added tests. I have not yet added package info, which was TBD in their design.