### PR TITLE
Don't use walrus operator in interpreter query script

### DIFF
--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -255,5 +255,6 @@ def platform_tags(archs: Sequence[str]) -> Iterator[str]:
                 if _is_compatible(arch, glibc_version):
                     yield "manylinux_{}_{}_{}".format(*glibc_version, arch)
                     # Handle the legacy manylinux1, manylinux2010, manylinux2014 tags.
-                    if legacy_tag := _LEGACY_MANYLINUX_MAP.get(glibc_version):
+                    legacy_tag = _LEGACY_MANYLINUX_MAP.get(glibc_version)
+                    if legacy_tag:
                         yield f"{legacy_tag}_{arch}"


### PR DESCRIPTION
Fix `uv run -p 3.7` by not using a walrus operator. Python 3.7 isn't really supported anymore, but there's no reason to break interpreter discovery for it.