### PR TITLE
Log the debug error trace

### DIFF
--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use anstream::eprintln;
 use owo_colors::OwoColorize;
-use tracing::debug;
+use tracing::{debug, trace};
 use tracing_durations_export::DurationsLayerBuilder;
 use tracing_durations_export::plot::PlotConfig;
 use tracing_subscriber::filter::Directive;
@@ -68,6 +68,7 @@ async fn main() -> ExitCode {
     let result = run().await;
     debug!("Took {}ms", start.elapsed().as_millis());
     if let Err(err) = result {
+        trace!("Error trace: {err:?}");
         eprintln!("{}", "uv-dev failed".red().bold());
         for err in err.chain() {
             eprintln!("  {}: {}", "Caused by".red().bold(), err.to_string().trim());

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, bail};
 use console::Term;
 use owo_colors::{AnsiColors, OwoColorize};
 use tokio::sync::Semaphore;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 use uv_auth::Credentials;
 use uv_cache::Cache;
 use uv_client::{AuthIntegration, BaseClient, BaseClientBuilder, RegistryClientBuilder};
@@ -274,6 +274,7 @@ async fn gather_credentials(
                 publishing, you can ignore this error, but you need to provide credentials."
             )?;
 
+            trace!("Error trace: {err:?}");
             write_error_chain(
                 anyhow::Error::from(err)
                     .context("Trusted publishing failed")

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -706,6 +706,7 @@ pub(crate) async fn install(
                         Some(true) => ("error", AnsiColors::Red),
                     };
 
+                    trace!("Error trace: {err:?}");
                     write_error_chain(
                         err.context(format!("Failed to create registry entry for {key}"))
                             .as_ref(),

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -4,7 +4,7 @@ use owo_colors::{AnsiColors, OwoColorize};
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::str::FromStr;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
@@ -157,6 +157,7 @@ pub(crate) async fn upgrade(
             .into_iter()
             .sorted_unstable_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b))
         {
+            trace!("Error trace: {err:?}");
             write_error_chain(
                 err.context(format!("Failed to upgrade {}", name.green()))
                     .as_ref(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -17,7 +17,7 @@ use futures::FutureExt;
 use owo_colors::OwoColorize;
 use settings::PipTreeSettings;
 use tokio::task::spawn_blocking;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, trace};
 
 use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
@@ -2330,6 +2330,7 @@ where
     match result {
         Ok(code) => code.into(),
         Err(err) => {
+            trace!("Error trace: {err:?}");
             let mut causes = err.chain();
             eprintln!(
                 "{}: {}",


### PR DESCRIPTION
For #14425. We can see the error without `error(transparent)` applied by looking at the debug representation.