### PR TITLE
Includes `sys.prefix` in cached environment keys to avoid `--with` collisions across projects

### DIFF
--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -44,6 +44,8 @@ impl CachedEnvironment {
         printer: Printer,
         preview: PreviewMode,
     ) -> Result<Self, ProjectError> {
+        // Resolve the "base" interpreter, which resolves to an underlying parent interpreter if the
+        // given interpreter is a virtual environment.
         let base_interpreter = Self::base_interpreter(interpreter, cache)?;
 
         // Resolve the requirements with the interpreter.
@@ -73,15 +75,34 @@ impl CachedEnvironment {
             hash_digest(&distributions)
         };
 
-        // Concatenate the hashes of the interpreter path and the sys prefix. We don't want to
-        // share ephemeral environments between two different project venvs, for example.
-        let interpreter_hash =
-            cache_digest(&canonicalize_executable(base_interpreter.sys_executable())?);
-        let base_venv_hash = cache_digest(&interpreter.sys_prefix().canonicalize()?);
-        let cache_dir_name = interpreter_hash + &base_venv_hash;
+        // Construct a hash for the environment.
+        //
+        // Use the canonicalized base interpreter path since that's the interpreter we performed the
+        // resolution with and the interpreter the environment will be created with.
+        //
+        // We also include the canonicalized `sys.prefix` of the non-base interpreter, that is, the
+        // virtual environment's path. Originally, we shared cached environments independent of the
+        // environment they'd be layered on top of. However, this causes collisions as the overlay
+        // `.pth` file can be overridden by another instance of uv. Including this element in the key
+        // avoids this problem at the cost of creating separate cached environments for identical
+        // `--with` invocations across projects. We use `sys.prefix` rather than `sys.executable` so
+        // we can canonicalize it without invalidating the purpose of the element — it'd probably be
+        // safe to just use the absolute `sys.executable` as well.
+        //
+        // TODO(zanieb): Since we're not sharing these environmments across projects, we should move
+        // [`CachedEvnvironment::set_overlay`] etc. here since the values there should be constant
+        // now.
+        //
+        // TODO(zanieb): We should include the version of the base interpreter in the hash, so if
+        // the interpreter at the canonicalized path changes versions we construct a new
+        // environment.
+        let environment_hash = cache_digest(&(
+            &canonicalize_executable(base_interpreter.sys_executable())?,
+            &interpreter.sys_prefix().canonicalize()?,
+        ));
 
         // Search in the content-addressed cache.
-        let cache_entry = cache.entry(CacheBucket::Environments, cache_dir_name, resolution_hash);
+        let cache_entry = cache.entry(CacheBucket::Environments, environment_hash, resolution_hash);
 
         if cache.refresh().is_none() {
             if let Ok(root) = cache.resolve_link(cache_entry.path()) {

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -4983,7 +4983,7 @@ fn run_without_overlay() -> Result<()> {
     "###);
 
     // Import `iniconfig` in the context of a `tool run` command, which should fail. Note that
-    // typing-exensions gets installed again, because the venv is not shared.
+    // typing-extensions gets installed again, because the venv is not shared.
     uv_snapshot!(
         context.filters(),
         context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r#"

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -4777,7 +4777,7 @@ fn run_groups_include_requires_python() -> Result<()> {
         bar = ["iniconfig"]
         baz = ["iniconfig"]
         dev = ["sniffio", {include-group = "foo"}, {include-group = "baz"}]
-        
+
 
         [tool.uv.dependency-groups]
         foo = {requires-python="<3.13"}
@@ -4876,7 +4876,7 @@ fn exit_status_signal() -> Result<()> {
 
 #[test]
 fn run_repeated() -> Result<()> {
-    let context = TestContext::new_with_versions(&["3.13"]);
+    let context = TestContext::new_with_versions(&["3.13", "3.12"]);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
@@ -4923,22 +4923,25 @@ fn run_repeated() -> Result<()> {
     Resolved 1 package in [TIME]
     "###);
 
-    // Re-running as a tool shouldn't require reinstalling `typing-extensions`, since the environment is cached.
+    // Re-running as a tool does require reinstalling `typing-extensions`, since the base venv is
+    // different.
     uv_snapshot!(
         context.filters(),
-        context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
+        context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + typing-extensions==4.10.0
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
         import typing_extensions; import iniconfig
                                   ^^^^^^^^^^^^^^^^
     ModuleNotFoundError: No module named 'iniconfig'
-    "###);
+    "#);
 
     Ok(())
 }
@@ -4979,22 +4982,25 @@ fn run_without_overlay() -> Result<()> {
      + typing-extensions==4.10.0
     "###);
 
-    // Import `iniconfig` in the context of a `tool run` command, which should fail.
+    // Import `iniconfig` in the context of a `tool run` command, which should fail. Note that
+    // typing-exensions gets installed again, because the venv is not shared.
     uv_snapshot!(
         context.filters(),
-        context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r###"
+        context.tool_run().arg("--with").arg("typing-extensions").arg("python").arg("-c").arg("import typing_extensions; import iniconfig"), @r#"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + typing-extensions==4.10.0
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
         import typing_extensions; import iniconfig
                                   ^^^^^^^^^^^^^^^^
     ModuleNotFoundError: No module named 'iniconfig'
-    "###);
+    "#);
 
     // Re-running in the context of the project should reset the overlay.
     uv_snapshot!(


### PR DESCRIPTION
Fixes https://github.com/astral-sh/uv/issues/12889.