### PR TITLE
Propagate credentials to files on devpi indexes ending in `/+simple`

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -79,7 +79,8 @@ impl IndexUrl {
             segment => segment,
         };
 
-        if !last.eq_ignore_ascii_case("simple") {
+        // We also handle `/+simple` as it's used in devpi
+        if !(last.eq_ignore_ascii_case("simple") || last.eq_ignore_ascii_case("+simple")) {
             return None;
         }
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/13737

Not much to say here — devpi is common enough that we should support their weird `/+simple` URL format.