### PR TITLE
Update `lock::lock_requires_python` not to require Python 3.8

### DIFF
--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4297,10 +4297,13 @@ fn lock_requires_python() -> Result<()> {
     });
 
     // Validate that attempting to install with an unsupported Python version raises an error.
-    let context38 = TestContext::new("3.8").with_filtered_python_sources();
+    let context_unsupported = TestContext::new("3.9").with_filtered_python_sources();
 
-    fs_err::copy(pyproject_toml, context38.temp_dir.join("pyproject.toml"))?;
-    fs_err::copy(&lockfile, context38.temp_dir.join("uv.lock"))?;
+    fs_err::copy(
+        pyproject_toml,
+        context_unsupported.temp_dir.join("pyproject.toml"),
+    )?;
+    fs_err::copy(&lockfile, context_unsupported.temp_dir.join("uv.lock"))?;
 
     // Re-run with `--locked`.
     uv_snapshot!(context.filters(), context.lock().arg("--locked"), @r###"
@@ -4314,7 +4317,7 @@ fn lock_requires_python() -> Result<()> {
 
     // Install from the lockfile.
     // Note we need to disable Python fetches or we'll just download 3.12
-    uv_snapshot!(context38.filters(), context38.sync().arg("--frozen").arg("--no-python-downloads"), @r###"
+    uv_snapshot!(context_unsupported.filters(), context_unsupported.sync().arg("--frozen").arg("--no-python-downloads"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----


### PR DESCRIPTION
## Summary

Update `lock::lock_requires_python` not to require Python 3.8.

Fixes #13676

## Test Plan

`cargo test --no-default-features --features git,pypi,python` after removing Python 3.8.
