### PR TITLE
Ignore Python discovery errors during `uv python pin`

### DIFF
--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -110,6 +110,12 @@ pub(crate) async fn pin(
             warn_user_once!("{err}");
             None
         }
+        // If there was some other error, log it
+        Err(err) if !resolved => {
+            debug!("{err}");
+            None
+        }
+        // If `resolved` was requested, we must find an interpreter — fail otherwise
         Err(err) => return Err(err.into()),
     };
 


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/13935#issuecomment-2957300516 where we fail to write a pin file because we encounter an unusable interpreter. This is actually a special case where `MissingPython` is not raised because we want to show why we failed to find a usable interpreter, which is useful in commands where you _need_ an interpreter to use, but here we don't actually need it. Here, we just log the failure and move on.

Related https://github.com/astral-sh/uv/pull/13936