### PR TITLE
Reuse build (virtual) environments across resolution and installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5115,6 +5115,7 @@ name = "uv-distribution"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "dashmap",
  "either",
  "fs-err 3.1.1",
  "futures",
@@ -5937,9 +5938,8 @@ name = "uv-types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "boxcar",
+ "dashmap",
  "rustc-hash",
- "tempfile",
  "thiserror 2.0.12",
  "uv-cache",
  "uv-configuration",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5115,7 +5115,6 @@ name = "uv-distribution"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "dashmap",
  "either",
  "fs-err 3.1.1",
  "futures",

--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -4,7 +4,7 @@ use uv_pep508::PackageName;
 
 use crate::{PackageNameSpecifier, PackageNameSpecifiers};
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub enum BuildKind {
     /// A PEP 517 wheel build.
     #[default]

--- a/crates/uv-configuration/src/sources.rs
+++ b/crates/uv-configuration/src/sources.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum SourceStrategy {
     /// Use `tool.uv.sources` when resolving dependencies.

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -2,12 +2,13 @@
 //! [installer][`uv_installer`] and [build][`uv_build`] through [`BuildDispatch`]
 //! implementing [`BuildContext`].
 
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use futures::FutureExt;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
-use std::ffi::{OsStr, OsString};
-use std::path::Path;
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 
@@ -179,7 +180,7 @@ impl BuildContext for BuildDispatch<'_> {
         &self.shared_state.git
     }
 
-    fn build_arena(&self) -> &BuildArena {
+    fn build_arena(&self) -> &BuildArena<SourceBuild> {
         &self.shared_state.build_arena
     }
 
@@ -526,7 +527,7 @@ pub struct SharedState {
     /// The downloaded distributions.
     in_flight: InFlight,
     /// Build directories for any PEP 517 builds executed during resolution or installation.
-    build_arena: BuildArena,
+    build_arena: BuildArena<SourceBuild>,
 }
 
 impl SharedState {
@@ -565,7 +566,7 @@ impl SharedState {
     }
 
     /// Return the [`BuildArena`] used by the [`SharedState`].
-    pub fn build_arena(&self) -> &BuildArena {
+    pub fn build_arena(&self) -> &BuildArena<SourceBuild> {
         &self.build_arena
     }
 }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -38,6 +38,7 @@ uv-types = { workspace = true }
 uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
+dashmap = { workspace = true }
 either = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -38,7 +38,6 @@ uv-types = { workspace = true }
 uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
-dashmap = { workspace = true }
 either = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -108,6 +108,8 @@ pub enum Error {
     CacheHeal(String, HashAlgorithm),
     #[error("The source distribution requires Python {0}, but {1} is installed")]
     RequiresPython(VersionSpecifiers, Version),
+    #[error("Failed to identify base Python interpreter")]
+    BaseInterpreter(#[source] std::io::Error),
 
     /// A generic request middleware error happened while making a request.
     /// Refer to the error message for more details.

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -43,7 +43,7 @@ use uv_normalize::PackageName;
 use uv_pep440::{Version, release_specifiers_to_ranges};
 use uv_platform_tags::Tags;
 use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PyProjectToml, ResolutionMetadata};
-use uv_types::{BuildContext, BuildStack, SourceBuildTrait};
+use uv_types::{BuildContext, BuildKey, BuildStack, SourceBuildTrait};
 use uv_workspace::pyproject::ToolUvSources;
 
 use crate::distribution_database::ManagedClient;
@@ -2297,35 +2297,73 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             // In the uv build backend, the normalized filename and the disk filename are the same.
             name.to_string()
         } else {
-            let builder = self
-                .build_context
-                .setup_build(
-                    source_root,
-                    subdirectory,
-                    source_root,
-                    Some(&source.to_string()),
-                    source.as_dist(),
-                    source_strategy,
-                    if source.is_editable() {
-                        BuildKind::Editable
-                    } else {
-                        BuildKind::Wheel
-                    },
-                    BuildOutput::Debug,
-                    self.build_stack.cloned().unwrap_or_default(),
-                )
-                .await
-                .map_err(|err| Error::Build(err.into()))?;
+            // Identify the base Python interpreter to use in the cache key.
+            let base_python = if cfg!(unix) {
+                self.build_context
+                    .interpreter()
+                    .find_base_python()
+                    .map_err(Error::BaseInterpreter)?
+            } else {
+                self.build_context
+                    .interpreter()
+                    .to_base_python()
+                    .map_err(Error::BaseInterpreter)?
+            };
 
-            // Build the wheel.
-            let wheel = builder.wheel(temp_dir.path()).await.map_err(Error::Build)?;
+            let build_kind = if source.is_editable() {
+                BuildKind::Editable
+            } else {
+                BuildKind::Wheel
+            };
 
-            // Store a reference to the build context.
-            self.build_context
-                .build_arena()
-                .push(builder.into_build_dir());
+            let build_key = BuildKey {
+                base_python: base_python.into_boxed_path(),
+                source_root: source_root.to_path_buf().into_boxed_path(),
+                subdirectory: subdirectory
+                    .map(|subdirectory| subdirectory.to_path_buf().into_boxed_path()),
+                source_strategy,
+                build_kind,
+            };
 
-            wheel
+            match self.build_context.build_arena().entry(build_key) {
+                dashmap::Entry::Occupied(entry) => {
+                    debug!("Reusing existing build environment for: {source}");
+
+                    let builder = entry.into_ref();
+                    builder.wheel(temp_dir.path()).await.map_err(Error::Build)?
+                }
+                dashmap::Entry::Vacant(entry) => {
+                    debug!("Creating build environment for: {source}");
+
+                    let builder = self
+                        .build_context
+                        .setup_build(
+                            source_root,
+                            subdirectory,
+                            source_root,
+                            Some(&source.to_string()),
+                            source.as_dist(),
+                            source_strategy,
+                            if source.is_editable() {
+                                BuildKind::Editable
+                            } else {
+                                BuildKind::Wheel
+                            },
+                            BuildOutput::Debug,
+                            self.build_stack.cloned().unwrap_or_default(),
+                        )
+                        .await
+                        .map_err(|err| Error::Build(err.into()))?;
+
+                    // Build the wheel.
+                    let wheel = builder.wheel(temp_dir.path()).await.map_err(Error::Build)?;
+
+                    // Store the build context.
+                    entry.insert(builder);
+
+                    wheel
+                }
+            }
         };
 
         // Read the metadata from the wheel.
@@ -2380,6 +2418,26 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             }
         }
 
+        // Identify the base Python interpreter to use in the cache key.
+        let base_python = if cfg!(unix) {
+            self.build_context
+                .interpreter()
+                .find_base_python()
+                .map_err(Error::BaseInterpreter)?
+        } else {
+            self.build_context
+                .interpreter()
+                .to_base_python()
+                .map_err(Error::BaseInterpreter)?
+        };
+
+        // Determine whether this is an editable or non-editable build.
+        let build_kind = if source.is_editable() {
+            BuildKind::Editable
+        } else {
+            BuildKind::Wheel
+        };
+
         // Set up the builder.
         let mut builder = self
             .build_context
@@ -2390,11 +2448,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 Some(&source.to_string()),
                 source.as_dist(),
                 source_strategy,
-                if source.is_editable() {
-                    BuildKind::Editable
-                } else {
-                    BuildKind::Wheel
-                },
+                build_kind,
                 BuildOutput::Debug,
                 self.build_stack.cloned().unwrap_or_default(),
             )
