### PR TITLE
Document that `VerbatimUrl` does not preserve original string after serialization

### DIFF
--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -18,11 +18,16 @@ use uv_redacted::DisplaySafeUrl;
 use crate::Pep508Url;
 
 /// A wrapper around [`Url`] that preserves the original string.
+///
+/// The original string is not preserved after serialization/deserialization.
 #[derive(Debug, Clone, Eq)]
 pub struct VerbatimUrl {
     /// The parsed URL.
     url: DisplaySafeUrl,
     /// The URL as it was provided by the user.
+    ///
+    /// Even if originally set, this will be [`None`] after
+    /// serialization/deserialization.
     given: Option<ArcStr>,
 }
 


### PR DESCRIPTION
This came up in [discussion](https://github.com/astral-sh/uv/pull/14387#issuecomment-3032223670) on #14387.
