### PR TITLE
Add comment to `lock_redact_url_sources` indicating that we do not redact the credentials

### DIFF
--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -8355,6 +8355,7 @@ fn lock_redact_url_sources() -> Result<()> {
 
     let lock = context.read("uv.lock");
 
+    // The credentials are for a direct URL, and are included in the lockfile
     insta::with_settings!({
         filters => context.filters(),
     }, {


### PR DESCRIPTION
This was previously present, but got removed at some point