### PR TITLE
Use emscripten platform tags for Pyodide

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Os {
             Self::Illumos { .. } => write!(f, "illumos"),
             Self::Haiku { .. } => write!(f, "haiku"),
             Self::Android { .. } => write!(f, "android"),
-            Self::Pyodide { .. } => write!(f, "pyodide"),
+            Self::Pyodide { major, minor } => write!(f, "pyodide_{major}_{minor}"),
         }
     }
 }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -618,10 +618,16 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             }]
         }
         (Os::Pyodide { major, minor }, Arch::Wasm32) => {
-            vec![PlatformTag::Pyodide {
-                major: *major,
-                minor: *minor,
-            }]
+            // See: https://pyodide.org/en/stable/development/abi.html#pyodide-2024-0
+            if *major == 2024 && *minor == 0 {
+                vec![PlatformTag::Emscripten {
+                    major: 3,
+                    minor: 1,
+                    patch: 58,
+                }]
+            } else {
+                vec![]
+            }
         }
         _ => {
             return Err(PlatformError::OsVersionDetectionError(format!(


### PR DESCRIPTION
## Summary

I think the platform tag for Pyodide 2024 wheels is `emscripten_3_1_58_wasm32`. As far as I can tell, the `pyodide_2024_0_wasm32` piece doesn't actually show up in the wheels themselves, though I could be misunderstanding.

Builds on https://github.com/astral-sh/uv/pull/12731.

## Test Plan

```
cargo run pip install --python .venv-pyodide --target src/vendor https://github.com/pydantic/pydantic-core/releases/download/v2.35.1/pydantic_core-2.35.1-cp312-cp312-emscripten_3_1_58_wasm32.whl
```