### PR TITLE
Add missing trailing newline to outdated error

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -128,7 +128,7 @@ impl OperationDiagnostic {
                 None
             }
             pip::operations::Error::OutdatedEnvironment => {
-                anstream::eprint!("{}", err);
+                anstream::eprintln!("{}", err);
                 None
             }
             err => Some(err),


### PR DESCRIPTION
Unlike the other branch in match, which uses a fully formatted error, we need to print the newline ourselves.

Before (top) and after (bottom):

<img width="1296" height="585" alt="image" src="https://github.com/user-attachments/assets/b4122ed5-591b-4fd9-a9b7-31b1e506d8aa" />
