### PR TITLE
use $TMPDIR/uv-locks instead of putting lockfiles directly in $TMPDIR

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -739,8 +739,8 @@ impl SourceBuild {
         // lock the output dir, but setuptools always writes to `build/` in the source tree,
         // regardless of whether its output dir is set to somewhere else.
         let canonical_source_path = self.source_tree.canonicalize()?;
-        let build_lock_path =
-            std::env::temp_dir().join(format!("uv-{}.lock", cache_digest(&canonical_source_path)));
+        let build_lock_path = uv_fs::locks_temp_dir()?
+            .join(format!("uv-{}.lock", cache_digest(&canonical_source_path)));
         let _lock =
             LockedFile::acquire(build_lock_path, self.source_tree.to_string_lossy()).await?;
 

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 use std::env::consts::ARCH;
 use std::fmt::{Display, Formatter};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 use std::sync::OnceLock;
-use std::{env, io};
 
 use configparser::ini::Ini;
 use fs_err as fs;
@@ -625,7 +625,8 @@ impl Interpreter {
         } else {
             // Otherwise, use a global lockfile.
             LockedFile::acquire(
-                env::temp_dir().join(format!("uv-{}.lock", cache_digest(&self.sys_executable))),
+                uv_fs::locks_temp_dir()?
+                    .join(format!("uv-{}.lock", cache_digest(&self.sys_executable))),
                 self.sys_prefix.user_display(),
             )
             .await

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -722,21 +722,23 @@ impl ScriptInterpreter {
         match script {
             Pep723ItemRef::Script(script) => {
                 LockedFile::acquire(
-                    std::env::temp_dir().join(format!("uv-{}.lock", cache_digest(&script.path))),
+                    uv_fs::locks_temp_dir()?
+                        .join(format!("uv-{}.lock", cache_digest(&script.path))),
                     script.path.simplified_display(),
                 )
                 .await
             }
             Pep723ItemRef::Remote(.., url) => {
                 LockedFile::acquire(
-                    std::env::temp_dir().join(format!("uv-{}.lock", cache_digest(url))),
+                    uv_fs::locks_temp_dir()?.join(format!("uv-{}.lock", cache_digest(url))),
                     url.to_string(),
                 )
                 .await
             }
             Pep723ItemRef::Stdin(metadata) => {
                 LockedFile::acquire(
-                    std::env::temp_dir().join(format!("uv-{}.lock", cache_digest(&metadata.raw))),
+                    uv_fs::locks_temp_dir()?
+                        .join(format!("uv-{}.lock", cache_digest(&metadata.raw))),
                     "stdin".to_string(),
                 )
                 .await
@@ -989,7 +991,7 @@ impl ProjectInterpreter {
     /// Grab a file lock for the environment to prevent concurrent writes across processes.
     pub(crate) async fn lock(workspace: &Workspace) -> Result<LockedFile, std::io::Error> {
         LockedFile::acquire(
-            std::env::temp_dir().join(format!(
+            uv_fs::locks_temp_dir()?.join(format!(
                 "uv-{}.lock",
                 cache_digest(workspace.install_path())
             )),


### PR DESCRIPTION
As @zanieb has pointed out in chat, moving file locks around makes us vulnerable to races between different versions of `uv` that don't agree on the file lock path. I'm comfortable ignoring that as rare enough not to matter, but I'm curious what other folks think.

Atomically creating a directory with universal write permissions also turned out to be surprisingly complicated, requiring us to spawn a shell command that first sets `umask`. My instinct is that this command will be portable to all flavors of Unix, but if we'd rather skip shelling out and tolerate the extremely brief mkdir-then-chmod race, that could also make sense. Feedback needed.