### PR TITLE
default the test buckets dir to the canonicalized temp dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4584,7 +4584,6 @@ dependencies = [
  "ctrlc",
  "dotenvy",
  "dunce",
- "etcetera",
  "filetime",
  "flate2",
  "fs-err 3.1.1",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -114,7 +114,6 @@ assert_cmd = { version = "2.0.16" }
 assert_fs = { version = "1.1.2" }
 base64 = { workspace = true }
 byteorder = { version = "1.5.0" }
-etcetera = { workspace = true }
 filetime = { version = "0.2.25" }
 flate2 = { workspace = true, default-features = false }
 ignore = { version = "0.4.23" }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -13,7 +13,6 @@ use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{ChildPath, PathChild, PathCopy, PathCreateDir, SymlinkToFile};
 use base64::{Engine, prelude::BASE64_STANDARD as base64};
-use etcetera::BaseStrategy;
 use futures::StreamExt;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -407,25 +406,24 @@ impl TestContext {
         self
     }
 
-    /// Discover the path to the XDG state directory. We use this, rather than the OS-specific
-    /// temporary directory, because on macOS (and Windows on GitHub Actions), they involve
-    /// symlinks. (On macOS, the temporary directory is, like `/var/...`, which resolves to
-    /// `/private/var/...`.)
+    /// Default to the canonicalized path to the temp directory. We need to do this because on
+    /// macOS (and Windows on GitHub Actions) the standard temp dir is a symlink. (On macOS, the
+    /// temporary directory is, like `/var/...`, which resolves to `/private/var/...`.)
     ///
     /// It turns out that, at least on macOS, if we pass a symlink as `current_dir`, it gets
     /// _immediately_ resolved (such that if you call `current_dir` in the running `Command`, it
-    /// returns resolved symlink). This is problematic, as we _don't_ want to resolve symlinks
-    /// for user-provided paths.
+    /// returns resolved symlink). This breaks some snapshot tests, since we _don't_ want to
+    /// resolve symlinks for user-provided paths.
     pub fn test_bucket_dir() -> PathBuf {
-        env::var(EnvVars::UV_INTERNAL__TEST_DIR)
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                etcetera::base_strategy::choose_base_strategy()
-                    .expect("Failed to find base strategy")
-                    .data_dir()
-                    .join("uv")
-                    .join("tests")
-            })
+        if let Some(test_dir) = env::var_os(EnvVars::UV_INTERNAL__TEST_DIR) {
+            test_dir.into()
+        } else {
+            std::env::temp_dir()
+                .canonicalize()
+                .expect("failed to canonicalize temp dir")
+                .join("uv")
+                .join("tests")
+        }
     }
 
     /// Create a new test context with multiple Python versions.


### PR DESCRIPTION
Previously we were using the XDG data dir to avoid symlinks, but there's no particular guarantee that that's not going to be a symlink too. Using the temp dir by default is also slightly nicer for a couple reasons: It's sometimes faster (an in-memory tempfs on e.g. Arch), and it makes overriding `$TMPDIR` or `%TMP%` sufficient to control where tests put temp files, without needing to override `UV_INTERNAL__TEST_DIR` too.