### PR TITLE
Fix handling of inverted `~=` with `python_version` and `python_full_version`

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -292,7 +292,7 @@ impl Version {
     ///
     /// When the iterator yields no elements.
     #[inline]
-    pub fn new<I, R>(release_numbers: I) -> Self
+    pub fn new<I, R>(release_segments: I) -> Self
     where
         I: IntoIterator<Item = R>,
         R: Borrow<u64>,
@@ -302,7 +302,7 @@ impl Version {
                 small: VersionSmall::new(),
             },
         }
-        .with_release(release_numbers)
+        .with_release(release_segments)
     }
 
     /// Whether this is an alpha/beta/rc or dev version

--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -1,7 +1,7 @@
 use arcstr::ArcStr;
 use std::str::FromStr;
 use uv_normalize::{ExtraName, GroupName};
-use uv_pep440::{Version, VersionPattern, VersionSpecifier};
+use uv_pep440::{Operator, Version, VersionPattern, VersionSpecifier};
 
 use crate::cursor::Cursor;
 use crate::marker::MarkerValueExtra;
@@ -282,12 +282,26 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
                     parse_inverted_version_expr(&l_string, operator, key, reporter)
                 }
                 // '...' == <env key>
-                MarkerValue::MarkerEnvString(key) => Some(MarkerExpression::String {
-                    key,
+                MarkerValue::MarkerEnvString(key) => {
                     // Invert the operator to normalize the expression order.
-                    operator: operator.invert(),
-                    value: l_string,
-                }),
+                    if let Some(operator) = operator.invert() {
+                        Some(MarkerExpression::String {
+                            key,
+                            operator,
+                            value: l_string,
+                        })
+                    } else {
+                        debug_assert_eq!(operator, MarkerOperator::TildeEqual);
+                        reporter.report(
+                            MarkerWarningKind::StringStringComparison,
+                            format!(
+                                "Comparing a string with `~=` doesn't make sense:
+                                '{l_string}' {operator} {r_value}, will be ignored"
+                            ),
+                        );
+                        None
+                    }
+                }
                 // `"test" in extras` or `"dev" in dependency_groups`
                 MarkerValue::MarkerEnvList(key) => {
                     let operator =
@@ -484,9 +498,6 @@ fn parse_inverted_version_expr(
     key: MarkerValueVersion,
     reporter: &mut impl Reporter,
 ) -> Option<MarkerExpression> {
-    // Invert the operator to normalize the expression order.
-    let marker_operator = marker_operator.invert();
-
     // Not star allowed here, `'3.*' == python_version` is not a valid PEP 440 comparison.
     let version = match value.parse::<Version>() {
         Ok(version) => version,
@@ -501,6 +512,25 @@ fn parse_inverted_version_expr(
 
             return None;
         }
+    };
+
+    // Invert the operator to normalize the expression order.
+    let Some(marker_operator) = marker_operator.invert() else {
+        // The only operator that can't be inverted is `~=`.
+        debug_assert_eq!(marker_operator, MarkerOperator::TildeEqual);
+        return Some(MarkerExpression::VersionInvertedTilde {
+            key,
+            specifier: match VersionSpecifier::from_version(Operator::TildeEqual, version) {
+                Ok(specifier) => specifier,
+                Err(err) => {
+                    reporter.report(
+                        MarkerWarningKind::Pep440Error,
+                        format!("Invalid operator/version combination: {err}"),
+                    );
+                    return None;
+                }
+            },
+        });
     };
 
     let Some(operator) = marker_operator.to_pep440_operator() else {

--- a/crates/uv-pep508/src/marker/simplify.rs
+++ b/crates/uv-pep508/src/marker/simplify.rs
@@ -410,6 +410,10 @@ fn is_negation(left: &MarkerExpression, right: &MarkerExpression) -> bool {
                     .negate()
                     .is_some_and(|negated| negated == *specifier2.operator())
         }
+        MarkerExpression::VersionInvertedTilde { .. } => {
+            // The inversion is not a single expression.
+            false
+        }
         MarkerExpression::VersionIn {
             key,
             versions,

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -268,20 +268,22 @@ impl MarkerOperator {
     }
 
     /// Inverts this marker operator.
-    pub(crate) fn invert(self) -> MarkerOperator {
-        match self {
+    ///
+    /// `~=` has no inverse.
+    pub(crate) fn invert(self) -> Option<MarkerOperator> {
+        Some(match self {
             Self::LessThan => Self::GreaterThan,
             Self::LessEqual => Self::GreaterEqual,
             Self::GreaterThan => Self::LessThan,
             Self::GreaterEqual => Self::LessEqual,
             Self::Equal => Self::Equal,
             Self::NotEqual => Self::NotEqual,
-            Self::TildeEqual => Self::TildeEqual,
+            Self::TildeEqual => return None,
             Self::In => Self::Contains,
             Self::NotIn => Self::NotContains,
             Self::Contains => Self::In,
             Self::NotContains => Self::NotIn,
-        }
+        })
     }
 
     /// Negates this marker operator.
@@ -513,6 +515,12 @@ pub enum MarkerExpression {
         key: MarkerValueVersion,
         specifier: VersionSpecifier,
     },
+    /// Special case for `<version key> ~= python_version` and
+    /// `<version key> ~= python_full_version`.
+    VersionInvertedTilde {
+        key: MarkerValueVersion,
+        specifier: VersionSpecifier,
+    },
     /// A version in list expression, e.g. `<version key> in <quoted list of PEP 440 versions>`.
     ///
     /// A special case of [`MarkerExpression::String`] with the [`MarkerOperator::In`] operator for
@@ -526,7 +534,7 @@ pub enum MarkerExpression {
         versions: Vec<Version>,
         operator: ContainerOperator,
     },
-    /// An string marker comparison, e.g. `sys_platform == '...'`.
+    /// A string marker comparison, e.g. `sys_platform == '...'`.
     ///
     /// Inverted string expressions, e.g `'...' == sys_platform`, are also normalized to this form.
     String {
@@ -551,6 +559,8 @@ pub enum MarkerExpression {
 pub(crate) enum MarkerExpressionKind {
     /// A version expression, e.g. `<version key> <version op> <quoted PEP 440 version>`.
     Version(MarkerValueVersion),
+    /// An inverted tilde-equal version expression, e.g. `<version key> ~= <quoted PEP 440 version>`.
+    VersionInvertedTilde(MarkerValueVersion),
     /// A version `in` expression, e.g. `<version key> in <quoted list of PEP 440 versions>`.
     VersionIn(MarkerValueVersion),
     /// A string marker comparison, e.g. `sys_platform == '...'`.
@@ -667,6 +677,9 @@ impl MarkerExpression {
     pub(crate) fn kind(&self) -> MarkerExpressionKind {
         match self {
             MarkerExpression::Version { key, .. } => MarkerExpressionKind::Version(*key),
+            MarkerExpression::VersionInvertedTilde { key, .. } => {
+                MarkerExpressionKind::VersionInvertedTilde(*key)
+            }
             MarkerExpression::VersionIn { key, .. } => MarkerExpressionKind::VersionIn(*key),
             MarkerExpression::String { key, .. } => MarkerExpressionKind::String(*key),
             MarkerExpression::List { pair, .. } => MarkerExpressionKind::List(pair.key()),
@@ -686,6 +699,10 @@ impl Display for MarkerExpression {
                 }
                 write!(f, "{key} {op} '{version}'")
             }
+            MarkerExpression::VersionInvertedTilde { key, specifier } => {
+                let (op, version) = (specifier.operator(), specifier.version());
+                write!(f, "'{version}' {op} {key}")
+            }
             MarkerExpression::VersionIn {
                 key,
                 versions,
@@ -703,7 +720,8 @@ impl Display for MarkerExpression {
                     operator,
                     MarkerOperator::Contains | MarkerOperator::NotContains
                 ) {
-                    return write!(f, "'{value}' {} {key}", operator.invert());
+                    // Unwrap safety: `in` and `not in` have inverses.
+                    return write!(f, "'{value}' {} {key}", operator.invert().unwrap());
                 }
 
                 write!(f, "{key} {operator} '{value}'")
@@ -2843,6 +2861,39 @@ mod test {
         );
     }
 
+    #[test]
+    fn test_tilde_equal_inverted_normalization() {
+        assert_eq!(
+            m("'3.0' ~= python_version"),
+            m("python_version >= '3' and python_version <= '3.0'")
+        );
+
+        assert_eq!(
+            m("'3.10' ~= python_version"),
+            m("python_version >= '3' and python_version <= '3.10'")
+        );
+
+        assert_eq!(
+            m("'3.10.0' ~= python_version"),
+            m("python_version >= '3' and python_version <= '3.10'")
+        );
+
+        assert_eq!(
+            m("'3.10' ~= python_full_version"),
+            m("python_full_version < '3.11' and python_full_version >= '3.10.0'")
+        );
+
+        assert_eq!(
+            m("'3.10.10' ~= python_full_version"),
+            m("python_full_version < '3.11' and python_full_version >= '3.10.0'")
+        );
+
+        assert_simplifies(
+            "python_version == '3.0.*'",
+            "python_full_version == '3.0.*'",
+        );
+    }
+
     /// This tests marker implication.
     ///
     /// Specifically, these test cases come from a [bug] where `foo` and `bar`
@@ -2926,7 +2977,7 @@ mod test {
         );
         assert_eq!(
             m("'3.6' ~= python_version").negate(),
-            m("python_version < '3.6' or python_version != '3.*'")
+            m("python_full_version < '3' or python_full_version >= '3.7'")
         );
         assert_eq!(
             m("python_version ~= '3.6.2'").negate(),


### PR DESCRIPTION
Fix the handling of `"<version>" ~= python_version` and `"<version>" ~= python_full_version`, which need custom handling as we know the number of digits on the RHS, but not their meaning.