### PR TITLE
Rename `DirectorySymlink` to the more descriptive `PythonMinorVersionLink`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -26,7 +26,7 @@ use crate::implementation::ImplementationName;
 use crate::installation::PythonInstallation;
 use crate::interpreter::Error as InterpreterError;
 use crate::interpreter::{StatusCodeError, UnexpectedResponseError};
-use crate::managed::{ManagedPythonInstallations, MinorVersionLink};
+use crate::managed::{ManagedPythonInstallations, PythonMinorVersionLink};
 #[cfg(windows)]
 use crate::microsoft_store::find_microsoft_store_pythons;
 use crate::virtualenv::Error as VirtualEnvError;
@@ -348,8 +348,8 @@ fn python_executables_from_installed<'a>(
                                 // If this is a CPython implementation, it's a minor version request, and a
                                 // minor version symlink directory (or junction on Windows) exists,
                                 // use an executable path containing that directory.
-                                MinorVersionLink::from_installation(&installation, preview)
-                                    .filter(MinorVersionLink::symlink_exists)
+                                PythonMinorVersionLink::from_installation(&installation, preview)
+                                    .filter(PythonMinorVersionLink::symlink_exists)
                                     .map(|minor_version_link| {
                                         minor_version_link.symlink_executable.clone()
                                     })

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -26,7 +26,7 @@ use crate::implementation::ImplementationName;
 use crate::installation::PythonInstallation;
 use crate::interpreter::Error as InterpreterError;
 use crate::interpreter::{StatusCodeError, UnexpectedResponseError};
-use crate::managed::{DirectorySymlink, ManagedPythonInstallations};
+use crate::managed::{ManagedPythonInstallations, MinorVersionLink};
 #[cfg(windows)]
 use crate::microsoft_store::find_microsoft_store_pythons;
 use crate::virtualenv::Error as VirtualEnvError;
@@ -348,10 +348,10 @@ fn python_executables_from_installed<'a>(
                                 // If this is a CPython implementation, it's a minor version request, and a
                                 // minor version symlink directory (or junction on Windows) exists,
                                 // use an executable path containing that directory.
