### PR TITLE
Add debug message when skipping Python downloads

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -112,7 +112,7 @@ impl PythonInstallation {
             && client_builder.connectivity.is_online();
 
         if !downloads_enabled {
-            debug!("Downloads disabled. Skipping...");
+            debug!("Python downloads are disabled. Skipping check for available downloads...");
             return Err(err);
         }
 


### PR DESCRIPTION
# Description
Several users, myself included, had some issues with Anki (recently migrated to uv). 
https://forums.ankiweb.net/t/bug-anki-25-07-fails-to-launch-on-linux/63475

zanieb came in and gave us pointers, including looking at our uv logs. 
https://github.com/ankitects/anki/pull/4074#issuecomment-3046992777
log: https://github.com/Grinkers/uv/pull/1#issuecomment-3047538135

The actual issue was that I had a system config in /etc/uv/uv.toml but uv wasn't giving useful feedback for its combining/unification.

A higher level issue is that there's nice logs, however logging is initialized after! We want to log files read, but need to read the files to know what log level to use.
https://github.com/astral-sh/uv/blob/7e48292fac968b015c4521e193b09e27af1d5c7b/crates/uv-settings/src/lib.rs#L68
https://github.com/astral-sh/uv/blob/7e48292fac968b015c4521e193b09e27af1d5c7b/crates/uv/src/lib.rs#L354

zanieb mentioned there's https://github.com/astral-sh/uv/issues/13123, so consider this a +1 to that.

## Result
The end of the output will be:
```
DEBUG Downloads disabled. Skipping...
DEBUG Released lock at `/tmp/uv-823c7b0e73da3e08.lock`
error: No interpreter found for Python 3.13.5 in managed installations
```

Sorry for the minuscule sized PR. Feel free to close if there's a bigger logging pass.