### PR TITLE
Follow-up minor refactoring of transparent Python upgrade code

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -350,7 +350,7 @@ fn python_executables_from_installed<'a>(
                                         &installation,
                                         preview,
                                     )
-                                    .filter(PythonMinorVersionLink::symlink_exists)
+                                    .filter(PythonMinorVersionLink::exists)
                                     .map(
                                         |minor_version_link| {
                                             minor_version_link.symlink_executable.clone()

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -533,11 +533,11 @@ impl PythonInstallationMinorVersionKey {
     /// [`PythonInstallationMinorVersionKey`] to the installation with highest [`PythonInstallationKey`]
     /// for that minor version key.
     #[inline]
-    pub fn highest_installations_by_minor_version_key<I>(
+    pub fn highest_installations_by_minor_version_key<'a, I>(
         installations: I,
     ) -> FxHashMap<Self, ManagedPythonInstallation>
     where
-        I: IntoIterator<Item = ManagedPythonInstallation>,
+        I: IntoIterator<Item = &'a ManagedPythonInstallation>,
     {
         let mut minor_versions = FxHashMap::default();
         for installation in installations {

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -232,7 +232,7 @@ async fn do_uninstall(
     let remaining_installations: Vec<_> = installations.find_all()?.collect();
     let remaining_minor_versions =
         PythonInstallationMinorVersionKey::highest_installations_by_minor_version_key(
-            remaining_installations,
+            remaining_installations.iter(),
         );
 
     for (_, installation) in remaining_minor_versions
@@ -249,7 +249,7 @@ async fn do_uninstall(
             if let Some(minor_version_link) =
                 PythonMinorVersionLink::from_installation(installation, preview)
             {
-                if minor_version_link.symlink_exists() {
+                if minor_version_link.exists() {
                     let result = if cfg!(windows) {
                         fs_err::remove_dir(minor_version_link.symlink_directory.as_path())
                     } else {

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -507,20 +507,7 @@ impl TestContext {
             for (version, executable) in &python_versions {
                 let parent = python_dir.child(version.to_string());
                 parent.create_dir_all().unwrap();
-                // Ensure the link points to the canonicalized patch version path if
-                // the `python-patch` feature is enabled
-                if cfg!(feature = "python-patch") {
-                    parent
-                        .child("python3")
-                        .symlink_to_file(
-                            executable
-                                .canonicalize()
-                                .expect("Failed to canonicalize executable path"),
-                        )
-                        .unwrap();
-                } else {
-                    parent.child("python3").symlink_to_file(executable).unwrap();
-                }
+                parent.child("python3").symlink_to_file(executable).unwrap();
             }
         }
 

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -507,7 +507,20 @@ impl TestContext {
             for (version, executable) in &python_versions {
                 let parent = python_dir.child(version.to_string());
                 parent.create_dir_all().unwrap();
-                parent.child("python3").symlink_to_file(executable).unwrap();
+                // Ensure the link points to the canonicalized patch version path if
+                // the `python-patch` feature is enabled
+                if cfg!(feature = "python-patch") {
+                    parent
+                        .child("python3")
+                        .symlink_to_file(
+                            executable
+                                .canonicalize()
+                                .expect("Failed to canonicalize executable path"),
+                        )
+                        .unwrap();
+                } else {
+                    parent.child("python3").symlink_to_file(executable).unwrap();
+                }
             }
         }
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4474,17 +4474,6 @@ fn lock_requires_python_exact() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.venv().arg("-p").arg("3.13.0"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Using CPython 3.13.0 interpreter at: [PYTHON-3.13.0]
-    Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    ");
-
     uv_snapshot!(context.filters(), context.lock(), @r"
     success: true
     exit_code: 0

--- a/crates/uv/tests/it/pip_compile_scenarios.rs
+++ b/crates/uv/tests/it/pip_compile_scenarios.rs
@@ -422,17 +422,6 @@ fn python_patch_override_patch_compatible() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("python-patch-override-patch-compatible-a==1.0.0")?;
 
-    uv_snapshot!(filters, context.venv().arg("-p").arg("3.9.20"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Using CPython 3.9.20 interpreter at: [PYTHON-3.9.20]
-    Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    ");
-
     let output = uv_snapshot!(filters, command(&context, python_versions)
         .arg("--python-version=3.9.0")
         , @r"

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -4066,17 +4066,6 @@ fn python_greater_than_current_patch() {
     let mut filters = context.filters();
     filters.push((r"python-greater-than-current-patch-", "package-"));
 
-    uv_snapshot!(filters, context.venv().arg("-p").arg("3.9.12"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Using CPython 3.9.12 interpreter at: [PYTHON-3.9.12]
-    Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    ");
-
     uv_snapshot!(filters, command(&context)
         .arg("python-greater-than-current-patch-a==1.0.0")
         , @r"


### PR DESCRIPTION
This PR:
* renames `PythonMinorVersionLink::symlink_exists()` to `..::exists`
* avoids rediscovering installations by chaining together new installations with pre-existing installations when searching for the highest patch per minor version key
* renames a couple of related errors and updates their messages to be more specific
* renames `create_bin_link` to `create_link_to_executable`
* removes a constructor that is no longer used (`PythonMinorVersinLink::from_interpreter()`)
