### PR TITLE
Fix PyPI publish test script

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -223,7 +223,7 @@ def get_filenames(url: str, client: httpx.Client) -> list[str]:
     response = client.get(url)
     data = response.text
     # Works for the indexes in the list
-    href_text = r"<a(?: +[\w-]+=(?:'[^']+'|\"[^\"]+\"))* *>([^<>]+)</a>"
+    href_text = r"<a(?:\s*[\w-]+=(?:'[^']+'|\"[^\"]+\"))* *>([^<>]+)</a>"
     return [m.group(1) for m in re.finditer(href_text, data)]
 
 

--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -163,39 +163,37 @@ all_targets: dict[str, TargetConfiguration] = local_targets | {
 }
 
 
-def get_latest_version(project_name: str, client: httpx.Client) -> Version:
+def get_latest_version(target: str, client: httpx.Client) -> Version:
     """Return the latest version on all indexes of the package."""
     # To keep the number of packages small we reuse them across targets, so we have to
     # pick a version that doesn't exist on any target yet
     versions = set()
-    for target_config in all_targets.values():
-        if target_config.project_name != project_name:
-            continue
-        url = target_config.index_url + project_name + "/"
+    target_config = all_targets[target]
+    url = target_config.index_url + target_config.project_name + "/"
 
-        # Get with retries
-        error = None
-        for _ in range(5):
-            try:
-                versions.update(collect_versions(url, client))
-                break
-            except httpx.HTTPError as err:
-                error = err
-                print(
-                    f"Error getting version for {project_name}, sleeping for 1s: {err}",
-                    file=sys.stderr,
-                )
-                time.sleep(1)
-            except InvalidSdistFilename as err:
-                # Sometimes there's a link that says "status page"
-                error = err
-                print(
-                    f"Invalid index page for {project_name}, sleeping for 1s: {err}",
-                    file=sys.stderr,
-                )
-                time.sleep(1)
-        else:
-            raise RuntimeError(f"Failed to fetch {url}") from error
+    # Get with retries
+    error = None
+    for _ in range(5):
+        try:
+            versions.update(collect_versions(url, client))
+            break
+        except httpx.HTTPError as err:
+            error = err
+            print(
+                f"Error getting version for {target_config.project_name}, sleeping for 1s: {err}",
+                file=sys.stderr,
+            )
+            time.sleep(1)
+        except InvalidSdistFilename as err:
+            # Sometimes there's a link that says "status page"
+            error = err
+            print(
+                f"Invalid index page for {target_config.project_name}, sleeping for 1s: {err}",
+                file=sys.stderr,
+            )
+            time.sleep(1)
+    else:
+        raise RuntimeError(f"Failed to fetch {url}") from error
     return max(versions)
 
 
@@ -363,7 +361,7 @@ def publish_project(target: str, uv: Path, client: httpx.Client):
         print(f"\nPublish {project_name} for {target}", file=sys.stderr)
 
         # The distributions are build to the dist directory of the project.
-        previous_version = get_latest_version(project_name, client)
+        previous_version = get_latest_version(target, client)
         version = get_new_version(previous_version)
         project_dir = build_project_at_version(target, version, uv)
 


### PR DESCRIPTION
The script stumbled over a newline introduced in https://github.com/pypi/warehouse/pull/18266 (which is valid).

Also fixed: Don't read versions for the same package from other indexes. We were using `project_name` here instead of `target`, while using the latter and only reading from a single index simplifies the code too.