### PR TITLE
Escape requires version for built_by_uv test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4817,6 +4817,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
+ "regex",
  "rustc-hash",
  "schemars",
  "serde",

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -57,4 +57,5 @@ schemars = ["dep:schemars", "uv-pypi-types/schemars"]
 [dev-dependencies]
 indoc = { workspace = true }
 insta = { version = "1.40.0", features = ["filters"] }
+regex = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
This keeps the hash stable across uv releases.

Fixes #14695
