### PR TITLE
[DOCS] build and publish package to PyPI from GitHub Actions

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -375,3 +375,39 @@ steps:
   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 [repository secret]:
   https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
+
+## Build and Publish
+
+To build and publish your package to PyPI from GitHub Actions:
+
+1. Add a [trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your PyPI project.
+2. Create a workflow (e.g., `.github/workflows/publish.yml`) with the following steps:
+
+   ```yaml
+   name: "Publish"
+   on:
+     release:
+       types: ["published"]
+   permissions:
+     id-token: write
+     contents: read
+   jobs:
+     run:
+       runs-on: ubuntu-latest
+       environment: pypi
+       steps:
+         - uses: actions/checkout@v4
+         - name: Install uv
+           uses: astral-sh/setup-uv@v5
+           with:
+             enable-cache: true
+             cache-dependency-glob: uv.lock
+         - name: Set up Python
+           run: uv python install 3.13
+         - name: Build
+           run: uv build
+         - name: Publish
+           run: uv publish
+   ```
+
+This workflow builds and publishes your package to PyPI automatically when a GitHub Release is published. No PyPI credentials are needed if using a trusted publisher.

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -395,7 +395,9 @@ To build and publish your package to PyPI from GitHub Actions:
    jobs:
      run:
        runs-on: ubuntu-latest
-       environment: pypi
+       environment:
+        name: pypi
+        url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
        steps:
          - uses: actions/checkout@v4
          - name: Install uv

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -396,8 +396,8 @@ To build and publish your package to PyPI from GitHub Actions:
      run:
        runs-on: ubuntu-latest
        environment:
-        name: pypi
-        url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+         name: pypi
+         url: https://pypi.org/p/<package-name> # Replace <package-name> with your PyPI project name
        steps:
          - uses: actions/checkout@v4
          - name: Install uv

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -380,7 +380,8 @@ steps:
 
 To build and publish your package to PyPI from GitHub Actions:
 
-1. Add a [trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your PyPI project.
+1. Add a [trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to your
+   PyPI project.
 2. Create a workflow (e.g., `.github/workflows/publish.yml`) with the following steps:
 
    ```yaml
@@ -410,4 +411,5 @@ To build and publish your package to PyPI from GitHub Actions:
            run: uv publish
    ```
 
-This workflow builds and publishes your package to PyPI automatically when a GitHub Release is published. No PyPI credentials are needed if using a trusted publisher.
+This workflow builds and publishes your package to PyPI automatically when a GitHub Release is
+published. No PyPI credentials are needed if using a trusted publisher.


### PR DESCRIPTION
## Summary

I just finished up setting my workflow for UV using GitHub Actions to publish my PIP project and wanted to add this to the GitHub integrations guide.

## Test Plan

<!-- How was it tested? -->
I tested this workflow on [my own repository ](https://github.com/kiankyars/pypi/actions/workflows/publish.yml) and it successfully builds and publishes to pypi.org. Refer to the picture below if you don't want to check the repository.
![Screenshot 2025-07-01 at 18 20 57](https://github.com/user-attachments/assets/ee96575b-fe04-4b00-9fd8-287d03e95bf9)
