### PR TITLE
Skip Windows Python interpreters that return a broken MSIX package code

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -884,6 +884,14 @@ impl Error {
                     );
                     false
                 }
+                #[cfg(windows)]
+                InterpreterError::CorruptWindowsPackage { path, err } => {
+                    debug!(
+                        "Skipping bad interpreter at {} from {source}: {err}",
+                        path.display()
+                    );
+                    false
+                }
                 InterpreterError::NotFound(path)
                 | InterpreterError::BrokenSymlink(BrokenSymlink { path, .. }) => {
                     // If the interpreter is from an active, valid virtual environment, we should


### PR DESCRIPTION
Currently we treat all spawn failures as fatal, because they indicate a broken interpreter. In this case, I think we should just skip these broken interpreters — though I don't know the root cause of why it's broken yet.

Closes https://github.com/astral-sh/uv/issues/14637
See https://discord.com/channels/1039017663004942429/1039017663512449056/1394758502647333025