### PR TITLE
avoid fetching an exact, cached commit, even if it isn't locked

### DIFF
--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -12,6 +12,7 @@ use tracing::debug;
 use uv_cache_key::{RepositoryUrl, cache_digest};
 use uv_fs::LockedFile;
 use uv_git_types::{GitHubRepository, GitOid, GitReference, GitUrl};
+use uv_static::EnvVars;
 use uv_version::version;
 
 use crate::{Fetch, GitSource, Reporter};
@@ -54,6 +55,10 @@ impl GitResolver {
         url: &GitUrl,
         client: ClientWithMiddleware,
     ) -> Result<Option<GitOid>, GitResolverError> {
+        if std::env::var_os(EnvVars::UV_NO_GITHUB_FAST_PATH).is_some() {
+            return Ok(None);
+        }
+
         let reference = RepositoryReference::from(url);
 
         // If the URL is already precise, return it.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -727,4 +727,7 @@ impl EnvVars {
 
     /// Equivalent to the `--project` command-line argument.
     pub const UV_PROJECT: &'static str = "UV_PROJECT";
+
+    /// Disable GitHub-specific requests that allow uv to skip `git fetch` in some circumstances.
+    pub const UV_NO_GITHUB_FAST_PATH: &'static str = "UV_NO_GITHUB_FAST_PATH";
 }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2111,6 +2111,55 @@ fn install_git_public_https_missing_commit() {
     "###);
 }
 
+#[test]
+#[cfg(feature = "git")]
+fn install_git_public_https_exact_commit() {
+    let context = TestContext::new(DEFAULT_PYTHON_VERSION);
+
+    // `uv pip install` a Git dependency with an exact commit.
+    uv_snapshot!(context.filters(), context.pip_install()
+        // Normally Updating/Updated notifications are suppressed in tests (because their order can
+        // be nondeterministic), but here that's exactly what we want to test for.
+        .env_remove(EnvVars::UV_TEST_NO_CLI_PROGRESS)
+        // Whether fetching happens during resolution or later depends on whether the GitHub fast
+        // path is taken, which isn't reliable. Disable it, so that we get a stable order of events
+        // here.
+        .env(EnvVars::UV_NO_GITHUB_FAST_PATH, "true")
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389")
+        , @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+       Updating https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+        Updated https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    Resolved 1 package in [TIME]
+       Building uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389
+          Built uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    ");
+
+    // Run the exact same command again, with that commit now in cache.
+    uv_snapshot!(context.filters(), context.pip_install()
+        .env_remove(EnvVars::UV_TEST_NO_CLI_PROGRESS)
+        .env(EnvVars::UV_NO_GITHUB_FAST_PATH, "true")
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389")
+        , @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+       Updating https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+        Updated https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    Resolved 1 package in [TIME]
+    Audited 1 package in [TIME]
+    ");
+}
+
 /// Install a package from a private GitHub repository using a PAT
 #[test]
 #[cfg(all(not(windows), feature = "git"))]

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2153,8 +2153,6 @@ fn install_git_public_https_exact_commit() {
     ----- stdout -----
 
     ----- stderr -----
-       Updating https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
-        Updated https://github.com/astral-test/uv-public-pypackage (b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     Resolved 1 package in [TIME]
     Audited 1 package in [TIME]
     ");

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -235,6 +235,10 @@ non-editable
 
 Ignore `.env` files when executing `uv run` commands.
 
+### `UV_NO_GITHUB_FAST_PATH`
+
+Disable GitHub-specific requests that allow uv to skip `git fetch` in some circumstances.
+
 ### `UV_NO_INSTALLER_METADATA`
 
 Skip writing `uv` installer metadata files (e.g., `INSTALLER`, `REQUESTED`, and `direct_url.json`) to site-packages `.dist-info` directories.


### PR DESCRIPTION
This is ~a rough draft of~ one approach we might take to fixing https://github.com/astral-sh/uv/issues/13513

Here's a complete repro of the bug (arguably) in that ticket:

```
$ cd `mktemp -d`
$ cat << EOF > requirements.txt                                                                           
feedparser @ git+https://github.com/kurtmckee/feedparser@6c2a412a1569303c6c02d82ef38c08e19f81315e
EOF
$ uv venv
...
$ uv pip install -r requirements.txt 2>&1 | cat
   Updating https://github.com/kurtmckee/feedparser (6c2a412a1569303c6c02d82ef38c08e19f81315e)
    Updated https://github.com/kurtmckee/feedparser (6c2a412a1569303c6c02d82ef38c08e19f81315e)
Resolved 7 packages in 12ms
Installed 7 packages in 7ms
...
$ uv pip install -r requirements.txt 2>&1 | cat
   Updating https://github.com/kurtmckee/feedparser (6c2a412a1569303c6c02d82ef38c08e19f81315e)
    Updated https://github.com/kurtmckee/feedparser (6c2a412a1569303c6c02d82ef38c08e19f81315e)
Resolved 7 packages in 18ms
Audited 7 packages in 0.02ms
```

The problem is that we keep fetching the repo every time, even though this commit is definitely in cache. With the changes in this PR, the extra fetch is gone:

```
$ uv pip install -r requirements.txt 2>&1 | cat
Resolved 7 packages in 15ms
Audited 7 packages in 0.07ms
```

This ~draft~ PR notices that the ref we're trying to fetch looks exactly like a commit, and it checks (`rev-parse`) whether that commit is already present in the cached repo and interprets it as a locked (`precise`) ref if so. ~The implementation is kind of sloppy as is, and it should probably be factored into smaller functions out and also tested,~ but I need feedback on the overall approach.

Another approach we could take here could be to change our interpretation of these looks-like-a-commit refs such that we _always_ assume they're commits at parse time. (In other words, mark the with `precise` OIDs as soon as we parse them.) If we did that, we'd probably want to add checks to make sure that we catch it if that assumption is ever violated. It looks like we used to behave more like this, but then we [replaced that with the current behavior](https://github.com/astral-sh/uv/pull/10803), and if we want to go this way I'll need to make sure I understand exactly why we did that.

@ibraheemdev would you have time to take a look at this? Also cc @charliermarsh and @zanieb.