### PR TITLE
feat: upgrade dependencies in pyproject.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,8 +1270,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.0",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -3219,6 +3240,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,6 +3535,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4615,6 +4661,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5423,6 +5480,7 @@ dependencies = [
  "owo-colors",
  "petgraph",
  "predicates",
+ "prettytable-rs",
  "regex",
  "reqwest",
  "rkyv",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -671,6 +671,10 @@ pub struct UpgradeProjectArgs {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Search recursively for pyproject.toml files.
+    #[arg(long, env = EnvVars::UV_UPGRADE_RECURSIVE)]
+    pub recursive: bool,
+
     /// The Python interpreter to use during resolution (overrides pyproject.toml).
     ///
     /// A Python interpreter is required for building source distributions to determine package

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -716,6 +716,10 @@ pub struct UpgradeProjectArgs {
         value_parser = parse_maybe_string,
     )]
     pub python: Option<Maybe<String>>,
+
+    /// Upgrade only the given requirements (i.e. `uv<0.5`) instead of pyproject.toml files.
+    #[arg(required = false, value_parser = parse_requirement)]
+    pub requirements: Vec<Maybe<Requirement>>,
 }
 
 // Note that the ordering of the variants is significant, as when given a list of operations
@@ -1363,6 +1367,18 @@ fn parse_dependency_type(input: &str) -> Result<Maybe<DependencyType>, String> {
         Ok(Maybe::None)
     } else {
         match DependencyType::from_str(input) {
+            Ok(table) => Ok(Maybe::Some(table)),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+}
+
+/// Parse a string like `uv<0.5` into an [`Requirement`], mapping the empty string to `None`.
+fn parse_requirement(input: &str) -> Result<Maybe<Requirement>, String> {
+    if input.is_empty() {
+        Ok(Maybe::None)
+    } else {
+        match Requirement::from_str(input) {
             Ok(table) => Ok(Maybe::Some(table)),
             Err(err) => Err(err.to_string()),
         }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -695,6 +695,9 @@ pub struct UpgradeProjectArgs {
     )]
     pub allow: Vec<Maybe<usize>>,
 
+    #[command(flatten)]
+    pub refresh: RefreshArgs,
+
     /// The Python interpreter to use during resolution (overrides pyproject.toml).
     ///
     /// A Python interpreter is required for building source distributions to determine package

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -665,6 +665,32 @@ pub struct VersionArgs {
     pub python: Option<Maybe<String>>,
 }
 
+#[derive(Args)]
+pub struct UpgradeProjectArgs {
+    /// Run without performing the upgrade.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// The Python interpreter to use during resolution (overrides pyproject.toml).
+    ///
+    /// A Python interpreter is required for building source distributions to determine package
+    /// metadata when there are not wheels.
+    ///
+    /// The interpreter is also used as the fallback value for the minimum Python version if
+    /// `requires-python` is not set.
+    ///
+    /// See `uv help python` for details on Python discovery and supported request formats.
+    #[arg(
+        long,
+        short,
+        env = EnvVars::UV_PYTHON,
+        verbatim_doc_comment,
+        help_heading = "Python options",
+        value_parser = parse_maybe_string,
+    )]
+    pub python: Option<Maybe<String>>,
+}
+
 // Note that the ordering of the variants is significant, as when given a list of operations
 // to perform, we sort them and apply them in order, so users don't have to think too hard about it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
@@ -1105,6 +1131,8 @@ pub enum ProjectCommand {
     Remove(RemoveArgs),
     /// Read or update the project's version.
     Version(VersionArgs),
+    /// Upgrade the project's dependency constraints.
+    Upgrade(UpgradeProjectArgs),
     /// Update the project's environment.
     ///
     /// Syncing ensures that all project dependencies are installed and up-to-date with the

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -375,7 +375,7 @@ impl<'a> IndexLocations {
     }
 
     /// Clone the index locations into a [`IndexUrls`] instance.
