### PR TITLE
Warn users on `~=` python version specifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5224,6 +5224,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-redacted",
  "uv-small-str",
+ "uv-warnings",
  "version-ranges",
 ]
 

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -29,6 +29,7 @@ uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
+uv-warnings = { workspace = true }
 
 arcstr = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/uv-pep440/src/version_ranges.rs
+++ b/crates/uv-pep440/src/version_ranges.rs
@@ -130,11 +130,10 @@ impl From<VersionSpecifier> for Ranges<Version> {
 ///
 /// See: <https://github.com/pypa/pip/blob/a432c7f4170b9ef798a15f035f5dfdb4cc939f35/src/pip/_internal/resolution/resolvelib/candidates.py#L540>
 pub fn release_specifiers_to_ranges(specifiers: VersionSpecifiers) -> Ranges<Version> {
-    let mut range = Ranges::full();
-    for specifier in specifiers {
-        range = range.intersection(&release_specifier_to_range(specifier));
-    }
-    range
+    specifiers
+        .into_iter()
+        .map(release_specifier_to_range)
+        .fold(Ranges::full(), |acc, range| acc.intersection(&range))
 }
 
 /// Convert the [`VersionSpecifier`] to a PubGrub-compatible version range, using release-only

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -416,7 +416,7 @@ impl VersionSpecifier {
         &self.operator
     }
 
-    /// Get the version, e.g. `<=` in `<= 2.0.0`
+    /// Get the version, e.g. `2.0.0` in `<= 2.0.0`
     pub fn version(&self) -> &Version {
         &self.version
     }
@@ -614,6 +614,11 @@ impl VersionSpecifier {
             | Operator::NotEqualStar
             | Operator::NotEqual => false,
         }
+    }
+
+    /// Returns true if this is a `~=` specifier without a patch version (e.g. `~=3.11`).
+    pub fn is_tilde_without_patch(&self) -> bool {
+        self.operator == Operator::TildeEqual && self.version.release().len() == 2
     }
 }
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4536,9 +4536,10 @@ fn lock_requires_python_exact() -> Result<()> {
 }
 
 /// Lock a requirement from PyPI with a compatible release Python bound.
+#[cfg(feature = "python-patch")]
 #[test]
 fn lock_requires_python_compatible_specifier() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.13.0");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
@@ -4546,7 +4547,7 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
         [project]
         name = "warehouse"
         version = "1.0.0"
-        requires-python = "~=3.12"
+        requires-python = "~=3.13"
         "#,
     )?;
 
@@ -4556,7 +4557,7 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The release specifier (`~=3.12`) contains a compatible release match without a patch version. This will be interpreted as `>=3.12, <4`. Did you mean `~=3.12.[X]` to freeze the minor version?
+    warning: The release specifier (`~=3.13`) contains a compatible release match without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to freeze the minor version?
     Resolved 1 package in [TIME]
     "###);
 
@@ -4565,7 +4566,7 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
         [project]
         name = "warehouse"
         version = "1.0.0"
-        requires-python = "~=3.12, <3.13"
+        requires-python = "~=3.13, <3.14"
         "#,
     )?;
 
@@ -4583,7 +4584,7 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
         [project]
         name = "warehouse"
         version = "1.0.0"
-        requires-python = "~=3.12.0"
+        requires-python = "~=3.13.0"
         "#,
     )?;
 


### PR DESCRIPTION
Close #7426

## Summary

Picking up on #8284, I noticed that the `requires_python` object already has its specifiers canonicalized in the `intersection` method, meaning `~=3.12` is converted to `>=3.12, <4`. To fix this, we check and warn in `intersection`.

## Test Plan

Used the same tests from #8284.
