### PR TITLE
optionally disable file locking

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3596,6 +3596,10 @@ pub struct AddArgs {
     #[arg(long, env = EnvVars::UV_NO_SYNC, value_parser = clap::builder::BoolishValueParser::new(), conflicts_with = "frozen")]
     pub no_sync: bool,
 
+    /// Disable file locking (flock) operations 
+    #[arg(long, env = EnvVars::UV_UNSAGE_IGNORE_FLOCK, value_parser = clap::builder::BoolishValueParser::new())]
+    pub unsage_ignore_flock: bool,
+
     /// Assert that the `uv.lock` will remain unchanged.
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -149,6 +149,9 @@ impl EnvVars {
     /// Disable use of uv-managed Python versions.
     pub const UV_NO_MANAGED_PYTHON: &'static str = "UV_NO_MANAGED_PYTHON";
 
+    /// Disable file locking (flock) operations or ignore 
+    pub const UV_UNSAGE_IGNORE_FLOCK: &'static str = "UV_UNSAGE_IGNORE_FLOCK";
+
     /// Equivalent to the
     /// [`python-downloads`](../reference/settings.md#python-downloads) setting and, when disabled, the
     /// `--no-python-downloads` option. Whether uv should allow Python downloads.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1296,6 +1296,7 @@ impl AddSettings {
             tag,
             branch,
             no_sync,
+            unsage_ignore_flock,
             locked,
             frozen,
             active,


### PR DESCRIPTION
## Summary
Closes #13626 
this PR adds a `UV_UNSAFE_IGNORE_FLOCK` to disable file locking (flock) operations 

## Test Plan
manual testing 
