### PR TITLE
Multiple modules in namespace packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,6 +4785,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
+ "rustc-hash",
  "schemars",
  "serde",
  "sha2",

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -31,6 +31,7 @@ flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true }
 globset = { workspace = true }
 itertools = { workspace = true }
+rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/uv-build-backend/src/settings.rs
+++ b/crates/uv-build-backend/src/settings.rs
@@ -34,15 +34,19 @@ pub struct BuildBackendSettings {
     /// For namespace packages with a single module, the path can be dotted, e.g., `foo.bar` or
     /// `foo-stubs.bar`.
     ///
+    /// For namespace packages with multiple modules, the path can be a list, e.g.,
+    /// `["foo", "bar"]`. We recommend using a single module per package, splitting multiple
+    /// packages into a workspace.
+    ///
     /// Note that using this option runs the risk of creating two packages with different names but
     /// the same module names. Installing such packages together leads to unspecified behavior,
     /// often with corrupted files or directory trees.
     #[option(
         default = r#"None"#,
-        value_type = "str",
+        value_type = "str | list[str]",
         example = r#"module-name = "sklearn""#
     )]
-    pub module_name: Option<String>,
+    pub module_name: Option<ModuleName>,
 
     /// Glob expressions which files and directories to additionally include in the source
     /// distribution.
@@ -179,6 +183,17 @@ impl Default for BuildBackendSettings {
             data: WheelDataIncludes::default(),
         }
     }
+}
+
+/// Whether to include a single module or multiple modules.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum ModuleName {
+    /// A single module name.
+    Name(String),
+    /// Multiple module names, which are all included.
+    Names(Vec<String>),
 }
 
 /// Data includes for wheels.

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -1,6 +1,7 @@
 use fs_err::File;
 use globset::{GlobSet, GlobSetBuilder};
 use itertools::Itertools;
+use rustc_hash::FxHashSet;
 use sha2::{Digest, Sha256};
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -127,55 +128,61 @@ fn write_wheel(
         source_tree,
         pyproject_toml,
         &settings.module_root,
-        settings.module_name.as_deref(),
+        settings.module_name.as_ref(),
         settings.namespace,
     )?;
 
-    // For convenience, have directories for the whole tree in the wheel
-    for ancestor in module_relative.ancestors().skip(1) {
-        if ancestor == Path::new("") {
-            continue;
-        }
-        wheel_writer.write_directory(&ancestor.portable_display().to_string())?;
-    }
-
     let mut files_visited = 0;
