### PR TITLE
Add `UV_PACKAGE` environment variable

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -594,7 +594,7 @@ pub struct VersionArgs {
     pub refresh: RefreshArgs,
 
     /// Update the version of a specific package in the workspace.
-    #[arg(long, conflicts_with = "isolated")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "isolated")]
     pub package: Option<PackageName>,
 
     /// The Python interpreter to use for resolving and syncing.
@@ -2397,7 +2397,7 @@ pub struct BuildArgs {
     /// directory if no source directory is provided.
     ///
     /// If the workspace member does not exist, uv will exit with an error.
-    #[arg(long, conflicts_with("all_packages"))]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with("all_packages"))]
     pub package: Option<PackageName>,
 
     /// Builds all packages in the workspace.
@@ -3124,7 +3124,7 @@ pub struct RunArgs {
     /// Run the command in a specific package in the workspace.
     ///
     /// If the workspace member does not exist, uv will exit with an error.
-    #[arg(long, conflicts_with = "all_packages")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "all_packages")]
     pub package: Option<PackageName>,
 
     /// Avoid discovering the project or workspace.
@@ -3368,7 +3368,7 @@ pub struct SyncArgs {
     /// declared by the specified workspace member package.
     ///
     /// If the workspace member does not exist, uv will exit with an error.
-    #[arg(long, conflicts_with = "all_packages")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "all_packages")]
     pub package: Option<PackageName>,
 
     /// Sync the environment for a Python script, rather than the current project.
@@ -3642,7 +3642,7 @@ pub struct AddArgs {
     pub refresh: RefreshArgs,
 
     /// Add the dependency to a specific package in the workspace.
-    #[arg(long, conflicts_with = "isolated")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "isolated")]
     pub package: Option<PackageName>,
 
     /// Add the dependency to the specified Python script, rather than to a project.
@@ -3744,7 +3744,7 @@ pub struct RemoveArgs {
     pub refresh: RefreshArgs,
 
     /// Remove the dependencies from a specific package in the workspace.
-    #[arg(long, conflicts_with = "isolated")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "isolated")]
     pub package: Option<PackageName>,
 
     /// Remove the dependency from the specified Python script, rather than from a project.
@@ -3933,7 +3933,7 @@ pub struct ExportArgs {
     /// Export the dependencies for a specific package in the workspace.
     ///
     /// If the workspace member does not exist, uv will exit with an error.
-    #[arg(long, conflicts_with = "all_packages")]
+    #[arg(long, env = EnvVars::UV_PACKAGE, conflicts_with = "all_packages")]
     pub package: Option<PackageName>,
 
     /// Prune the given package from the dependency tree.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -100,6 +100,10 @@ impl EnvVars {
     /// file as the constraints file. Uses space-separated list of files.
     pub const UV_CONSTRAINT: &'static str = "UV_CONSTRAINT";
 
+    /// Equivalent to the `--package` command-line argument. If set, uv
+    /// will run the command in this workspace member.
+    pub const UV_PACKAGE: &'static str = "UV_PACKAGE";
+
     /// Equivalent to the `--build-constraint` command-line argument. If set, uv will use this file
     /// as constraints for any source distribution builds. Uses space-separated list of files.
     pub const UV_BUILD_CONSTRAINT: &'static str = "UV_BUILD_CONSTRAINT";


### PR DESCRIPTION
## Summary

Resolves #13826.

This PR introduces the environment variable `UV_PACKAGE`, which is the same as `--package` for commands that execute in a workspace (e.g., `uv build`).


## Test Plan

![image](https://github.com/user-attachments/assets/54a27482-8d56-40a1-9b9e-219b253fd1e6)

