### PR TITLE
Preserve original trailing slash if present in `find-links` URLs

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -990,7 +990,7 @@ fn parse_find_links(input: &str) -> Result<Maybe<PipFindLinks>, String> {
     if input.is_empty() {
         Ok(Maybe::None)
     } else {
-        IndexUrl::parse_preserving_trailing_slash(input)
+        IndexUrl::parse_find_links(input)
             .map(Index::from_find_links)
             .map(|index| Index {
                 origin: Some(Origin::Cli),

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -990,7 +990,7 @@ fn parse_find_links(input: &str) -> Result<Maybe<PipFindLinks>, String> {
     if input.is_empty() {
         Ok(Maybe::None)
     } else {
-        IndexUrl::from_str(input)
+        IndexUrl::parse_preserving_trailing_slash(input)
             .map(Index::from_find_links)
             .map(|index| Index {
                 origin: Some(Origin::Cli),

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use futures::{FutureExt, StreamExt};
@@ -150,20 +149,10 @@ impl<'a> FlatIndexClient<'a> {
                 Self::read_from_directory(&path, index)
                     .map_err(|err| FlatIndexError::FindLinksDirectory(path.clone(), err))
             }
-            IndexUrl::Pypi(url) | IndexUrl::Url(url) => {
-                // If the URL was originally provided with a slash, we restore that slash
-                // before making a request.
-                let url_with_original_slash =
-                    if url.given().is_some_and(|given| given.ends_with('/')) {
-                        index.url_with_trailing_slash()
-                    } else {
-                        Cow::Borrowed(index.url())
-                    };
-
-                self.read_from_url(&url_with_original_slash, index)
-                    .await
-                    .map_err(|err| FlatIndexError::FindLinksUrl(url.to_url(), err))
-            }
+            IndexUrl::Pypi(url) | IndexUrl::Url(url) => self
+                .read_from_url(url, index)
+                .await
+                .map_err(|err| FlatIndexError::FindLinksUrl(url.to_url(), err)),
         }
     }
 

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -222,7 +222,7 @@ impl Index {
     pub fn relative_to(mut self, root_dir: &Path) -> Result<Self, IndexUrlError> {
         if let IndexUrl::Path(ref url) = self.url {
             if let Some(given) = url.given() {
-                self.url = IndexUrl::parse(given, Some(root_dir))?;
+                self.url = IndexUrl::parse_simple_api(given, Some(root_dir))?;
             }
         }
         Ok(self)

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -117,6 +117,18 @@ impl IndexUrl {
         }
     }
 
+    /// Return the raw URL for the index with a trailing slash.
+    pub fn url_with_trailing_slash(&self) -> Cow<'_, DisplaySafeUrl> {
+        let path = self.url().path();
+        if path.ends_with('/') {
+            Cow::Borrowed(self.url())
+        } else {
+            let mut url = self.url().clone();
+            url.set_path(&format!("{path}/"));
+            Cow::Owned(url)
+        }
+    }
+
     /// Convert the index URL into a [`DisplaySafeUrl`].
     pub fn into_url(self) -> DisplaySafeUrl {
         match self {
@@ -725,5 +737,24 @@ mod tests {
         assert!(is_disambiguated_path(
             "git+https://github.com/example/repo.git"
         ));
+    }
+
+    #[test]
+    fn test_index_url_with_trailing_slash() {
+        let url_with_trailing_slash = DisplaySafeUrl::parse("https://example.com/path/").unwrap();
+
+        let index_url_with_given_slash =
+            IndexUrl::parse("https://example.com/path/", None).unwrap();
+        assert_eq!(
+            &*index_url_with_given_slash.url_with_trailing_slash(),
+            &url_with_trailing_slash
+        );
+
+        let index_url_without_given_slash =
+            IndexUrl::parse("https://example.com/path", None).unwrap();
+        assert_eq!(
+            &*index_url_without_given_slash.url_with_trailing_slash(),
+            &url_with_trailing_slash
+        );
     }
 }

--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -821,8 +821,9 @@ impl TryFrom<RequirementSourceWire> for RequirementSource {
                 conflict,
             } => Ok(Self::Registry {
                 specifier,
-                index: index
-                    .map(|index| IndexMetadata::from(IndexUrl::from(VerbatimUrl::from_url(index)))),
+                index: index.map(|index| {
+                    IndexMetadata::from(IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index)))
+                }),
                 conflict,
             }),
             RequirementSourceWire::Git { git } => {

--- a/crates/uv-distribution-types/src/status_code_strategy.rs
+++ b/crates/uv-distribution-types/src/status_code_strategy.rs
@@ -196,7 +196,8 @@ mod tests {
     fn test_decision_default_400() {
         let strategy = IndexStatusCodeStrategy::Default;
         let status_code = StatusCode::BAD_REQUEST;
-        let index_url = IndexUrl::parse("https://internal-registry.com/simple", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://internal-registry.com/simple", None).unwrap();
         let capabilities = IndexCapabilities::default();
         let decision = strategy.handle_status_code(status_code, &index_url, &capabilities);
         assert_eq!(
@@ -209,7 +210,8 @@ mod tests {
     fn test_decision_default_401() {
         let strategy = IndexStatusCodeStrategy::Default;
         let status_code = StatusCode::UNAUTHORIZED;
-        let index_url = IndexUrl::parse("https://internal-registry.com/simple", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://internal-registry.com/simple", None).unwrap();
         let capabilities = IndexCapabilities::default();
         let decision = strategy.handle_status_code(status_code, &index_url, &capabilities);
         assert_eq!(
@@ -224,7 +226,8 @@ mod tests {
     fn test_decision_default_403() {
         let strategy = IndexStatusCodeStrategy::Default;
         let status_code = StatusCode::FORBIDDEN;
-        let index_url = IndexUrl::parse("https://internal-registry.com/simple", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://internal-registry.com/simple", None).unwrap();
         let capabilities = IndexCapabilities::default();
         let decision = strategy.handle_status_code(status_code, &index_url, &capabilities);
         assert_eq!(
@@ -239,7 +242,8 @@ mod tests {
     fn test_decision_default_404() {
         let strategy = IndexStatusCodeStrategy::Default;
         let status_code = StatusCode::NOT_FOUND;
-        let index_url = IndexUrl::parse("https://internal-registry.com/simple", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://internal-registry.com/simple", None).unwrap();
         let capabilities = IndexCapabilities::default();
         let decision = strategy.handle_status_code(status_code, &index_url, &capabilities);
         assert_eq!(decision, IndexStatusCodeDecision::Ignore);
@@ -249,7 +253,8 @@ mod tests {
 
     #[test]
     fn test_decision_pytorch() {
-        let index_url = IndexUrl::parse("https://download.pytorch.org/whl/cu118", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://download.pytorch.org/whl/cu118", None).unwrap();
         let strategy = IndexStatusCodeStrategy::from_index_url(&index_url);
         let capabilities = IndexCapabilities::default();
         // Test we continue on 403 for PyTorch registry.
@@ -275,7 +280,8 @@ mod tests {
         let strategy = IndexStatusCodeStrategy::IgnoreErrorCodes {
             status_codes: status_codes.iter().copied().collect::<FxHashSet<_>>(),
         };
-        let index_url = IndexUrl::parse("https://internal-registry.com/simple", None).unwrap();
+        let index_url =
+            IndexUrl::parse_simple_api("https://internal-registry.com/simple", None).unwrap();
         let capabilities = IndexCapabilities::default();
         // Test each ignored status code
         for status_code in status_codes {

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -37,9 +37,8 @@ use tracing::instrument;
 use uv_cache_key::CanonicalUrl;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{DependencyGroups, NoBinary, NoBuild};
-use uv_distribution_types::Requirement;
 use uv_distribution_types::{
-    IndexUrl, NameRequirementSpecification, UnresolvedRequirement,
+    IndexUrl, NameRequirementSpecification, Requirement, UnresolvedRequirement,
     UnresolvedRequirementSpecification,
 };
 use uv_fs::{CWD, Simplified};
@@ -152,7 +151,7 @@ impl RequirementsSpecification {
                     find_links: requirements_txt
                         .find_links
                         .into_iter()
-                        .map(IndexUrl::from)
+                        .map(IndexUrl::from_verbatim_url_preserving_trailing_slash)
                         .collect(),
                     no_binary: requirements_txt.no_binary,
                     no_build: requirements_txt.only_binary,

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -141,17 +141,19 @@ impl RequirementsSpecification {
                         .map(Requirement::from)
                         .map(NameRequirementSpecification::from)
                         .collect(),
-                    index_url: requirements_txt.index_url.map(IndexUrl::from),
+                    index_url: requirements_txt
+                        .index_url
+                        .map(IndexUrl::from_simple_api_url),
                     extra_index_urls: requirements_txt
                         .extra_index_urls
                         .into_iter()
-                        .map(IndexUrl::from)
+                        .map(IndexUrl::from_simple_api_url)
                         .collect(),
                     no_index: requirements_txt.no_index,
                     find_links: requirements_txt
                         .find_links
                         .into_iter()
-                        .map(IndexUrl::from_verbatim_url_preserving_trailing_slash)
+                        .map(IndexUrl::from_find_links_url)
                         .collect(),
                     no_binary: requirements_txt.no_binary,
                     no_build: requirements_txt.only_binary,

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1346,7 +1346,7 @@ impl PylockTomlWheel {
         };
 
         let index = if let Some(index) = index {
-            IndexUrl::from(VerbatimUrl::from_url(index.clone()))
+            IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index.clone()))
         } else {
             // Including the index is only a SHOULD in PEP 751. If it's omitted, we treat the
             // URL (less the filename) as the index. This isn't correct, but it's the best we can
@@ -1354,7 +1354,7 @@ impl PylockTomlWheel {
             // of this URL (since we cache under the hash of the index).
             let mut index = file_url.to_url().map_err(PylockTomlErrorKind::ToUrl)?;
             index.path_segments_mut().unwrap().pop();
-            IndexUrl::from(VerbatimUrl::from_url(index))
+            IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index))
         };
 
         let file = Box::new(uv_distribution_types::File {
@@ -1502,7 +1502,7 @@ impl PylockTomlSdist {
         };
 
         let index = if let Some(index) = index {
-            IndexUrl::from(VerbatimUrl::from_url(index.clone()))
+            IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index.clone()))
         } else {
             // Including the index is only a SHOULD in PEP 751. If it's omitted, we treat the
             // URL (less the filename) as the index. This isn't correct, but it's the best we can
@@ -1510,7 +1510,7 @@ impl PylockTomlSdist {
             // of this URL (since we cache under the hash of the index).
             let mut index = file_url.to_url().map_err(PylockTomlErrorKind::ToUrl)?;
             index.path_segments_mut().unwrap().pop();
-            IndexUrl::from(VerbatimUrl::from_url(index))
+            IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index))
         };
 
         let file = Box::new(uv_distribution_types::File {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2521,7 +2521,7 @@ impl Package {
                     yanked: None,
                 });
 
-                let index = IndexUrl::from(VerbatimUrl::from_url(
+                let index = IndexUrl::from_simple_api_url(VerbatimUrl::from_url(
                     url.to_url().map_err(LockErrorKind::InvalidUrl)?,
                 ));
 
@@ -2595,7 +2595,7 @@ impl Package {
                     yanked: None,
                 });
 
-                let index = IndexUrl::from(
+                let index = IndexUrl::from_simple_api_url(
                     VerbatimUrl::from_absolute_path(workspace_root.join(path))
                         .map_err(LockErrorKind::RegistryVerbatimUrl)?,
                 );
@@ -2808,13 +2808,13 @@ impl Package {
     pub fn index(&self, root: &Path) -> Result<Option<IndexUrl>, LockError> {
         match &self.id.source {
             Source::Registry(RegistrySource::Url(url)) => {
-                let index = IndexUrl::from(VerbatimUrl::from_url(
+                let index = IndexUrl::from_simple_api_url(VerbatimUrl::from_url(
                     url.to_url().map_err(LockErrorKind::InvalidUrl)?,
                 ));
                 Ok(Some(index))
             }
             Source::Registry(RegistrySource::Path(path)) => {
-                let index = IndexUrl::from(
+                let index = IndexUrl::from_simple_api_url(
                     VerbatimUrl::from_absolute_path(root.join(path))
                         .map_err(LockErrorKind::RegistryVerbatimUrl)?,
                 );
@@ -4283,7 +4283,7 @@ impl Wheel {
                     url: file_location,
                     yanked: None,
                 });
-                let index = IndexUrl::from(VerbatimUrl::from_url(
+                let index = IndexUrl::from_simple_api_url(VerbatimUrl::from_url(
                     url.to_url().map_err(LockErrorKind::InvalidUrl)?,
                 ));
                 Ok(RegistryBuiltWheel {
@@ -4325,7 +4325,7 @@ impl Wheel {
                     url: file_location,
                     yanked: None,
                 });
-                let index = IndexUrl::from(
+                let index = IndexUrl::from_simple_api_url(
                     VerbatimUrl::from_absolute_path(root.join(index_path))
                         .map_err(LockErrorKind::RegistryVerbatimUrl)?,
                 );
@@ -4825,7 +4825,9 @@ fn normalize_requirement(
                     index.remove_credentials();
                     index
                 })
-                .map(|index| IndexMetadata::from(IndexUrl::from(VerbatimUrl::from_url(index))));
+                .map(|index| {
+                    IndexMetadata::from(IndexUrl::from_simple_api_url(VerbatimUrl::from_url(index)))
+                });
             Ok(Requirement {
                 name: requirement.name,
                 extras: requirement.extras,

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -111,7 +111,7 @@ impl Preference {
                 package
                     .index
                     .as_ref()
-                    .map(|index| IndexUrl::from(VerbatimUrl::from(index.clone()))),
+                    .map(|index| IndexUrl::from_simple_api_url(VerbatimUrl::from(index.clone()))),
             ),
             // `pylock.toml` doesn't have fork annotations.
             fork_markers: vec![],


### PR DESCRIPTION
As part of #14245 and #14346, uv was normalizing trailing slashes for find-links URLs by removing them. However, find-links URLs have different meanings depending on whether a trailing slash is present (as evidenced in 301 redirects from PyPI and #14367). This PR preserves trailing slashes if present in find-links URLs.
 
Fixes #14367
