### PR TITLE
Serialize Python requests for tools as canonicalized strings

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -67,6 +67,26 @@ pub enum PythonRequest {
     Key(PythonDownloadRequest),
 }
 
+impl<'a> serde::Deserialize<'a> for PythonRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'a>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(PythonRequest::parse(&s))
+    }
+}
+
+impl serde::Serialize for PythonRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let s = self.to_canonical_string();
+        serializer.serialize_str(&s)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -158,14 +158,18 @@ pub(crate) async fn refine_interpreter(
     Ok(Some(interpreter))
 }
 
-/// Installs tool executables for a given package and handles any conflicts.
-pub(crate) fn install_executables(
+/// Finalizes a tool installation, after creation of an environment.
+///
+/// Installs tool executables for a given package, handling any conflicts.
+///
+/// Adds a receipt for the tool.
+pub(crate) fn finalize_tool_install(
     environment: &PythonEnvironment,
     name: &PackageName,
     installed_tools: &InstalledTools,
     options: ToolOptions,
     force: bool,
-    python: Option<String>,
+    python: Option<PythonRequest>,
     requirements: Vec<Requirement>,
     constraints: Vec<Requirement>,
     overrides: Vec<Requirement>,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -33,7 +33,9 @@ use crate::commands::project::{
     EnvironmentSpecification, PlatformState, ProjectError, resolve_environment, resolve_names,
     sync_environment, update_environment,
 };
-use crate::commands::tool::common::{install_executables, refine_interpreter, remove_entrypoints};
+use crate::commands::tool::common::{
+    finalize_tool_install, refine_interpreter, remove_entrypoints,
+};
 use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::{diagnostics, reporters::PythonDownloadReporter};
 use crate::printer::Printer;
@@ -592,13 +594,13 @@ pub(crate) async fn install(
         }
     };
 
-    install_executables(
+    finalize_tool_install(
         &environment,
         &from.name,
         &installed_tools,
         options,
         force || invalid_tool_receipt,
-        python,
+        python_request,
         requirements,
         constraints,
         overrides,

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -29,7 +29,7 @@ use crate::commands::project::{
 };
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::common::remove_entrypoints;
-use crate::commands::{ExitStatus, conjunction, tool::common::install_executables};
+use crate::commands::{ExitStatus, conjunction, tool::common::finalize_tool_install};
 use crate::printer::Printer;
 use crate::settings::{NetworkSettings, ResolverInstallerSettings};
 
@@ -375,7 +375,7 @@ async fn upgrade_tool(
         remove_entrypoints(&existing_tool_receipt);
 
         // If we modified the target tool, reinstall the entrypoints.
-        install_executables(
+        finalize_tool_install(
             &environment,
             name,
             installed_tools,


### PR DESCRIPTION
When working on support for reading global Python pins in tool operations, I noticed that we weren't using the canonicalized Python request in receipts — we were using the raw string provided by the user. Since we'll need to compare these values, we should be using the canonicalized string.

The `Tool` and `ToolReceipt` types have been updated to hold a `PythonRequest` instead of a `String`, and `Serialize` was implemented for `PythonRequest` so canonicalization can happen at the edge instead of being the caller's responsibility.