### PR TITLE
Allow Python requests with missing segments

### DIFF
--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1623,7 +1623,7 @@ fn python_install_emulated_macos() {
     ");
 
     // Install an x86_64 version (assuming an aarch64 host)
-    uv_snapshot!(context.filters(), context.python_install().arg("cpython-3.13-macos-x86_64"), @r"
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13-x86_64"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1654,7 +1654,7 @@ fn python_install_emulated_macos() {
     ----- stderr -----
     ");
 
-    uv_snapshot!(context.filters(), context.python_install().arg("cpython-3.13-macos-aarch64"), @r"
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13-aarch64"), @r"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
This allows `PythonDownloadRequest` which is used for parsing general install key requests to have missing segments, which unblocks requests like `windows-aarch64` or `cpython-linux` (whereas before those would require `any-any-windows-aarch64` and `cpython-any-linux` respectively). We still require strict ordering of segments.

Previously, we only allowed missing segments at the end of the key.

This uses a state machine for parsing, which is quite a bit more complicated.

I'm a little hesitant about the possibility that this regresses error messages and the complexity of the implementation, but `uv run -p aarch64` seems valuable following #13724. The alternative to this would probably be to make these explicit in various places? e.g., expose `--python-arch`, `--python-libc`, and `--python-os`? Or make `--python-platform` (which already exists) accept a subset of the keys?

There is a possibility of regressions here, e.g., if something matches this parser it will not fallback to the `PythonRequest::ExecutableName` case and we've made this parser more permissive, but I think that should be quite rare?