### PR TITLE
(f)lock during `uv run`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -365,8 +365,6 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 .await?
                 .into_environment()?;
 
-                let _lock = environment.lock().await?;
-
                 let build_constraints = script
                     .metadata()
                     .tool
@@ -383,6 +381,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                                 .map(|constraint| Requirement::from(constraint.clone())),
                         )
                     });
+
+                let _lock = environment.lock().await?;
 
                 match update_environment(
                     environment,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -239,6 +239,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             .await?
             .into_environment()?;
 
+            let _lock = environment.lock().await?;
+
             // Determine the lock mode.
             let mode = if frozen {
                 LockMode::Frozen
@@ -362,6 +364,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 )
                 .await?
                 .into_environment()?;
+
+                let _lock = environment.lock().await?;
 
                 let build_constraints = script
                     .metadata()
@@ -685,6 +689,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                         .map(|lock| (lock, project.workspace().install_path().to_owned()));
                 }
             } else {
+                let _lock = venv.lock().await?;
+
                 // Determine the lock mode.
                 let mode = if frozen {
                     LockMode::Frozen


### PR DESCRIPTION
This is very similar to the locking added for `uv sync`, `uv add`, and `uv remove` in https://github.com/astral-sh/uv/pull/13869. Improving our (f)locking in general is tracked in
https://github.com/astral-sh/uv/issues/13883.

This is a minimal change that un-breaks parallel invocations of `uv run`. It's too easy to confuse locking as in "lockfile generation" and locking as in "file locking to prevent race conditions", so we probably need a broader overhaul of how these things are named. It's also too easy to miss a callsite here, or to accidentally retain one of these locks across `run_to_completion`, so ideally we could move this file locking down to a lower-level function that's shared by all these callers, possibly `pip::operations::install`. I want to get this minimal change through testing and review before I tackle either of those.

Here's a repro of the current race condition in `uv run`, which this PR fixes. Add a bunch of dependencies to provoke it, as suggested in #12751:

```
$ cd `mktemp -d`
$ uv init --package --name scratch
Initialized project `scratch`
$ uv add boto3 fastapi numba pandas polars protobuf pyarrow pydantic requests urllib3 scikit-learn jupyter
...
$ rm -r .venv && uv run -q scratch & uv run -q scratch
[1] 1451463
error: Failed to install: jupyterlab_widgets-3.0.15-py3-none-any.whl (jupyterlab-widgets==3.0.15)
  Caused by: failed to copy file from /home/jacko/.cache/uv/archive-v0/zXFcriPVQ1wOXqf_UUK1u/jupyterlab_widgets-3.0.15.data/data/share/jupyter/labextensions/@jupyter-widgets/jupyterlab-manager/schemas/@jupyter-widgets/jupyterlab-manager/plugin.json to /tmp/tmp.NFEGYgsQnF/.venv/lib/python3.13/site-packages/jupyterlab_widgets-3.0.15.data/data/share/jupyter/labextensions/@jupyter-widgets/jupyterlab-manager/schemas/@jupyter-widgets/jupyterlab-manager/plugin.json: No such file or directory (os error 2)
```

With this change:

```
$ rm -r .venv && ~/uv/target/fast-build/uv run -q scratch & ~/uv/target/fast-build/uv run -q scratch
[1] 1452335
Hello from scratch!
[1]  + done       ~/uv/target/fast-build/uv run -q scratch
Hello from scratch!

# Run 100 invocations in parallel.
$ rm -r .venv && for i in `seq 100` ; do ~/uv/target/fast-build/uv run -q scratch & done
[lots of job output, no failures]
```