### PR TITLE
GCP Artifact Registry download URLs must have /simple path

### DIFF
--- a/docs/guides/integration/alternative-indexes.md
+++ b/docs/guides/integration/alternative-indexes.md
@@ -142,7 +142,7 @@ To use Google Artifact Registry, add the index to your project:
 ```toml title="pyproject.toml"
 [[tool.uv.index]]
 name = "private-registry"
-url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>"
+url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/simple/"
 ```
 
 ### Authenticate with a Google access token
@@ -219,8 +219,8 @@ First, add a `publish-url` to the index you want to publish packages to. For exa
 ```toml title="pyproject.toml" hl_lines="4"
 [[tool.uv.index]]
 name = "private-registry"
-url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>"
-publish-url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>"
+url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/simple/"
+publish-url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/"
 ```
 
 Then, configure credentials (if not using keyring):
@@ -239,7 +239,7 @@ $ uv publish --index private-registry
 To use `uv publish` without adding the `publish-url` to the project, you can set `UV_PUBLISH_URL`:
 
 ```console
-$ export UV_PUBLISH_URL=https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>
+$ export UV_PUBLISH_URL=https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/
 $ uv publish
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The current **uv** [docs](https://docs.astral.sh/uv/guides/integration/alternative-indexes/#google-artifact-registry) for **Google Artifact Registry** integration state that download URLs are expressed as

```toml
url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>"
```

I just found, by following the documentation, that this is incomplete. Instead, they should be 

```toml
url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/simple/"
```
in order to work. The trailing `/` is optional, but I also included it to conform to the standard used in the sections referring to other cloud providers within this same page.

This PR makes the necessary change to the documentation.

## Test Plan

1. [Create](https://cloud.google.com/artifact-registry/docs/python/store-python#create) a GCP Artifact Registry repository.
2. Add it to a **Python** project using

```bash
export ARTIFACT_REGISTRY_PULL_TOKEN=$(
    gcloud auth print-access-token --project=<PROJECT>
)

export UV_INDEX_BUILD_USERNAME=oauth2accesstoken
export UV_INDEX_BUILD_PASSWORD="$ARTIFACT_REGISTRY_PULL_TOKEN
```

and

```toml
[[tool.uv.index]]
name = "BUILD"
url = "https://<REGION>-python.pkg.dev/<PROJECT>/<REPOSITORY>/simple/"
```

3. Assuming packages were added to that repository using `uv publish`, pull one of these using `uv add <package>`.