### PR TITLE
Filter managed Python distributions by platform before querying when included in request

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -640,7 +640,7 @@ fn find_all_minor(
 /// Note interpreters may be excluded by the given [`EnvironmentPreference`], [`PythonPreference`],
 /// [`VersionRequest`], or [`PlatformRequest`].
 ///
-/// The [`PlatformRequest`] is currently on applied to managed Python installations before querying
+/// The [`PlatformRequest`] is currently only applied to managed Python installations before querying
 /// the interpreter. The caller is responsible for ensuring it is applied otherwise.
 ///
 /// See [`python_executables`] for more information on discovery.

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -9,6 +9,7 @@ pub use crate::discovery::{
     PythonPreference, PythonRequest, PythonSource, PythonVariant, VersionRequest,
     find_python_installations,
 };
+pub use crate::downloads::PlatformRequest;
 pub use crate::environment::{InvalidEnvironmentKind, PythonEnvironment};
 pub use crate::implementation::ImplementationName;
 pub use crate::installation::{PythonInstallation, PythonInstallationKey};


### PR DESCRIPTION
In the case where we have platform information in a Python request, we should filter managed Python distributions by it prior to querying them.

Closes https://github.com/astral-sh/uv/issues/13935