### PR TITLE
docs: integration with marimo guide

### DIFF
--- a/docs/guides/integration/index.md
+++ b/docs/guides/integration/index.md
@@ -4,6 +4,7 @@ Learn how to integrate uv with other software:
 
 - [Using in Docker images](./docker.md)
 - [Using with Jupyter](./jupyter.md)
+- [Using with marimo](./marimo.md)
 - [Using with pre-commit](./pre-commit.md)
 - [Using in GitHub Actions](./github.md)
 - [Using in GitLab CI/CD](./gitlab.md)

--- a/docs/guides/integration/index.md
+++ b/docs/guides/integration/index.md
@@ -3,8 +3,8 @@
 Learn how to integrate uv with other software:
 
 - [Using in Docker images](./docker.md)
-- [Using with Jupyter](./jupyter.md)
-- [Using with marimo](./marimo.md)
+- [Using with Jupyter notebooks](./jupyter.md)
+- [Using with marimo notebooks](./marimo.md)
 - [Using with pre-commit](./pre-commit.md)
 - [Using in GitHub Actions](./github.md)
 - [Using in GitLab CI/CD](./gitlab.md)

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -67,7 +67,7 @@ To run marimo in a virtual environment that isn't associated with a
 === "macOS and Linux"
 
     ```console
-    $ uv venv --seed
+    $ uv venv
     $ uv pip install numpy
     $ uv pip install marimo
     $ .venv/bin/marimo edit
@@ -76,7 +76,7 @@ To run marimo in a virtual environment that isn't associated with a
 === "Windows"
 
     ```pwsh-session
-    PS> uv venv --seed
+    PS> uv venv
     PS> uv pip install numpy
     PS> uv pip install marimo
     PS> .venv\Scripts\marimo edit

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -1,0 +1,91 @@
+---
+title: Using uv with marimo
+description:
+  A complete guide to using uv with marimo notebooks for interactive computing, script
+  execution, and data apps.
+---
+
+# Using uv with marimo
+
+[marimo](https://github.com/marimo-team/marimo) is an open-source Python notebook that blends
+interactive computing with the reproducibility and reusability of traditional software, letting you
+version with Git, run as scripts, and share as apps. Because marimo notebooks are stored as pure
+Python scripts, they are able to integrate tightly with uv.
+
+You can readily use marimo in uv projects, as standalone scripts that contain their own
+dependencies, in non-project environments, and as a standalone tool.
+
+## Using marimo within a project
+
+If you're working within a [project](../../concepts/projects/index.md), you can start a marimo
+notebook with access to the project's virtual environment with the following command (assuming marimo is
+a project dependency):
+
+```console
+$ uv run marimo edit my_notebook.py
+```
+
+To make additional packages available to your notebook, either add them to your project with `uv
+add`, or use marimo's built-in package installation UI, which will invoke `uv add` on your
+behalf.
+
+If marimo is not a project dependency, you can still run a notebook with
+
+```console
+$ uv run --with marimo marimo edit my_notebook.py
+```
+
+which will let you import your project's modules. However, packages installed via marimo's
+UI when running in this way will not be added to your project, and may
+disappear on subsequent marimo invocations.
+
+## Using marimo with inline script metadata
+
+Because marimo notebooks are stored as Python scripts, they can encapsulate their own dependencies
+using inline script metadata, using uv's [support for scripts](../../guides/scripts.md). For
+example:
+
+```console
+$ uv add --script my_notebook.py numpy
+```
+
+To run a notebook containing script metadata, use
+
+```console
+$ uvx marimo edit --sandbox my_notebook.py
+```
+
+and marimo will automatically use uv to start your notebook in an isolated virtual environment with
+your script's dependencies. Packages installed from the marimo UI will automatically be added to
+the notebook's script metadata.
+
+## Using marimo in a non-project environment
+
+To run marimo in a virtual environment that isn't associated with a
+[project](../../concepts/projects/index.md), add marimo to the environment directly:
+
+=== "macOS and Linux"
+
+    ```console
+    $ uv venv --seed
+    $ uv pip install numpy
+    $ uv pip install marimo
+    $ .venv/bin/marimo edit
+    ```
+
+=== "Windows"
+
+    ```pwsh-session
+    PS> uv venv --seed
+    PS> uv pip install numpy
+    PS> uv pip install marimo
+    PS> .venv\Scripts\marimo edit
+    ```
+
+From here, `import numpy` will work within the notebook, and marimo's UI installer will add
+packages to the environment with `uv pip install` on your behalf.
+
+## Using marimo as a standalone tool
+
+For adhoc access to marimo notebooks, start a marimo server at any time, in an isolated environment, with
+`uvx marimo edit`.

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -85,6 +85,14 @@ To run marimo in a virtual environment that isn't associated with a
 From here, `import numpy` will work within the notebook, and marimo's UI installer will add
 packages to the environment with `uv pip install` on your behalf.
 
