### PR TITLE
Support python@latest for newest, stable, discoverable Python

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -195,7 +195,9 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Default | PythonRequest::Any => Some(Self::default()),
+            PythonRequest::Default | PythonRequest::Any | PythonRequest::Latest => {
+                Some(Self::default())
+            }
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -458,6 +458,7 @@ impl ManagedPythonInstallation {
             }
             PythonRequest::Version(version) => version.matches_version(&self.version()),
             PythonRequest::Key(request) => request.satisfied_by_key(self.key()),
+            PythonRequest::Latest => true,
         }
     }
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -636,13 +636,7 @@ async fn get_or_create_environment(
             Target::Version(_, _, _, version) => Some(PythonRequest::Version(
                 VersionRequest::from_str(&version.to_string()).map_err(anyhow::Error::from)?,
             )),
-            // TODO(zanieb): Add `PythonRequest::Latest`
-            Target::Latest(_, _, _) => {
-                return Err(anyhow::anyhow!(
-                    "Requesting the 'latest' Python version is not yet supported"
-                )
-                .into())
-            }
+            Target::Latest(_, _, _) => Some(PythonRequest::Latest),
         };
 
         if let Some(target_request) = &target_request {

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1952,14 +1952,16 @@ fn tool_run_python_at_version() {
     // Request `@latest` (not yet supported)
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("python@latest")
-        .arg("--version"), @r###"
-    success: false
-    exit_code: 2
+        .arg("--version"), @r"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    Python 3.12.[X]
 
     ----- stderr -----
-    error: Requesting the 'latest' Python version is not yet supported
-    "###);
+    Resolved in [TIME]
+    Audited in [TIME]
+    ");
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes #13535

## Summary

Support `python@latest` to find and use the latest stable Python version available on the system.
It finds the highest discoverable, stable Python version excluding prerelease
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Tested locally with `target/debug/uv tool run python@latest --version`.
Added test cases in `crates/uv-python/src/lib.rs`

<!-- How was it tested? -->
