### PR TITLE
Allow `alpha`, `beta`, and `rc` prefixes in tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -66,7 +66,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"uv\.exe", "uv"),
     // uv version display
     (
-        r"uv(-.*)? \d+\.\d+\.\d+(\+\d+)?( \(.*\))?",
+        r"uv(-.*)? \d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?( \([^)]*\))?",
         r"uv [VERSION] ([COMMIT] DATE)",
     ),
     // Trim end-of-line whitespaces, to allow removing them on save.
@@ -254,7 +254,7 @@ impl TestContext {
         let added_filters = [
             (r"home = .+".to_string(), "home = [PYTHON_HOME]".to_string()),
             (
-                r"uv = \d+\.\d+\.\d+".to_string(),
+                r"uv = \d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?".to_string(),
                 "uv = [UV_VERSION]".to_string(),
             ),
             (

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -905,7 +905,7 @@ fn version_get_fallback_unmanaged_short() -> Result<()> {
         .filters()
         .into_iter()
         .chain([(
-            r"\d+\.\d+\.\d+(\+\d+)?( \(.*\))?",
+            r"\d+\.\d+\.\d+(-alpha\.\d+)?(\+\d+)?( \(.*\))?",
             r"[VERSION] ([COMMIT] DATE)",
         )])
         .collect::<Vec<_>>();
@@ -972,7 +972,10 @@ fn version_get_fallback_unmanaged_json() -> Result<()> {
         .filters()
         .into_iter()
         .chain([
-            (r#"version": "\d+.\d+.\d+""#, r#"version": "[VERSION]""#),
+            (
+                r#"version": "\d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?""#,
+                r#"version": "[VERSION]""#,
+            ),
             (
                 r#"short_commit_hash": ".*""#,
                 r#"short_commit_hash": "[HASH]""#,
@@ -1175,7 +1178,7 @@ fn self_version_short() -> Result<()> {
         .filters()
         .into_iter()
         .chain([(
-            r"\d+\.\d+\.\d+(\+\d+)?( \(.*\))?",
+            r"\d+\.\d+\.\d+(-alpha\.\d+)?(\+\d+)?( \(.*\))?",
             r"[VERSION] ([COMMIT] DATE)",
         )])
         .collect::<Vec<_>>();
@@ -1220,7 +1223,10 @@ fn self_version_json() -> Result<()> {
         .filters()
         .into_iter()
         .chain([
-            (r#"version": "\d+.\d+.\d+""#, r#"version": "[VERSION]""#),
+            (
+                r#"version": "\d+\.\d+\.\d+(-(alpha|beta|rc)\.\d+)?(\+\d+)?""#,
+                r#"version": "[VERSION]""#,
+            ),
             (
                 r#"short_commit_hash": ".*""#,
                 r#"short_commit_hash": "[HASH]""#,


### PR DESCRIPTION
## Summary

A bunch of tests currently fail if you try to use a pre-release version. This PR makes the regular expressions more lenient.