+## Running marimo notebooks as scripts
+
+Run your notebooks as scripts with
+
+```console
+$ uv run my_notebook.py
+```
+
 ## Using marimo as a standalone tool
 
 For adhoc access to marimo notebooks, start a marimo server at any time, in an isolated environment, with

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -12,12 +12,12 @@ interactive computing with the reproducibility and reusability of traditional so
 version with Git, run as scripts, and share as apps. Because marimo notebooks are stored as pure
 Python scripts, they are able to integrate tightly with uv.
 
-You can readily use marimo as a standalone tool, as scripts that contain their own dependencies, in
+You can readily use marimo as a standalone tool, as self-contained scripts, in
 projects, and in non-project environments.
 
 ## Using marimo as a standalone tool
 
-For adhoc access to marimo notebooks, start a marimo server at any time in an isolated environment
+For ad-hoc access to marimo notebooks, start a marimo server at any time in an isolated environment
 with:
 
 ```console
@@ -39,13 +39,13 @@ using inline script metadata, via uv's [support for scripts](../../guides/script
 $ uv add --script my_notebook.py numpy
 ```
 
-To run a notebook containing script metadata, use
+To run a notebook containing inline script metadata, use
 
 ```console
 $ uvx marimo edit --sandbox my_notebook.py
 ```
 
-and marimo will automatically use uv to start your notebook in an isolated virtual environment with
+marimo will automatically use uv to start your notebook in an isolated virtual environment with
 your script's dependencies. Packages installed from the marimo UI will automatically be added to the
 notebook's script metadata.
 

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -12,13 +12,53 @@ interactive computing with the reproducibility and reusability of traditional so
 version with Git, run as scripts, and share as apps. Because marimo notebooks are stored as pure
 Python scripts, they are able to integrate tightly with uv.
 
-You can readily use marimo in uv projects, as standalone scripts that contain their own
-dependencies, in non-project environments, and as a standalone tool.
+You can readily use marimo as a standalone tool, as scripts that contain their own
+dependencies, in projects, and in non-project environments.
+
+## Using marimo as a standalone tool
+
+For adhoc access to marimo notebooks, start a marimo server at any time in an isolated environment with:
+
+```console
+$ uvx marimo edit
+```
+
+Start a specific notebook with
+
+```console
+$ uvx marimo edit my_notebook.py
+```
+
+## Using marimo with inline script metadata
+
+Because marimo notebooks are stored as Python scripts, they can encapsulate their own dependencies
+using inline script metadata, via uv's [support for scripts](../../guides/scripts.md). For
+example:
+
+```console
+$ uv add --script my_notebook.py numpy
+```
+
+To run a notebook containing script metadata, use
+
+```console
+$ uvx marimo edit --sandbox my_notebook.py
+```
+
+and marimo will automatically use uv to start your notebook in an isolated virtual environment with
+your script's dependencies. Packages installed from the marimo UI will automatically be added to
+the notebook's script metadata.
+
+You can optionally run these notebooks as scripts with
+
+```console
+$ uv run my_notebook.py
+```
 
 ## Using marimo within a project
 
 If you're working within a [project](../../concepts/projects/index.md), you can start a marimo
-notebook with access to the project's virtual environment with the following command (assuming marimo is
+notebook with access to the project's virtual environment via the following command (assuming marimo is
 a project dependency):
 
 ```console
@@ -38,26 +78,6 @@ $ uv run --with marimo marimo edit my_notebook.py
 which will let you import your project's modules. However, packages installed via marimo's
 UI when running in this way will not be added to your project, and may
 disappear on subsequent marimo invocations.
-
-## Using marimo with inline script metadata
-
-Because marimo notebooks are stored as Python scripts, they can encapsulate their own dependencies
-using inline script metadata, using uv's [support for scripts](../../guides/scripts.md). For
-example:
-
-```console
-$ uv add --script my_notebook.py numpy
-```
-
-To run a notebook containing script metadata, use
-
-```console
-$ uvx marimo edit --sandbox my_notebook.py
-```
-
-and marimo will automatically use uv to start your notebook in an isolated virtual environment with
-your script's dependencies. Packages installed from the marimo UI will automatically be added to
-the notebook's script metadata.
 
 ## Using marimo in a non-project environment
 
@@ -92,8 +112,3 @@ Run your notebooks as scripts with
 ```console
 $ uv run my_notebook.py
 ```
-
-## Using marimo as a standalone tool
-
-For adhoc access to marimo notebooks, start a marimo server at any time, in an isolated environment, with
-`uvx marimo edit`.

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -12,8 +12,8 @@ interactive computing with the reproducibility and reusability of traditional so
 version with Git, run as scripts, and share as apps. Because marimo notebooks are stored as pure
 Python scripts, they are able to integrate tightly with uv.
 
-You can readily use marimo as a standalone tool, as self-contained scripts, in
-projects, and in non-project environments.
+You can readily use marimo as a standalone tool, as self-contained scripts, in projects, and in
+non-project environments.
 
 ## Using marimo as a standalone tool
 
@@ -24,7 +24,7 @@ with:
 $ uvx marimo edit
 ```
 