-    for entry in WalkDir::new(src_root.join(module_relative))
-        .sort_by_file_name()
-        .into_iter()
-        .filter_entry(|entry| !exclude_matcher.is_match(entry.path()))
-    {
-        let entry = entry.map_err(|err| Error::WalkDir {
-            root: source_tree.to_path_buf(),
-            err,
-        })?;
+    let mut prefix_directories = FxHashSet::default();
+    for module_relative in module_relative {
+        // For convenience, have directories for the whole tree in the wheel
+        for ancestor in module_relative.ancestors().skip(1) {
+            if ancestor == Path::new("") {
+                continue;
+            }
+            // Avoid duplicate directories in the zip.
+            if prefix_directories.insert(ancestor.to_path_buf()) {
+                wheel_writer.write_directory(&ancestor.portable_display().to_string())?;
+            }
+        }
 
-        files_visited += 1;
-        if files_visited > 10000 {
-            warn_user_once!(
-                "Visited more than 10,000 files for wheel build. \
+        for entry in WalkDir::new(src_root.join(module_relative))
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(|entry| !exclude_matcher.is_match(entry.path()))
+        {
+            let entry = entry.map_err(|err| Error::WalkDir {
+                root: source_tree.to_path_buf(),
+                err,
+            })?;
+
+            files_visited += 1;
+            if files_visited > 10000 {
+                warn_user_once!(
+                    "Visited more than 10,000 files for wheel build. \
                 Consider using more constrained includes or more excludes."
-            );
-        }
+                );
+            }
 
-        // We only want to take the module root, but since excludes start at the source tree root,
-        // we strip higher than we iterate.
-        let match_path = entry
-            .path()
-            .strip_prefix(source_tree)
-            .expect("walkdir starts with root");
-        let entry_path = entry
-            .path()
-            .strip_prefix(&src_root)
-            .expect("walkdir starts with root");
-        if exclude_matcher.is_match(match_path) {
-            trace!("Excluding from module: `{}`", match_path.user_display());
-            continue;
-        }
+            // We only want to take the module root, but since excludes start at the source tree root,
+            // we strip higher than we iterate.
+            let match_path = entry
+                .path()
+                .strip_prefix(source_tree)
+                .expect("walkdir starts with root");
+            let entry_path = entry
+                .path()
+                .strip_prefix(&src_root)
+                .expect("walkdir starts with root");
+            if exclude_matcher.is_match(match_path) {
+                trace!("Excluding from module: `{}`", match_path.user_display());
+                continue;
+            }
 
-        let entry_path = entry_path.portable_display().to_string();
-        debug!("Adding to wheel: {entry_path}");
-        wheel_writer.write_dir_entry(&entry, &entry_path)?;
+            let entry_path = entry_path.portable_display().to_string();
+            debug!("Adding to wheel: {entry_path}");
+            wheel_writer.write_dir_entry(&entry, &entry_path)?;
+        }
     }
     debug!("Visited {files_visited} files for wheel build");
 
@@ -269,7 +276,7 @@ pub fn build_editable(
         source_tree,
         &pyproject_toml,
         &settings.module_root,
-        settings.module_name.as_deref(),
+        settings.module_name.as_ref(),
         settings.namespace,
     )?;
 

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -140,15 +140,28 @@ src
 ```
 
 While we do not recommend this structure (i.e., you should use a workspace with multiple packages
-instead), it is supported by passing a list to the `module-name` option:
+instead), it is supported by setting `module-name` to a list of names:
 
 ```toml title="pyproject.toml"
 [tool.uv.build-backend]
 module-name = ["foo", "bar"]
 ```
 
-The `namespace = true` option offers an opt-out to enumerating all modules for complex namespace
-packages. Declaring an explicit `module-name` should be preferred over `namespace = true`.
+For packages with many modules or complex namespaces, the `namespace = true` option can be used to
+avoid explicitly declaring each module name, e.g.:
+
+```toml title="pyproject.toml"
+[tool.uv.build-backend]
+namespace = true
+```
+
+!!! warning
+
+    Using `namespace = true` disables safety checks. Using an explicit list of module names is
+    strongly recommended outside of legacy projects.
+
+The `namespace` option can also be used with `module-name` to explicitly declare the root, e.g., for
+the project structure:
 
 ```text
 pyproject.toml
@@ -160,7 +173,7 @@ src
         └── __init__.py
 ```
 
-And the configuration would be:
+The recommended configuration would be:
 
 ```toml title="pyproject.toml"
 [tool.uv.build-backend]

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -134,16 +134,37 @@ the project structure:
 pyproject.toml
 src
 ├── foo
-│   └── __init__.py
+│   └── __init__.py
 └── bar
     └── __init__.py
 ```
 
 While we do not recommend this structure (i.e., you should use a workspace with multiple packages
-instead), it is supported via the `namespace` option:
+instead), it is supported by passing a list to the `module-name` option:
 
 ```toml title="pyproject.toml"
 [tool.uv.build-backend]
+module-name = ["foo", "bar"]
+```
+
+The `namespace = true` option offers an opt-out to enumerating all modules for complex namespace
+packages. Declaring an explicit `module-name` should be preferred over `namespace = true`.
+
+```text
+pyproject.toml
+src
+└── foo
+    ├── bar
+    │   └── __init__.py
+    └── baz
+        └── __init__.py
+```
+
+And the configuration would be:
+
+```toml title="pyproject.toml"
+[tool.uv.build-backend]
+module-name = "foo"
 namespace = true
 ```
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -474,13 +474,17 @@ being the module name, and which contain a `__init__.pyi` file.
 For namespace packages with a single module, the path can be dotted, e.g., `foo.bar` or
 `foo-stubs.bar`.
 
+For namespace packages with multiple modules, the path can be a list, e.g.,
+`["foo", "bar"]`. We recommend using a single module per package, splitting multiple
+packages into a workspace.
+
 Note that using this option runs the risk of creating two packages with different names but
 the same module names. Installing such packages together leads to unspecified behavior,
 often with corrupted files or directory trees.
 
 **Default value**: `None`
 
-**Type**: `str`
+**Type**: `str | list[str]`
 
 **Example usage**:
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -668,10 +668,14 @@
           "default": true
         },
         "module-name": {
-          "description": "The name of the module directory inside `module-root`.\n\nThe default module name is the package name with dots and dashes replaced by underscores.\n\nPackage names need to be valid Python identifiers, and the directory needs to contain a\n`__init__.py`. An exception are stubs packages, whose name ends with `-stubs`, with the stem\nbeing the module name, and which contain a `__init__.pyi` file.\n\nFor namespace packages with a single module, the path can be dotted, e.g., `foo.bar` or\n`foo-stubs.bar`.\n\nNote that using this option runs the risk of creating two packages with different names but\nthe same module names. Installing such packages together leads to unspecified behavior,\noften with corrupted files or directory trees.",
-          "type": [
-            "string",
-            "null"
+          "description": "The name of the module directory inside `module-root`.\n\nThe default module name is the package name with dots and dashes replaced by underscores.\n\nPackage names need to be valid Python identifiers, and the directory needs to contain a\n`__init__.py`. An exception are stubs packages, whose name ends with `-stubs`, with the stem\nbeing the module name, and which contain a `__init__.pyi` file.\n\nFor namespace packages with a single module, the path can be dotted, e.g., `foo.bar` or\n`foo-stubs.bar`.\n\nFor namespace packages with multiple modules, the path can be a list, e.g.,\n`[\"foo\", \"bar\"]`. We recommend using a single module per package, splitting multiple\npackages into a workspace.\n\nNote that using this option runs the risk of creating two packages with different names but\nthe same module names. Installing such packages together leads to unspecified behavior,\noften with corrupted files or directory trees.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModuleName"
+            },
+            {
+              "type": "null"
+            }
           ],
           "default": null
         },
