### PR TITLE
trim content of `INSTALLER` file

### DIFF
--- a/crates/uv-distribution-types/src/installed.rs
+++ b/crates/uv-distribution-types/src/installed.rs
@@ -365,7 +365,7 @@ impl InstalledDist {
     pub fn installer(&self) -> Result<Option<String>, InstalledDistError> {
         let path = self.install_path().join("INSTALLER");
         match fs::read_to_string(path) {
-            Ok(installer) => Ok(Some(installer)),
+            Ok(installer) => Ok(Some(installer.trim().to_owned())),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err.into()),
         }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

We are using UV as a library and `installer()` returned `"pip\n"`. The packages got installed by the pip package manager and not by UV. pip seems to add a new line to the installer and UV does not.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
