### PR TITLE
Disallow arm64 Windows Python installs for now

### DIFF
--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -109,6 +109,13 @@ impl Arch {
     /// architecture is transparently emulated or is a microarchitecture with worse performance
     /// characteristics.
     pub(crate) fn supports(self, other: Self) -> bool {
+        // Short-term override: There aren't many Windows ARM64 wheels
+        // yet, so we want users to fall back to x86-64 by default. See
+        // https://github.com/astral-sh/uv/issues/12906
+        if cfg!(windows) && matches!(other.family, target_lexicon::Architecture::Aarch64(_)) {
+            return false;
+        }
+
         if self == other {
             return true;
         }


### PR DESCRIPTION
See #12906 and astral-sh/python-build-standalone#387 - as soon as we start shipping arm64 Windows Python builds in python-build-standalone, uv is going to start discovering them, and there aren't enough arm64 Windows wheels for that to make sense as a default yet. As a very minimal stopgap, consider those builds incompatible.

No functional change expected at the moment, but this unblocks python-build-standalone shipping arm64 Windows Python builds and lets us manage the transition in some better way like a configuration knob.