### PR TITLE
use a laughably large test timeout (10 min) to unbreak CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default]
 # Mark tests that take longer than 10s as slow.
-# Terminate after 90s as a stop-gap measure to terminate on deadlock.
-slow-timeout =  { period = "10s", terminate-after = 9 }
+# Terminate after 10 minutes as a stop-gap measure to terminate on deadlock.
+slow-timeout =  { period = "10s", terminate-after = 60 }


### PR DESCRIPTION
Two minutes wasn't enough here: https://github.com/astral-sh/uv/pull/14170

It sounds like the real fix will have something to do with our Depot setup, but in the meantime we might want to tolerate excessively slow tests to unbreak CI? Eager to get other people's thoughts here. (Will wait to see if CI even passes before tagging anyone.)