### PR TITLE
Add a link to PyPI FAQ to clarify what per-project token is.

### DIFF
--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -31,8 +31,8 @@ the effect of declaring a build system in the
     This setting makes PyPI reject your uploaded package from publishing. It does not affect
     security or privacy settings on alternative registries.
 
-    We also recommend only generating per-project tokens: Without a PyPI token matching the project,
-    it can't be accidentally published.
+    We also recommend only generating [per-project PyPI API tokens](https://pypi.org/help/#apitoken):
+    Without a PyPI token matching the project, it can't be accidentally published.
 
 ## Building your package
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change adds a link to PyPI FAQ about API tokens on the package publishing guide page. To me it wasn't clear what are meant in this section of the docs and it required a little bit of research. Adding explicit link might help beginners. 

<!-- What's the purpose of the change? What does it do, and why? -->