### PR TITLE
Fix doctests

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -11,7 +11,7 @@
 //! let marker = r#"requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8""#;
 //! let dependency_specification = Requirement::<VerbatimUrl>::from_str(marker).unwrap();
 //! assert_eq!(dependency_specification.name.as_ref(), "requests");
-//! assert_eq!(dependency_specification.extras, vec![ExtraName::from_str("security").unwrap(), ExtraName::from_str("tests").unwrap()]);
+//! assert_eq!(dependency_specification.extras, vec![ExtraName::from_str("security").unwrap(), ExtraName::from_str("tests").unwrap()].into());
 //! ```
 
 #![warn(missing_docs)]

--- a/crates/uv-requirements-txt/src/shquote.rs
+++ b/crates/uv-requirements-txt/src/shquote.rs
@@ -146,8 +146,8 @@ fn unquote_open_escape(acc: &mut String, cursor: &mut std::iter::Enumerate<std::
 ///
 /// # Examples
 ///
-/// ```
-/// assert_eq!(r_shquote::unquote("foobar").unwrap(), "foobar");
+/// ```no_build
+/// assert_eq!(unquote("foobar").unwrap(), "foobar");
 /// ```
 pub(crate) fn unquote(source: &str) -> Result<Option<String>, UnquoteError> {
     // If the string does not contain any single-quotes, double-quotes, or escape sequences, it


### PR DESCRIPTION
`cargo nextest run` doesn't run them, but `cargo insta test --test-runner nextest` does, which surfaced those failures.