### PR TITLE
Add proto and tlsv1.2 to curl commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1642,7 +1642,7 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Download binary for last version"
-        run: curl -LsSf "https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz" | tar -xvz
+        run: curl -LsSf --proto '=https' --tlsv1.2 "https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz" | tar -xvz
 
       - name: "Check cache compatibility"
         run: python scripts/check_cache_compat.py --uv-current ./uv --uv-previous ./uv-x86_64-unknown-linux-gnu/uv
@@ -1664,7 +1664,7 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Download binary for last version"
-        run: curl -LsSf "https://github.com/astral-sh/uv/releases/latest/download/uv-aarch64-apple-darwin.tar.gz" | tar -xvz
+        run: curl -LsSf --proto '=https' --tlsv1.2 "https://github.com/astral-sh/uv/releases/latest/download/uv-aarch64-apple-darwin.tar.gz" | tar -xvz
 
       - name: "Check cache compatibility"
         run: python scripts/check_cache_compat.py --uv-current ./uv --uv-previous ./uv-aarch64-apple-darwin/uv
@@ -2310,7 +2310,7 @@ jobs:
 
       # Download embedded Python.
       - name: "Download embedded Python"
-        run: curl -LsSf https://www.python.org/ftp/python/3.11.8/python-3.11.8-embed-amd64.zip -o python-3.11.8-embed-amd64.zip
+        run: curl -LsSf --proto '=https' --tlsv1.2 https://www.python.org/ftp/python/3.11.8/python-3.11.8-embed-amd64.zip -o python-3.11.8-embed-amd64.zip
 
       - name: "Unzip embedded Python"
         run: 7z x python-3.11.8-embed-amd64.zip -oembedded-python

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install uv with our standalone installers:
 
 ```bash
 # On macOS and Linux.
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | sh
 ```
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@ uv provides a standalone installer to download and install uv:
     Use `curl` to download the script and execute it with `sh`:
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/install.sh | sh
+    $ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | sh
     ```
 
     If your system doesn't have `curl`, you can use `wget`:
@@ -25,7 +25,7 @@ uv provides a standalone installer to download and install uv:
     Request a specific version by including it in the URL:
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh
+    $ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/0.7.13/install.sh | sh
     ```
 
 === "Windows"
@@ -51,7 +51,7 @@ uv provides a standalone installer to download and install uv:
     === "macOS and Linux"
 
         ```console
-        $ curl -LsSf https://astral.sh/uv/install.sh | less
+        $ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | less
         ```
 
     === "Windows"

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Install uv with our official standalone installer:
 === "macOS and Linux"
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/install.sh | sh
+    $ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | sh
     ```
 
 === "Windows"

--- a/docs/reference/installer.md
+++ b/docs/reference/installer.md
@@ -11,7 +11,7 @@ To change the installation path, use `UV_INSTALL_DIR`:
 === "macOS and Linux"
 
     ```console
-    $ curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/custom/path" sh
+    $ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/custom/path" sh
     ```
 
 === "Windows"
@@ -26,7 +26,7 @@ The installer may also update your shell profiles to ensure the uv binary is on 
 disable this behavior, use `INSTALLER_NO_MODIFY_PATH`. For example:
 
 ```console
-$ curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
+$ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
 ```
 
 If installed with `INSTALLER_NO_MODIFY_PATH`, subsequent operations, like `uv self update`, will not
@@ -38,7 +38,7 @@ In ephemeral environments like CI, use `UV_UNMANAGED_INSTALL` to install uv to a
 preventing the installer from modifying shell profiles or environment variables:
 
 ```console
-$ curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/custom/path" sh
+$ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/custom/path" sh
 ```
 
 The use of `UV_UNMANAGED_INSTALL` will also disable self-updates (via `uv self update`).
@@ -50,5 +50,5 @@ options can be passed directly to the installation script. For example, to see t
 options:
 
 ```console
-$ curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --help
+$ curl -LsSf --proto '=https' --tlsv1.2 https://astral.sh/uv/install.sh | sh -s -- --help
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Use `--proto '=https' --tlsv1.2` in `curl` commands.

## Test Plan

Added the flags also to `.github/workflows/ci.yml`. Thus, if the CI works, it should also be working in general.
