### PR TITLE
doc: Sync PyTorch integration index for CUDA and ROCm versions

### DIFF
--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -85,21 +85,21 @@ In such cases, the first step is to add the relevant PyTorch index to your `pypr
     explicit = true
     ```
 
-=== "CUDA 12.1"
+=== "CUDA 12.6"
 
     ```toml
     [[tool.uv.index]]
-    name = "pytorch-cu121"
-    url = "https://download.pytorch.org/whl/cu121"
+    name = "pytorch-cu126"
+    url = "https://download.pytorch.org/whl/cu126"
     explicit = true
     ```
 
-=== "CUDA 12.4"
+=== "CUDA 12.8"
 
     ```toml
     [[tool.uv.index]]
-    name = "pytorch-cu124"
-    url = "https://download.pytorch.org/whl/cu124"
+    name = "pytorch-cu128"
+    url = "https://download.pytorch.org/whl/cu128"
     explicit = true
     ```
 
@@ -108,7 +108,7 @@ In such cases, the first step is to add the relevant PyTorch index to your `pypr
     ```toml
     [[tool.uv.index]]
     name = "pytorch-rocm"
-    url = "https://download.pytorch.org/whl/rocm6.2"
+    url = "https://download.pytorch.org/whl/rocm6.3"
     explicit = true
     ```
 
@@ -154,7 +154,7 @@ Next, update the `pyproject.toml` to point `torch` and `torchvision` to the desi
     ]
     ```
 
-=== "CUDA 12.1"
+=== "CUDA 12.6"
 
     PyTorch doesn't publish CUDA builds for macOS. As such, we gate on `sys_platform` to instruct uv to limit
     the PyTorch index to Linux and Windows, falling back to PyPI on macOS:
@@ -162,14 +162,14 @@ Next, update the `pyproject.toml` to point `torch` and `torchvision` to the desi
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "pytorch-cu121", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+      { index = "pytorch-cu126", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     ]
     torchvision = [
-      { index = "pytorch-cu121", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+      { index = "pytorch-cu126", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     ]
     ```
 
-=== "CUDA 12.4"
+=== "CUDA 12.8"
 
     PyTorch doesn't publish CUDA builds for macOS. As such, we gate on `sys_platform` to instruct uv to limit
     the PyTorch index to Linux and Windows, falling back to PyPI on macOS:
@@ -177,10 +177,10 @@ Next, update the `pyproject.toml` to point `torch` and `torchvision` to the desi
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+      { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     ]
     torchvision = [
-      { index = "pytorch-cu124", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+      { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     ]
     ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Just to sync the documentation with PyTorch's officially recommended installation method.
![image](https://github.com/user-attachments/assets/7be0aea6-b51b-4083-acae-fbe8aa79c363)
**Change:**
* CUDA 12.1 to CUDA 12.6
* CUDA 12.4 to CUDA 12.8
* ROCm 6.2 to ROCm 6.3
## Test Plan
Run doc server in local.
Result:
<details><summary>CUDA 12.6</summary>
<p>

![image](https://github.com/user-attachments/assets/962a1058-3922-4709-a57f-200939d0a397)
![image](https://github.com/user-attachments/assets/0dae693f-2dc1-4d3e-9186-d26aa84c7d73)

</p>
</details> 
<details><summary>CUDA 12.8</summary>
<p>

![image](https://github.com/user-attachments/assets/dc12d09b-f8f2-41d3-b185-cb1e4e8b062b)
![image](https://github.com/user-attachments/assets/1b5490e3-6265-4bad-8af2-eab0a207adab)

</p>
</details> 
<details><summary>ROCm6</summary>
<p>

![image](https://github.com/user-attachments/assets/3b17a24f-3210-4a99-a81b-f8f2f5578b73)
![image](https://github.com/user-attachments/assets/c7baae55-14e5-45d0-94a0-164ab31bbffc)

</p>
</details> 


