### PR TITLE
Update redirect implementation to handle more cases and be more testable

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -151,6 +151,18 @@ impl<'a> RegistryClientBuilder<'a> {
         self
     }
 
+    /// Allows credentials to be propagated on cross-origin redirects.
+    ///
+    /// WARNING: This should only be available for tests. In production code, propagating credentials
+    /// during cross-origin redirects can lead to security vulnerabilities including credential
+    /// leakage to untrusted domains.
+    #[cfg(test)]
+    #[must_use]
+    pub fn allow_cross_origin_credentials(mut self) -> Self {
+        self.base_client_builder = self.base_client_builder.allow_cross_origin_credentials();
+        self
+    }
+
     pub fn build(self) -> RegistryClient {
         // Build a base client
         let builder = self
@@ -1219,6 +1231,7 @@ impl Connectivity {
 mod tests {
     use std::str::FromStr;
 
+    use url::Url;
     use uv_normalize::PackageName;
     use uv_pypi_types::{JoinRelativeError, SimpleJson};
     use uv_redacted::DisplaySafeUrl;
@@ -1263,7 +1276,7 @@ mod tests {
         // Configure the redirect server to respond with a 302 to the auth server
         Mock::given(method("GET"))
             .respond_with(
-                ResponseTemplate::new(302).insert_header("Location", format!("{}", &auth_base_url)),
+                ResponseTemplate::new(302).insert_header("Location", format!("{auth_base_url}")),
             )
             .mount(&redirect_server)
             .await;
@@ -1271,7 +1284,9 @@ mod tests {
         let redirect_server_url = DisplaySafeUrl::parse(&redirect_server.uri())?;
 
         let cache = Cache::temp()?;
-        let registry_client = RegistryClientBuilder::new(cache).build();
+        let registry_client = RegistryClientBuilder::new(cache)
+            .allow_cross_origin_credentials()
+            .build();
         let client = registry_client.cached_client().uncached();
 
         assert_eq!(
@@ -1292,7 +1307,7 @@ mod tests {
         assert_eq!(
             client
                 .for_host(&redirect_server_url)
-                .get(format!("{url}"))
+                .get(Url::from(url))
                 .send()
                 .await?
                 .status(),
@@ -1329,7 +1344,9 @@ mod tests {
         let redirect_server_url = DisplaySafeUrl::parse(&redirect_server.uri())?.join("foo/")?;
 
         let cache = Cache::temp()?;
-        let registry_client = RegistryClientBuilder::new(cache).build();
+        let registry_client = RegistryClientBuilder::new(cache)
+            .allow_cross_origin_credentials()
+            .build();
         let client = registry_client.cached_client().uncached();
 
         let mut url = redirect_server_url.clone();
@@ -1339,7 +1356,7 @@ mod tests {
         assert_eq!(
             client
                 .for_host(&url)
-                .get(format!("{url}"))
+                .get(Url::from(url))
                 .send()
                 .await?
                 .status(),
@@ -1367,6 +1384,7 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path_regex("/foo/"))
+            .and(basic_auth(username, password))
             .respond_with(
                 ResponseTemplate::new(307).insert_header("Location", "bar/baz/".to_string()),
             )
@@ -1374,7 +1392,9 @@ mod tests {
             .await;
 
         let cache = Cache::temp()?;
-        let registry_client = RegistryClientBuilder::new(cache).build();
+        let registry_client = RegistryClientBuilder::new(cache)
+            .allow_cross_origin_credentials()
+            .build();
         let client = registry_client.cached_client().uncached();
 
         let redirect_server_url = DisplaySafeUrl::parse(&redirect_server.uri())?.join("foo/")?;
@@ -1385,7 +1405,7 @@ mod tests {
         assert_eq!(
             client
                 .for_host(&url)
-                .get(format!("{url}"))
+                .get(Url::from(url))
                 .send()
                 .await?
                 .status(),
@@ -1422,7 +1442,7 @@ mod tests {
         assert_eq!(
             client
                 .for_host(&url)
-                .get(format!("{}", url.clone()))
+                .get(Url::from(url.clone()))
                 .send()
                 .await?
                 .url()


### PR DESCRIPTION
This PR factors out and updates the redirect handling logic from #13595. It handles a few new cases:
* If a 303 redirect is received for any method other than GET or HEAD, converts it to a GET. Unlike `reqwest`, it does not do this conversion for 301s or 302s (which is not required by RFC 7231 and was not the original intention of the spec).
* If the original request did not have a Referer header, does not include a Referer header in the redirect request.
* If the redirect is a cross-origin request, removes sensitive headers to avoid leaking credentials to untrusted domains. 
* * This change had the side effect of breaking mock server tests that redirected from `localhost` to `pypi-proxy.fly.dev`. I have added a `CrossOriginCredentialsPolicy` enum with a `#[cfg(test)]`-only `Insecure` variant. This allows existing tests to continue to work while still making it impossible to propagate credentials on cross-origin requests outside of tests.
* * I've updated the main redirect integration test to check if cross-origin requests fail (there is, by design, no way to configure an insecure cross-origin policy from the command line). But critically, netrc credentials for the new location can still be successfully fetched on a cross-origin redirect (tested in `pip_install_redirect_with_netrc_cross_origin`).
* One of the goals of the refactor was to make the redirect handling logic unit-testable. This PR adds a number of unit tests checking things like proper propagation of credentials on redirects on the same domain (and removal on cross-origin) and HTTP 303 POST-to-GET conversion.

The following table illustrates the different behaviors on current `main`, the initial (reverted) redirect handling PR (#12920), the PR that restores #12920 and fixes the 303s bug (#13595), and this PR (#13754). We want to propagate credentials on same-origin but not cross-origin redirects, and we want to look up netrc credentials on redirects.

| Behavior                                                   | main | reverted #12920 | fix #13595  | update #13754 |
|---------------------------------------|------|--------------|-------------|----------------|
| Propagate credentials on same-origin redirects  | No    | Yes                 | Yes          | Yes                        |
| Propagate credentials on cross-origin redirects | No    | Yes                 | Yes          | No                         |
| Look up netrc credentials on redirects  | No    | Yes                 | Yes          | Yes                        |
| Handle 303s without failing                  | Yes   | No                   | Yes          | Yes                        |

Depends on #13595.
