### PR TITLE
Return `Cow` from `UrlString::with_` methods

### DIFF
--- a/crates/uv-distribution-types/src/file.rs
+++ b/crates/uv-distribution-types/src/file.rs
@@ -166,7 +166,7 @@ impl UrlString {
     pub fn without_fragment(&self) -> Cow<'_, Self> {
         self.as_ref()
             .split_once('#')
-            .map(|(path, _)| url_string_cow_from_str(path))
+            .map(|(path, _)| Cow::Owned(UrlString(SmallString::from(path))))
             .unwrap_or(Cow::Borrowed(self))
     }
 
@@ -175,7 +175,7 @@ impl UrlString {
     pub fn without_trailing_slash(&self) -> Cow<'_, Self> {
         self.as_ref()
             .strip_suffix('/')
-            .map(url_string_cow_from_str)
+            .map(|path| Cow::Owned(UrlString(SmallString::from(path))))
             .unwrap_or(Cow::Borrowed(self))
     }
 }
@@ -202,10 +202,6 @@ impl Display for UrlString {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
-}
-
-fn url_string_cow_from_str(path: &str) -> Cow<'_, UrlString> {
-    Cow::Owned(UrlString(SmallString::from(path)))
 }
 
 /// An error that occurs when a [`FileLocation`] is not a valid URL.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1490,7 +1490,11 @@ impl Lock {
                                 .version
                                 .as_ref()
                                 .expect("version for registry source");
-                            return Ok(SatisfiesResult::MissingRemoteIndex(name, version, url));
+                            return Ok(SatisfiesResult::MissingRemoteIndex(
+                                name,
+                                version,
+                                url.into_owned(),
+                            ));
                         }
                     }
                     RegistrySource::Path(path) => {
@@ -4692,7 +4696,7 @@ impl From<Hash> for Hashes {
 /// Convert a [`FileLocation`] into a normalized [`UrlString`].
 fn normalize_file_location(location: &FileLocation) -> Result<UrlString, ToUrlError> {
     match location {
-        FileLocation::AbsoluteUrl(absolute) => Ok(absolute.without_fragment()),
+        FileLocation::AbsoluteUrl(absolute) => Ok(absolute.without_fragment().into_owned()),
         FileLocation::RelativeUrl(_, _) => Ok(normalize_url(location.to_url()?)),
     }
 }


### PR DESCRIPTION
A minor performance improvement as a follow-up to #14245 (and an accompanying test).
