### PR TITLE
Bump MSRV and `rust-toolchain` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 homepage = "https://pypi.org/project/uv/"
 documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"

--- a/clippy.toml
+++ b/clippy.toml
@@ -37,7 +37,7 @@ disallowed-methods = [
   "std::fs::soft_link",
   "std::fs::symlink_metadata",
   "std::fs::write",
-  "std::os::unix::fs::symlink",
-  "std::os::windows::fs::symlink_dir",
-  "std::os::windows::fs::symlink_file",
+  { path = "std::os::unix::fs::symlink", allow-invalid = true },
+  { path = "std::os::windows::fs::symlink_dir", allow-invalid = true },
+  { path = "std::os::windows::fs::symlink_file", allow-invalid = true },
 ]

--- a/crates/uv-fs/src/which.rs
+++ b/crates/uv-fs/src/which.rs
@@ -17,7 +17,7 @@ fn get_binary_type(path: &Path) -> windows::core::Result<u32> {
         .chain(Some(0))
         .collect::<Vec<u16>>();
     // SAFETY: winapi call
-    unsafe { GetBinaryTypeW(PCWSTR(name.as_ptr()), &mut binary_type)? };
+    unsafe { GetBinaryTypeW(PCWSTR(name.as_ptr()), &raw mut binary_type)? };
     Ok(binary_type)
 }
 

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1433,7 +1433,7 @@ pub(crate) fn is_windows_store_shim(path: &Path) -> bool {
             0,
             buf.as_mut_ptr().cast(),
             buf.len() as u32 * 2,
-            &mut bytes_returned,
+            &raw mut bytes_returned,
             std::ptr::null_mut(),
         ) != 0
     };

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -521,7 +521,7 @@ if __name__ == "__main__":
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "This test will spawn a GUI and wait until you close the window."]
     fn gui_launcher() -> Result<()> {
         // Create Temp Dirs
         let temp_dir = assert_fs::TempDir::new()?;

--- a/crates/uv/tests/it/ecosystem.rs
+++ b/crates/uv/tests/it/ecosystem.rs
@@ -73,8 +73,8 @@ fn saleor() -> Result<()> {
 // Currently ignored because the project doesn't build with `uv` yet.
 //
 // Source: https://github.com/apache/airflow/blob/c55438d9b2eb9b6680641eefdd0cbc67a28d1d29/pyproject.toml
-#[ignore]
 #[test]
+#[ignore = "Airflow doesn't build with `uv` yet"]
 fn airflow() -> Result<()> {
     lock_ecosystem_package("3.12", "airflow")
 }

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -3,9 +3,8 @@
 use std::env::current_dir;
 use std::fs;
 use std::io::Cursor;
-use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::Result;
 use assert_fs::prelude::*;
 use flate2::write::GzEncoder;
 use fs_err::File;
@@ -4801,97 +4800,6 @@ fn compile_editable_url_requirement() -> Result<()> {
     "###);
 
     Ok(())
-}
-
-#[test]
-#[ignore]
-fn cache_errors_are_non_fatal() -> Result<()> {
-    let context = TestContext::new("3.12");
-    let requirements_in = context.temp_dir.child("requirements.in");
-    // No git dep, git has its own locking strategy
-    requirements_in.write_str(indoc! {r"
-        # pypi wheel
-        pandas
-        # url wheel
-        flask @ https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl
-        # url source dist
-        werkzeug @ https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz
-    "
-    })?;
-
-    // Pick a file from each kind of cache
-    let interpreter_cache = context
-        .cache_dir
-        .path()
-        .join("interpreter-v0")
-        .read_dir()?
-        .next()
-        .context("Expected a python interpreter cache file")??
-        .path();
-    let cache_files = [
-        PathBuf::from("simple-v0/pypi/numpy.msgpack"),
-        PathBuf::from(
-            "wheels-v0/pypi/python-dateutil/python_dateutil-2.8.2-py2.py3-none-any.msgpack",
-        ),
-        PathBuf::from("wheels-v0/url/4b8be67c801a7ecb/flask/flask-3.0.0-py3-none-any.msgpack"),
-        PathBuf::from("built-wheels-v0/url/6781bd6440ae72c2/werkzeug/metadata.msgpack"),
-        interpreter_cache,
-    ];
-
-    let check = || {
-        uv_snapshot!(context.filters(), context.pip_compile()
-                .arg("pip")
-                .arg("compile")
-                .arg(requirements_in.path())
-                // It's sufficient to check that we resolve to a fix number of packages
-                .stdout(std::process::Stdio::null()), @r###"
-            success: true
-            exit_code: 0
-            ----- stdout -----
-
-            ----- stderr -----
-            Resolved 13 packages in [TIME]
-            "###
-        );
-    };
-
-    insta::allow_duplicates! {
-        check();
-
-        // Replace some cache files with invalid contents
-        for file in &cache_files {
-            let file = context.cache_dir.join(file);
-            if !file.is_file() {
-                bail!("Missing cache file {}", file.user_display());
-            }
-            fs_err::write(file, "I borken you cache")?;
-        }
-
-        check();
-
-        #[cfg(unix)]
-        {
-            use fs_err::os::unix::fs::OpenOptionsExt;
-
-            // Make some files unreadable, so that the read instead of the deserialization will fail
-            for file in cache_files {
-                let file = context.cache_dir.join(file);
-                if !file.is_file() {
-                    bail!("Missing cache file {}", file.user_display());
-                }
-
-                fs_err::OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .mode(0o000)
-                    .open(file)?;
-            }
-        }
-
-        check();
-
-        Ok(())
-    }
 }
 
 /// Resolve a distribution from an HTML-only registry.

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2344,7 +2344,7 @@ fn install_git_private_https_pat_at_ref() {
 /// See: <https://github.com/astral-sh/uv/issues/1980>.
 #[test]
 #[cfg(feature = "git")]
-#[ignore]
+#[ignore = "Modifies the user's keyring"]
 fn install_git_private_https_pat_and_username() {
     let context = TestContext::new(DEFAULT_PYTHON_VERSION);
     let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86"
+channel = "1.88"


### PR DESCRIPTION
## Summary

Per our versioning policy, we stay two versions back (and 1.88 was released today).