### PR TITLE
Remove `python-managed` marker from `sync_dry_run` test

### DIFF
--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -7767,7 +7767,6 @@ fn find_links_relative_in_config_works_from_subdir() -> Result<()> {
 }
 
 #[test]
-#[cfg(feature = "python-managed")]
 fn sync_dry_run() -> Result<()> {
     let context = TestContext::new_with_versions(&["3.8", "3.12"]);
 


### PR DESCRIPTION
Not sure why this is present, it does not seem to use a managed interpreter
