### PR TITLE
Use the canonical `ImplementationName` -> `&str` implementation

### DIFF
--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -44,12 +44,26 @@ impl ImplementationName {
             Self::GraalPy => "GraalPy",
         }
     }
+
+    pub fn executable_name(self) -> &'static str {
+        match self {
+            Self::CPython => "python",
+            Self::PyPy | Self::GraalPy => self.into(),
+        }
+    }
 }
 
 impl LenientImplementationName {
     pub fn pretty(&self) -> &str {
         match self {
             Self::Known(implementation) => implementation.pretty(),
+            Self::Unknown(name) => name,
+        }
+    }
+
+    pub fn executable_name(&self) -> &str {
+        match self {
+            Self::Known(implementation) => implementation.executable_name(),
             Self::Unknown(name) => name,
         }
     }

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -362,11 +362,7 @@ impl ManagedPythonInstallation {
     /// If windowed is true, `pythonw.exe` is selected over `python.exe` on windows, with no changes
     /// on non-windows.
     pub fn executable(&self, windowed: bool) -> PathBuf {
-        let implementation = match self.implementation() {
-            ImplementationName::CPython => "python",
-            ImplementationName::PyPy => "pypy",
-            ImplementationName::GraalPy => "graalpy",
-        };
+        let implementation: &str = self.implementation().into();
 
         let version = match self.implementation() {
             ImplementationName::CPython => {

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -362,7 +362,7 @@ impl ManagedPythonInstallation {
     /// If windowed is true, `pythonw.exe` is selected over `python.exe` on windows, with no changes
     /// on non-windows.
     pub fn executable(&self, windowed: bool) -> PathBuf {
-        let implementation: &str = self.implementation().into();
+        let implementation = self.implementation().executable_name();
 
         let version = match self.implementation() {
             ImplementationName::CPython => {


### PR DESCRIPTION
Motivated by some code duplication highlighted in https://github.com/astral-sh/uv/pull/14201, I noticed we weren't taking advantage of the existing implementation for casting to a str here. Unfortunately, we do need a special case for CPython still.