### PR TITLE
Update documentation for GHA to use v6

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 ```
 
 It is considered best practice to pin to a specific uv version, e.g., with:
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           # Install a specific version of uv.
           version: "0.7.19"
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
         run: uv python install
@@ -93,10 +93,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: ".python-version"
 ```
@@ -116,10 +116,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: "pyproject.toml"
 ```
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
 ```
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Install the project
         run: uv sync --locked --all-extras --dev
@@ -212,7 +212,7 @@ persisting the cache:
 
 ```yaml title="example.yml"
 - name: Enable caching
-  uses: astral-sh/setup-uv@v5
+  uses: astral-sh/setup-uv@v6
   with:
     enable-cache: true
 ```
@@ -221,7 +221,7 @@ You can configure the action to use a custom cache directory on the runner:
 
 ```yaml title="example.yml"
 - name: Define a custom uv cache path
-  uses: astral-sh/setup-uv@v5
+  uses: astral-sh/setup-uv@v6
   with:
     enable-cache: true
     cache-local-path: "/path/to/cache"
@@ -231,7 +231,7 @@ Or invalidate it when the lockfile changes:
 
 ```yaml title="example.yml"
 - name: Define a cache dependency glob
-  uses: astral-sh/setup-uv@v5
+  uses: astral-sh/setup-uv@v6
   with:
     enable-cache: true
     cache-dependency-glob: "uv.lock"
@@ -241,7 +241,7 @@ Or when any requirements file changes:
 
 ```yaml title="example.yml"
 - name: Define a cache dependency glob
-  uses: astral-sh/setup-uv@v5
+  uses: astral-sh/setup-uv@v6
   with:
     enable-cache: true
     cache-dependency-glob: "requirements**.txt"


### PR DESCRIPTION
## Summary

`astral-sh/setup-uv@v6` is the latest version of GitHub actions.

## Test Plan

Documentation update
