### PR TITLE
Better error message for version specifier with missing operator

### DIFF
--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -1387,7 +1387,7 @@ mod tests {
         assert_eq!(
             result.unwrap_err().to_string(),
             indoc! {"
-            Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?):
+            Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
             3`2
             ^^^^
             "}
@@ -1810,7 +1810,7 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "\
-Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==5.4.3`?):
+Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==5.4.3`?:
 >=1.2.3, 5.4.3, >=3.4.5
         ^^^^^^
 "

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -1388,7 +1388,7 @@ mod tests {
             result.unwrap_err().to_string(),
             indoc! {"
             Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
-            3`2
+            3.12
             ^^^^
             "}
         );

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -717,7 +717,7 @@ impl std::fmt::Display for VersionOperatorBuildError {
             let version_specifier =
                 VersionSpecifier::from_pattern(Operator::Equal, version_pattern.clone()).unwrap();
             write!(f, ". Did you mean `{version_specifier}`?")?;
-        };
+        }
         Ok(())
     }
 }
@@ -1386,11 +1386,11 @@ mod tests {
         let result = VersionSpecifiers::from_str("3.12");
         assert_eq!(
             result.unwrap_err().to_string(),
-            indoc! {r#"
+            indoc! {"
             Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?):
             3`2
             ^^^^
-            "#}
+            "}
         );
     }
 

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -627,7 +627,15 @@ impl FromStr for VersionSpecifier {
         // operator but we don't know yet if it has a star
         let operator = s.eat_while(['=', '!', '~', '<', '>']);
         if operator.is_empty() {
-            return Err(ParseErrorKind::MissingOperator.into());
+            // Attempt to parse the version from the rest of the scanner to provide a more useful error message in MissingOperator.
+            // If it is not able to be parsed (i.e. not a valid version), it will just be None and no additional info will be added to the error message.
+            s.eat_while(|c: char| c.is_whitespace());
+            let version = s.eat_while(|c: char| !c.is_whitespace());
+            s.eat_while(|c: char| c.is_whitespace());
+            return Err(ParseErrorKind::MissingOperator(VersionOperatorBuildError {
+                vpat_option: version.parse().ok(),
+            })
+            .into());
         }
         let operator = Operator::from_str(operator).map_err(ParseErrorKind::InvalidOperator)?;
         s.eat_while(|c: char| c.is_whitespace());
@@ -695,6 +703,26 @@ impl std::fmt::Display for VersionSpecifierBuildError {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct VersionOperatorBuildError {
+    vpat_option: Option<VersionPattern>,
+}
+
+impl std::error::Error for VersionOperatorBuildError {}
+
+impl std::fmt::Display for VersionOperatorBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let message = match &self.vpat_option {
+            Some(v) => format!(" (did you mean \"=={}\"?)", v.clone().into_version()),
+            None => String::new(),
+        };
+        write!(
+            f,
+            "Unexpected end of version specifier, expected operator{message}",
+        )
+    }
+}
+
 /// The specific kind of error that can occur when building a version specifier
 /// from an operator and version pair.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -748,9 +776,7 @@ impl std::fmt::Display for VersionSpecifierParseError {
             ParseErrorKind::InvalidOperator(ref err) => err.fmt(f),
             ParseErrorKind::InvalidVersion(ref err) => err.fmt(f),
             ParseErrorKind::InvalidSpecifier(ref err) => err.fmt(f),
-            ParseErrorKind::MissingOperator => {
-                write!(f, "Unexpected end of version specifier, expected operator")
-            }
+            ParseErrorKind::MissingOperator(ref err) => err.fmt(f),
             ParseErrorKind::MissingVersion => {
                 write!(f, "Unexpected end of version specifier, expected version")
             }
@@ -768,7 +794,7 @@ enum ParseErrorKind {
     InvalidOperator(OperatorParseError),
     InvalidVersion(VersionPatternParseError),
     InvalidSpecifier(VersionSpecifierBuildError),
-    MissingOperator,
+    MissingOperator(VersionOperatorBuildError),
     MissingVersion,
     InvalidTrailing(String),
 }
@@ -1357,6 +1383,32 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_specifier_missing_operator_error() {
+        let result = VersionSpecifiers::from_str("3.12");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            indoc! {r#"
+            Failed to parse version: Unexpected end of version specifier, expected operator (did you mean "==3.12"?):
+            3.12
+            ^^^^
+            "#}
+        );
+    }
+
+    #[test]
+    fn test_parse_specifier_missing_operator_invalid_version_error() {
+        let result = VersionSpecifiers::from_str("blergh");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            indoc! {r"
+            Failed to parse version: Unexpected end of version specifier, expected operator:
+            blergh
+            ^^^^^^
+            "}
+        );
+    }
+
+    #[test]
     fn test_non_star_after_star() {
         let result = VersionSpecifiers::from_str("== 0.9.*.1");
         assert_eq!(
@@ -1386,7 +1438,10 @@ mod tests {
         let result = VersionSpecifiers::from_str("blergh");
         assert_eq!(
             result.unwrap_err().inner.err,
-            ParseErrorKind::MissingOperator.into(),
+            ParseErrorKind::MissingOperator(VersionOperatorBuildError {
+                vpat_option: Option::None
+            })
+            .into(),
         );
     }
 
@@ -1395,7 +1450,13 @@ mod tests {
     fn test_invalid_specifier() {
         let specifiers = [
             // Operator-less specifier
-            ("2.0", ParseErrorKind::MissingOperator.into()),
+            (
+                "2.0",
+                ParseErrorKind::MissingOperator(VersionOperatorBuildError {
+                    vpat_option: VersionPattern::from_str("2.0").ok(),
+                })
+                .into(),
+            ),
             // Invalid operator
             (
                 "=>2.0",
@@ -1735,7 +1796,9 @@ mod tests {
     fn error_message_version_specifiers_parse_error() {
         let specs = ">=1.2.3, 5.4.3, >=3.4.5";
         let err = VersionSpecifierParseError {
-            kind: Box::new(ParseErrorKind::MissingOperator),
+            kind: Box::new(ParseErrorKind::MissingOperator(VersionOperatorBuildError {
+                vpat_option: VersionPattern::from_str("5.4.3").ok(),
+            })),
         };
         let inner = Box::new(VersionSpecifiersParseErrorInner {
             err,
@@ -1748,7 +1811,7 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "\
-Failed to parse version: Unexpected end of version specifier, expected operator:
+Failed to parse version: Unexpected end of version specifier, expected operator (did you mean \"==5.4.3\"?):
 >=1.2.3, 5.4.3, >=3.4.5
         ^^^^^^
 "

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11424,7 +11424,7 @@ fn add_invalid_requires_python() -> Result<()> {
         "#
     })?;
 
-    uv_snapshot!(context.add().arg("anyio"), @r###"
+    uv_snapshot!(context.add().arg("anyio"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -11435,10 +11435,10 @@ fn add_invalid_requires_python() -> Result<()> {
       |
     4 | requires-python = "3.12"
       |                   ^^^^^^
-    Failed to parse version: Unexpected end of version specifier, expected operator (did you mean "==3.12"?):
+    Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==3.12`?:
     3.12
     ^^^^
-    "###);
+    "#);
 
     Ok(())
 }

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11408,6 +11408,41 @@ fn add_invalid_ignore_error_code() -> Result<()> {
     Ok(())
 }
 
+/// uv should fail to parse `pyproject.toml` if `require-python`
+/// contains an invalid specifier and try to return a helpful hint.
+#[test]
+fn add_invalid_requires_python() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = "3.12"
+        dependencies = []
+        "#
+    })?;
+
+    uv_snapshot!(context.add().arg("anyio"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse: `pyproject.toml`
+      Caused by: TOML parse error at line 4, column 19
+      |
+    4 | requires-python = "3.12"
+      |                   ^^^^^^
+    Failed to parse version: Unexpected end of version specifier, expected operator (did you mean "==3.12"?):
+    3.12
+    ^^^^
+    "###);
+
+    Ok(())
+}
+
 /// In authentication "always", the normal authentication flow should still work.
 #[test]
 fn add_auth_policy_always_with_credentials() -> Result<()> {

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -6961,7 +6961,7 @@ fn invalid_metadata_requires_python() -> Result<()> {
       ╰─▶ Because validation==2.0.0 has invalid metadata and you require validation==2.0.0, we can conclude that your requirements are unsatisfiable.
 
           hint: Metadata for `validation` (v2.0.0) could not be parsed:
-            Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==12`?):
+            Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==12`?:
             12
             ^^
     "###

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -6961,7 +6961,7 @@ fn invalid_metadata_requires_python() -> Result<()> {
       ╰─▶ Because validation==2.0.0 has invalid metadata and you require validation==2.0.0, we can conclude that your requirements are unsatisfiable.
 
           hint: Metadata for `validation` (v2.0.0) could not be parsed:
-            Failed to parse version: Unexpected end of version specifier, expected operator (did you mean "==12"?):
+            Failed to parse version: Unexpected end of version specifier, expected operator. Did you mean `==12`?):
             12
             ^^
     "###

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -6961,7 +6961,7 @@ fn invalid_metadata_requires_python() -> Result<()> {
       ╰─▶ Because validation==2.0.0 has invalid metadata and you require validation==2.0.0, we can conclude that your requirements are unsatisfiable.
 
           hint: Metadata for `validation` (v2.0.0) could not be parsed:
-            Failed to parse version: Unexpected end of version specifier, expected operator:
+            Failed to parse version: Unexpected end of version specifier, expected operator (did you mean "==12"?):
             12
             ^^
     "###


### PR DESCRIPTION
## Summary

When missing an operator for version parsing, it would give an error that was hard to know how to fix if you were not familiar with version specifiers / PEP-440:

```
Unexpected end of version specifier, expected operator
```

Now, it will attempt to provide a more useful hint if it can parse the version from the remaining scanner:

```
Unexpected end of version specifier, expected operator. Did you mean `==3.12`?
```
## Test Plan

Unit tests in `version_specifier.rs` were added/updated for the following cases:
- `test_parse_specifier_missing_operator_error`
- `test_parse_specifier_missing_operator_invalid_version_error`
- `test_invalid_word`
- `test_invalid_specifier`
- `error_message_version_specifiers_parse_error`

A test in `edit.rs` for failing to parse the `pyproject.toml` when using `add` was also included to match the request in the original issue:
- `add_invalid_requires_python`

I didn't add cases where no version specifier is provided because it seemed like it doesn't get to the point of parsing in that case, so it should not happen.


## Reference

Fixes #13126