### PR TITLE
Add `uv python pin --rm` to remove `.python-version` pins

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5032,6 +5032,10 @@ pub struct PythonPinArgs {
     /// directory, this version will be used instead.
     #[arg(long)]
     pub global: bool,
+
+    /// Remove the Python version pin.
+    #[arg(long, conflicts_with = "request", conflicts_with = "resolved")]
+    pub rm: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -20,6 +20,7 @@ use crate::commands::{ExitStatus, project::find_requires_python};
 use crate::printer::Printer;
 
 /// Pin to a specific Python version.
+#[allow(clippy::fn_params_excessive_bools)]
 pub(crate) async fn pin(
     project_dir: &Path,
     request: Option<String>,
@@ -27,6 +28,7 @@ pub(crate) async fn pin(
     python_preference: PythonPreference,
     no_project: bool,
     global: bool,
+    rm: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -55,6 +57,19 @@ pub(crate) async fn pin(
     } else {
         PythonVersionFile::discover(project_dir, &VersionFileDiscoveryOptions::default()).await
     };
+
+    if rm {
+        let Some(file) = version_file? else {
+            bail!("No Python version file found");
+        };
+        fs_err::tokio::remove_file(file.path()).await?;
+        writeln!(
+            printer.stdout(),
+            "Removed Python version file at `{}`",
+            file.path().user_display()
+        )?;
+        return Ok(ExitStatus::Success);
+    }
 
     let Some(request) = request else {
         // Display the current pinned Python version

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1466,6 +1466,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.python_preference,
                 args.no_project,
                 args.global,
+                args.rm,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1056,6 +1056,7 @@ pub(crate) struct PythonPinSettings {
     pub(crate) resolved: bool,
     pub(crate) no_project: bool,
     pub(crate) global: bool,
+    pub(crate) rm: bool,
 }
 
 impl PythonPinSettings {
@@ -1068,6 +1069,7 @@ impl PythonPinSettings {
             resolved,
             no_project,
             global,
+            rm,
         } = args;
 
         Self {
@@ -1075,6 +1077,7 @@ impl PythonPinSettings {
             resolved: flag(resolved, no_resolved).unwrap_or(false),
             no_project,
             global,
+            rm,
         }
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2904,6 +2904,7 @@ uv python pin [OPTIONS] [REQUEST]
 </dd><dt id="uv-python-pin--resolved"><a href="#uv-python-pin--resolved"><code>--resolved</code></a></dt><dd><p>Write the resolved Python interpreter path instead of the request.</p>
 <p>Ensures that the exact same interpreter is used.</p>
 <p>This option is usually not safe to use when committing the <code>.python-version</code> file to version control.</p>
+</dd><dt id="uv-python-pin--rm"><a href="#uv-python-pin--rm"><code>--rm</code></a></dt><dd><p>Remove the Python version pin</p>
 </dd><dt id="uv-python-pin--verbose"><a href="#uv-python-pin--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (<a href="https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives">https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives</a>)</p>
 </dd></dl>


### PR DESCRIPTION
I realized it is non-trivial to delete the global Python version pin, and that we were missing this simple functionality