### PR TITLE
Download versions in `uv python pin` if not found

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1464,9 +1464,12 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.request,
                 args.resolved,
                 globals.python_preference,
+                globals.python_downloads,
                 args.no_project,
                 args.global,
                 args.rm,
+                args.install_mirrors,
+                globals.network_settings,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1057,12 +1057,13 @@ pub(crate) struct PythonPinSettings {
     pub(crate) no_project: bool,
     pub(crate) global: bool,
     pub(crate) rm: bool,
+    pub(crate) install_mirrors: PythonInstallMirrors,
 }
 
 impl PythonPinSettings {
     /// Resolve the [`PythonPinSettings`] from the CLI and workspace configuration.
     #[allow(clippy::needless_pass_by_value)]
-    pub(crate) fn resolve(args: PythonPinArgs, _filesystem: Option<FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(args: PythonPinArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let PythonPinArgs {
             request,
             no_resolved,
@@ -1072,12 +1073,17 @@ impl PythonPinSettings {
             rm,
         } = args;
 
+        let install_mirrors = filesystem
+            .map(|fs| fs.install_mirrors.clone())
+            .unwrap_or_default();
+
         Self {
             request,
             resolved: flag(resolved, no_resolved).unwrap_or(false),
             no_project,
             global,
             rm,
+            install_mirrors,
         }
     }
 }

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -817,6 +817,32 @@ fn python_pin_with_comments() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
+fn python_pin_install() {
+    let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_python_sources();
+
+    // Should not install 3.12 when downloads are not automatic
+    uv_snapshot!(context.filters(), context.python_pin().arg("3.12"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Pinned `.python-version` to `3.12`
+
+    ----- stderr -----
+    warning: No interpreter found for Python 3.12 in [PYTHON SOURCES]
+    ");
+
+    uv_snapshot!(context.filters(), context.python_pin().arg("3.12").env("UV_PYTHON_DOWNLOADS", "auto"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Pinned `.python-version` to `3.12`
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn python_pin_rm() {
     let context: TestContext = TestContext::new_with_versions(&["3.12"]);
 


### PR DESCRIPTION
As another follow-up in the vein of https://github.com/astral-sh/uv/pull/13944, I noticed `uv python pin` doesn't download Python versions, which is a bit weird because we'll warn it's not found.