### PR TITLE
Build `path` sources without build systems by default

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -729,12 +729,14 @@ fn path_source(
             })
         } else {
             // Determine whether the project is a package or virtual.
+            // If the `package` option is unset, check if `tool.uv.package` is set
+            // on the path source (otherwise, default to `true`).
             let is_package = package.unwrap_or_else(|| {
                 let pyproject_path = install_path.join("pyproject.toml");
                 fs_err::read_to_string(&pyproject_path)
                     .ok()
                     .and_then(|contents| PyProjectToml::from_string(contents).ok())
-                    .map(|pyproject_toml| pyproject_toml.is_package())
+                    .and_then(|pyproject_toml| pyproject_toml.tool_uv_package())
                     .unwrap_or(true)
             });
 

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -83,17 +83,20 @@ impl PyProjectToml {
     /// non-package ("virtual") project.
     pub fn is_package(&self) -> bool {
         // If `tool.uv.package` is set, defer to that explicit setting.
-        if let Some(is_package) = self
-            .tool
-            .as_ref()
-            .and_then(|tool| tool.uv.as_ref())
-            .and_then(|uv| uv.package)
-        {
+        if let Some(is_package) = self.tool_uv_package() {
             return is_package;
         }
 
         // Otherwise, a project is assumed to be a package if `build-system` is present.
         self.build_system.is_some()
+    }
+
+    /// Returns the value of `tool.uv.package` if set.
+    pub fn tool_uv_package(&self) -> Option<bool> {
+        self.tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.package)
     }
 
     /// Returns `true` if the project uses a dynamic version.

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -13381,7 +13381,9 @@ fn add_path_with_no_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Audited in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + dep==0.1.0 (from file://[TEMP_DIR]/dep)
     ");
 
     let pyproject_toml = context.read("pyproject.toml");
@@ -13452,7 +13454,9 @@ fn add_path_outside_workspace_no_default() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
     Resolved 2 packages in [TIME]
-    Audited in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + dep==0.1.0 (from file://[TEMP_DIR]/external_dep)
     ");
 
     let pyproject_toml = fs_err::read_to_string(workspace_toml)?;

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7205,12 +7205,12 @@ fn lock_exclusion() -> Result<()> {
         ]
 
         [package.metadata]
-        requires-dist = [{ name = "project", virtual = "../" }]
+        requires-dist = [{ name = "project", directory = "../" }]
 
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { virtual = "../" }
+        source = { directory = "../" }
         "#
         );
     });
@@ -7793,7 +7793,7 @@ fn lock_dev_transitive() -> Result<()> {
         [package.metadata]
         requires-dist = [
             { name = "baz", editable = "baz" },
-            { name = "foo", virtual = "../foo" },
+            { name = "foo", directory = "../foo" },
             { name = "iniconfig", specifier = ">1" },
         ]
 
@@ -7815,7 +7815,7 @@ fn lock_dev_transitive() -> Result<()> {
         [[package]]
         name = "foo"
         version = "0.1.0"
-        source = { virtual = "../foo" }
+        source = { directory = "../foo" }
 
         [package.metadata]
 
@@ -13651,7 +13651,7 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
         [[package]]
         name = "dependency"
         version = "0.1.0"
-        source = { virtual = "dependency" }
+        source = { directory = "dependency" }
         dependencies = [
             { name = "iniconfig", marker = "python_full_version >= '3.10'" },
         ]
@@ -13677,7 +13677,7 @@ fn lock_narrowed_python_version_upper() -> Result<()> {
         ]
 
         [package.metadata]
-        requires-dist = [{ name = "dependency", marker = "python_full_version >= '3.10'", virtual = "dependency" }]
+        requires-dist = [{ name = "dependency", marker = "python_full_version >= '3.10'", directory = "dependency" }]
         "#
         );
     });
@@ -17173,10 +17173,10 @@ fn lock_implicit_virtual_project() -> Result<()> {
     Ok(())
 }
 
-/// Lock a project that has a path dependency that is implicitly virtual (by way of omitting
-/// `build-system`).
+/// Lock a project that has a path dependency that is implicitly non-virtual (despite
+/// omitting `build-system`).
 #[test]
