### PR TITLE
Switch `sync_dry_run` test to Python 3.9

### DIFF
--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -7768,7 +7768,7 @@ fn find_links_relative_in_config_works_from_subdir() -> Result<()> {
 
 #[test]
 fn sync_dry_run() -> Result<()> {
-    let context = TestContext::new_with_versions(&["3.8", "3.12"]);
+    let context = TestContext::new_with_versions(&["3.9", "3.12"]);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
@@ -7845,7 +7845,7 @@ fn sync_dry_run() -> Result<()> {
         [project]
         name = "project"
         version = "0.1.0"
-        requires-python = "==3.8.*"
+        requires-python = "==3.9.*"
         dependencies = ["iniconfig"]
         "#,
     )?;
@@ -7856,7 +7856,7 @@ fn sync_dry_run() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
+    Using CPython 3.9.[X] interpreter at: [PYTHON-3.9]
     Would replace existing virtual environment at: .venv
     Resolved 2 packages in [TIME]
     Would update lockfile at: uv.lock
@@ -7871,7 +7871,7 @@ fn sync_dry_run() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
+    Using CPython 3.9.[X] interpreter at: [PYTHON-3.9]
     Removed virtual environment at: .venv
     Creating virtual environment at: .venv
     Resolved 2 packages in [TIME]


### PR DESCRIPTION
## Summary

Switch the `sync_dry_run` test to use Python 3.9 instead of Python 3.8. I didn't previously catch it since it was marked as `python_managed`.

## Test Plan

`cargo test --no-default-features --features git,pypi,python` without Python 3.8 installed.