### PR TITLE
make `uv sync --check` outdated a non-error status 1

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -127,6 +127,10 @@ impl OperationDiagnostic {
                 native_tls_hint(err);
                 None
             }
+            pip::operations::Error::OutdatedEnvironment => {
+                anstream::eprint!("{}", err);
+                None
+            }
             err => Some(err),
         }
     }

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -657,9 +657,9 @@ fn check() -> Result<()> {
     )?;
 
     // Running `uv sync --check` should fail.
-    uv_snapshot!(context.filters(), context.sync().arg("--check"), @r###"
+    uv_snapshot!(context.filters(), context.sync().arg("--check"), @r"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -669,8 +669,8 @@ fn check() -> Result<()> {
     Would download 1 package
     Would install 1 package
      + iniconfig==2.0.0
-    error: The environment is outdated; run `uv sync` to update the environment
-    "###);
+    The environment is outdated; run `uv sync` to update the environment
+    ");
 
     // Sync the environment.
     uv_snapshot!(context.filters(), context.sync(), @r###"


### PR DESCRIPTION
In the case of `uv sync` all we really need to do is handle the `OutdatedEnvironment` error (precisely the error we yield only on dry-runs when everything Works but we determine things are outdated) in `OperationDiagnostic::report` (the post-processor on all `operations::install` calls) because any diagnostic handled by that gets downgraded to from status 2 to status 1 (although I don't know if that's really intentional or a random other bug in our status handling... but I figured it's best to highlight that other potential status code incongruence than not rely on it 😄).

Fixes #12603