### PR TITLE
Temporarily disable Artifactory registry test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1480,9 +1480,9 @@ jobs:
         run: ./uv run -p ${{ env.PYTHON_VERSION }} scripts/registries-test.py --uv ./uv --color always --all
         env:
           RUST_LOG: uv=debug
-          UV_TEST_ARTIFACTORY_TOKEN: ${{ secrets.UV_TEST_ARTIFACTORY_TOKEN }}
-          UV_TEST_ARTIFACTORY_URL: ${{ secrets.UV_TEST_ARTIFACTORY_URL }}
-          UV_TEST_ARTIFACTORY_USERNAME: ${{ secrets.UV_TEST_ARTIFACTORY_USERNAME }}
+          # UV_TEST_ARTIFACTORY_TOKEN: ${{ secrets.UV_TEST_ARTIFACTORY_TOKEN }}
+          # UV_TEST_ARTIFACTORY_URL: ${{ secrets.UV_TEST_ARTIFACTORY_URL }}
+          # UV_TEST_ARTIFACTORY_USERNAME: ${{ secrets.UV_TEST_ARTIFACTORY_USERNAME }}
           UV_TEST_AWS_URL: ${{ secrets.UV_TEST_AWS_URL }}
           UV_TEST_AWS_USERNAME: aws
           UV_TEST_AZURE_TOKEN: ${{ secrets.UV_TEST_AZURE_TOKEN }}

--- a/scripts/registries-test.py
+++ b/scripts/registries-test.py
@@ -56,7 +56,8 @@ DEFAULT_TIMEOUT = 30
 DEFAULT_PKG_NAME = "astral-registries-test-pkg"
 
 KNOWN_REGISTRIES = [
-    "artifactory",
+    # TODO(john): Restore this when subscription starts up again
+    # "artifactory",
     "azure",
     "aws",
     "cloudsmith",


### PR DESCRIPTION
I'm waiting on a response to get our subscription back up. Then I can re-enable this. But for now, this would cause failing CI tests.
