### PR TITLE
Only update existing symlink directories on preview uninstall

### DIFF
--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -240,7 +240,7 @@ async fn do_uninstall(
         .iter()
         .filter(|(minor_version, _)| uninstalled_minor_versions.contains(minor_version))
     {
-        installation.ensure_minor_version_link(preview)?;
+        installation.update_minor_version_link(preview)?;
     }
     // For each uninstalled installation, check if there are no remaining installations
     // for its minor version. If there are none remaining, remove the symlink directory


### PR DESCRIPTION
On preview uninstall, we should not create a new minor version symlink directory if one doesn't exist. We should only update existing ones.
