### PR TITLE
docs(guides): Add Python and PyPy mirror configuration

### DIFF
--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -142,6 +142,25 @@ $ uv python upgrade
 See the [`python upgrade`](../concepts/python-versions.md#upgrading-python-versions) documentation
 for more details.
 
+## Configuring Python download sources
+
+Configure alternative download sources (mirrors) for Python and PyPy distributions. This replaces
+the default download location and can be useful for faster downloads or offline environments. For
+more details on how uv manages Python distributions, refer to the
+[Python distributions documentation](../concepts/python-versions.md#managed-python-distributions).
+
+You can configure these mirrors via CLI options, environment variables, or a configuration file.
+
+For Python, use the [`--mirror`](../reference/cli.md#uv-python-install--mirror) CLI option, the
+[`UV_PYTHON_INSTALL_MIRROR`](../reference/environment.md#uv_python_install_mirror) environment
+variable, or the [`python-install-mirror`](../reference/settings.md#python-install-mirror) setting
+in a configuration file.
+
+For PyPy, use the [`--pypy-mirror`](../reference/cli.md#uv-python-install--pypy-mirror) CLI option,
+the [`UV_PYPY_INSTALL_MIRROR`](../reference/environment.md#uv_pypy_install_mirror) environment
+variable, or the [`pypy-install-mirror`](../reference/settings.md#pypy-install-mirror) setting in a
+configuration file.
+
 ## Next steps
 
 To learn more about `uv python`, see the [Python version concept](../concepts/python-versions.md)


### PR DESCRIPTION
## Summary

Adds a new section to `guides/install-python.md` explaining how to configure alternative download sources (mirrors) for Python and PyPy distributions. 
I considered including examples, but ultimately chose to use a link pointing to a centralized example.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Running a document server locally in strict mode.
![image](https://github.com/user-attachments/assets/41a6d7ba-e7b1-40ef-81e3-ff97625e6b95)

