### PR TITLE
Restore Docker image annotations and fix attestations

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -339,14 +339,14 @@ jobs:
     steps:
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: astral
+          password: ${{ secrets.DOCKERHUB_TOKEN_RW }}
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: astral
-          password: ${{ secrets.DOCKERHUB_TOKEN_RW }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Depot doesn't support annotating images, so we need to do so manually
       # afterwards. Mutating the manifest is desirable regardless, because we


### PR DESCRIPTION
More follow-up to #13459 

- Depot doesn't support annotations, so we push those manually
- Docker push for the re-tag was breaking the manifest, since we need to annotate manually, we just do that instead
- We attest after the annotation

A bit of an aside

- We test building the extra images, it's very fast and I don't see why it's better to gate it

I tested this on my fork then cleaned it up a bit for a commit here. You can see the images at

- https://github.com/zanieb/uv/pkgs/container/uv 
- https://hub.docker.com/r/astral/uv/tags