### PR TITLE
Only run macOS tests on `main` without opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,8 @@ jobs:
   cargo-test-macos:
     timeout-minutes: 15
     needs: determine_changes
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    # Only run macOS tests on main without opt-in
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test:macos' || github.ref == 'refs/heads/main') }}
     runs-on: macos-latest-xlarge # github-macos-14-aarch64-6
     name: "cargo test | macos"
     steps:


### PR DESCRIPTION
These runners are expensive and have limited concurrency, let's just run them on `main`.