### PR TITLE
Stabilize the uv build backend

### DIFF
--- a/crates/uv-build-backend/src/settings.rs
+++ b/crates/uv-build-backend/src/settings.rs
@@ -4,10 +4,6 @@ use uv_macros::OptionsMetadata;
 
 /// Settings for the uv build backend (`uv_build`).
 ///
-/// !!! note
-///
-///     The uv build backend is currently in preview and may change in any future release.
-///
 /// Note that those settings only apply when using the `uv_build` backend, other build backends
 /// (such as hatchling) have their own configuration.
 ///

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -448,12 +448,6 @@ impl BuildContext for BuildDispatch<'_> {
         build_kind: BuildKind,
         version_id: Option<&'data str>,
     ) -> Result<Option<DistFilename>, BuildDispatchError> {
-        // Direct builds are a preview feature with the uv build backend.
-        if self.preview.is_disabled() {
-            trace!("Preview is disabled, not checking for direct build");
-            return Ok(None);
-        }
-
         let source_tree = if let Some(subdir) = subdirectory {
             source.join(subdir)
         } else {

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -188,15 +188,6 @@ async fn build_impl(
     printer: Printer,
     preview: PreviewMode,
 ) -> Result<BuildResult> {
-    if list && preview.is_disabled() {
-        // We need the direct build for list and that is preview only.
-        writeln!(
-            printer.stderr(),
-            "The `--list` option is only available in preview mode; add the `--preview` flag to use `--list`"
-        )?;
-        return Ok(BuildResult::Failure);
-    }
-
     // Extract the resolver settings.
     let ResolverSettings {
         index_locations,
@@ -615,10 +606,7 @@ async fn build_package(
         }
 
         BuildAction::List
-    } else if preview.is_enabled()
-        && !force_pep517
-        && check_direct_build(source.path(), source.path().user_display())
-    {
+    } else if !force_pep517 && check_direct_build(source.path(), source.path().user_display()) {
         BuildAction::DirectBuild
     } else {
         BuildAction::Pep517

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -224,7 +224,6 @@ fn preserve_executable_bit() -> Result<()> {
         .init()
         .arg("--build-backend")
         .arg("uv")
-        .arg("--preview")
         .arg(&project_dir)
         .assert()
         .success();
@@ -316,8 +315,7 @@ fn rename_module() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-wheel")
-        .arg(temp_dir.path())
-        .env("UV_PREVIEW", "1"), @r###"
+        .arg(temp_dir.path()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -391,8 +389,7 @@ fn rename_module_editable_build() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-editable")
-        .arg(temp_dir.path())
-        .env("UV_PREVIEW", "1"), @r###"
+        .arg(temp_dir.path()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -568,8 +565,7 @@ fn build_sdist_with_long_path() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-sdist")
-        .arg(temp_dir.path())
-        .env("UV_PREVIEW", "1"), @r###"
+        .arg(temp_dir.path()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -602,8 +598,7 @@ fn sdist_error_without_module() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-sdist")
-        .arg(temp_dir.path())
-        .env("UV_PREVIEW", "1"), @r"
+        .arg(temp_dir.path()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -617,8 +612,7 @@ fn sdist_error_without_module() -> Result<()> {
     uv_snapshot!(context
         .build_backend()
         .arg("build-sdist")
-        .arg(temp_dir.path())
-        .env("UV_PREVIEW", "1"), @r"
+        .arg(temp_dir.path()), @r"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -682,7 +676,6 @@ fn complex_namespace_packages() -> Result<()> {
 
         context
             .build()
-            .arg("--preview")
             .arg(project.path())
             .arg("--out-dir")
             .arg(dist.path())
@@ -731,7 +724,6 @@ fn complex_namespace_packages() -> Result<()> {
         context.filters(),
         context
             .pip_install()
-            .arg("--preview")
             .arg("-e")
             .arg("complex-project-part_a")
             .arg("-e")
@@ -778,7 +770,6 @@ fn symlinked_file() -> Result<()> {
     let project = context.temp_dir.child("project");
     context
         .init()
-        .arg("--preview")
         .arg("--build-backend")
         .arg("uv")
         .arg(project.path())

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -2,9 +2,8 @@
 
 !!! note
 
-    The uv build backend is currently in preview and may change without warning.
-
-    When preview mode is not enabled, uv uses [hatchling](https://pypi.org/project/hatchling/) as the default build backend.
+    Currently, the default build backend for `uv init` is
+    [hatchling](https://pypi.org/project/hatchling/). This will change to `uv` in a future version.
 
 A build backend transforms a source tree (i.e., a directory) into a source distribution or a wheel.
 While uv supports all build backends (as specified by PEP 517), it includes a `uv_build` backend

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -396,10 +396,6 @@ pydantic = { path = "/path/to/pydantic", editable = true }
 
 Settings for the uv build backend (`uv_build`).
 
-!!! note
-
-    The uv build backend is currently in preview and may change in any future release.
-
 Note that those settings only apply when using the `uv_build` backend, other build backends
 (such as hatchling) have their own configuration.
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -644,7 +644,7 @@
       ]
     },
     "BuildBackendSettings": {
-      "description": "Settings for the uv build backend (`uv_build`).\n\n!!! note\n\n    The uv build backend is currently in preview and may change in any future release.\n\nNote that those settings only apply when using the `uv_build` backend, other build backends\n(such as hatchling) have their own configuration.\n\nAll options that accept globs use the portable glob patterns from\n[PEP 639](https://packaging.python.org/en/latest/specifications/glob-patterns/).",
+      "description": "Settings for the uv build backend (`uv_build`).\n\nNote that those settings only apply when using the `uv_build` backend, other build backends\n(such as hatchling) have their own configuration.\n\nAll options that accept globs use the portable glob patterns from\n[PEP 639](https://packaging.python.org/en/latest/specifications/glob-patterns/).",
       "type": "object",
       "properties": {
         "data": {


### PR DESCRIPTION
The uv build backend has gone through some feedback cycles, we expect no more major configuration changes, and we're ready to take the next step: The uv build backend in stable.

This PR stabilizes:

* Using `uv_build` as build backend
* The documentation of the uv build backend
* The direct build fast path, where uv doesn't use PEP 517 if you're using `uv_build` in a compatible version.
* `uv build --list`, which is limited to `uv_build`.

It does not:
* Make `uv_build` the default on `uv init`
* Make `--package` the default on `uv init`
