### PR TITLE
Request arm64 Python in aarch64-windows smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2261,7 +2261,7 @@ jobs:
           name: uv-windows-aarch64-${{ github.sha }}
 
       - name: "Validate global Python install"
-        run: py -3.13 ./scripts/check_system_python.py --uv ./uv.exe
+        run: py -3.13-arm64 ./scripts/check_system_python.py --uv ./uv.exe
 
   # Test our PEP 514 integration that installs Python into the Windows registry.
   system-test-windows-registry:


### PR DESCRIPTION
The Python interpreter selected by `py` recently changed to x64 instead of arm64. 

Closes https://github.com/astral-sh/uv/pull/14652
See https://github.com/astral-sh/uv/pull/14652