-                                DirectorySymlink::from_installation(&installation, preview)
-                                    .filter(DirectorySymlink::symlink_exists)
-                                    .map(|directory_symlink| {
-                                        directory_symlink.symlink_executable.clone()
+                                MinorVersionLink::from_installation(&installation, preview)
+                                    .filter(MinorVersionLink::symlink_exists)
+                                    .map(|minor_version_link| {
+                                        minor_version_link.symlink_executable.clone()
                                     })
                                     .unwrap_or_else(|| installation.executable(false))
                             },

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -525,7 +525,7 @@ impl ManagedPythonInstallation {
     /// Ensure the environment contains the symlink directory (or junction on Windows)
     /// pointing to the patch directory for this minor version.
     pub fn ensure_minor_version_link(&self, preview: PreviewMode) -> Result<(), Error> {
-        if let Some(minor_version_link) = MinorVersionLink::from_installation(self, preview) {
+        if let Some(minor_version_link) = PythonMinorVersionLink::from_installation(self, preview) {
             minor_version_link.create_directory()?;
         }
         Ok(())
@@ -658,7 +658,7 @@ impl ManagedPythonInstallation {
 /// A representation of a minor version symlink directory (or junction on Windows)
 /// linking to the home directory of a Python installation.
 #[derive(Clone, Debug)]
-pub struct MinorVersionLink {
+pub struct PythonMinorVersionLink {
     /// The symlink directory (or junction on Windows)
     pub symlink_directory: PathBuf,
     /// The full path to the executable including the symlink directory
@@ -669,7 +669,7 @@ pub struct MinorVersionLink {
     pub target_directory: PathBuf,
 }
 
-impl MinorVersionLink {
+impl PythonMinorVersionLink {
     /// Attempt to derive a path from an executable path that substitutes a minor
     /// version symlink directory (or junction on Windows) for the patch version
     /// directory.
@@ -757,7 +757,7 @@ impl MinorVersionLink {
         installation: &ManagedPythonInstallation,
         preview: PreviewMode,
     ) -> Option<Self> {
-        MinorVersionLink::from_executable(
+        PythonMinorVersionLink::from_executable(
             installation.executable(false).as_path(),
             installation.key(),
             preview,
@@ -765,7 +765,11 @@ impl MinorVersionLink {
     }
 
     pub fn from_interpreter(interpreter: &Interpreter, preview: PreviewMode) -> Option<Self> {
-        MinorVersionLink::from_executable(interpreter.sys_executable(), &interpreter.key(), preview)
+        PythonMinorVersionLink::from_executable(
+            interpreter.sys_executable(),
+            &interpreter.key(),
+            preview,
+        )
     }
 
     pub fn create_directory(&self) -> Result<(), Error> {

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -525,8 +525,8 @@ impl ManagedPythonInstallation {
     /// Ensure the environment contains the symlink directory (or junction on Windows)
     /// pointing to the patch directory for this minor version.
     pub fn ensure_minor_version_link(&self, preview: PreviewMode) -> Result<(), Error> {
-        if let Some(directory_symlink) = DirectorySymlink::from_installation(self, preview) {
-            directory_symlink.create_directory()?;
+        if let Some(minor_version_link) = MinorVersionLink::from_installation(self, preview) {
+            minor_version_link.create_directory()?;
         }
         Ok(())
     }
@@ -655,10 +655,10 @@ impl ManagedPythonInstallation {
     }
 }
 
-/// A representation of a symlink directory (or junction on Windows) linking to
-/// the home directory of a Python installation.
+/// A representation of a minor version symlink directory (or junction on Windows)
+/// linking to the home directory of a Python installation.
 #[derive(Clone, Debug)]
-pub struct DirectorySymlink {
+pub struct MinorVersionLink {
     /// The symlink directory (or junction on Windows)
     pub symlink_directory: PathBuf,
     /// The full path to the executable including the symlink directory
@@ -669,7 +669,7 @@ pub struct DirectorySymlink {
     pub target_directory: PathBuf,
 }
 
-impl DirectorySymlink {
+impl MinorVersionLink {
     /// Attempt to derive a path from an executable path that substitutes a minor
     /// version symlink directory (or junction on Windows) for the patch version
     /// directory.
@@ -737,27 +737,27 @@ impl DirectorySymlink {
             &executable_name.to_string_lossy(),
             implementation,
         );
-        let directory_symlink = Self {
+        let minor_version_link = Self {
             symlink_directory,
             symlink_executable,
             target_directory,
         };
-        // If preview mode is disabled, still return a `DirectorySymlink` for
+        // If preview mode is disabled, still return a `MinorVersionSymlink` for
         // existing symlinks, allowing continued operations without the `--preview`
         // flag after initial symlink directory installation.
         if preview.is_disabled() {
-            if !directory_symlink.symlink_exists() {
+            if !minor_version_link.symlink_exists() {
                 return None;
             }
         }
-        Some(directory_symlink)
+        Some(minor_version_link)
     }
 
     pub fn from_installation(
         installation: &ManagedPythonInstallation,
         preview: PreviewMode,
     ) -> Option<Self> {
-        DirectorySymlink::from_executable(
+        MinorVersionLink::from_executable(
             installation.executable(false).as_path(),
             installation.key(),
             preview,
@@ -765,7 +765,7 @@ impl DirectorySymlink {
     }
 
     pub fn from_interpreter(interpreter: &Interpreter, preview: PreviewMode) -> Option<Self> {
-        DirectorySymlink::from_executable(interpreter.sys_executable(), &interpreter.key(), preview)
+        MinorVersionLink::from_executable(interpreter.sys_executable(), &interpreter.key(), preview)
     }
 
     pub fn create_directory(&self) -> Result<(), Error> {

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use uv_configuration::PreviewMode;
 use uv_fs::{CWD, Simplified, cachedir};
 use uv_pypi_types::Scheme;
-use uv_python::managed::{MinorVersionLink, create_bin_link};
+use uv_python::managed::{PythonMinorVersionLink, create_bin_link};
 use uv_python::{Interpreter, VirtualEnvironment};
 use uv_shell::escape_posix_for_single_quotes;
 use uv_version::version;
@@ -148,9 +148,11 @@ pub(crate) fn create(
     fs::write(location.join(".gitignore"), "*")?;
 
     let executable_target = if upgradeable && interpreter.is_standalone() {
-        if let Some(minor_version_link) =
-            MinorVersionLink::from_executable(base_python.as_path(), &interpreter.key(), preview)
-        {
+        if let Some(minor_version_link) = PythonMinorVersionLink::from_executable(
+            base_python.as_path(),
+            &interpreter.key(),
+            preview,
+        ) {
             if tracing::enabled!(tracing::Level::DEBUG) {
                 let debug_symlink_term = if cfg!(windows) {
                     "junction"

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use uv_configuration::PreviewMode;
 use uv_fs::{CWD, Simplified, cachedir};
 use uv_pypi_types::Scheme;
-use uv_python::managed::{DirectorySymlink, create_bin_link};
+use uv_python::managed::{MinorVersionLink, create_bin_link};
 use uv_python::{Interpreter, VirtualEnvironment};
 use uv_shell::escape_posix_for_single_quotes;
 use uv_version::version;
@@ -148,8 +148,8 @@ pub(crate) fn create(
     fs::write(location.join(".gitignore"), "*")?;
 
     let executable_target = if upgradeable && interpreter.is_standalone() {
-        if let Some(directory_symlink) =
-            DirectorySymlink::from_executable(base_python.as_path(), &interpreter.key(), preview)
+        if let Some(minor_version_link) =
+            MinorVersionLink::from_executable(base_python.as_path(), &interpreter.key(), preview)
         {
             if tracing::enabled!(tracing::Level::DEBUG) {
                 let debug_symlink_term = if cfg!(windows) {
@@ -160,16 +160,16 @@ pub(crate) fn create(
                 debug!(
                     "Using {} {} instead of base Python path: {}",
                     debug_symlink_term,
-                    &directory_symlink.symlink_directory.display(),
+                    &minor_version_link.symlink_directory.display(),
                     &base_python.display()
                 );
             }
-            if !directory_symlink.symlink_exists() {
-                directory_symlink
+            if !minor_version_link.symlink_exists() {
+                minor_version_link
                     .create_directory()
                     .map_err(Error::Python)?;
             }
-            directory_symlink.symlink_executable.clone()
+            minor_version_link.symlink_executable.clone()
         } else {
             base_python.clone()
         }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -16,7 +16,7 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::downloads::{self, DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
 use uv_python::managed::{
-    ManagedPythonInstallation, ManagedPythonInstallations, MinorVersionLink, create_bin_link,
+    ManagedPythonInstallation, ManagedPythonInstallations, PythonMinorVersionLink, create_bin_link,
     python_executable_dir,
 };
 use uv_python::platform::{Arch, Libc};
@@ -640,7 +640,7 @@ fn create_bin_links(
         let target = bin.join(target);
         let executable = if upgradeable {
             if let Some(minor_version_link) =
-                MinorVersionLink::from_installation(installation, preview)
+                PythonMinorVersionLink::from_installation(installation, preview)
             {
                 minor_version_link.symlink_executable.clone()
             } else {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -16,7 +16,7 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::downloads::{self, DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
 use uv_python::managed::{
-    DirectorySymlink, ManagedPythonInstallation, ManagedPythonInstallations, create_bin_link,
+    ManagedPythonInstallation, ManagedPythonInstallations, MinorVersionLink, create_bin_link,
     python_executable_dir,
 };
 use uv_python::platform::{Arch, Libc};
@@ -639,10 +639,10 @@ fn create_bin_links(
     for target in targets {
         let target = bin.join(target);
         let executable = if upgradeable {
-            if let Some(directory_symlink) =
-                DirectorySymlink::from_installation(installation, preview)
+            if let Some(minor_version_link) =
+                MinorVersionLink::from_installation(installation, preview)
             {
-                directory_symlink.symlink_executable.clone()
+                minor_version_link.symlink_executable.clone()
             } else {
                 installation.executable(false)
             }

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::downloads::PythonDownloadRequest;
-use uv_python::managed::{DirectorySymlink, ManagedPythonInstallations, python_executable_dir};
+use uv_python::managed::{ManagedPythonInstallations, MinorVersionLink, python_executable_dir};
 use uv_python::{PythonInstallationKey, PythonInstallationMinorVersionKey, PythonRequest};
 
 use crate::commands::python::install::format_executables;
@@ -244,19 +244,19 @@ async fn do_uninstall(
     // (or junction on Windows) if it exists.
     for installation in &matching_installations {
         if !remaining_minor_versions.contains_key(installation.minor_version_key()) {
-            if let Some(directory_symlink) =
-                DirectorySymlink::from_installation(installation, preview)
+            if let Some(minor_version_link) =
+                MinorVersionLink::from_installation(installation, preview)
             {
-                if directory_symlink.symlink_exists() {
+                if minor_version_link.symlink_exists() {
                     let result = if cfg!(windows) {
-                        fs_err::remove_dir(directory_symlink.symlink_directory.as_path())
+                        fs_err::remove_dir(minor_version_link.symlink_directory.as_path())
                     } else {
-                        fs_err::remove_file(directory_symlink.symlink_directory.as_path())
+                        fs_err::remove_file(minor_version_link.symlink_directory.as_path())
                     };
                     if result.is_err() {
                         return Err(anyhow::anyhow!(
                             "Failed to remove symlink directory {}",
-                            directory_symlink.symlink_directory.display()
+                            minor_version_link.symlink_directory.display()
                         ));
                     }
                     let symlink_term = if cfg!(windows) {
@@ -267,7 +267,7 @@ async fn do_uninstall(
                     debug!(
                         "Removed {}: {}",
                         symlink_term,
-                        directory_symlink.symlink_directory.to_string_lossy()
+                        minor_version_link.symlink_directory.to_string_lossy()
                     );
                 }
             }

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -13,7 +13,9 @@ use tracing::{debug, warn};
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::downloads::PythonDownloadRequest;
-use uv_python::managed::{ManagedPythonInstallations, MinorVersionLink, python_executable_dir};
+use uv_python::managed::{
+    ManagedPythonInstallations, PythonMinorVersionLink, python_executable_dir,
+};
 use uv_python::{PythonInstallationKey, PythonInstallationMinorVersionKey, PythonRequest};
 
 use crate::commands::python::install::format_executables;
@@ -245,7 +247,7 @@ async fn do_uninstall(
     for installation in &matching_installations {
         if !remaining_minor_versions.contains_key(installation.minor_version_key()) {
             if let Some(minor_version_link) =
-                MinorVersionLink::from_installation(installation, preview)
+                PythonMinorVersionLink::from_installation(installation, preview)
             {
                 if minor_version_link.symlink_exists() {
                     let result = if cfg!(windows) {


### PR DESCRIPTION
The `DirectorySymlink` struct assumes that it will be a Python minor version link, so this renaming makes the intention clearer.
