### PR TITLE
Fix incorrect run instructions in fastapi integration guide

### DIFF
--- a/docs/guides/integration/fastapi.md
+++ b/docs/guides/integration/fastapi.md
@@ -86,7 +86,7 @@ dependencies = [
 From there, you can run the FastAPI application with:
 
 ```console
-$ uv run fastapi dev
+$ uv run -m fastapi dev
 ```
 
 `uv run` will automatically resolve and lock the project dependencies (i.e., create a `uv.lock`


### PR DESCRIPTION
## Summary

The documentation describing how to run a fastapi project in the uv/fastapi integration guide is incorrect. The existing directions result in the error "Failed to canonicalize script path". This change updates the documentation to add the `-m` flag to the `uv run` command , which is necessary to run a module from a uv project dependency.

## Test Plan

The CI build should ensure that documentation still builds properly. This is a documentation-only change.
