### PR TITLE
Correct sync documentation to correct a misleading comment on `uv lock --check`

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -41,13 +41,11 @@ version is excluded, the lockfile will be considered outdated. However, if you c
 constraints such that the existing locked version is still included, the lockfile will still be
 considered up-to-date.
 
-You can check if the lockfile is up-to-date by passing the `--check` flag to `uv lock`:
+You can check if the lockfile is up-to-date by passing the `--locked` flag to `uv lock`:
 
 ```console
-$ uv lock --check
+$ uv lock --locked
 ```
-
-This is equivalent to the `--locked` flag for other commands.
 
 !!! important
 


### PR DESCRIPTION
## Summary

Updated the [sync documentation](https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date) because it was refering to an option `--check` that, it seems, it does not exist anymore.

Not sure if it's related to this [`UV_FROZEN=0 uv lock --check fails #`](https://github.com/astral-sh/uv/issues/13385)

## Test Plan

Execute the command:

```bash
uv lock --check
```
and got the output:

```bash
error: unexpected argument '--check' found
```