-Start a specific notebook with
+Start a specific notebook with:
 
 ```console
 $ uvx marimo edit my_notebook.py
@@ -33,23 +33,24 @@ $ uvx marimo edit my_notebook.py
 ## Using marimo with inline script metadata
 
 Because marimo notebooks are stored as Python scripts, they can encapsulate their own dependencies
-using inline script metadata, via uv's [support for scripts](../../guides/scripts.md). For example:
+using inline script metadata, via uv's [support for scripts](../../guides/scripts.md). For example,
+to add `numpy` as a dependency to your notebook, use this command:
 
 ```console
 $ uv add --script my_notebook.py numpy
 ```
 
-To run a notebook containing inline script metadata, use
+To interactively edit a notebook containing inline script metadata, use:
 
 ```console
 $ uvx marimo edit --sandbox my_notebook.py
 ```
 
-marimo will automatically use uv to start your notebook in an isolated virtual environment with
-your script's dependencies. Packages installed from the marimo UI will automatically be added to the
+marimo will automatically use uv to start your notebook in an isolated virtual environment with your
+script's dependencies. Packages installed from the marimo UI will automatically be added to the
 notebook's script metadata.
 
-You can optionally run these notebooks as scripts with
+You can optionally run these notebooks as Python scripts, without opening an interactive session:
 
 ```console
 $ uv run my_notebook.py
@@ -69,46 +70,39 @@ To make additional packages available to your notebook, either add them to your 
 `uv add`, or use marimo's built-in package installation UI, which will invoke `uv add` on your
 behalf.
 
-If marimo is not a project dependency, you can still run a notebook with
+If marimo is not a project dependency, you can still run a notebook with the following command:
 
 ```console
 $ uv run --with marimo marimo edit my_notebook.py
 ```
 
-which will let you import your project's modules. However, packages installed via marimo's UI when
-running in this way will not be added to your project, and may disappear on subsequent marimo
-invocations.
+This will let you import your project's modules while editing your notebook. However, packages
+installed via marimo's UI when running in this way will not be added to your project, and may
+disappear on subsequent marimo invocations.
 
 ## Using marimo in a non-project environment
 
 To run marimo in a virtual environment that isn't associated with a
 [project](../../concepts/projects/index.md), add marimo to the environment directly:
 
-=== "macOS and Linux"
-
-    ```console
-    $ uv venv
-    $ uv pip install numpy
-    $ uv pip install marimo
-    $ .venv/bin/marimo edit
-    ```
-
-=== "Windows"
-
-    ```pwsh-session
-    PS> uv venv
-    PS> uv pip install numpy
-    PS> uv pip install marimo
-    PS> .venv\Scripts\marimo edit
-    ```
+```console
+$ uv venv
+$ uv pip install numpy
+$ uv pip install marimo
+$ uv run marimo edit
+```
 
 From here, `import numpy` will work within the notebook, and marimo's UI installer will add packages
 to the environment with `uv pip install` on your behalf.
 
 ## Running marimo notebooks as scripts
 
-Run your notebooks as scripts with
+Regardless of how your dependencies are managed (with inline script metadata, within a project, or
+with a non-project environment), you can run marimo notebooks as scripts with:
 
 ```console
 $ uv run my_notebook.py
 ```
+
+This executes your notebook as a Python script, without opening an interactive session in your
+browser.

--- a/docs/guides/integration/marimo.md
+++ b/docs/guides/integration/marimo.md
@@ -1,8 +1,8 @@
 ---
 title: Using uv with marimo
 description:
