### PR TITLE
Update the tilde version specifier warning to include more context

### DIFF
--- a/crates/uv-distribution-types/src/requires_python.rs
+++ b/crates/uv-distribution-types/src/requires_python.rs
@@ -5,11 +5,10 @@ use version_ranges::Ranges;
 use uv_distribution_filename::WheelFilename;
 use uv_pep440::{
     LowerBound, UpperBound, Version, VersionSpecifier, VersionSpecifiers,
-    release_specifier_to_range, release_specifiers_to_ranges,
+    release_specifiers_to_ranges,
 };
 use uv_pep508::{MarkerExpression, MarkerTree, MarkerValueVersion};
 use uv_platform_tags::{AbiTag, LanguageTag};
-use uv_warnings::warn_user_once;
 
 /// The `Requires-Python` requirement specifier.
 ///
@@ -67,27 +66,7 @@ impl RequiresPython {
     ) -> Option<Self> {
         // Convert to PubGrub range and perform an intersection.
         let range = specifiers
-            .map(|specs| {
-                // Warn if there’s exactly one `~=` specifier without a patch.
-                if let [spec] = &specs[..] {
-                    if spec.is_tilde_without_patch() {
-                        if let Some((lo_b, hi_b)) = release_specifier_to_range(spec.clone(), false)
-                            .bounding_range()
-                            .map(|(l, u)| (l.cloned(), u.cloned()))
-                        {
-                            let lo_spec = LowerBound::new(lo_b).specifier().unwrap();
-                            let hi_spec = UpperBound::new(hi_b).specifier().unwrap();
-                            warn_user_once!(
-                                "The release specifier (`{spec}`) contains a compatible release \
-                                match without a patch version. This will be interpreted as \
-                                `{lo_spec}, {hi_spec}`. Did you mean `{spec}.0` to freeze the \
-                                minor version?"
-                            );
-                        }
-                    }
-                }
-                release_specifiers_to_ranges(specs.clone())
-            })
+            .map(|specs| release_specifiers_to_ranges(specs.clone()))
             .reduce(|acc, r| acc.intersection(&r))?;
 
         // If the intersection is empty, return `None`.

--- a/crates/uv-pep440/src/lib.rs
+++ b/crates/uv-pep440/src/lib.rs
@@ -34,7 +34,7 @@ pub use {
         VersionPatternParseError,
     },
     version_specifier::{
-        VersionSpecifier, VersionSpecifierBuildError, VersionSpecifiers,
+        TildeVersionSpecifier, VersionSpecifier, VersionSpecifierBuildError, VersionSpecifiers,
         VersionSpecifiersParseError,
     },
 };

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4551,15 +4551,15 @@ fn lock_requires_python_compatible_specifier() -> Result<()> {
         "#,
     )?;
 
-    uv_snapshot!(context.filters(), context.lock(), @r###"
+    uv_snapshot!(context.filters(), context.lock(), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    warning: The release specifier (`~=3.13`) contains a compatible release match without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to freeze the minor version?
+    warning: The `requires-python` specifier (`~=3.13`) in `warehouse` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.13, <4`. Did you mean `~=3.13.0` to constrain the version as `>=3.13.0, <3.14`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.
     Resolved 1 package in [TIME]
-    "###);
+    ");
 
     pyproject_toml.write_str(
         r#"


### PR DESCRIPTION
Follows https://github.com/astral-sh/uv/pull/14008