### PR TITLE
Warn on empty index directory

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -483,6 +483,9 @@ pub(crate) async fn add(
             if !path.is_dir() {
                 bail!("Directory not found for index: {url}");
             }
+            if fs_err::read_dir(&path)?.next().is_none() {
+                warn_user_once!("Index directory `{url}` is empty; falling back to PyPI.");
+            }
         }
     }
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -9398,6 +9398,38 @@ fn add_index_with_non_existent_relative_path_with_same_name_as_index() -> Result
     Ok(())
 }
 
+#[test]
+fn add_index_empty_directory() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let packages = context.temp_dir.child("test-index");
+    packages.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--index").arg("test-index"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Index directory `file://[TEMP_DIR]/test-index` is empty; falling back to PyPI.
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    Ok(())
+}
+
 /// Add a PyPI requirement.
 #[test]
 fn add_group_comment() -> Result<()> {

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -9420,7 +9420,7 @@ fn add_index_empty_directory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Index directory `file://[TEMP_DIR]/test-index` is empty; falling back to PyPI.
+    warning: Index directory `file://[TEMP_DIR]/test-index` is empty, skipping
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]


### PR DESCRIPTION
Close #13922

## Summary

Add a warning if the directory given by the `--index` argument is empty.

## Test Plan

Added test case `add_index_empty_directory` in `edit.rs`