@@ -2403,14 +2457,24 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Build the metadata.
         let dist_info = builder.metadata().await.map_err(Error::Build)?;
+
+        // Store the build context.
+        self.build_context.build_arena().insert(
+            BuildKey {
+                base_python: base_python.into_boxed_path(),
+                source_root: source_root.to_path_buf().into_boxed_path(),
+                subdirectory: subdirectory
+                    .map(|subdirectory| subdirectory.to_path_buf().into_boxed_path()),
+                source_strategy,
+                build_kind,
+            },
+            builder,
+        );
+
+        // Return the `.dist-info` directory, if it exists.
         let Some(dist_info) = dist_info else {
             return Ok(None);
         };
-
-        // Store a reference to the build context.
-        self.build_context
-            .build_arena()
-            .push(builder.into_build_dir());
 
         // Read the metadata from disk.
         debug!("Prepared metadata for: {source}");

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -31,9 +31,8 @@ uv-redacted = { workspace = true }
 uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
-boxcar = { workspace = true }
+dashmap = { workspace = true }
 rustc-hash = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [features]

--- a/crates/uv-types/src/builds.rs
+++ b/crates/uv-types/src/builds.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use dashmap::{DashMap, Entry};
+use dashmap::DashMap;
 
 use uv_configuration::{BuildKind, SourceStrategy};
 use uv_pep508::PackageName;
@@ -77,8 +77,8 @@ impl<T> BuildArena<T> {
         self.0.insert(key, value);
     }
 
-    /// Get a build entry from the arena.
-    pub fn entry(&self, key: BuildKey) -> Entry<BuildKey, T> {
-        self.0.entry(key)
+    /// Remove a build entry from the arena.
+    pub fn remove(&self, key: &BuildKey) -> Option<T> {
+        self.0.remove(key).map(|entry| entry.1)
     }
 }


### PR DESCRIPTION
## Summary

The basic idea here is that we can (should) reuse a build environment across resolution (`prepare_metadata_for_build_wheel`) and installation. This also happens to solve the build-PyTorch-from-source problem, since we use a consistent build environment between the invocations.

Since `SourceDistributionBuilder` is stateless, we instead store the builds on `BuildContext`, and we key them by various properties: the underlying interpreter, the configuration settings, etc. This just ensures that if we build the same package twice within a process, we don't accidentally reuse an incompatible build (virtual) environment. (Note that still drop build environments at the end of the command, and don't attempt to reuse them across processes.)

Closes #14269.