@@ -1051,6 +1055,22 @@
     "MarkerTree": {
       "description": "A PEP 508-compliant marker expression, e.g., `sys_platform == 'Darwin'`",
       "type": "string"
+    },
+    "ModuleName": {
+      "description": "Whether to include a single module or multiple modules.",
+      "anyOf": [
+        {
+          "description": "A single module name.",
+          "type": "string"
+        },
+        {
+          "description": "Multiple module names, which are all included.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "PackageName": {
       "description": "The normalized name of a package.\n\nConverts the name to lowercase and collapses runs of `-`, `_`, and `.` down to a single `-`.\nFor example, `---`, `.`, and `__` are all converted to a single `-`.\n\nSee: <https://packaging.python.org/en/latest/specifications/name-normalization/>",


### PR DESCRIPTION
Support multiple root modules in namespace packages by enumerating them:

```toml
[tool.uv.build-backend]
module-name = ["foo", "bar"]
```

This allows applications with multiple root packages without migrating to workspaces. Since those are regular module names (we iterate over them an process each one like a single module names), it allows combining dotted (namespace) names and regular names. It also technically allows combining regular and stub modules, even though this is even less recommends.

We don't recommend this structure (please use a workspace instead, or structure everything in one root module), but it reduces the number of cases that need `namespace = true`.

Fixes #14435
Fixes #14438