### PR TITLE
Transition "Uploading" to "Uploaded" in `uv publish`

### DIFF
--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -146,6 +146,7 @@ pub(crate) async fn publish(
         info!("Upload succeeded");
 
         if uploaded {
+            write!(printer.stderr(), "\x1b[1A\x1b[2K")?;
             writeln!(
                 printer.stderr(),
                 "{} {filename} {}",

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -144,7 +144,15 @@ pub(crate) async fn publish(
         )
         .await?; // Filename and/or URL are already attached, if applicable.
         info!("Upload succeeded");
-        if !uploaded {
+
+        if uploaded {
+            writeln!(
+                printer.stderr(),
+                "{} {filename} {}",
+                "Uploaded".bold().green(),
+                format!("({bytes:.1}{unit})").dimmed()
+            )?;
+        } else {
             writeln!(
                 printer.stderr(),
                 "{}",


### PR DESCRIPTION
## Summary

`uv publish` shows `Uploading <filename> <size>` for each file when uploading, it however does not transition to `Uploaded <filename> <size>` when finished. 
