### PR TITLE
Only show the first match per platform (and architecture) by default in `uv python list` 

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -169,7 +169,7 @@ pub(crate) async fn list(
 
         // Only show the latest patch version for each download unless all were requested.
         //
-        // We toggle off platforms/arches based on all_platforms/all_arches because
+        // We toggle off platforms/arches based unless all_platforms/all_arches because
         // we want to only show the "best" option for each version by default, even
         // if e.g. the x86_32 build would also work on x86_64.
         if !matches!(kind, Kind::System) {

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -167,16 +167,20 @@ pub(crate) async fn list(
             }
         }
 
-        // Only show the latest patch version for each download unless all were requested
+        // Only show the latest patch version for each download unless all were requested.
+        //
+        // We toggle off platforms/arches based on all_platforms/all_arches because
+        // we want to only show the "best" option for each version by default, even
+        // if e.g. the x86_32 build would also work on x86_64.
         if !matches!(kind, Kind::System) {
             if let [major, minor, ..] = *key.version().release() {
                 if !seen_minor.insert((
-                    *key.os(),
+                    all_platforms.then_some(*key.os()),
                     major,
                     minor,
                     key.variant(),
                     key.implementation(),
-                    *key.arch(),
+                    all_arches.then_some(*key.arch()),
                     *key.libc(),
                 )) {
                     if matches!(kind, Kind::Download) && !all_versions {
@@ -186,13 +190,13 @@ pub(crate) async fn list(
             }
             if let [major, minor, patch] = *key.version().release() {
                 if !seen_patch.insert((
-                    *key.os(),
+                    all_platforms.then_some(*key.os()),
                     major,
                     minor,
                     patch,
                     key.variant(),
                     key.implementation(),
-                    *key.arch(),
+                    all_arches.then_some(*key.arch()),
                     key.libc(),
                 )) {
                     if matches!(kind, Kind::Download) {


### PR DESCRIPTION
This is an alternative to #13701 