### PR TITLE
Fix the current directory change issue upon activation of a relocatable venv within fish

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -300,7 +300,7 @@ pub(crate) fn create(
             }
             (true, "activate.bat") => r"%~dp0..".to_string(),
             (true, "activate.fish") => {
-                r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#.to_string()
+                r#""$(dirname -- "$(dirname -- "$(realpath -- "$(status filename)")")")""#.to_string()
             }
             // Note:
             // * relocatable activate scripts appear not to be possible in csh and nu shell


### PR DESCRIPTION
## Summary


Activating a relocatable venv within fish shell will change current directory unexpectedly.
An example:
```fish
~ > pwd
/home/user

~ > uv venv --relocatable
Using CPython 3.13.3 interpreter at: /usr/bin/python3.13
Creating virtual environment at: ./.venv
Activate with: source .venv/bin/activate.fish

~ > source .venv/bin/activate.fish

(project) ~/.venv/bin > pwd   # current directory is changed here!
/home/user/.venv/bin
```
This PR removes `cd` command in activate script. And the current directory will not be changed any more.

Versions:
```
fish: 4.0.1
uv: 0.7.12
```

## Test Plan
```fish
set old_cwd (pwd)
uv venv --relocatable
source .venv/bin/activate.fish
set cwd (pwd)
test "$old_cwd" = "$cwd"
```
