### PR TITLE
Make `requirements_txt_ssh_git_username` not write into homedir

### DIFF
--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1230,7 +1230,7 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
 
     // Ensure that we fail without passing the correct key (and don't go to the dev machine's
     // credential helper).
-    // Override UserKnownHostsFile to prevent OpenSSH from writing into user's home directory.
+    // Overriding UserKnownHostsFile prevents OpenSSH from writing into user's home directory.
     let failing_git_ssh_command = format!(
         "ssh -i {} -o IdentitiesOnly=yes -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
         fake_deploy_key.portable_display()
@@ -1275,9 +1275,9 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
     reduce_ssh_key_file_permissions(&ssh_deploy_key)?;
 
     // Use the specified SSH key, and only that key, ignore `~/.ssh/config`, disable host key
-    // verification for Windows.
+    // verification for Windows, don't write the accepted host to the user home.
     let git_ssh_command = format!(
-        "ssh -i {} -o IdentitiesOnly=yes -F /dev/null -o StrictHostKeyChecking=no",
+        "ssh -i {} -o IdentitiesOnly=yes -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
         ssh_deploy_key.portable_display()
     );
 

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1230,8 +1230,9 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
 
     // Ensure that we fail without passing the correct key (and don't go to the dev machine's
     // credential helper).
+    // Override UserKnownHostsFile to prevent OpenSSH from writing into user's home directory.
     let failing_git_ssh_command = format!(
-        "ssh -i {} -o IdentitiesOnly=yes -F /dev/null -o StrictHostKeyChecking=no",
+        "ssh -i {} -o IdentitiesOnly=yes -F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
         fake_deploy_key.portable_display()
     );
     let mut filters = context.filters();


### PR DESCRIPTION
## Summary

Modify `requirements_txt_ssh_git_username` test to pass `-o UserKnownHostsFile=/dev/null` to OpenSSH, in order to prevent it from trying to write into the known-hosts in user's home directory. To add insult to the injury, OpenSSH ignores `HOME` and writes into the actual home when it is explicitly overridden for the purpose of testing.

## Test Plan

`cargo test --no-default-features --features=git,pypi,python` in an environment where the user can't write to `pw_home` (but can to `${HOME}`). Previously the test would fail:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot: requirements_txt_ssh_git_username
Source: crates/uv/tests/it/export.rs:1252
────────────────────────────────────────────────────────────────────────────────
Expression: snapshot
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
    7     7 │   ├─▶ failed to clone into: [PATH]
    8     8 │   ├─▶ failed to fetch branch, tag, or commit `d780faf0ac91257d4d5a4f0c5a0e4509608c0071`
    9     9 │   ╰─▶ process didn't exit successfully: [GIT_COMMAND_ERROR]
   10    10 │       --- stderr
         11 │+      Could not create directory '/var/lib/portage/home/.ssh' (Permission denied).
         12 │+      Failed to add the host to the list of known hosts (/var/lib/portage/home/.ssh/known_hosts).
   11    13 │       Load key "[TEMP_DIR]/fake_deploy_key": [ERROR]
   12    14 │       git@github.com: Permission denied (publickey).
   13    15 │       fatal: Could not read from remote repository.
   14    16 │ 
────────────┴───────────────────────────────────────────────────────────────────
```
