### PR TITLE
Fix optional cfg gates

### DIFF
--- a/crates/uv-configuration/src/name_specifiers.rs
+++ b/crates/uv-configuration/src/name_specifiers.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, str::FromStr};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::str::FromStr;
 
 use uv_pep508::PackageName;
 

--- a/crates/uv-configuration/src/required_version.rs
+++ b/crates/uv-configuration/src/required_version.rs
@@ -1,5 +1,6 @@
-use std::str::FromStr;
-use std::{borrow::Cow, fmt::Formatter};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::{fmt::Formatter, str::FromStr};
 
 use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers, VersionSpecifiersParseError};
 

--- a/crates/uv-configuration/src/trusted_host.rs
+++ b/crates/uv-configuration/src/trusted_host.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Deserializer};
-use std::{borrow::Cow, str::FromStr};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::str::FromStr;
 use url::Url;
 
 /// A host specification (wildcard, or host, with optional scheme and/or port) for which

--- a/crates/uv-distribution-types/src/pip_index.rs
+++ b/crates/uv-distribution-types/src/pip_index.rs
@@ -3,7 +3,9 @@
 //! flags set.
 
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{borrow::Cow, path::Path};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::path::Path;
 
 use crate::{Index, IndexUrl};
 

--- a/crates/uv-distribution-types/src/status_code_strategy.rs
+++ b/crates/uv-distribution-types/src/status_code_strategy.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, ops::Deref};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::ops::Deref;
 
 use http::StatusCode;
 use rustc_hash::FxHashSet;

--- a/crates/uv-python/src/python_version.rs
+++ b/crates/uv-python/src/python_version.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "schemars")]
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, str::FromStr};
+#[cfg(feature = "schemars")]
+use std::borrow::Cow;
+use std::str::FromStr;
 
 use jiff::{Timestamp, ToSpan, tz::TimeZone};
 

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -6,6 +6,7 @@
 //!
 //! Then lowers them into a dependency specification.
 
+#[cfg(feature = "schemars")]
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Formatter;


### PR DESCRIPTION
Running `cargo clippy` in individual crates could raise warnings due to unused imports as `Cow` is only used with `#[cfg(feature = "schemars")]`