### PR TITLE
When validating lockfile, take account of indexes defined as sources in path dependencies

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1233,7 +1233,7 @@ impl Lock {
         build_constraints: &[Requirement],
         dependency_groups: &BTreeMap<GroupName, Vec<Requirement>>,
         dependency_metadata: &DependencyMetadata,
-        indexes: Option<&IndexLocations>,
+        indexes: Option<Cow<'_, IndexLocations>>,
         tags: &Tags,
         hasher: &HashStrategy,
         index: &InMemoryIndex,
@@ -1399,7 +1399,7 @@ impl Lock {
         }
 
         // Collect the set of available indexes (both `--index-url` and `--find-links` entries).
-        let remotes = indexes.map(|locations| {
+        let remotes = indexes.as_ref().map(|locations| {
             locations
                 .allowed_indexes()
                 .into_iter()
@@ -1412,7 +1412,7 @@ impl Lock {
                 .collect::<BTreeSet<_>>()
         });
 
-        let locals = indexes.map(|locations| {
+        let locals = indexes.as_ref().map(|locations| {
             locations
                 .allowed_indexes()
                 .into_iter()

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1445,6 +1445,8 @@ impl Lock {
             queue.push_back(root);
         }
 
+        // Unlike path dependencies, Git dependencies are immutable. Their sources cannot change
+        // without the hashes changing, so we know their indexes are still present.
         while let Some(package) = queue.pop_front() {
             // If the lockfile references an index that was not provided, we can't validate it.
             if let Source::Registry(index) = &package.id.source {

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -215,14 +215,6 @@ impl<'lock> LockTarget<'lock> {
         }
     }
 
-    /// If this is a workspace, returns path dependency source indexes, otherwise return [`None`].
-    pub(crate) fn path_dependency_source_indexes(&self) -> Option<&[Index]> {
-        match self {
-            Self::Workspace(workspace) => Some(workspace.path_dependency_source_indexes()),
-            Self::Script(..) => None,
-        }
-    }
-
     /// Return the `Requires-Python` bound for the [`LockTarget`].
     #[allow(clippy::result_large_err)]
     pub(crate) fn requires_python(self) -> Result<Option<RequiresPython>, ProjectError> {

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -215,6 +215,14 @@ impl<'lock> LockTarget<'lock> {
         }
     }
 
+    /// If this is a workspace, returns path dependency source indexes, otherwise return [`None`].
+    pub(crate) fn path_dependency_source_indexes(&self) -> Option<&[Index]> {
+        match self {
+            Self::Workspace(workspace) => Some(workspace.path_dependency_source_indexes()),
+            Self::Script(..) => None,
+        }
+    }
+
     /// Return the `Requires-Python` bound for the [`LockTarget`].
     #[allow(clippy::result_large_err)]
     pub(crate) fn requires_python(self) -> Result<Option<RequiresPython>, ProjectError> {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -27559,7 +27559,7 @@ fn lock_conflict_for_disjoint_platform() -> Result<()> {
 }
 
 /// Test that lockfile validation includes explicit indexes from path dependencies.
-/// `<https://github.com/astral-sh/uv/issues/11419>`
+/// <https://github.com/astral-sh/uv/issues/11419>
 #[test]
 fn lock_path_dependency_explicit_index() -> Result<()> {
     let context = TestContext::new("3.12");

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -27557,3 +27557,397 @@ fn lock_conflict_for_disjoint_platform() -> Result<()> {
 
     Ok(())
 }
+
+/// Test that lockfile validation includes explicit indexes from path dependencies.
+/// `<https://github.com/astral-sh/uv/issues/11419>`
+#[test]
+fn lock_path_dependency_explicit_index() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create the path dependency with explicit index
+    let pkg_a = context.temp_dir.child("pkg_a");
+    fs_err::create_dir_all(&pkg_a)?;
+
+    let pyproject_toml = pkg_a.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = { index = "inner-index" }
+
+        [[tool.uv.index]]
+        name = "inner-index"
+        url = "https://pypi-proxy.fly.dev/simple"
+        explicit = true
+        "#,
+    )?;
+
+    // Create a project that depends on pkg_a
+    let pkg_b = context.temp_dir.child("pkg_b");
+    fs_err::create_dir_all(&pkg_b)?;
+
+    let pyproject_toml = pkg_b.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pkg-a"]
+
+        [tool.uv.sources]
+        pkg-a = { path = "../pkg_a/", editable = true }
+        black = { index = "outer-index" }
+
+        [[tool.uv.index]]
+        name = "outer-index"
+        url = "https://outer-index.com/simple"
+        explicit = true
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check").current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Test that lockfile validation works correctly when path dependency has
+/// both explicit and non-explicit indexes.
+#[test]
+fn lock_path_dependency_mixed_indexes() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create the path dependency with both explicit and non-explicit indexes
+    let pkg_a = context.temp_dir.child("pkg_a");
+    fs_err::create_dir_all(&pkg_a)?;
+
+    let pyproject_toml = pkg_a.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig", "anyio"]
+
+        [tool.uv.sources]
+        iniconfig = { index = "explicit-index" }
+        anyio = { index = "non-explicit-index" }
+
+        [[tool.uv.index]]
+        name = "non-explicit-index"
+        url = "https://pypi-proxy.fly.dev/simple"
+
+        [[tool.uv.index]]
+        name = "explicit-index"
+        url = "https://pypi.org/simple"
+        explicit = true
+        "#,
+    )?;
+
+    // Create a project that depends on pkg_a
+    let pkg_b = context.temp_dir.child("pkg_b");
+    fs_err::create_dir_all(&pkg_b)?;
+
+    let pyproject_toml = pkg_b.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pkg-a"]
+
+        [tool.uv.sources]
+        pkg-a = { path = "../pkg_a/", editable = true }
+        black = { index = "outer-index" }
+
+        [[tool.uv.index]]
+        name = "outer-index"
+        url = "https://outer-index.com/simple"
+        explicit = true
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 6 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check").current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 6 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Test that path dependencies without an index don't affect validation.
+#[test]
+fn lock_path_dependency_no_index() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create the path dependency without explicit indexes
+    let pkg_a = context.temp_dir.child("pkg_a");
+    fs_err::create_dir_all(&pkg_a)?;
+
+    let pyproject_toml = pkg_a.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["requests"]
+        "#,
+    )?;
+
+    // Create a project that depends on pkg_a
+    let pkg_b = context.temp_dir.child("pkg_b");
+    fs_err::create_dir_all(&pkg_b)?;
+
+    let pyproject_toml = pkg_b.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pkg-a"]
+
+        [tool.uv.sources]
+        pkg-a = { path = "../pkg_a/", editable = true }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check").current_dir(&pkg_b), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Test that a nested path dependency with an explicit index validates correctly.
+#[test]
+fn lock_nested_path_dependency_explicit_index() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create the inner dependency with explicit index
+    let pkg_a = context.temp_dir.child("pkg_a");
+    fs_err::create_dir_all(&pkg_a)?;
+
+    let pyproject_toml = pkg_a.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = { index = "inner-index" }
+
+        [[tool.uv.index]]
+        name = "inner-index"
+        url = "https://pypi-proxy.fly.dev/simple"
+        explicit = true
+        "#,
+    )?;
+
+    // Create intermediate dependency that depends on pkg_a
+    let pkg_b = context.temp_dir.child("pkg_b");
+    fs_err::create_dir_all(&pkg_b)?;
+
+    let pyproject_toml = pkg_b.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pkg-a"]
+
+        [tool.uv.sources]
+        pkg-a = { path = "../pkg_a/", editable = true }
+        "#,
+    )?;
+
+    // Create a project that depends on intermediate dependency
+    let pkg_c = context.temp_dir.child("pkg_c");
+    fs_err::create_dir_all(&pkg_c)?;
+
+    let pyproject_toml = pkg_c.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-c"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pkg-b"]
+
+        [tool.uv.sources]
+        pkg-b = { path = "../pkg_b/", editable = true }
+        black = { index = "outer-index" }
+
+        [[tool.uv.index]]
+        name = "outer-index"
+        url = "https://outer-index.com/simple"
+        explicit = true
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().current_dir(&pkg_c), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.lock().arg("--check").current_dir(&pkg_c), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Test that validating circular path dependency indexes doesn't cause an infinite loop.
+// TODO(john): Validation doesn't hang but the `uv lock --check` step fails to validate
+// in the circular path dependency case (same behavior as prior to the fix for path
+// dependency index lock validation).
+#[test]
+fn lock_circular_path_dependency_explicit_index() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create pkg_a (with explicit index) that depends on pkg_b
+    let pkg_a = context.temp_dir.child("pkg_a");
+    fs_err::create_dir_all(&pkg_a)?;
+
+    let pyproject_toml = pkg_a.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-a"
+        version = "0.1.0"
+        requires-python = ">=3.10"
+        dependencies = ["pkg-b", "iniconfig"]
+
+        [tool.uv.sources]
+        pkg-b = { path = "../pkg_b/", editable = true }
+        iniconfig = { index = "index-a" }
+
+        [[tool.uv.index]]
+        name = "index-a"
+        url = "https://pypi-proxy.fly.dev/simple"
+        explicit = true
+        "#,
+    )?;
+
+    // Create pkg_b that depends on pkg_a. This is a circular dependency.
+    let pkg_b = context.temp_dir.child("pkg_b");
+    fs_err::create_dir_all(&pkg_b)?;
+
+    let pyproject_toml = pkg_b.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "pkg-b"
+        version = "0.1.0"
+        requires-python = ">=3.10"
+        dependencies = ["pkg-a", "anyio"]
+
+        [tool.uv.sources]
+        pkg-a = { path = "../pkg_a/", editable = true }
+        anyio = { index = "index-b" }
+
+        [[tool.uv.index]]
+        name = "index-b"
+        url = "https://pypi.org/simple"
+        explicit = true
+        default = true
+        "#,
+    )?;
+
+    // This should not hang or crash due to the circular dependency
+    uv_snapshot!(context.filters(), context.lock().current_dir(&pkg_a), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 8 packages in [TIME]
+    ");
+
+    // TODO(john): This currently fails due to circular dependency validation issues
+    uv_snapshot!(context.filters(), context.lock().arg("--check").current_dir(&pkg_a), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 8 packages in [TIME]
+    error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
As described in #11419, when an index was defined as a source in a path dependency (and that index ended up in the lockfile), it would cause lockfile validation to incorrectly determine that the file had changed. This PR adds those indexes to the list uv uses to validate. 

This adds those path dependency source indexes as a new field on `Workspace` (including from transitive path dependencies). It includes cycle detection to handle the case of circular path dependencies.

This includes test for explicit indexes in a path dependency, a combination of explicit and non-explicit, path dependencies without indexes defined, nested (transitive) path dependencies, and circular path dependencies. The circular path dependency test does not hang (indicating successful cycle detection) but lockfile validation still indicates the file has changed. This is not a change from `main` so I have marked this as a `TODO`.

Closes #11419