### PR TITLE
Universal sync_required_environment_hint test

### DIFF
--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -4,7 +4,7 @@ use assert_fs::{fixture::ChildPath, prelude::*};
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 
-use crate::common::{TestContext, download_to_disk, uv_snapshot, venv_bin_path};
+use crate::common::{TestContext, download_to_disk, packse_index_url, uv_snapshot, venv_bin_path};
 use predicates::prelude::predicate;
 use tempfile::tempdir_in;
 use uv_fs::Simplified;
@@ -9609,45 +9609,27 @@ fn direct_url_dependency_metadata() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 #[test]
 fn sync_required_environment_hint() -> Result<()> {
     let context = TestContext::new("3.13");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
-        r#"
+    pyproject_toml.write_str(&formatdoc! {r#"
         [project]
         name = "example"
         version = "0.1.0"
         requires-python = ">=3.13.2"
-        dependencies = ["wheel_tag_test"]
+        dependencies = ["no-sdist-no-wheels-with-matching-platform-a"]
+
+        [[tool.uv.index]]
+        name = "packse"
+        url = "{}"
+        default = true
         "#,
-    )?;
+        packse_index_url()
+    })?;
 
-    // Populate the `--find-links` entries.
-    fs_err::create_dir_all(context.temp_dir.join("links"))?;
-
-    for entry in fs_err::read_dir(context.workspace_root.join("scripts/links"))? {
-        let entry = entry?;
-        let path = entry.path();
-        if path
-            .file_name()
-            .and_then(|file_name| file_name.to_str())
-            .is_some_and(|file_name| file_name.starts_with("wheel_tag_test-"))
-        {
-            let dest = context
-                .temp_dir
-                .join("links")
-                .join(path.file_name().unwrap());
-            fs_err::copy(&path, &dest)?;
-        }
-    }
-
-    uv_snapshot!(context.filters(), context.lock()
-            .arg("--no-index")
-            .arg("--find-links")
-            .arg(context.temp_dir.join("links")), @r"
+    uv_snapshot!(context.filters(), context.lock().env_remove("UV_EXCLUDE_NEWER"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -9657,21 +9639,21 @@ fn sync_required_environment_hint() -> Result<()> {
     ");
 
     let mut filters = context.filters();
-    filters.push((r"(macOS|Linux) \(`.*`\)", "[PLATFORM] (`[TAG]`)"));
+    filters.push((
+        r"You're on [^ ]+ \(`.*`\)",
+        "You're on [PLATFORM] (`[TAG]`)",
+    ));
 
-    uv_snapshot!(filters, context.sync()
-            .arg("--no-index")
-            .arg("--find-links")
-            .arg(context.temp_dir.join("links")), @r"
+    uv_snapshot!(filters, context.sync().env_remove("UV_EXCLUDE_NEWER"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    error: Distribution `wheel-tag-test==0.1.0 @ registry+links` can't be installed because it doesn't have a source distribution or wheel for the current platform
+    error: Distribution `no-sdist-no-wheels-with-matching-platform-a==1.0.0 @ registry+https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/` can't be installed because it doesn't have a source distribution or wheel for the current platform
 
-    hint: You're on [PLATFORM] (`[TAG]`), but `wheel-tag-test` (v0.1.0) only has wheels for the following platform: `win_amd64`; consider adding your platform to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
+    hint: You're on [PLATFORM] (`[TAG]`), but `no-sdist-no-wheels-with-matching-platform-a` (v1.0.0) only has wheels for the following platform: `macosx_10_0_ppc64`; consider adding your platform to `tool.uv.required-environments` to ensure uv resolves to a version with compatible wheels
     ");
 
     Ok(())


### PR DESCRIPTION
Use the packse case `no-sdist-no-wheels-with-matching-platform` for a platform independent `sync_required_environment_hint` test.

Fixes #13890