### PR TITLE
Fix reachable panic in CLI flag handling

### DIFF
--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -14,7 +14,7 @@ pub fn flag(yes: bool, no: bool) -> Option<bool> {
         (true, false) => Some(true),
         (false, true) => Some(false),
         (false, false) => None,
-        (..) => unreachable!("Clap should make this impossible"),
+        (true, true) => None,
     }
 }
 


### PR DESCRIPTION
## Summary

Previously it was possible to reach panic condition in CLI flag handling when opposing flags were passed at different subcommand levels.

For example `uv self --offline version --no-offline` panics with the following `RUST_BACKTRACE`.

```
thread 'main2' panicked at crates\uv-cli\src\options.rs:17:17:
internal error: entered unreachable code: Clap should make this impossible
stack backtrace:
   0:     0x7ff6ee2a2ffc - <unknown>
   1:     0x7ff6ede968da - <unknown>
   2:     0x7ff6ee2a2557 - <unknown>
   3:     0x7ff6ee2a2e54 - <unknown>
   4:     0x7ff6ee2a2195 - <unknown>
   5:     0x7ff6ee2c96d2 - <unknown>
   6:     0x7ff6ee2c965f - <unknown>
   7:     0x7ff6ee2ccd4e - <unknown>
   8:     0x7ff6f031b941 - <unknown>
   9:     0x7ff6ee4e434a - <unknown>
  10:     0x7ff6ee674184 - <unknown>
  11:     0x7ff6ee65ebde - <unknown>
  12:     0x7ff6ef495290 - <unknown>
  13:     0x7ff6edcc6622 - <unknown>
  14:     0x7ff6ee2c40bd - <unknown>
  15:     0x7ff852477374 - BaseThreadInitThunk
  16:     0x7ff8527dcc91 - RtlUserThreadStart

thread 'main' panicked at C:\a\uv\uv\crates\uv\src\lib.rs:2275:10:
Tokio executor failed, was there a panic?: Any { .. }
stack backtrace:
   0:     0x7ff6ee2a2ffc - <unknown>
   1:     0x7ff6ede968da - <unknown>
   2:     0x7ff6ee2a2557 - <unknown>
   3:     0x7ff6ee2a2e54 - <unknown>
   4:     0x7ff6ee2a2195 - <unknown>
   5:     0x7ff6ee2c9709 - <unknown>
   6:     0x7ff6ee2c965f - <unknown>
   7:     0x7ff6ee2ccd4e - <unknown>
   8:     0x7ff6f031b941 - <unknown>
   9:     0x7ff6f031bd10 - <unknown>
  10:     0x7ff6edda51a2 - <unknown>
  11:     0x7ff6ef494186 - <unknown>
  12:     0x7ff6edda5f92 - <unknown>
  13:     0x7ff6f02f544c - <unknown>
  14:     0x7ff852477374 - BaseThreadInitThunk
  15:     0x7ff8527dcc91 - RtlUserThreadStart
```

## Test Plan

The panic condition is removed in favor of `None` so should be impossible to reach condition now.

Based on the unreachable message, not sure if this is some issue with Clap or uv's usage of it but seems reasonable they would cancel out to `None`.
