### PR TITLE
Move the pip interface documentation into the concepts section

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,5 +7,6 @@ Read the concept documents to learn more about uv's features:
 - [Python versions](./python-versions.md)
 - [Resolution](./resolution.md)
 - [Caching](./cache.md)
+- [The pip interface](../pip/index.md)
 
 Looking for a quick introduction to features? See the [guides](../guides/index.md) instead.

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -134,6 +134,16 @@ nav:
       - Python versions: concepts/python-versions.md
       - Resolution: concepts/resolution.md
       - Caching: concepts/cache.md
+      # Note:  The `pip` section was moved to the `concepts/` section but the
+      # top-level directory structure was retained to ease the transition.
+      - The pip interface:
+          - pip/index.md
+          - Using environments: pip/environments.md
+          - Managing packages: pip/packages.md
+          - Inspecting environments: pip/inspection.md
+          - Declaring dependencies: pip/dependencies.md
+          - Locking environments: pip/compile.md
+          - Compatibility with pip: pip/compatibility.md
   - Configuration:
       - configuration/index.md
       - Configuration files: configuration/files.md
@@ -142,14 +152,6 @@ nav:
       - Package indexes: configuration/indexes.md
       - Installer: configuration/installer.md
       - Build backend: configuration/build-backend.md
-  - The pip interface:
-      - pip/index.md
-      - Using environments: pip/environments.md
-      - Managing packages: pip/packages.md
-      - Inspecting environments: pip/inspection.md
-      - Declaring dependencies: pip/dependencies.md
-      - Locking environments: pip/compile.md
-      - Compatibility with pip: pip/compatibility.md
   - Reference:
       - reference/index.md
       - Commands: reference/cli.md


### PR DESCRIPTION
The motivation here being a reduction in the length of the navigation. I don't think we did this in the first place because we didn't have the capability to do another nested level, but now we're doing that for Projects.