### PR TITLE
`setup-python/v5` exists, `v6` don't exists.

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -96,7 +96,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"
 ```
@@ -119,7 +119,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version-file: "pyproject.toml"
 ```


### PR DESCRIPTION
## Summary

I suddenly found wrong documentation with setup-python in https://docs.astral.sh/uv/guides/integration/github/#setting-up-python.

`setup-python/v5` exists, `setup-python/v6` don't exists.


## Test Plan

nothing