### PR TITLE
Differentiate between implicit vs explicit architecture requests

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2723,7 +2723,7 @@ mod tests {
 
     use crate::{
         discovery::{PythonRequest, VersionRequest},
-        downloads::PythonDownloadRequest,
+        downloads::{ArchRequest, PythonDownloadRequest},
         implementation::ImplementationName,
         platform::{Arch, Libc, Os},
     };
@@ -2813,10 +2813,10 @@ mod tests {
                     PythonVariant::Default
                 )),
                 implementation: Some(ImplementationName::CPython),
-                arch: Some(Arch {
+                arch: Some(ArchRequest::Explicit(Arch {
                     family: Architecture::Aarch64(Aarch64Architecture::Aarch64),
                     variant: None
-                }),
+                })),
                 os: Some(Os(target_lexicon::OperatingSystem::Darwin(None))),
                 libc: Some(Libc::None),
                 prereleases: None
@@ -2848,10 +2848,10 @@ mod tests {
                     PythonVariant::Default
                 )),
                 implementation: None,
-                arch: Some(Arch {
+                arch: Some(ArchRequest::Explicit(Arch {
                     family: Architecture::Aarch64(Aarch64Architecture::Aarch64),
                     variant: None
-                }),
+                })),
                 os: None,
                 libc: None,
                 prereleases: None

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -61,7 +61,9 @@ impl InstallRequest {
                 Ok(download) => download,
                 Err(downloads::Error::NoDownloadFound(request))
                     if request.libc().is_some_and(Libc::is_musl)
-                        && request.arch().is_some_and(Arch::is_arm) =>
+                        && request
+                            .arch()
+                            .is_some_and(|arch| Arch::is_arm(&arch.inner())) =>
                 {
                     return Err(anyhow::anyhow!(
                         "uv does not yet provide musl Python distributions on aarch64."

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -97,15 +97,14 @@ fn python_find() {
     let arch = Arch::from_env();
 
     uv_snapshot!(context.filters(), context.python_find()
-    .arg(format!("cpython-3.12-{os}-{arch}"))
-    , @r###"
+        .arg(format!("cpython-3.12-{os}-{arch}")), @r"
     success: true
     exit_code: 0
     ----- stdout -----
     [PYTHON-3.12]
 
     ----- stderr -----
-    "###);
+    ");
 
     // Request PyPy (which should be missing)
     uv_snapshot!(context.filters(), context.python_find().arg("pypy"), @r"


### PR DESCRIPTION
In https://github.com/astral-sh/uv/pull/13721#issuecomment-2920530601 I presumed that all the installation problems in https://github.com/astral-sh/uv/pull/13722 were solved by https://github.com/astral-sh/uv/pull/13709 but they were not because we don't differentiate between implicit and explicit architecture requests so a request for `aarch64` is considered satisfied by an existing `x86-64` installation even if the user explicitly requested that architecture.

Now, we track if it was explicit or implicit, requiring an exact match in the former case, and a `supports` in the latter.

We considered doing this for other items in the request, like the operating system but we don't have a `supports()` concept there. It might make sense for libc in the future.