### PR TITLE
Add method to get packages involved in a `NoSolutionError`

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use indexmap::IndexSet;
+use itertools::Itertools;
 use owo_colors::OwoColorize;
 use pubgrub::{
     DefaultStringReporter, DerivationTree, Derived, External, Range, Ranges, Reporter, Term,
@@ -416,8 +417,7 @@ impl NoSolutionError {
             .packages()
             .into_iter()
             .filter_map(|p| p.name())
-            .collect::<rustc_hash::FxHashSet<_>>()
-            .into_iter()
+            .unique()
     }
 }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -409,6 +409,16 @@ impl NoSolutionError {
         }
         Ok(())
     }
+
+    /// Get the packages that are involved in this error.
+    pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
+        self.error
+            .packages()
+            .into_iter()
+            .filter_map(|p| p.name())
+            .collect::<rustc_hash::FxHashSet<_>>()
+            .into_iter()
+    }
 }
 
 impl std::fmt::Debug for NoSolutionError {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

In pixi we overlay the PyPI packages over the conda packages and we sometimes need to figure out what PyPI packages are involved in the no-solution error. We could parse the error message, but this is pretty error-prone, so it would be good to get access to more information. A lot of information in this module is private and should probably stay this way, but package names are easy enough to expose. This would help us a lot!

I collect into a HashSet to remove duplication, and did not want to expose a rustc_hash datastructure directly, thats's why I've chosen to expose as an iterator :)

Let me know if any changes need to be done, and thanks!