-fn lock_implicit_virtual_path() -> Result<()> {
+fn lock_implicit_package_path() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -17243,7 +17243,7 @@ fn lock_implicit_virtual_path() -> Result<()> {
         [[package]]
         name = "child"
         version = "0.1.0"
-        source = { virtual = "child" }
+        source = { directory = "child" }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -17281,7 +17281,7 @@ fn lock_implicit_virtual_path() -> Result<()> {
         [package.metadata]
         requires-dist = [
             { name = "anyio", specifier = ">3" },
-            { name = "child", virtual = "child" },
+            { name = "child", directory = "child" },
         ]
 
         [[package]]
@@ -17317,20 +17317,21 @@ fn lock_implicit_virtual_path() -> Result<()> {
     Resolved 6 packages in [TIME]
     "###);
 
-    // Install from the lockfile. The virtual project should _not_ be installed.
-    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    // Install from the lockfile. The path dependency should be installed.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 4 packages in [TIME]
-    Installed 4 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
      + anyio==4.3.0
+     + child==0.1.0 (from file://[TEMP_DIR]/child)
      + idna==3.6
      + iniconfig==2.0.0
      + sniffio==1.3.1
-    "###);
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -5939,6 +5939,91 @@ fn sync_override_package() -> Result<()> {
      ~ project==0.0.0 (from file://[TEMP_DIR]/)
     ");
 
+    // Update the source `tool.uv` to `package = true`
+    let pyproject_toml = context.temp_dir.child("core").child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "core"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [tool.uv]
+        package = true
+        "#,
+    )?;
+
+    // Mark the source as `package = false`.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["core"]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [tool.uv.sources]
+        core = { path = "./core", package = false }
+        "#,
+    )?;
+
+    // Syncing the project should _not_ install `core`.
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ project==0.0.0 (from file://[TEMP_DIR]/)
+    ");
+
+    // Remove the `package = false` mark.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.0.0"
+        requires-python = ">=3.12"
+        dependencies = ["core"]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [tool.uv.sources]
+        core = { path = "./core" }
+        "#,
+    )?;
+
+    // Syncing the project _should_ install `core`.
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 2 packages in [TIME]
+     + core==0.1.0 (from file://[TEMP_DIR]/core)
+     ~ project==0.0.0 (from file://[TEMP_DIR]/)
+    ");
+
     Ok(())
 }
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -116,8 +116,9 @@ with the default build system.
     the presence of a `[build-system]` table is not required in other packages. For legacy reasons,
     if a build system is not defined, then `setuptools.build_meta:__legacy__` is used to build the
     package. Packages you depend on may not explicitly declare their build system but are still
-    installable. Similarly, if you add a dependency on a local package or install it with `uv pip`,
-    uv will always attempt to build and install it.
+    installable (e.g., the default behavior for [installing path sources](./dependencies.md#installing-path-sources)).
+    Similarly, if you add a dependency on a local package or install it with `uv pip`, uv will
+    always attempt to build and install it.
 
 ### Build system options
 

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -116,9 +116,9 @@ with the default build system.
     the presence of a `[build-system]` table is not required in other packages. For legacy reasons,
     if a build system is not defined, then `setuptools.build_meta:__legacy__` is used to build the
     package. Packages you depend on may not explicitly declare their build system but are still
-    installable (e.g., the default behavior for [installing path sources](./dependencies.md#installing-path-sources)).
-    Similarly, if you add a dependency on a local package or install it with `uv pip`, uv will
-    always attempt to build and install it.
+    installable. Similarly, if you [add a dependency on a local project](./dependencies.md#path)
+    or install it with `uv pip`, uv will attempt to build and install it regardless of the presence
+    of a `[build-system]` table.
 
 ### Build system options
 

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -412,7 +412,7 @@ $ uv add ~/projects/bar/
 
 By default, a path dependency project is installed in the environment as a package, unless it is
 explicitly marked as a [non-package](./config.md#build-systems). This is true even if it lacks a
-[`[build-system] table`](./config.md#build-systems). If you'd like to override this behavior and
+[`[build-system]` table](./config.md#build-systems). If you'd like to override this behavior and
 ensure the path dependency is not installed as a package, set `package = false` on the source:
 
 ```toml title="pyproject.toml"

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -410,6 +410,30 @@ $ uv add ~/projects/bar/
 
 ### Path dependency installation
 
+By default, a path dependency project is installed in the environment as a package, unless it is
+explicitly marked as a [non-package](./config.md#build-systems). This is true even if it lacks a
+[`[build-system] table`](./config.md#build-systems). If you'd like to override this behavior and
+ensure the path dependency is not installed as a package, set `package = false` on the source:
+
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
+
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = false }
+```
+
+If the path dependency project is marked as a non-package, but you'd like to install it as a
+package, set `package = true` on the source:
+
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
+
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = true }
+```
+
 An [editable installation](#editable-dependencies) is not used for path dependencies by default. An
 editable installation may be requested for project directories:
 
@@ -426,32 +450,6 @@ dependencies = ["bar"]
 [tool.uv.sources]
 bar = { path = "../projects/bar", editable = true }
 ```
-
-Similarly, if a project is marked as a [non-package](./config.md#build-systems), but you'd like to
-install it in the environment as a package, set `package = true` on the source:
-
-```toml title="pyproject.toml"
-[project]
-dependencies = ["bar"]
-
-[tool.uv.sources]
-bar = { path = "../projects/bar", package = true }
-```
-
-If the dependency project is not marked as a non-package and no value is set for `package` on the
-source, the default behavior is to install it as a package, even if it lacks a
-[[build-system] table](./config.md#build-systems). If you'd like to avoid installing it, set
-`package = false` on the source:
-
-```toml title="pyproject.toml"
-[project]
-dependencies = ["bar"]
-
-[tool.uv.sources]
-bar = { path = "../projects/bar", package = false }
-```
-
-This will override the default behavior and the path dependency's own `tool.uv.package` value.
 
 For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better fit.
 

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -408,31 +408,11 @@ Or, a path to a project directory:
 $ uv add ~/projects/bar/
 ```
 
-### Path dependency installation
+!!! important
 
-By default, a path dependency project is installed in the environment as a package, unless it is
-explicitly marked as a [non-package](./config.md#build-systems). This is true even if it lacks a
-[`[build-system]` table](./config.md#build-systems). If you'd like to override this behavior and
-ensure the path dependency is not installed as a package, set `package = false` on the source:
-
-```toml title="pyproject.toml"
-[project]
-dependencies = ["bar"]
-
-[tool.uv.sources]
-bar = { path = "../projects/bar", package = false }
-```
-
-If the path dependency project is marked as a non-package, but you'd like to install it as a
-package, set `package = true` on the source:
-
-```toml title="pyproject.toml"
-[project]
-dependencies = ["bar"]
-
-[tool.uv.sources]
-bar = { path = "../projects/bar", package = true }
-```
+    When using a directory as a path dependency, uv will attempt to build and install the target as
+    a package by default. See the [virtual dependency](#virtual-dependencies) documentation for
+    details.
 
 An [editable installation](#editable-dependencies) is not used for path dependencies by default. An
 editable installation may be requested for project directories:
@@ -451,7 +431,10 @@ dependencies = ["bar"]
 bar = { path = "../projects/bar", editable = true }
 ```
 
-For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better fit.
+!!! tip
+
+    For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better
+    fit.
 
 ### Workspace member
 
@@ -818,6 +801,39 @@ Or, to opt-out of using an editable dependency in a workspace:
 
 ```console
 $ uv add --no-editable ./path/foo
+```
+
+## Virtual dependencies
+
+uv allows dependencies to be "virtual", in which the dependency itself is not installed as a
+[package](./config.md#project-packaging), but its dependencies are.
+
+By default, only workspace members without build systems declared are virtual.
+
+A dependency with a [`path` source](#path) is not virtual unless it explicitly sets
+[`tool.uv.package = false`](../../reference/settings.md#package). Unlike working _in_ the dependent
+project with uv, the package will be built even if a [build system](./config.md#build-systems) is
+not declared.
+
+To treat a dependency as virtual, set `package = false` on the source:
+
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
+
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = false }
+```
+
+Similarly, if a dependency sets `tool.uv.package = false`, it can be overridden by declaring
+`package = true` on the source:
+
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
+
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = true }
 ```
 
 ## Dependency specifiers

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -438,6 +438,21 @@ $ uv add ~/projects/bar/
     bar = { path = "../projects/bar", package = true }
     ```
 
+    If the project is not marked as a non-package and no value is set for `package` on the source, the default behavior is to install it as a package, even if it lacks a [build
+    specification](./config.md#build-systems). If you'd like to avoid installing it, set
+    `package = false` on the source:
+
+    ```toml title="pyproject.toml"
+    [project]
+    dependencies = ["bar"]
+
+    [tool.uv.sources]
+    bar = { path = "../projects/bar", package = false }
+    ```
+
+    This will override the default behavior and the path dependency's own `tool.uv.package`
+    value.
+
     For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better
     fit.
 

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -408,53 +408,52 @@ Or, a path to a project directory:
 $ uv add ~/projects/bar/
 ```
 
-!!! important
+### Path dependency installation
 
-    An [editable installation](#editable-dependencies) is not used for path dependencies by
-    default. An editable installation may be requested for project directories:
+An [editable installation](#editable-dependencies) is not used for path dependencies by default. An
+editable installation may be requested for project directories:
 
-    ```console
-    $ uv add --editable ../projects/bar/
-    ```
+```console
+$ uv add --editable ../projects/bar/
+```
 
-    Which will result in a `pyproject.toml` with:
+Which will result in a `pyproject.toml` with:
 
-    ```toml title="pyproject.toml"
-    [project]
-    dependencies = ["bar"]
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
 
-    [tool.uv.sources]
-    bar = { path = "../projects/bar", editable = true }
-    ```
+[tool.uv.sources]
+bar = { path = "../projects/bar", editable = true }
+```
 
-    Similarly, if a project is marked as a [non-package](./config.md#build-systems), but you'd
-    like to install it in the environment as a package, set `package = true` on the source:
+Similarly, if a project is marked as a [non-package](./config.md#build-systems), but you'd like to
+install it in the environment as a package, set `package = true` on the source:
 
-    ```toml title="pyproject.toml"
-    [project]
-    dependencies = ["bar"]
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
 
-    [tool.uv.sources]
-    bar = { path = "../projects/bar", package = true }
-    ```
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = true }
+```
 
-    If the project is not marked as a non-package and no value is set for `package` on the source, the default behavior is to install it as a package, even if it lacks a [build
-    specification](./config.md#build-systems). If you'd like to avoid installing it, set
-    `package = false` on the source:
+If the dependency project is not marked as a non-package and no value is set for `package` on the
+source, the default behavior is to install it as a package, even if it lacks a
+[[build-system] table](./config.md#build-systems). If you'd like to avoid installing it, set
+`package = false` on the source:
 
-    ```toml title="pyproject.toml"
-    [project]
-    dependencies = ["bar"]
+```toml title="pyproject.toml"
+[project]
+dependencies = ["bar"]
 
-    [tool.uv.sources]
-    bar = { path = "../projects/bar", package = false }
-    ```
+[tool.uv.sources]
+bar = { path = "../projects/bar", package = false }
+```
 
-    This will override the default behavior and the path dependency's own `tool.uv.package`
-    value.
+This will override the default behavior and the path dependency's own `tool.uv.package` value.
 
-    For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better
-    fit.
+For multiple packages in the same repository, [_workspaces_](./workspaces.md) may be a better fit.
 
 ### Workspace member
 


### PR DESCRIPTION
We currently treat path sources as virtual if they do not specify a build system, which is surprising behavior. This PR updates the behavior to treat path sources as packages unless the path source is explicitly marked as `package = false` or its own `tool.uv.package` is set to `false`.

Closes #12015
