### PR TITLE
Debug `sync_dry_run` flake by panicking with verbose output on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,10 @@ jobs:
 
       - name: "Cargo test"
         run: |
-          while true; do
-            cargo nextest run \
-              sync_dry_run \
-              --features python-patch \
-              --workspace \
-              --status-level fail --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
-          done
+          cargo nextest run \
+            --features python-patch \
+            --workspace \
+            --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
   cargo-test-macos:
     timeout-minutes: 15
@@ -258,14 +255,11 @@ jobs:
 
       - name: "Cargo test"
         run: |
-          while true; do
-              cargo nextest run \
-                sync_dry_run \
-                --no-default-features \
-                --features python,python-managed,pypi,git,performance,crates-io \
-                --workspace \
-                --status-level fail --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
-          done
+          cargo nextest run \
+            --no-default-features \
+            --features python,python-managed,pypi,git,performance,crates-io \
+            --workspace \
+            --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
 
   cargo-test-windows:
     timeout-minutes: 15
@@ -329,7 +323,7 @@ jobs:
             --no-default-features \
             --features python,pypi,python-managed \
             --workspace \
-            --status-level fail --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
+            --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
       # Get crash dumps to debug the `exit_code: -1073741819` failures (contd.)
       - name: Analyze crashes

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -7881,9 +7881,11 @@ fn sync_dry_run() -> Result<()> {
 
     let output = context.sync().arg("--dry-run").arg("-vv").output()?;
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("Would replace existing virtual environment") {
-        panic!("{}", stderr);
-    };
+    assert!(
+        !stderr.contains("Would replace existing virtual environment"),
+        "{}",
+        stderr
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Investigating #13744 

I tried reproducing here by running the test in a loop, but could not. I presume it's an interaction with other tests.

This drops the snapshot, but I think it's worth it to try to examine the flake?