-    pub fn index_urls(&'a self) -> IndexUrls {
+    pub fn index_urls(&self) -> IndexUrls {
         IndexUrls {
             indexes: self.indexes.clone(),
             no_index: self.no_index,

--- a/crates/uv-distribution-types/src/requires_python.rs
+++ b/crates/uv-distribution-types/src/requires_python.rs
@@ -1,11 +1,11 @@
 use std::collections::Bound;
-
+use std::str::FromStr;
 use version_ranges::Ranges;
 
 use uv_distribution_filename::WheelFilename;
 use uv_pep440::{
     LowerBound, UpperBound, Version, VersionSpecifier, VersionSpecifiers,
-    release_specifiers_to_ranges,
+    VersionSpecifiersParseError, release_specifiers_to_ranges,
 };
 use uv_pep508::{MarkerExpression, MarkerTree, MarkerValueVersion};
 use uv_platform_tags::{AbiTag, LanguageTag};
@@ -501,6 +501,19 @@ impl RequiresPython {
                 true
             }
         })
+    }
+
+    /// Remove trailing zeroes from all specifiers
+    pub fn remove_zeroes(&self) -> String {
+        self.specifiers().remove_zeroes().to_string()
+    }
+}
+
+impl FromStr for RequiresPython {
+    type Err = VersionSpecifiersParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        VersionSpecifiers::from_str(s).map(|v| Self::from_specifiers(&v))
     }
 }
 

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -411,7 +411,7 @@ pub async fn persist_with_retry(
         // So every time we fail, we need to reset the `NamedTempFile` to try again.
         //
         // Every time we (re)try we call this outer closure (`let persist = ...`), so it needs to
-        // be at least a `FnMut` (as opposed to `Fnonce`). However the closure needs to return a
+        // be at least a `FnMut` (as opposed to `FnOnce`). However the closure needs to return a
         // totally owned `Future` (so effectively it returns a `FnOnce`).
         //
         // But if the `Future` is totally owned it *necessarily* can't write back the `NamedTempFile`

--- a/crates/uv-pep440/src/lib.rs
+++ b/crates/uv-pep440/src/lib.rs
@@ -30,8 +30,8 @@ pub use version_ranges::{
 pub use {
     version::{
         BumpCommand, LocalSegment, LocalVersion, LocalVersionSlice, MIN_VERSION, Operator,
-        OperatorParseError, Prerelease, PrereleaseKind, Version, VersionParseError, VersionPattern,
-        VersionPatternParseError,
+        OperatorParseError, Prerelease, PrereleaseKind, Version, VersionDigit, VersionParseError,
+        VersionPattern, VersionPatternParseError,
     },
     version_specifier::{
         TildeVersionSpecifier, VersionSpecifier, VersionSpecifierBuildError, VersionSpecifiers,

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -882,6 +882,7 @@ impl Version {
         let downgrade = ordering == Ordering::Greater
             && (operator == Operator::GreaterThan
                 || operator == Operator::GreaterThanEqual
+                || operator == Operator::TildeEqual
                 || operator == Operator::Equal
                 || operator == Operator::EqualStar)
             || ordering == Ordering::Equal && operator == Operator::GreaterThan;
@@ -894,6 +895,7 @@ impl Version {
         let opeq = operator == Operator::Equal;
         let oplt = operator == Operator::LessThan;
         let ople = operator == Operator::LessThanEqual;
+        let opte = operator == Operator::TildeEqual;
         let orle = ordering != Ordering::Greater;
         let enough_len = old.len() >= new.len();
         let subtract = downgrade && zero && enough_len && !opeq;
@@ -902,7 +904,7 @@ impl Version {
             // set version to 0 (negative delta) or don't change it
             if subtract { *new.last().unwrap() } else { 0 }
         } else {
-            u64::from(!(op_equal || ople && orle && enough_len || opgt)) // add 1 if operator needs
+            u64::from(!(op_equal || opte || ople && orle && enough_len || opgt)) // add 1 if operator needs
         };
         let addsub = |v: u64| if subtract { v - delta } else { v + delta };
         if downgrade || orle {

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::num::NonZero;
 use std::ops::Deref;
 use std::sync::LazyLock;
@@ -2846,6 +2846,58 @@ impl From<VersionParseError> for VersionPatternParseError {
         Self {
             kind: Box::new(PatternErrorKind::Version(err)),
         }
+    }
+}
+
+/// Store digits for a small version
+#[derive(Default)]
+pub struct VersionDigit {
+    major: usize,
+    minor: usize,
+    patch: usize,
+    build: usize,
+}
+
+impl VersionDigit {
+    /// Increase a digit
+    pub fn add(&mut self, digit: usize) {
+        match digit {
+            1 => self.major += 1,
+            2 => self.minor += 1,
+            3 => self.patch += 1,
+            4 => self.build += 1,
+            _ => {}
+        }
+    }
+
+    /// Increase all digits from `other`
+    pub fn add_other(&mut self, other: &Self) {
+        self.major += other.major;
+        self.minor += other.minor;
+        self.patch += other.patch;
+        self.build = other.build;
+    }
+
+    /// Are all digits empty?
+    pub fn is_empty(&self) -> bool {
+        self.major == 0 && self.minor == 0 && self.patch == 0 && self.build == 0
+    }
+
+    /// Format all digits as 1.2.3.4 if not empty.
+    pub fn format(&self, prefix: &str, suffix: &str) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+        format!(
+            "{prefix}{}.{}.{}.{}{suffix}",
+            self.major, self.minor, self.patch, self.build
+        )
+    }
+}
+
+impl Display for VersionDigit {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.format("", ""))
     }
 }
 

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -2075,6 +2075,11 @@ Failed to parse version: Unexpected end of version specifier, expected operator.
             (2, "1.2.3", "<=1.2.0", "<=1.3.0", 1),
             (3, "1.2.3", "<=1.2.2", "<=1.2.3", 1),
             (4, "1.2.3.4", "<=1.2.3.3", "<=1.2.3.4", 1),
+            (1, "1.2.3", "~=0.9", "~=1.2", 1),
+            (1, "1.2.3", "~=0.9.1", "~=1.2.3", 1),
+            (0, "1.2.3", "~=1.0", "", 0),
+            (2, "1.2.3", "~=1.1.2", "~=1.2.3", 1),
+            (0, "1.2.3", "~=1.2.2", "", 0),
             (1, "1.2.3", "==0.*", "==1.*", 1),
             (2, "1.2.3", "==1.0.*", "==1.2.*", 1),
             (2, "1.2.3", "==1.1.*", "==1.2.*", 1),
@@ -2102,6 +2107,10 @@ Failed to parse version: Unexpected end of version specifier, expected operator.
             (2, "1.2.3", ">=1.3.1", ">=1.2.3", 2),
             (3, "1.2.3", ">=1.2.4", ">=1.2.3", 2),
             (4, "1.2.3.4", ">=1.2.3.5", ">=1.2.3.4", 2),
+            (1, "1.2.3", "~=2.0", "~=1.2", 2),
+            (2, "1.2.3", "~=1.3", "~=1.2", 2),
+            (2, "1.2.3", "~=1.3.2", "~=1.2.3", 2),
+            (3, "1.2.3", "~=1.2.5", "~=1.2.3", 2),
             (1, "1.2.3", "==2.*", "==1.*", 2),
             (1, "1.2.3", "==2.0.*", "==1.2.*", 2),
             (1, "1.2.3", "==2.1.*", "==1.2.*", 2),
@@ -2164,16 +2173,16 @@ Failed to parse version: Unexpected end of version specifier, expected operator.
             );
             assert_eq!(
                 bumped, should_bump,
-                "[{i}]: did {not}bump {old} to {modified} for {latest}{testcase}"
+                "[{i}]: did {not}bump {old} to {new} for {latest}{testcase}"
             );
             assert!(
                 skipped.is_empty(),
-                "[{i}]: skipped {skipped}: did not bump {old} to {modified} {latest}{testcase}",
+                "[{i}]: skipped {skipped}: did not bump {old} to {new} {latest}{testcase}",
             );
             assert_eq!(
                 upgraded,
                 should_bump && *upgrade == 1,
-                "[{i}]: did not {} {old} to {modified} for {latest}{testcase}",
+                "[{i}]: did not {} {old} to {new} for {latest}{testcase}",
                 if *upgrade == 1 {
                     "upgrade"
                 } else {

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 use url::Url;
 
 use uv_cache_key::{CacheKey, CacheKeyHasher};
-use uv_normalize::{ExtraName, PackageName};
+pub use uv_normalize::{ExtraName, PackageName};
 
 use crate::cursor::Cursor;
 pub use crate::marker::{
@@ -224,10 +224,10 @@ impl<'de, T: Pep508Url> Deserialize<'de> for Requirement<T> {
     {
         struct RequirementVisitor<T>(std::marker::PhantomData<T>);
 
-        impl<T: Pep508Url> serde::de::Visitor<'_> for RequirementVisitor<T> {
+        impl<T: Pep508Url> de::Visitor<'_> for RequirementVisitor<T> {
             type Value = Requirement<T>;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("a string containing a PEP 508 requirement")
             }
 

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1155,6 +1155,17 @@ impl EnvVars {
     #[attr_hidden]
     pub const UV_UPGRADE_RECURSIVE: &'static str = "UV_UPGRADE_RECURSIVE";
 
+    /// Which pyproject.toml tables should `uv upgrade` search?
+    ///
+    /// Default `prod,dev,optional,groups`.
+    ///
+    /// * prod: `project.dependencies`
+    /// * dev: `tool.uv.dev-dependencies`
+    /// * optional: `project.optional-dependencies`
+    /// * groups: `dependency-groups`
+    #[attr_hidden]
+    pub const UV_UPGRADE_TYPES: &'static str = "UV_UPGRADE_TYPES";
+
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
     ///
     /// This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1151,6 +1151,10 @@ impl EnvVars {
     #[attr_added_in("0.5.31")]
     pub const UV_RUN_MAX_RECURSION_DEPTH: &'static str = "UV_RUN_MAX_RECURSION_DEPTH";
 
+    /// Should `uv upgrade` allow recursive search for pyproject.toml files?
+    #[attr_hidden]
+    pub const UV_UPGRADE_RECURSIVE: &'static str = "UV_UPGRADE_RECURSIVE";
+
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
     ///
     /// This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1166,6 +1166,12 @@ impl EnvVars {
     #[attr_hidden]
     pub const UV_UPGRADE_TYPES: &'static str = "UV_UPGRADE_TYPES";
 
+    /// Which version digits are allowed to change? Others will be skipped.
+    ///
+    /// Default `1,2,3,4` (major, minor, patch, build number).
+    #[attr_hidden]
+    pub const UV_UPGRADE_ALLOW: &'static str = "UV_UPGRADE_ALLOW";
+
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
     ///
     /// This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1845,6 +1845,40 @@ pub enum DependencyType {
     Group(GroupName),
 }
 
+impl DependencyType {
+    pub fn iter() -> [Self; 4] {
+        [
+            Self::Production,
+            Self::Dev,
+            Self::Optional(ExtraName::from_str("e").ok().unwrap()),
+            Self::Group(GroupName::from_str("g").ok().unwrap()),
+        ]
+    }
+}
+
+impl FromStr for DependencyType {
+    type Err = DependencyTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // case-insensitive, allow abbreviations
+        match s.to_lowercase().as_str() {
+            "prod" | "prd" | "p" => Ok(Self::Production),
+            "dev" | "d" => Ok(Self::Dev),
+            "optional" | "opt" | "o" | "extra" | "e" => {
+                Ok(Self::Optional(ExtraName::from_str("e").ok().unwrap()))
+            }
+            "groups" | "group" | "g" => Ok(Self::Group(GroupName::from_str("g").ok().unwrap())),
+            _ => Err(DependencyTypeError::Unknown(s.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DependencyTypeError {
+    #[error("unknown value for: `{0}` (allowed: `prod,dev,optional,groups`)")]
+    Unknown(String),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(test, derive(Serialize))]
 pub struct BuildBackendSettingsSchema;

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1,17 +1,24 @@
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 use std::str::FromStr;
-use std::{fmt, iter, mem};
+use std::{
+    fmt,
+    io::{self, Write},
+    iter, mem,
+};
 
 use itertools::Itertools;
+use owo_colors::OwoColorize;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use toml_edit::{
-    Array, ArrayOfTables, DocumentMut, Formatted, Item, RawString, Table, TomlError, Value,
+    Array, ArrayOfTables, DocumentMut, Formatted, Item, RawString, Table, TableLike, TomlError,
+    Value,
 };
 use uv_cache_key::CanonicalUrl;
-use uv_distribution_types::Index;
+use uv_distribution_types::{Index, RequiresPython};
 use uv_fs::PortablePath;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionDigit, VersionParseError, VersionSpecifier, VersionSpecifiers};
@@ -268,7 +275,29 @@ type UpgradeResult = (
     bool,
     DependencyType,
     Option<usize>,
+    Option<RequiresPython>,
 );
+
+type VersionedPackages = FxHashMap<Option<RequiresPython>, FxHashSet<PackageName>>;
+
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct PackageVersions {
+    versions: HashMap<PackageName, HashMap<Option<RequiresPython>, Version>>,
+}
+
+impl PackageVersions {
+    pub fn insert(&mut self, name: PackageName, version: Version, python: Option<RequiresPython>) {
+        self.versions
+            .entry(name)
+            .or_default()
+            .insert(python, version);
+    }
+
+    #[allow(clippy::ref_option)]
+    fn find(&self, name: &PackageName, python: &Option<RequiresPython>) -> Option<&Version> {
+        self.versions.get(name).and_then(|v| v.get(python))
+    }
+}
 
 impl PyProjectTomlMut {
     /// Initialize a [`PyProjectTomlMut`] from a [`str`].
@@ -1210,17 +1239,17 @@ impl PyProjectTomlMut {
         types
     }
 
-    /// Returns package names of all dependencies with version constraints.
+    /// Returns package names of all dependencies with version constraints, including requires-python.
     ///
     /// This method searches `project.dependencies`, `project.optional-dependencies`,
     /// `dependency-groups` and `tool.uv.dev-dependencies`.
-    pub fn find_versioned_dependencies(&self) -> FxHashSet<PackageName> {
-        let mut versioned_dependencies = FxHashSet::default();
+    pub fn find_versioned_dependencies(&self) -> VersionedPackages {
+        let mut versioned_dependencies = FxHashMap::default();
 
         if let Some(project) = self.doc.get("project").and_then(Item::as_table) {
             // Check `project.dependencies`.
             if let Some(dependencies) = project.get("dependencies").and_then(Item::as_array) {
-                Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies);
+                Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies, None);
             }
 
             // Check `project.optional-dependencies`.
@@ -1235,13 +1264,18 @@ impl PyProjectTomlMut {
                     let Ok(_extra) = ExtraName::from_str(extra) else {
                         continue;
                     };
-                    Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies);
+                    Self::extract_names_if_versioned(
+                        &mut versioned_dependencies,
+                        dependencies,
+                        None,
+                    );
                 }
             }
         }
 
         // Check `dependency-groups`.
         if let Some(groups) = self.doc.get("dependency-groups").and_then(Item::as_table) {
+            let group_requires_python = self.get_uv_tool_dep_groups_requires_python();
             for (group, dependencies) in groups {
                 let Ok(_group) = GroupName::from_str(group) else {
                     continue;
@@ -1249,7 +1283,12 @@ impl PyProjectTomlMut {
                 let Some(dependencies) = dependencies.as_array() else {
                     continue;
                 };
-                Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies);
+                let requires_python = group_requires_python.get(&_group.to_string());
+                Self::extract_names_if_versioned(
+                    &mut versioned_dependencies,
+                    dependencies,
+                    requires_python,
+                );
             }
         }
 
@@ -1263,25 +1302,33 @@ impl PyProjectTomlMut {
             .and_then(|uv| uv.get("dev-dependencies"))
             .and_then(Item::as_array)
         {
-            Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies);
+            Self::extract_names_if_versioned(&mut versioned_dependencies, dependencies, None);
         }
 
         versioned_dependencies
     }
 
-    fn extract_names_if_versioned(types: &mut FxHashSet<PackageName>, dependencies: &Array) {
+    fn extract_names_if_versioned(
+        packages: &mut VersionedPackages,
+        dependencies: &Array,
+        group_requires: Option<&RequiresPython>,
+    ) {
+        let mut found = FxHashMap::default();
         for dep in dependencies {
             let Some(req) = dep.as_str().and_then(try_parse_requirement) else {
                 continue;
             };
-            let name = req.name;
-            if types.contains(&name) {
+            // Skip requirements without version constraints
+            if req.version_or_url.is_none() {
                 continue;
             }
-            // Skip requirements without version constraints
-            if let Some(VersionOrUrl::VersionSpecifier(_)) = req.version_or_url {
-                types.insert(name);
-            }
+            found
+                .entry(group_requires)
+                .or_insert_with(FxHashSet::default)
+                .insert(req.name);
+        }
+        for (requires, names) in found {
+            packages.entry(requires.cloned()).or_default().extend(names);
         }
     }
 
@@ -1291,13 +1338,15 @@ impl PyProjectTomlMut {
     /// `dependency-groups` and `tool.uv.dev-dependencies`.
     pub fn upgrade_all_dependencies(
         &mut self,
-        latest_versions: &FxHashMap<&PackageName, Version>,
+        latest_versions: &PackageVersions,
         tables: &[DependencyType],
         allow: &[usize],
         skipped: &mut VersionDigit,
-    ) -> (usize, Vec<UpgradeResult>) {
+        requires_python: &Option<RequiresPython>,
+    ) -> (Vec<UpgradeResult>, usize, usize) {
         let mut all_upgrades = Vec::new();
-        let mut found = 0;
+        let mut all_found = 0;
+        let mut all_skipped = 0;
 
         // Check `project.dependencies`
         if let Some(item) = tables
@@ -1310,15 +1359,17 @@ impl PyProjectTomlMut {
             })
             .flatten()
         {
-            found += item.as_array().map_or(0, Array::len);
-            Self::replace_dependencies(
+            let (found, count_skipped) = Self::replace_dependencies(
                 latest_versions,
                 &mut all_upgrades,
                 item,
                 &DependencyType::Production,
                 allow,
                 skipped,
+                requires_python,
             );
+            all_found += found;
+            all_skipped += count_skipped;
         }
 
         // Check `project.optional-dependencies`
@@ -1338,43 +1389,49 @@ impl PyProjectTomlMut {
                 .map(|(key, value)| (ExtraName::from_str(key.get()).ok(), value))
             {
                 if let Some(_extra) = extra {
-                    found += item.as_array().map_or(0, Array::len);
-                    Self::replace_dependencies(
+                    let (found, count_skipped) = Self::replace_dependencies(
                         latest_versions,
                         &mut all_upgrades,
                         item,
                         &DependencyType::Optional(_extra),
                         allow,
                         skipped,
+                        requires_python,
                     );
+                    all_found += found;
+                    all_skipped += count_skipped;
                 }
             }
         }
 
         // Check `dependency-groups`.
-        if let Some(groups) = tables
-            .iter()
-            .find(|t| matches!(t, DependencyType::Group(_)))
-            .and_then(|_| {
-                self.doc
-                    .get_mut("dependency-groups")
-                    .and_then(Item::as_table_like_mut)
-            })
-        {
-            for (group, item) in groups
-                .iter_mut()
-                .map(|(key, value)| (GroupName::from_str(key.get()).ok(), value))
-            {
-                if let Some(_group) = group {
-                    found += item.as_array().map_or(0, Array::len);
-                    Self::replace_dependencies(
-                        latest_versions,
-                        &mut all_upgrades,
-                        item,
-                        &DependencyType::Group(_group),
-                        allow,
-                        skipped,
-                    );
+        if tables.iter().any(|t| matches!(t, DependencyType::Group(_))) {
+            let group_requires_python = self.get_uv_tool_dep_groups_requires_python();
+            let dep_groups = self
+                .doc
+                .get_mut("dependency-groups")
+                .and_then(Item::as_table_like_mut);
+            if let Some(groups) = dep_groups {
+                for (group, item) in groups
+                    .iter_mut()
+                    .map(|(key, value)| (GroupName::from_str(key.get()).ok(), value))
+                {
+                    if let Some(_group) = group {
+                        let python = group_requires_python
+                            .get(&_group.to_string())
+                            .or(requires_python.as_ref());
+                        let (found, count_skipped) = Self::replace_dependencies(
+                            latest_versions,
+                            &mut all_upgrades,
+                            item,
+                            &DependencyType::Group(_group),
+                            allow,
+                            skipped,
+                            &python.cloned(),
+                        );
+                        all_found += found;
+                        all_skipped += count_skipped;
+                    }
                 }
             }
         }
@@ -1392,60 +1449,105 @@ impl PyProjectTomlMut {
             })
             .flatten()
         {
-            found += item.as_array().map_or(0, Array::len);
-            Self::replace_dependencies(
+            let (found, count_skipped) = Self::replace_dependencies(
                 latest_versions,
                 &mut all_upgrades,
                 item,
                 &DependencyType::Dev,
                 allow,
                 skipped,
+                requires_python,
             );
+            all_found += found;
+            all_skipped += count_skipped;
         }
 
-        (found, all_upgrades)
+        (all_upgrades, all_found, all_skipped)
     }
 
+    fn get_uv_tool_dep_groups_requires_python(&self) -> FxHashMap<String, RequiresPython> {
+        self.doc
+            .get("tool")
+            .and_then(Item::as_table_like)
+            .and_then(|tool| tool.get("uv").and_then(Item::as_table_like))
+            .and_then(|uv| uv.get("dependency-groups").and_then(Item::as_table_like))
+            .map(Self::map_requires_python)
+            .unwrap_or_default()
+    }
+
+    fn map_requires_python(groups: &dyn TableLike) -> FxHashMap<String, RequiresPython> {
+        groups
+            .get_values()
+            .iter()
+            .filter_map(|(keys, value)| {
+                value
+                    .as_inline_table()
+                    .and_then(|i| i.get("requires-python"))
+                    .and_then(|requires| {
+                        requires
+                            .as_str()
+                            .and_then(|v| VersionSpecifiers::from_str(v).ok())
+                    })
+                    .map(|specifiers| {
+                        (
+                            keys.iter().join("."),
+                            RequiresPython::from_specifiers(&specifiers),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    #[allow(clippy::ref_option)]
     fn replace_dependencies(
-        latest_versions: &FxHashMap<&PackageName, Version>,
+        latest_versions: &PackageVersions,
         all_upgrades: &mut Vec<UpgradeResult>,
         item: &mut Item,
         dependency_type: &DependencyType,
         allow: &[usize],
         skipped: &mut VersionDigit,
-    ) {
+        requires_python: &Option<RequiresPython>,
+    ) -> (usize, usize) {
         if let Some(dependencies) = item.as_array_mut().filter(|d| !d.is_empty()) {
-            Self::replace_upgrades(
+            return Self::replace_upgrades(
                 latest_versions,
                 all_upgrades,
                 dependencies,
                 dependency_type,
                 allow,
                 skipped,
+                requires_python,
             );
         }
+        (0, 0)
     }
 
+    #[allow(clippy::ref_option)]
     fn find_upgrades(
-        latest_versions: &FxHashMap<&PackageName, Version>,
+        latest_versions: &PackageVersions,
         dependencies: &mut Array,
         dependency_type: &DependencyType,
         allow: &[usize],
         skipped: &mut VersionDigit,
-    ) -> Vec<UpgradeResult> {
+        requires_python: &Option<RequiresPython>,
+    ) -> (Vec<UpgradeResult>, usize, usize) {
         let mut upgrades = Vec::new();
+        let mut count_skipped = 0;
+        let mut found = 0;
+        let error = format!("{}{}", "error".red().bold(), ":".bold());
         for (i, dep) in dependencies.iter().enumerate() {
             let Some(mut req) = dep.as_str().and_then(try_parse_requirement) else {
                 continue;
             };
+            found += 1;
             let old = req.clone();
             // Skip requirements without version constraints
             let Some(VersionOrUrl::VersionSpecifier(mut version_specifiers)) = req.version_or_url
             else {
                 continue;
             };
-            if let Some(upgrade) = latest_versions.get(&old.name) {
-                let (bumped, upgraded, semver) =
+            if let Some(upgrade) = latest_versions.find(&old.name, requires_python) {
+                let (bumped, upgraded, semver, skip) =
                     version_specifiers.bump_last(upgrade, allow, skipped);
                 if bumped {
                     req.version_or_url = Some(VersionOrUrl::VersionSpecifier(version_specifiers));
@@ -1458,33 +1560,47 @@ impl PyProjectTomlMut {
                         upgraded,
                         dependency_type.clone(),
                         semver,
+                        requires_python.clone(),
                     ));
+                } else if skip {
+                    count_skipped += 1;
                 }
+            } else {
+                writeln!(
+                    io::stderr(),
+                    "{error} No latest found for {} {version_specifiers}",
+                    old.name
+                )
+                .expect("write to stderr failed");
             }
         }
-        upgrades
+        (upgrades, found, count_skipped)
     }
 
+    #[allow(clippy::ref_option)]
     fn replace_upgrades(
-        latest_versions: &FxHashMap<&PackageName, Version>,
+        latest_versions: &PackageVersions,
         all_upgrades: &mut Vec<UpgradeResult>,
         dependencies: &mut Array,
         dependency_type: &DependencyType,
         allow: &[usize],
         skipped: &mut VersionDigit,
-    ) {
-        let upgrades = Self::find_upgrades(
+        requires_python: &Option<RequiresPython>,
+    ) -> (usize, usize) {
+        let (upgrades, found, count_skipped) = Self::find_upgrades(
             latest_versions,
             dependencies,
             dependency_type,
             allow,
             skipped,
+            requires_python,
         );
-        for (i, _dep, _old, new, _upgrade, _upgraded, _, _) in &upgrades {
+        for (i, _dep, _old, new, _upgrade, _upgraded, _, _, _) in &upgrades {
             let string = new.to_string();
             dependencies.replace(*i, toml_edit::Value::from(string));
         }
         all_upgrades.extend(upgrades);
+        (found, count_skipped)
     }
 
     pub fn version(&mut self) -> Result<Version, Error> {

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1291,7 +1291,7 @@ impl PyProjectTomlMut {
     /// `dependency-groups` and `tool.uv.dev-dependencies`.
     pub fn upgrade_all_dependencies(
         &mut self,
-        latest_versions: &FxHashMap<PackageName, Version>,
+        latest_versions: &FxHashMap<&PackageName, Version>,
         tables: &[DependencyType],
         allow: &[usize],
         skipped: &mut VersionDigit,
@@ -1407,7 +1407,7 @@ impl PyProjectTomlMut {
     }
 
     fn replace_dependencies(
-        latest_versions: &FxHashMap<PackageName, Version>,
+        latest_versions: &FxHashMap<&PackageName, Version>,
         all_upgrades: &mut Vec<UpgradeResult>,
         item: &mut Item,
         dependency_type: &DependencyType,
@@ -1427,7 +1427,7 @@ impl PyProjectTomlMut {
     }
 
     fn find_upgrades(
-        latest_versions: &FxHashMap<PackageName, Version>,
+        latest_versions: &FxHashMap<&PackageName, Version>,
         dependencies: &mut Array,
         dependency_type: &DependencyType,
         allow: &[usize],
@@ -1466,7 +1466,7 @@ impl PyProjectTomlMut {
     }
 
     fn replace_upgrades(
-        latest_versions: &FxHashMap<PackageName, Version>,
+        latest_versions: &FxHashMap<&PackageName, Version>,
         all_upgrades: &mut Vec<UpgradeResult>,
         dependencies: &mut Array,
         dependency_type: &DependencyType,

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -88,6 +88,7 @@ miette = { workspace = true, features = ["fancy-no-backtrace"] }
 open = { workspace = true }
 owo-colors = { workspace = true }
 petgraph = { workspace = true }
+prettytable-rs = "0.10.0"
 reqwest = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub(crate) use project::remove::remove;
 pub(crate) use project::run::{RunCommand, run};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
+pub(crate) use project::update::upgrade_project_dependencies;
 pub(crate) use project::version::{project_version, self_version};
 pub(crate) use publish::publish;
 pub(crate) use python::dir::dir as python_dir;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -74,6 +74,7 @@ pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod sync;
 pub(crate) mod tree;
+pub(crate) mod update;
 pub(crate) mod version;
 
 /// The source of a missing lockfile error.

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -387,7 +387,7 @@ pub(crate) async fn remove(
     Ok(ExitStatus::Success)
 }
 
-/// Represents the destination where dependencies are added, either to a project or a script.
+/// Represents the destination where dependencies are removed, either to a project or a script.
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 enum RemoveTarget {

--- a/crates/uv/src/commands/project/update.rs
+++ b/crates/uv/src/commands/project/update.rs
@@ -1,0 +1,159 @@
+use std::env;
+use std::fmt::Write;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::str::FromStr;
+
+use anyhow::Result;
+use owo_colors::OwoColorize;
+use prettytable::format::FormatBuilder;
+use prettytable::row;
+use tokio::sync::Semaphore;
+
+use uv_cache::{Cache, Refresh};
+use uv_cache_info::Timestamp;
+use uv_cli::{Maybe, UpgradeProjectArgs};
+use uv_client::{BaseClientBuilder, RegistryClientBuilder};
+use uv_configuration::Concurrency;
+use uv_distribution_types::{IndexCapabilities, IndexLocations};
+use uv_pep440::{Version, VersionSpecifiers};
+use uv_pep508::{PackageName, Requirement};
+use uv_resolver::{PrereleaseMode, RequiresPython};
+use uv_warnings::warn_user;
+use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
+
+use crate::commands::ExitStatus;
+use crate::commands::pip::latest::LatestClient;
+use crate::printer::Printer;
+
+/// Upgrade all dependencies in the project requirements (pyproject.toml).
+///
+/// This doesn't read or modify uv.lock, only constraints like `<1.0` are bumped.
+pub(crate) async fn upgrade_project_dependencies(args: UpgradeProjectArgs) -> Result<ExitStatus> {
+    let pyproject_toml = Path::new("pyproject.toml");
+    let content = match fs_err::tokio::read_to_string(pyproject_toml).await {
+        Ok(content) => content,
+        Err(err) => {
+            if err.kind() == ErrorKind::NotFound {
+                warn_user!("No pyproject.toml found in current directory");
+                return Ok(ExitStatus::Error);
+            }
+            return Err(err.into());
+        }
+    };
+    let mut toml = match PyProjectTomlMut::from_toml(&content, DependencyTarget::PyProjectToml) {
+        Ok(toml) => toml,
+        Err(err) => {
+            warn_user!("Couldn't read pyproject.toml: {}", err);
+            return Ok(ExitStatus::Error);
+        }
+    };
+
+    #[allow(deprecated)]
+    let cache_dir = env::home_dir().unwrap().join(".cache/uv");
+    let cache = Cache::from_settings(false, Some(cache_dir))?.init()?;
+    let capabilities = IndexCapabilities::default();
+    let client_builder = BaseClientBuilder::new();
+
+    // Initialize the registry client.
+    let client = RegistryClientBuilder::try_from(client_builder)?
+        .cache(cache.clone().with_refresh(Refresh::All(Timestamp::now())))
+        .index_locations(&IndexLocations::default())
+        .build();
+    let download_concurrency = Semaphore::new(Concurrency::default().downloads);
+
+    let python = args.python.and_then(Maybe::into_option).or_else(|| {
+        toml.get_requires_python()
+            .map(std::string::ToString::to_string)
+    });
+    let version_specifiers = python.and_then(|s| VersionSpecifiers::from_str(&s).ok());
+    let requires_python = version_specifiers
+        .map(|v| RequiresPython::from_specifiers(&v))
+        .unwrap_or_else(|| RequiresPython::greater_than_equal_version(&Version::new([4]))); // allow any by default
+
+    // Initialize the client to fetch the latest version of each package.
+    let client = LatestClient {
+        client: &client,
+        capabilities: &capabilities,
+        prerelease: PrereleaseMode::Disallow,
+        exclude_newer: None,
+        tags: None,
+        requires_python: &requires_python,
+    };
+
+    let find_latest = async |name: String| {
+        client
+            .find_latest(
+                &PackageName::from_str(name.as_str()).unwrap(),
+                None,
+                &download_concurrency,
+            )
+            .await
+            .ok()
+            .flatten()
+            .map(uv_distribution_filename::DistFilename::into_version)
+    };
+
+    let printer = Printer::Default;
+    let mut stderr = printer.stderr();
+    let info = "info".cyan();
+    let info = info.bold();
+
+    let (found, all_upgrades) = toml.upgrade_all_dependencies(&find_latest).await;
+    if all_upgrades.is_empty() {
+        if found == 0 {
+            writeln!(
+                stderr,
+                "{info}{} No dependencies found in pyproject.toml",
+                ":".bold()
+            )?;
+        } else {
+            writeln!(
+                stderr,
+                "{info}{} No upgrades found in pyproject.toml, check manually if not committed yet",
+                ":".bold()
+            )?;
+        }
+        return Ok(ExitStatus::Success);
+    }
+    let mut table = prettytable::Table::new();
+    table.set_format(FormatBuilder::new().column_separator(' ').build());
+    let dry_run = if args.dry_run {
+        "upgraded (dry run)"
+    } else {
+        "upgraded"
+    };
+    table.add_row(row![r->"#", rb->"name", Fr->"-old", bFg->"+new", "latest", dry_run]); // diff-like
+    let remove_spaces = |v: &Requirement| {
+        v.clone()
+            .version_or_url
+            .unwrap()
+            .to_string()
+            .replace(' ', "")
+    };
+    all_upgrades
+        .iter()
+        .enumerate()
+        .for_each(|(i, (_, _dep, old, new, version, upgraded))| {
+            let from = remove_spaces(old);
+            let to = remove_spaces(new);
+            let upordown = if *upgraded { "✅ up" } else { "❌ down" };
+            table.add_row(
+                row![r->i + 1, rb->old.name, Fr->from, bFg->to, version.to_string(), upordown],
+            );
+        });
+    table.printstd();
+    if !args.dry_run {
+        if let Err(err) = fs_err::tokio::write(pyproject_toml, toml.to_string()).await {
+            return Err(err.into());
+        }
+        writeln!(
+            stderr,
+            "{info}{} pyproject.toml upgraded 🚀 Check manually then update {} and run tests",
+            ":".bold(),
+            "`uv lock -U && uv sync`".green().bold()
+        )?;
+    }
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/uv/src/commands/project/update.rs
+++ b/crates/uv/src/commands/project/update.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsStr;
 use std::fmt::Write;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -9,18 +10,19 @@ use owo_colors::OwoColorize;
 use prettytable::format::FormatBuilder;
 use prettytable::row;
 use tokio::sync::Semaphore;
-
 use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
 use uv_cli::{Maybe, UpgradeProjectArgs};
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::Concurrency;
+use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{IndexCapabilities, IndexLocations};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::{PackageName, Requirement};
 use uv_resolver::{PrereleaseMode, RequiresPython};
 use uv_warnings::warn_user;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
+use walkdir::WalkDir;
 
 use crate::commands::ExitStatus;
 use crate::commands::pip::latest::LatestClient;
@@ -30,130 +32,219 @@ use crate::printer::Printer;
 ///
 /// This doesn't read or modify uv.lock, only constraints like `<1.0` are bumped.
 pub(crate) async fn upgrade_project_dependencies(args: UpgradeProjectArgs) -> Result<ExitStatus> {
-    let pyproject_toml = Path::new("pyproject.toml");
-    let content = match fs_err::tokio::read_to_string(pyproject_toml).await {
-        Ok(content) => content,
-        Err(err) => {
-            if err.kind() == ErrorKind::NotFound {
-                warn_user!("No pyproject.toml found in current directory");
-                return Ok(ExitStatus::Error);
-            }
-            return Err(err.into());
-        }
-    };
-    let mut toml = match PyProjectTomlMut::from_toml(&content, DependencyTarget::PyProjectToml) {
-        Ok(toml) => toml,
-        Err(err) => {
-            warn_user!("Couldn't read pyproject.toml: {}", err);
-            return Ok(ExitStatus::Error);
-        }
-    };
-
-    #[allow(deprecated)]
-    let cache_dir = env::home_dir().unwrap().join(".cache/uv");
-    let cache = Cache::from_settings(false, Some(cache_dir))?.init()?;
-    let capabilities = IndexCapabilities::default();
-    let client_builder = BaseClientBuilder::new();
-
-    // Initialize the registry client.
-    let client = RegistryClientBuilder::try_from(client_builder)?
-        .cache(cache.clone().with_refresh(Refresh::All(Timestamp::now())))
-        .index_locations(&IndexLocations::default())
-        .build();
-    let download_concurrency = Semaphore::new(Concurrency::default().downloads);
-
-    let python = args.python.and_then(Maybe::into_option).or_else(|| {
-        toml.get_requires_python()
-            .map(std::string::ToString::to_string)
-    });
-    let version_specifiers = python.and_then(|s| VersionSpecifiers::from_str(&s).ok());
-    let requires_python = version_specifiers
-        .map(|v| RequiresPython::from_specifiers(&v))
-        .unwrap_or_else(|| RequiresPython::greater_than_equal_version(&Version::new([4]))); // allow any by default
-
-    // Initialize the client to fetch the latest version of each package.
-    let client = LatestClient {
-        client: &client,
-        capabilities: &capabilities,
-        prerelease: PrereleaseMode::Disallow,
-        exclude_newer: None,
-        tags: None,
-        requires_python: &requires_python,
-    };
-
-    let find_latest = async |name: String| {
-        client
-            .find_latest(
-                &PackageName::from_str(name.as_str()).unwrap(),
-                None,
-                &download_concurrency,
-            )
-            .await
-            .ok()
-            .flatten()
-            .map(uv_distribution_filename::DistFilename::into_version)
+    let tomls = match args
+        .recursive
+        .then(|| search_pyproject_tomls(Path::new(".")))
+    {
+        None => vec![".".to_string()],
+        Some(Ok(tomls)) => tomls,
+        Some(Err(err)) => return Err(err),
     };
 
     let printer = Printer::Default;
-    let mut stderr = printer.stderr();
-    let info = "info".cyan();
-    let info = info.bold();
+    let info = format!("{}{}", "info".cyan().bold(), ":".bold());
 
-    let (found, all_upgrades) = toml.upgrade_all_dependencies(&find_latest).await;
-    if all_upgrades.is_empty() {
-        if found == 0 {
+    let mut item_written = false;
+    let prepend = |written| {
+        if written {
+            writeln!(printer.stderr()).expect("");
+        }
+    };
+
+    let (mut all_found, mut all_bumped) = (0, 0);
+
+    for toml_dir in tomls {
+        prepend(item_written);
+        item_written = false;
+        let pyproject_toml = Path::new(&toml_dir).join("pyproject.toml");
+        let content = match fs_err::tokio::read_to_string(pyproject_toml.clone()).await {
+            Ok(content) => content,
+            Err(err) => {
+                if err.kind() == ErrorKind::NotFound {
+                    warn_user!("No pyproject.toml found in current directory");
+                    return Ok(ExitStatus::Error);
+                }
+                return Err(err.into());
+            }
+        };
+        let mut toml = match PyProjectTomlMut::from_toml(&content, DependencyTarget::PyProjectToml)
+        {
+            Ok(toml) => toml,
+            Err(err) => {
+                warn_user!("Couldn't read pyproject.toml: {}", err);
+                return Ok(ExitStatus::Error);
+            }
+        };
+
+        #[allow(deprecated)]
+        let cache_dir = env::home_dir().unwrap().join(".cache/uv");
+        let cache = Cache::from_settings(false, Some(cache_dir))?.init()?;
+        let capabilities = IndexCapabilities::default();
+        let client_builder = BaseClientBuilder::new();
+
+        // Initialize the registry client.
+        let client = RegistryClientBuilder::try_from(client_builder)?
+            .cache(cache.clone().with_refresh(Refresh::All(Timestamp::now())))
+            .index_locations(&IndexLocations::default())
+            .build();
+        let download_concurrency = Semaphore::new(Concurrency::default().downloads);
+
+        let python = args
+            .python
+            .clone()
+            .and_then(Maybe::into_option)
+            .or_else(|| {
+                toml.get_requires_python()
+                    .map(std::string::ToString::to_string)
+            });
+        let version_specifiers = python.and_then(|s| VersionSpecifiers::from_str(&s).ok());
+        let requires_python = version_specifiers
+            .map(|v| RequiresPython::from_specifiers(&v))
+            .unwrap_or_else(|| RequiresPython::greater_than_equal_version(&Version::new([4]))); // allow any by default
+
+        // Initialize the client to fetch the latest version of each package.
+        let client = LatestClient {
+            client: &client,
+            capabilities: &capabilities,
+            prerelease: PrereleaseMode::Disallow,
+            exclude_newer: None,
+            tags: None,
+            requires_python: &requires_python,
+        };
+
+        let find_latest = async |name: String| {
+            client
+                .find_latest(
+                    &PackageName::from_str(name.as_str()).unwrap(),
+                    None,
+                    &download_concurrency,
+                )
+                .await
+                .ok()
+                .flatten()
+                .map(DistFilename::into_version)
+        };
+
+        let relative = if toml_dir == "." {
+            String::new()
+        } else {
+            format!("{}/", &toml_dir[2..])
+        };
+        let subpath = format!("{relative}pyproject.toml");
+        let (found, upgrades) = toml.upgrade_all_dependencies(&find_latest).await;
+        let bumped = upgrades.len();
+        all_found += found;
+        all_bumped += bumped;
+        if upgrades.is_empty() {
+            if args.recursive && bumped == 0 {
+                continue; // Skip intermediate messages if nothing was changed
+            }
+            if found == 0 {
+                writeln!(
+                    printer.stderr(),
+                    "{info} No dependencies found in {subpath}"
+                )?;
+            } else {
+                writeln!(
+                    printer.stderr(),
+                    "{info} No upgrades found in {subpath}, check manually if not committed yet"
+                )?;
+            }
+            continue;
+        }
+        let mut table = prettytable::Table::new();
+        table.set_format(FormatBuilder::new().column_separator(' ').build());
+        let dry_run = format!(
+            "upgraded {subpath}{}",
+            if args.dry_run { " (dry run)" } else { "" }
+        );
+        table.add_row(row![r->"#", rb->"name", Fr->"-old", bFg->"+new", "latest", dry_run]); // diff-like
+        let remove_spaces = |v: &Requirement| {
+            v.clone()
+                .version_or_url
+                .unwrap()
+                .to_string()
+                .replace(' ', "")
+        };
+        upgrades
+            .iter()
+            .enumerate()
+            .for_each(|(i, (_, _dep, old, new, version, upgraded))| {
+                let from = remove_spaces(old);
+                let to = remove_spaces(new);
+                let upordown = if *upgraded { "✅ up" } else { "❌ down" };
+                table.add_row(
+                    row![r->i + 1, rb->old.name, Fr->from, bFg->to, version.to_string(), upordown],
+                );
+            });
+        table.printstd();
+        if !args.dry_run {
+            if let Err(err) = fs_err::tokio::write(pyproject_toml, toml.to_string()).await {
+                return Err(err.into());
+            }
             writeln!(
-                stderr,
-                "{info}{} No dependencies found in pyproject.toml",
-                ":".bold()
+                printer.stderr(),
+                "{info} {subpath} upgraded 🚀 Check manually, update lock + venv {} and run tests",
+                "`uv sync -U`".green().bold()
             )?;
+        }
+        item_written = true;
+    }
+    if args.recursive && all_bumped == 0 {
+        if all_found == 0 {
+            writeln!(printer.stderr(), "{info} No dependencies found recursively")?;
         } else {
             writeln!(
-                stderr,
-                "{info}{} No upgrades found in pyproject.toml, check manually if not committed yet",
-                ":".bold()
+                printer.stderr(),
+                "{info} No upgrades found recursively, check manually if not committed yet"
             )?;
         }
-        return Ok(ExitStatus::Success);
-    }
-    let mut table = prettytable::Table::new();
-    table.set_format(FormatBuilder::new().column_separator(' ').build());
-    let dry_run = if args.dry_run {
-        "upgraded (dry run)"
-    } else {
-        "upgraded"
-    };
-    table.add_row(row![r->"#", rb->"name", Fr->"-old", bFg->"+new", "latest", dry_run]); // diff-like
-    let remove_spaces = |v: &Requirement| {
-        v.clone()
-            .version_or_url
-            .unwrap()
-            .to_string()
-            .replace(' ', "")
-    };
-    all_upgrades
-        .iter()
-        .enumerate()
-        .for_each(|(i, (_, _dep, old, new, version, upgraded))| {
-            let from = remove_spaces(old);
-            let to = remove_spaces(new);
-            let upordown = if *upgraded { "✅ up" } else { "❌ down" };
-            table.add_row(
-                row![r->i + 1, rb->old.name, Fr->from, bFg->to, version.to_string(), upordown],
-            );
-        });
-    table.printstd();
-    if !args.dry_run {
-        if let Err(err) = fs_err::tokio::write(pyproject_toml, toml.to_string()).await {
-            return Err(err.into());
-        }
-        writeln!(
-            stderr,
-            "{info}{} pyproject.toml upgraded 🚀 Check manually then update {} and run tests",
-            ":".bold(),
-            "`uv lock -U && uv sync`".green().bold()
-        )?;
     }
 
     Ok(ExitStatus::Success)
+}
+
+/// Recursively search for pyproject.toml files.
+fn search_pyproject_tomls(root: &Path) -> Result<Vec<String>, anyhow::Error> {
+    let metadata = match fs_err::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(vec![]),
+        Err(err) => return Err(anyhow::Error::from(err)),
+    };
+
+    if !metadata.is_dir() {
+        return Ok(vec![]);
+    }
+
+    // Hint: Doesn't skip special folders like `build`, `dist` or `target`
+    let is_hidden_or_not_pyproject = |path: &Path| {
+        path.file_name().and_then(OsStr::to_str).is_some_and(|s| {
+            s.starts_with('.') || s.starts_with('_') || path.is_file() && s != "pyproject.toml"
+        })
+    };
+
+    let mut matches: Vec<_> = WalkDir::new(root)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_entry(|entry| {
+            // TODO(konsti): This should be prettier.
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .expect("walkdir starts with root");
+            let hidden = is_hidden_or_not_pyproject(relative);
+            !hidden
+        })
+        .filter_map(|entry| {
+            let path = entry.as_ref().unwrap().path();
+            if path.is_dir() {
+                None
+            } else {
+                Some(path.parent().unwrap().to_str().unwrap().to_string())
+            }
+        })
+        .collect();
+    matches.sort();
+
+    Ok(matches)
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2387,6 +2387,9 @@ async fn run_project(
             ))
             .await
         }
+        ProjectCommand::Upgrade(args) => {
+            Box::pin(commands::upgrade_project_dependencies(args)).await
+        }
         ProjectCommand::Tree(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::TreeSettings::resolve(args, filesystem, environment);

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -22,6 +22,7 @@ fn help() {
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
       version                    Read or update the project's version
+      upgrade                    Upgrade the project's dependency constraints
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format
@@ -103,6 +104,7 @@ fn help_flag() {
       add      Add dependencies to the project
       remove   Remove dependencies from the project
       version  Read or update the project's version
+      upgrade  Upgrade the project's dependency constraints
       sync     Update the project's environment
       lock     Update the project's lockfile
       export   Export the project's lockfile to an alternate format
@@ -182,6 +184,7 @@ fn help_short_flag() {
       add      Add dependencies to the project
       remove   Remove dependencies from the project
       version  Read or update the project's version
+      upgrade  Upgrade the project's dependency constraints
       sync     Update the project's environment
       lock     Update the project's lockfile
       export   Export the project's lockfile to an alternate format
@@ -886,6 +889,7 @@ fn help_unknown_subcommand() {
         add
         remove
         version
+        upgrade
         sync
         lock
         export
@@ -915,6 +919,7 @@ fn help_unknown_subcommand() {
         add
         remove
         version
+        upgrade
         sync
         lock
         export
@@ -973,6 +978,7 @@ fn help_with_global_option() {
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
       version                    Read or update the project's version
+      upgrade                    Upgrade the project's dependency constraints
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format
@@ -1095,6 +1101,7 @@ fn help_with_no_pager() {
       add                        Add dependencies to the project
       remove                     Remove dependencies from the project
       version                    Read or update the project's version
+      upgrade                    Upgrade the project's dependency constraints
       sync                       Update the project's environment
       lock                       Update the project's lockfile
       export                     Export the project's lockfile to an alternate format


### PR DESCRIPTION
## Summary
Provide `uv upgrade` to upgrade dependency constraints in pyproject.toml without changing/syncing uv.lock.

Closes #6794

## Test Plan
- Lots of manual testing 😅
- Unit tests

## Features
- `--dry-run` to check the diff manually before overwriting pyproject.toml
- Searches like the original find_dependency() method:
    * `[project.dependencies]` (prod)
    * `[project.optional-dependencies]` (optional)
    * `[dependency-groups]` (groups)
    * `[tool.uv.dev-dependencies]` (dev)
- `--types=prod,dev,optional,groups` searches given sections only
- `--allow=1,2,3,4` filters version digits (1=major, 2=minor, 3=patch, 4=build number)
- Supports the new [tool.uv.dependency-groups](https://github.com/astral-sh/uv/pull/13735) `requires-python` per group
    1. user-override (`--python=>=3.12`)
    2. group (`[tool.uv.dependency-groups]`)
    3. toml (`[project.requires-python]`)
- Common operators are covered
- Downgrades if needed (current constraint doesn't include latest, i.e. `>1000`)
- `--recursive` searches skip hidden directories
- Fetches latest versions in parallel
- Caches latest versions for 10 minutes to speed up subsequents runs
    * `--refresh` (cold cache) in this repo: `Upgraded 199/860 dependencies in 37 files` in 2 seconds
    * `--no-refresh` (hot cache) in this repo: `Upgraded 199/860 dependencies in 37 files` in 1 second
    * `--no-cache` (no cache) in this repo: `Upgraded 199/860 dependencies in 37 files` in 7 seconds
- Uses as much uv internals / code as possible
- Stays true to the original formatting except inside the constraints itself
    * `ollama<0.5, >=0.4` becomes `ollama>=0.4,<0.6` (uv sorts versions and removes inner space)
    * `; python_version >= \"3.11\"` becomes ` ; python_full_version >= '3.11'` (internal code)

Added for demonstration purposes:
```toml
[tool.uv.dependency-groups]
dev = {requires-python = ">3.10"}
```
<img width="997" alt="uv upgrade" src="https://github.com/user-attachments/assets/53edb518-ba2d-4f83-9fb0-b87fbd193c34" />

