### PR TITLE
Allow discovery of x86-64 managed Python builds on macOS

### DIFF
--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -143,7 +143,12 @@ impl Arch {
         // TODO: Implement `variant` support checks
 
         // Windows ARM64 runs emulated x86_64 binaries transparently
-        if cfg!(windows) && matches!(self.family, target_lexicon::Architecture::Aarch64(_)) {
+        // Similarly, macOS aarch64 runs emulated x86_64 binaries transparently if you have Rosetta
+        // installed. We don't try to be clever and check if that's the case here, we just assume
+        // that if x86_64 distributions are available, they're usable.
+        if (cfg!(windows) || cfg!(target_os = "macos"))
+            && matches!(self.family, target_lexicon::Architecture::Aarch64(_))
+        {
             return other.family == target_lexicon::Architecture::X86_64;
         }
 


### PR DESCRIPTION
Replacement for https://github.com/astral-sh/uv/pull/13474 (clobbered by a changed base)

Once these are explicitly installed, they should be discoverable and usable. Currently, they are not.