### PR TITLE
Make project and interpreter lock acquisition non-fatal

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -25,7 +25,7 @@ use tempfile::TempDir;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 use tokio::sync::{Mutex, Semaphore};
-use tracing::{Instrument, debug, info_span, instrument, warn};
+use tracing::{Instrument, debug, info_span, instrument};
 
 use uv_cache_key::cache_digest;
 use uv_configuration::PreviewMode;
@@ -459,7 +459,7 @@ impl SourceBuild {
             source_tree_lock = LockedFile::acquire(lock_path, self.source_tree.to_string_lossy())
                 .await
                 .inspect_err(|err| {
-                    warn!("Failed to acquire build lock: {err}");
+                    warn_user_once!("Failed to acquire build lock: {err}");
                 })
                 .ok();
         }

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -25,7 +25,7 @@ use tempfile::TempDir;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 use tokio::sync::{Mutex, Semaphore};
-use tracing::{Instrument, debug, info_span, instrument};
+use tracing::{Instrument, debug, info_span, instrument, warn};
 
 use uv_cache_key::cache_digest;
 use uv_configuration::PreviewMode;
@@ -459,7 +459,7 @@ impl SourceBuild {
             source_tree_lock = LockedFile::acquire(lock_path, self.source_tree.to_string_lossy())
                 .await
                 .inspect_err(|err| {
-                    warn_user_once!("Failed to acquire build lock: {err}");
+                    warn!("Failed to acquire build lock: {err}");
                 })
                 .ok();
         }

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::{Level, debug, enabled, warn};
+use tracing::{Level, debug, enabled};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -36,7 +36,7 @@ use uv_resolver::{
 };
 use uv_torch::{TorchMode, TorchStrategy};
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
@@ -240,7 +240,7 @@ pub(crate) async fn pip_install(
         .lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::{Level, debug, enabled};
+use tracing::{Level, debug, enabled, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -236,7 +236,13 @@ pub(crate) async fn pip_install(
         }
     }
 
-    let _lock = environment.lock().await?;
+    let _lock = environment
+        .lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     // Determine the markers to use for the resolution.
     let interpreter = environment.interpreter();

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::{Level, debug, enabled};
+use tracing::{Level, debug, enabled, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -36,7 +36,7 @@ use uv_resolver::{
 };
 use uv_torch::{TorchMode, TorchStrategy};
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
@@ -240,7 +240,7 @@ pub(crate) async fn pip_install(
         .lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -30,7 +30,7 @@ use uv_resolver::{
 };
 use uv_torch::{TorchMode, TorchStrategy};
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
@@ -215,7 +215,7 @@ pub(crate) async fn pip_sync(
         .lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -30,7 +30,7 @@ use uv_resolver::{
 };
 use uv_torch::{TorchMode, TorchStrategy};
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 use uv_workspace::WorkspaceCache;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
@@ -215,7 +215,7 @@ pub(crate) async fn pip_sync(
         .lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -211,7 +211,13 @@ pub(crate) async fn pip_sync(
         }
     }
 
-    let _lock = environment.lock().await?;
+    let _lock = environment
+        .lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     let interpreter = environment.interpreter();
 

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Result;
 use itertools::{Either, Itertools};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
@@ -100,7 +100,13 @@ pub(crate) async fn pip_uninstall(
         }
     }
 
-    let _lock = environment.lock().await?;
+    let _lock = environment
+        .lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     // Index the current `site-packages` directory.
     let site_packages = uv_installer::SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Result;
 use itertools::{Either, Itertools};
 use owo_colors::OwoColorize;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
@@ -17,6 +17,7 @@ use uv_python::EnvironmentPreference;
 use uv_python::PythonRequest;
 use uv_python::{Prefix, PythonEnvironment, Target};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
+use uv_warnings::warn_user_once;
 
 use crate::commands::pip::operations::report_target_environment;
 use crate::commands::{ExitStatus, elapsed};
@@ -104,7 +105,7 @@ pub(crate) async fn pip_uninstall(
         .lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Result;
 use itertools::{Either, Itertools};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
@@ -17,7 +17,6 @@ use uv_python::EnvironmentPreference;
 use uv_python::PythonRequest;
 use uv_python::{Prefix, PythonEnvironment, Target};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
-use uv_warnings::warn_user_once;
 
 use crate::commands::pip::operations::report_target_environment;
 use crate::commands::{ExitStatus, elapsed};
@@ -105,7 +104,7 @@ pub(crate) async fn pip_uninstall(
         .lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use tracing::debug;
+use tracing::{debug, warn};
 use url::Url;
 
 use uv_cache::Cache;
@@ -319,7 +319,13 @@ pub(crate) async fn add(
         }
     };
 
-    let _lock = target.acquire_lock().await?;
+    let _lock = target
+        .acquire_lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     let client_builder = BaseClientBuilder::new()
         .connectivity(network_settings.connectivity)

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use tracing::{debug, warn};
+use tracing::debug;
 use url::Url;
 
 use uv_cache::Cache;
@@ -323,7 +323,7 @@ pub(crate) async fn add(
         .acquire_lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use tracing::debug;
+use tracing::{debug, warn};
 use url::Url;
 
 use uv_cache::Cache;
@@ -323,7 +323,7 @@ pub(crate) async fn add(
         .acquire_lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1247,7 +1247,7 @@ impl ProjectEnvironment {
         let _lock = ProjectInterpreter::lock(workspace)
             .await
             .inspect_err(|err| {
-                warn!("Failed to acquire project environment lock: {err}");
+                warn_user_once!("Failed to acquire project environment lock: {err}");
             })
             .ok();
 
@@ -1470,7 +1470,7 @@ impl ScriptEnvironment {
         let _lock = ScriptInterpreter::lock(script)
             .await
             .inspect_err(|err| {
-                warn!("Failed to acquire script environment lock: {err}");
+                warn_user_once!("Failed to acquire script environment lock: {err}");
             })
             .ok();
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1247,7 +1247,7 @@ impl ProjectEnvironment {
         let _lock = ProjectInterpreter::lock(workspace)
             .await
             .inspect_err(|err| {
-                warn_user_once!("Failed to acquire project environment lock: {err}");
+                warn!("Failed to acquire project environment lock: {err}");
             })
             .ok();
 
@@ -1470,7 +1470,7 @@ impl ScriptEnvironment {
         let _lock = ScriptInterpreter::lock(script)
             .await
             .inspect_err(|err| {
-                warn_user_once!("Failed to acquire script environment lock: {err}");
+                warn!("Failed to acquire script environment lock: {err}");
             })
             .ok();
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1244,7 +1244,12 @@ impl ProjectEnvironment {
         preview: PreviewMode,
     ) -> Result<Self, ProjectError> {
         // Lock the project environment to avoid synchronization issues.
-        let _lock = ProjectInterpreter::lock(workspace).await?;
+        let _lock = ProjectInterpreter::lock(workspace)
+            .await
+            .inspect_err(|err| {
+                warn!("Failed to acquire project environment lock: {err}");
+            })
+            .ok();
 
         let upgradeable = preview.is_enabled()
             && python
@@ -1462,7 +1467,13 @@ impl ScriptEnvironment {
         preview: PreviewMode,
     ) -> Result<Self, ProjectError> {
         // Lock the script environment to avoid synchronization issues.
-        let _lock = ScriptInterpreter::lock(script).await?;
+        let _lock = ScriptInterpreter::lock(script)
+            .await
+            .inspect_err(|err| {
+                warn!("Failed to acquire script environment lock: {err}");
+            })
+            .ok();
+
         let upgradeable = python_request
             .as_ref()
             .is_none_or(|request| !request.includes_patch());

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_configuration::{
@@ -281,7 +281,13 @@ pub(crate) async fn remove(
         }
     };
 
-    let _lock = target.acquire_lock().await?;
+    let _lock = target
+        .acquire_lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     // Determine the lock mode.
     let mode = if locked {

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use uv_cache::Cache;
 use uv_configuration::{
@@ -285,7 +285,7 @@ pub(crate) async fn remove(
         .acquire_lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_configuration::{
@@ -285,7 +285,7 @@ pub(crate) async fn remove(
         .acquire_lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -240,7 +240,13 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             .await?
             .into_environment()?;
 
-            let _lock = environment.lock().await?;
+            let _lock = environment
+                .lock()
+                .await
+                .inspect_err(|err| {
+                    warn!("Failed to acquire environment lock: {err}");
+                })
+                .ok();
 
             // Determine the lock mode.
             let mode = if frozen {
@@ -386,7 +392,13 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                         )
                     });
 
-                let _lock = environment.lock().await?;
+                let _lock = environment
+                    .lock()
+                    .await
+                    .inspect_err(|err| {
+                        warn!("Failed to acquire environment lock: {err}");
+                    })
+                    .ok();
 
                 match update_environment(
                     environment,
@@ -699,7 +711,13 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                         .map(|lock| (lock, project.workspace().install_path().to_owned()));
                 }
             } else {
-                let _lock = venv.lock().await?;
+                let _lock = venv
+                    .lock()
+                    .await
+                    .inspect_err(|err| {
+                        warn!("Failed to acquire environment lock: {err}");
+                    })
+                    .ok();
 
                 // Determine the lock mode.
                 let mode = if frozen {

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -37,7 +37,7 @@ use uv_scripts::Pep723Item;
 use uv_settings::PythonInstallMirrors;
 use uv_shell::runnable::WindowsRunnable;
 use uv_static::EnvVars;
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache, WorkspaceError};
 
 use crate::commands::pip::loggers::{
@@ -244,7 +244,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 .lock()
                 .await
                 .inspect_err(|err| {
-                    warn!("Failed to acquire environment lock: {err}");
+                    warn_user_once!("Failed to acquire environment lock: {err}");
                 })
                 .ok();
 
@@ -396,7 +396,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     .lock()
                     .await
                     .inspect_err(|err| {
-                        warn!("Failed to acquire environment lock: {err}");
+                        warn_user_once!("Failed to acquire environment lock: {err}");
                     })
                     .ok();
 
@@ -715,7 +715,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     .lock()
                     .await
                     .inspect_err(|err| {
-                        warn!("Failed to acquire environment lock: {err}");
+                        warn_user_once!("Failed to acquire environment lock: {err}");
                     })
                     .ok();
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -37,7 +37,7 @@ use uv_scripts::Pep723Item;
 use uv_settings::PythonInstallMirrors;
 use uv_shell::runnable::WindowsRunnable;
 use uv_static::EnvVars;
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache, WorkspaceError};
 
 use crate::commands::pip::loggers::{
@@ -244,7 +244,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 .lock()
                 .await
                 .inspect_err(|err| {
-                    warn_user_once!("Failed to acquire environment lock: {err}");
+                    warn!("Failed to acquire environment lock: {err}");
                 })
                 .ok();
 
@@ -396,7 +396,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     .lock()
                     .await
                     .inspect_err(|err| {
-                        warn_user_once!("Failed to acquire environment lock: {err}");
+                        warn!("Failed to acquire environment lock: {err}");
                     })
                     .ok();
 
@@ -715,7 +715,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     .lock()
                     .await
                     .inspect_err(|err| {
-                        warn_user_once!("Failed to acquire environment lock: {err}");
+                        warn!("Failed to acquire environment lock: {err}");
                     })
                     .ok();
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use tracing::warn;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -169,7 +170,13 @@ pub(crate) async fn sync(
         ),
     };
 
-    let _lock = environment.lock().await?;
+    let _lock = environment
+        .lock()
+        .await
+        .inspect_err(|err| {
+            warn!("Failed to acquire environment lock: {err}");
+        })
+        .ok();
 
     // Notify the user of any environment changes.
     match &environment {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use tracing::warn;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -28,7 +29,7 @@ use uv_resolver::{FlatIndex, Installable, Lock};
 use uv_scripts::{Pep723ItemRef, Pep723Script};
 use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 use uv_workspace::pyproject::Source;
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
@@ -173,7 +174,7 @@ pub(crate) async fn sync(
         .lock()
         .await
         .inspect_err(|err| {
-            warn_user_once!("Failed to acquire environment lock: {err}");
+            warn!("Failed to acquire environment lock: {err}");
         })
         .ok();
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::warn;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -29,7 +28,7 @@ use uv_resolver::{FlatIndex, Installable, Lock};
 use uv_scripts::{Pep723ItemRef, Pep723Script};
 use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::pyproject::Source;
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
@@ -174,7 +173,7 @@ pub(crate) async fn sync(
         .lock()
         .await
         .inspect_err(|err| {
-            warn!("Failed to acquire environment lock: {err}");
+            warn_user_once!("Failed to acquire environment lock: {err}");
         })
         .ok();
 


### PR DESCRIPTION
## Summary

If we fail to acquire a lock on an environment, uv shouldn't fail; we should just warn. In some cases, users run uv with read-only permissions for their projects, etc.

For now, I kept any locks acquired _in the cache_ as hard failures, since we always need write-access to the cache.

Closes https://github.com/astral-sh/uv/issues/14411.
