### PR TITLE
Add an `ArchMode` to filter displayed architectures in `uv python list`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2799,7 +2799,8 @@ mod tests {
                 arch: None,
                 os: None,
                 libc: None,
-                prereleases: None
+                prereleases: None,
+                arch_mode: None,
             })
         );
         assert_eq!(
@@ -2818,7 +2819,8 @@ mod tests {
                 }),
                 os: Some(Os(target_lexicon::OperatingSystem::Darwin(None))),
                 libc: Some(Libc::None),
-                prereleases: None
+                prereleases: None,
+                arch_mode: None,
             })
         );
         assert_eq!(
@@ -2834,7 +2836,8 @@ mod tests {
                 arch: None,
                 os: None,
                 libc: None,
-                prereleases: None
+                prereleases: None,
+                arch_mode: None,
             })
         );
         assert_eq!(
@@ -2853,7 +2856,8 @@ mod tests {
                 }),
                 os: None,
                 libc: None,
-                prereleases: None
+                prereleases: None,
+                arch_mode: None,
             })
         );
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -17,7 +17,7 @@ use uv_python::downloads::{self, DownloadResult, ManagedPythonDownload, PythonDo
 use uv_python::managed::{
     ManagedPythonInstallation, ManagedPythonInstallations, python_executable_dir,
 };
-use uv_python::platform::{Arch, Libc};
+use uv_python::platform::{Arch, ArchMode, Libc};
 use uv_python::{
     PythonDownloads, PythonInstallationKey, PythonRequest, PythonVersionFile,
     VersionFileDiscoveryOptions, VersionFilePreference,
@@ -51,8 +51,7 @@ impl InstallRequest {
                     "`{}` is not a valid Python download request; see `uv help python` for supported formats and `uv python list --only-downloads` for available versions",
                     request.to_canonical_string()
                 )
-            })?
-            .fill()?;
+            })?.with_arch_mode(ArchMode::BestNative).fill()?;
 
         // Find a matching download
         let download =

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use std::fmt::Write;
 use uv_cli::PythonListFormat;
 use uv_pep440::Version;
+use uv_python::platform::ArchMode;
 
 use anyhow::Result;
 use itertools::Either;
@@ -80,7 +81,10 @@ pub(crate) async fn list(
             PythonListKinds::Downloads => Some(if all_platforms {
                 base_download_request
             } else {
-                base_download_request.fill_platform()?
+                base_download_request
+                    .fill_platform()?
+                    // Only show the best, native architecture by default
+                    .with_arch_mode(ArchMode::BestNative)
             }),
             PythonListKinds::Default => {
                 if python_downloads.is_automatic() {
@@ -89,7 +93,11 @@ pub(crate) async fn list(
                     } else if all_arches {
                         base_download_request.fill_platform()?.with_any_arch()
                     } else {
-                        base_download_request.fill_platform()?
+                        base_download_request
+                            .fill_platform()?
+                            // Only show the best, native architecture by default
+                            // TODO(zanieb): We should expose this option to the user
+                            .with_arch_mode(ArchMode::BestNative)
                     })
                 } else {
                     // If fetching is not automatic, then don't show downloads as available by default


### PR DESCRIPTION
I'm trying to unblock 

- https://github.com/astral-sh/uv/pull/13722
- https://github.com/astral-sh/uv/pull/13475

which currently fail due to showing more downloads in `uv python list` and selecting non-native installs during `uv python install`. I don't really want to show non-native downloads without opt-in (it'll just be too noisy), and we should prefer native installs, so this pull request adds a change to apply some filtering. This should have no effect on the existing behavior, but will resolve the failing CI in those pull requests.

Note, the modes do not yet capture the semantics we'll need for arm64 Windows, but I'll try to figure that out afterwards.

This is a little forward-looking, in that it adds support for filtering based on architecture variants as needed for

- #9788 

That pull request is currently blocked on allowing the user to express they only want to use `x86-64-v1` even if they have a `v3` compatible machine. I expect the spelling of the options for "best" and "compatible" native architectures to change a little.

I don't make this user-facing here, but we probably will in a subsequent change.