### PR TITLE
Remove transparent variants in `uv-extract` to enable retries

### DIFF
--- a/crates/uv-extract/src/error.rs
+++ b/crates/uv-extract/src/error.rs
@@ -2,11 +2,11 @@ use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error(transparent)]
+    #[error("Failed to read from zip file")]
     Zip(#[from] zip::result::ZipError),
-    #[error(transparent)]
+    #[error("Failed to read from zip file")]
     AsyncZip(#[from] async_zip::error::ZipError),
-    #[error(transparent)]
+    #[error("I/O operation failed during extraction")]
     Io(#[from] std::io::Error),
     #[error(
         "The top-level of the archive must only contain a list directory, but it contains: {0:?}"


### PR DESCRIPTION
## Summary

We think this is the culprit for the lack of retries in some settings (e.g., Python downloads).

See: https://github.com/astral-sh/uv/issues/14425.
