### PR TITLE
Update acj/freebsd-firecracker-action to v0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,7 @@ jobs:
           cross build --target x86_64-unknown-freebsd
 
       - name: Test in Firecracker VM
-        uses: acj/freebsd-firecracker-action@4d93174d9eea32cd2b2650f964af69f8c72eaff2 # v0.3.0 - see https://github.com/acj/freebsd-firecracker-action/issues/3#issuecomment-2931399473
+        uses: acj/freebsd-firecracker-action@5b4c9938e8b5ff1041c58e21515909a0e1500d59 # v0.4.1
         with:
           verbose: false
           checkout: false


### PR DESCRIPTION
This should hopefully fix the flakes we're seeing.

Fixes #13746, hopefully.