### PR TITLE
CHANGELOG: manylinux_2_28 is more like 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ This release also includes the stabilization of a couple `uv python install` fea
 
   uv allows performing [platform-specific resolution](https://docs.astral.sh/uv/concepts/resolution/#platform-specific-resolution) for explicit targets and provides short aliases, e.g., `linux`, for common targets.
 
-  Previously, the default target for `--python-platform linux` was `manylinux_2_17`, which is compatible with most Linux distributions from 2014 or newer. We now default to `manylinux_2_28`, which is compatible with most Linux distributions from 2017 or newer.  This change follows the lead of other tools, such as `cibuildwheel`, which changed their default to `manylinux_2_28` in [Mar 2025](https://github.com/pypa/cibuildwheel/pull/2330).
+  Previously, the default target for `--python-platform linux` was `manylinux_2_17`, which is compatible with most Linux distributions from 2014 or newer. We now default to `manylinux_2_28`, which is compatible with most Linux distributions from 2019 or newer.  This change follows the lead of other tools, such as `cibuildwheel`, which changed their default to `manylinux_2_28` in [Mar 2025](https://github.com/pypa/cibuildwheel/pull/2330).
 
   This change only affects users requesting a specific target platform. Otherwise, uv detects the `manylinux` target from your local glibc version.
 


### PR DESCRIPTION
I must have Googled something too fast, sorry. glibc 2.28 came out August 2018, Fedora 29 was the earliest to ship with it in October 2018, Debian 10 shipped with it in July 2019, and CentOS 8 shipped with it in September 2019.