### PR TITLE
define `UV_USE_ACTIVE_ENVIRONMENT` as an alternative to `--active`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -562,7 +562,7 @@ pub struct VersionArgs {
     ///
     /// If the project virtual environment is active or no virtual environment is active, this has
     /// no effect.
-    #[arg(long, overrides_with = "no_active")]
+    #[arg(long, env = EnvVars::UV_USE_ACTIVE_ENVIRONMENT, overrides_with = "no_active")]
     pub active: bool,
 
     /// Prefer project's virtual environment over an active environment.
@@ -3057,7 +3057,7 @@ pub struct RunArgs {
     ///
     /// If the project virtual environment is active or no virtual environment is active, this has
     /// no effect.
-    #[arg(long, overrides_with = "no_active")]
+    #[arg(long, env = EnvVars::UV_USE_ACTIVE_ENVIRONMENT, overrides_with = "no_active")]
     pub active: bool,
 
     /// Prefer project's virtual environment over an active environment.
@@ -3284,7 +3284,7 @@ pub struct SyncArgs {
     /// Instead of creating or updating the virtual environment for the project or script, the
     /// active virtual environment will be preferred, if the `VIRTUAL_ENV` environment variable is
     /// set.
-    #[arg(long, overrides_with = "no_active")]
+    #[arg(long, env = EnvVars::UV_USE_ACTIVE_ENVIRONMENT, overrides_with = "no_active")]
     pub active: bool,
 
     /// Prefer project's virtual environment over an active environment.
@@ -3613,7 +3613,7 @@ pub struct AddArgs {
     ///
     /// If the project virtual environment is active or no virtual environment is active, this has
     /// no effect.
-    #[arg(long, overrides_with = "no_active")]
+    #[arg(long, env = EnvVars::UV_USE_ACTIVE_ENVIRONMENT, overrides_with = "no_active")]
     pub active: bool,
 
     /// Prefer project's virtual environment over an active environment.
@@ -3692,7 +3692,7 @@ pub struct RemoveArgs {
     ///
     /// If the project virtual environment is active or no virtual environment is active, this has
     /// no effect.
-    #[arg(long, overrides_with = "no_active")]
+    #[arg(long, env = EnvVars::UV_USE_ACTIVE_ENVIRONMENT, overrides_with = "no_active")]
     pub active: bool,
 
     /// Prefer project's virtual environment over an active environment.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -256,6 +256,8 @@ impl EnvVars {
     /// for more details.
     pub const UV_PROJECT_ENVIRONMENT: &'static str = "UV_PROJECT_ENVIRONMENT";
 
+    pub const UV_USE_ACTIVE_ENVIRONMENT: &'static str = "UV_USE_ACTIVE_ENVIRONMENT";
+
     /// Specifies the directory to place links to installed, managed Python executables.
     pub const UV_PYTHON_BIN_DIR: &'static str = "UV_PYTHON_BIN_DIR";
 

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -4186,6 +4186,19 @@ fn sync_active_project_environment() -> Result<()> {
     Audited 1 package in [TIME]
     "###);
 
+    // UV_USE_ACTIVE_ENVIRONMENT is an alias for --active, so this also doesn't warn.
+    uv_snapshot!(context.filters(), context.sync()
+        .env(EnvVars::VIRTUAL_ENV, "foo")
+        .env(EnvVars::UV_USE_ACTIVE_ENVIRONMENT, "true"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Audited 1 package in [TIME]
+    "###);
+
     // Setting both the `VIRTUAL_ENV` and `UV_PROJECT_ENVIRONMENT` is fine if they agree
     uv_snapshot!(context.filters(), context.sync()
         .arg("--active")


### PR DESCRIPTION
We considered `UV_PROJECT_ENVIRONMENT=active`, but that env var doesn't affect script environments, and we probably want this to work the same way for both.

Closes https://github.com/astral-sh/uv/issues/11273.