### PR TITLE
Use Relaxed memory ordering

### DIFF
--- a/crates/uv-warnings/src/lib.rs
+++ b/crates/uv-warnings/src/lib.rs
@@ -13,12 +13,12 @@ pub static ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Enable user-facing warnings.
 pub fn enable() {
-    ENABLED.store(true, std::sync::atomic::Ordering::SeqCst);
+    ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Disable user-facing warnings.
 pub fn disable() {
-    ENABLED.store(false, std::sync::atomic::Ordering::SeqCst);
+    ENABLED.store(false, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Warn a user, if warnings are enabled.
@@ -28,7 +28,7 @@ macro_rules! warn_user {
         use $crate::anstream::eprintln;
         use $crate::owo_colors::OwoColorize;
 
-        if $crate::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {
+        if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
             let message = format!("{}", format_args!($($arg)*));
             let formatted = message.bold();
             eprintln!("{}{} {formatted}", "warning".yellow().bold(), ":".bold());
@@ -46,7 +46,7 @@ macro_rules! warn_user_once {
         use $crate::anstream::eprintln;
         use $crate::owo_colors::OwoColorize;
 
-        if $crate::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {
+        if $crate::ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
             if let Ok(mut states) = $crate::WARNINGS.lock() {
                 let message = format!("{}", format_args!($($arg)*));
                 if states.insert(message.clone()) {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This is a follow-up to https://github.com/astral-sh/uv/pull/13033#discussion_r2137343801. 

The goals of this PR include:
1. applying a consistent memory ordering for (simple) use cases that doesn't involve synchronization/interaction with other data structures (i.e. atomics in `uv-warning` and the one introduced in #13033)
2. relaxing the memory ordering from the strictest [`Ordering::SeqCst`](https://doc.rust-lang.org/nomicon/atomics.html#sequentially-consistent) to [`Ordering::Relaxed`](https://doc.rust-lang.org/nomicon/atomics.html#relaxed) for such use cases.

## Test Plan

<!-- How was it tested? -->
Unsure of how to test here. 