### PR TITLE
Remove `uv pip sync` suggestion with `pyproject.toml`

### DIFF
--- a/docs/pip/compile.md
+++ b/docs/pip/compile.md
@@ -127,10 +127,10 @@ To sync an environment with a `requirements.txt` file:
 $ uv pip sync requirements.txt
 ```
 
-To sync an environment with a `pyproject.toml` file:
+To sync an environment with a [PEP 751](https://peps.python.org/pep-0751/) `pylock.toml` file:
 
 ```console
-$ uv pip sync pyproject.toml
+$ uv pip sync pylock.toml
 ```
 
 ## Adding constraints


### PR DESCRIPTION
## Summary

I think doing this would almost always be a mistake, since it won't install any transitive dependencies. Instead, I took the opportunity to mention the `pylock.toml` format.

Closes https://github.com/astral-sh/uv/issues/14507#issuecomment-3050083116.