-  A complete guide to using uv with marimo notebooks for interactive computing, script
-  execution, and data apps.
+  A complete guide to using uv with marimo notebooks for interactive computing, script execution,
+  and data apps.
 ---
 
 # Using uv with marimo
@@ -12,12 +12,13 @@ interactive computing with the reproducibility and reusability of traditional so
 version with Git, run as scripts, and share as apps. Because marimo notebooks are stored as pure
 Python scripts, they are able to integrate tightly with uv.
 
-You can readily use marimo as a standalone tool, as scripts that contain their own
-dependencies, in projects, and in non-project environments.
+You can readily use marimo as a standalone tool, as scripts that contain their own dependencies, in
+projects, and in non-project environments.
 
 ## Using marimo as a standalone tool
 
-For adhoc access to marimo notebooks, start a marimo server at any time in an isolated environment with:
+For adhoc access to marimo notebooks, start a marimo server at any time in an isolated environment
+with:
 
 ```console
 $ uvx marimo edit
@@ -32,8 +33,7 @@ $ uvx marimo edit my_notebook.py
 ## Using marimo with inline script metadata
 
 Because marimo notebooks are stored as Python scripts, they can encapsulate their own dependencies
-using inline script metadata, via uv's [support for scripts](../../guides/scripts.md). For
-example:
+using inline script metadata, via uv's [support for scripts](../../guides/scripts.md). For example:
 
 ```console
 $ uv add --script my_notebook.py numpy
@@ -46,8 +46,8 @@ $ uvx marimo edit --sandbox my_notebook.py
 ```
 
 and marimo will automatically use uv to start your notebook in an isolated virtual environment with
-your script's dependencies. Packages installed from the marimo UI will automatically be added to
-the notebook's script metadata.
+your script's dependencies. Packages installed from the marimo UI will automatically be added to the
+notebook's script metadata.
 
 You can optionally run these notebooks as scripts with
 
@@ -58,15 +58,15 @@ $ uv run my_notebook.py
 ## Using marimo within a project
 
 If you're working within a [project](../../concepts/projects/index.md), you can start a marimo
-notebook with access to the project's virtual environment via the following command (assuming marimo is
-a project dependency):
+notebook with access to the project's virtual environment via the following command (assuming marimo
+is a project dependency):
 
 ```console
 $ uv run marimo edit my_notebook.py
 ```
 
-To make additional packages available to your notebook, either add them to your project with `uv
-add`, or use marimo's built-in package installation UI, which will invoke `uv add` on your
+To make additional packages available to your notebook, either add them to your project with
+`uv add`, or use marimo's built-in package installation UI, which will invoke `uv add` on your
 behalf.
 
 If marimo is not a project dependency, you can still run a notebook with
@@ -75,9 +75,9 @@ If marimo is not a project dependency, you can still run a notebook with
 $ uv run --with marimo marimo edit my_notebook.py
 ```
 
-which will let you import your project's modules. However, packages installed via marimo's
-UI when running in this way will not be added to your project, and may
-disappear on subsequent marimo invocations.
+which will let you import your project's modules. However, packages installed via marimo's UI when
+running in this way will not be added to your project, and may disappear on subsequent marimo
+invocations.
 
 ## Using marimo in a non-project environment
 
@@ -102,8 +102,8 @@ To run marimo in a virtual environment that isn't associated with a
     PS> .venv\Scripts\marimo edit
     ```
 
-From here, `import numpy` will work within the notebook, and marimo's UI installer will add
-packages to the environment with `uv pip install` on your behalf.
+From here, `import numpy` will work within the notebook, and marimo's UI installer will add packages
+to the environment with `uv pip install` on your behalf.
 
 ## Running marimo notebooks as scripts
 

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -109,6 +109,7 @@ nav:
           - guides/integration/index.md
           - Docker: guides/integration/docker.md
           - Jupyter: guides/integration/jupyter.md
+          - marimo: guides/integration/marimo.md
           - GitHub Actions: guides/integration/github.md
           - GitLab CI/CD: guides/integration/gitlab.md
           - Pre-commit: guides/integration/pre-commit.md


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change adds a new integration guide, on using uv with marimo notebooks. It is similar to but simpler than the existing Jupyter guide, since marimo stores notebooks as Python files and also integrates tightly with uv for package management.

The guide showcases four ways of using uv with marimo:

1. marimo as a standalone tool (`uvx`)
2. managing inline script metadata (an alternative to Jupyter kernels, marimo has no concept of kernels)
3. in project environments
4. in non-project environments

## Test Plan

N/A as this is a docs-only change. 
