### PR TITLE
Change `GlobDirFilter` fallback to `true`

### DIFF
--- a/crates/uv-globfilter/src/glob_dir_filter.rs
+++ b/crates/uv-globfilter/src/glob_dir_filter.rs
@@ -85,7 +85,7 @@ impl GlobDirFilter {
     /// don't end up including any child.
     pub fn match_directory(&self, path: &Path) -> bool {
         let Some(dfa) = &self.dfa else {
-            return false;
+            return true;
         };
 
         // Allow the root path


### PR DESCRIPTION
## Summary

I think `GlobDirFilter::match_directory` should return `true` if it failed to construct a DFA
to force a full directory traversal. Returning `false` means that the build backend excludes all files which
is unlikely what we want in that situation.

