### PR TITLE
Conditionalize version_extras test on the pypi feature

### DIFF
--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -1962,6 +1962,7 @@ fn version_set_evil_constraints() -> Result<()> {
 /// Bump the version with conflicting extras, to ensure we're activating the correct subset of
 /// extras during the resolve.
 #[test]
+#[cfg(feature = "pypi")]
 fn version_extras() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `version_extras` test added in 85c0fc963b1d4f6c8130c4b4446d15b8f6ac8ac4 needs to connect to PyPI. This PR conditionalizes it on the `pypi` extra so that people running the tests offline don’t have to skip that test explicitly.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
I already ran `cargo test` in the git checkout to confirm I didn’t somehow introduce a syntax error. I am also applying this PR as a patch to [the `uv` package in Fedora](https://src.fedoraproject.org/rpms/uv), which runs tests offline with the `pypi` feature disabled.
