### PR TITLE
Add hint when Python downloads are disabled

### DIFF
--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -129,7 +129,8 @@ pub(crate) async fn pin(
     {
         Ok(python) => Some(python),
         // If no matching Python version is found, don't fail unless `resolved` was requested
-        Err(uv_python::Error::MissingPython(err)) if !resolved => {
+        Err(uv_python::Error::MissingPython(err, ..)) if !resolved => {
+            // N.B. We omit the hint and just show the inner error message
             warn_user_once!("{err}");
             None
         }

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -195,6 +195,12 @@ impl TestContext {
             "managed installations, search path, or registry".to_string(),
             "[PYTHON SOURCES]".to_string(),
         ));
+        self.filters.push((
+            "registry or search path".to_string(),
+            "[PYTHON SOURCES]".to_string(),
+        ));
+        self.filters
+            .push(("search path".to_string(), "[PYTHON SOURCES]".to_string()));
         self
     }
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4318,14 +4318,16 @@ fn lock_requires_python() -> Result<()> {
 
     // Install from the lockfile.
     // Note we need to disable Python fetches or we'll just download 3.12
-    uv_snapshot!(context_unsupported.filters(), context_unsupported.sync().arg("--frozen").arg("--no-python-downloads"), @r###"
+    uv_snapshot!(context_unsupported.filters(), context_unsupported.sync().arg("--frozen").arg("--no-python-downloads"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     error: No interpreter found for Python >=3.12 in [PYTHON SOURCES]
-    "###);
+
+    hint: A managed Python download is available for Python >=3.12, but Python downloads are set to 'never'
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -873,6 +873,8 @@ fn python_find_script_python_not_found() {
 
     ----- stderr -----
     No interpreter found in [PYTHON SOURCES]
+
+    hint: A managed Python download is available, but Python downloads are set to 'never'
     ");
 }
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -196,14 +196,16 @@ fn python_install_automatic() {
     uv_snapshot!(context.filters(), context.run()
         .env_remove("VIRTUAL_ENV")
         .arg("--no-python-downloads")
-        .arg("python").arg("-c").arg("import sys; print(sys.version_info[:2])"), @r###"
+        .arg("python").arg("-c").arg("import sys; print(sys.version_info[:2])"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     error: No interpreter found in [PYTHON SOURCES]
-    "###);
+
+    hint: A managed Python download is available, but Python downloads are set to 'never'
+    ");
 
     // Otherwise, we should fetch the latest Python version
     uv_snapshot!(context.filters(), context.run()

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -164,7 +164,7 @@ fn python_pin() {
     // (skip on Windows because the snapshot is different and the behavior is not platform dependent)
     #[cfg(unix)]
     {
-        uv_snapshot!(context.filters(), context.python_pin().arg("pypy"), @r###"
+        uv_snapshot!(context.filters(), context.python_pin().arg("pypy"), @r"
         success: true
         exit_code: 0
         ----- stdout -----
@@ -172,7 +172,7 @@ fn python_pin() {
 
         ----- stderr -----
         warning: No interpreter found for PyPy in managed installations or search path
-        "###);
+        ");
 
         let python_version = context.read(PYTHON_VERSION_FILENAME);
         assert_snapshot!(python_version, @r###"
@@ -361,7 +361,7 @@ fn python_pin_global_creates_parent_dirs() {
 fn python_pin_no_python() {
     let context: TestContext = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.python_pin().arg("3.12"), @r###"
+    uv_snapshot!(context.filters(), context.python_pin().arg("3.12"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -369,7 +369,7 @@ fn python_pin_no_python() {
 
     ----- stderr -----
     warning: No interpreter found for Python 3.12 in managed installations or search path
-    "###);
+    ");
 }
 
 #[test]
@@ -448,7 +448,7 @@ fn python_pin_compatible_with_requires_python() -> Result<()> {
     "###);
 
     // Request a version that is compatible and uses a Python variant
-    uv_snapshot!(context.filters(), context.python_pin().arg("3.13t"), @r###"
+    uv_snapshot!(context.filters(), context.python_pin().arg("3.13t"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -456,7 +456,7 @@ fn python_pin_compatible_with_requires_python() -> Result<()> {
 
     ----- stderr -----
     warning: No interpreter found for Python 3.13t in [PYTHON SOURCES]
-    "###);
+    ");
 
     // Request a implementation version that is compatible
     uv_snapshot!(context.filters(), context.python_pin().arg("cpython@3.11"), @r###"
@@ -587,27 +587,17 @@ fn warning_pinned_python_version_not_installed() -> Result<()> {
 /// We do need a Python interpreter for `--resolved` pins
 #[test]
 fn python_pin_resolve_no_python() {
-    let context: TestContext = TestContext::new_with_versions(&[]);
+    let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_python_sources();
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.12"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
 
-    if cfg!(windows) {
-        uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.12"), @r###"
-        success: false
-        exit_code: 2
-        ----- stdout -----
+    ----- stderr -----
+    error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
 
-        ----- stderr -----
-        error: No interpreter found for Python 3.12 in managed installations, search path, or registry
-        "###);
-    } else {
-        uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.12"), @r###"
-        success: false
-        exit_code: 2
-        ----- stdout -----
-
-        ----- stderr -----
-        error: No interpreter found for Python 3.12 in managed installations or search path
-        "###);
-    }
+    hint: A managed Python download is available for Python 3.12, but Python downloads are set to 'never'
+    ");
 }
 
 #[test]
@@ -741,14 +731,16 @@ fn python_pin_resolve() {
     // Request an implementation that is not installed
     // (skip on Windows because the snapshot is different and the behavior is not platform dependent)
     #[cfg(unix)]
-    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("pypy"), @r###"
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("pypy"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     error: No interpreter found for PyPy in managed installations or search path
-    "###);
+
+    hint: A managed Python download is available for PyPy, but Python downloads are set to 'never'
+    ");
 
     let python_version = context.read(PYTHON_VERSION_FILENAME);
     insta::with_settings!({

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2050,6 +2050,54 @@ fn tool_run_python_at_version() {
 }
 
 #[test]
+fn tool_run_hint_version_not_available() {
+    let context = TestContext::new_with_versions(&[])
+        .with_filtered_counts()
+        .with_filtered_python_sources();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python@3.12")
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "never"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
+
+    hint: A managed Python download is available for Python 3.12, but Python downloads are set to 'never'
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python@3.12")
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "auto")
+        .env(EnvVars::UV_OFFLINE, "true"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
+
+    hint: A managed Python download is available for Python 3.12, but uv is set to offline mode
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python@3.12")
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "auto")
+        .env(EnvVars::UV_NO_MANAGED_PYTHON, "true"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
+
+    hint: A managed Python download is available for Python 3.12, but the Python preference is set to 'only system'
+    ");
+}
+
+#[test]
 fn tool_run_python_from() {
     let context = TestContext::new_with_versions(&["3.12", "3.11"])
         .with_filtered_counts()


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/uv/pull/14509 to provide the _reason_ downloads are disabled and surface it as a hint rather than a debug log.

e.g.,

```
❯ cargo run -q -- run --no-managed-python -p 3.13.4 python
error: No interpreter found for Python 3.13.4 in virtual environments or search path

hint: A managed Python download is available for Python 3.13.4, but the Python preference is set to 'only system'
```