### PR TITLE
Use SHA256 from GitHub API for Python downloads

### DIFF
--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -255,8 +255,14 @@ class CPythonFinder(Finder):
                 # Sort the assets to ensure deterministic results
                 row["assets"].sort(key=lambda asset: asset["browser_download_url"])
                 for asset in row["assets"]:
+                    # On more recent versions we don't have files with hashes anymore,
+                    # but on older versions GitHub didn't backfill the digest.
+                    if digest := asset["digest"]:
+                        sha256 = digest.removeprefix("sha256:")
+                    else:
+                        sha256 = None
                     url = asset["browser_download_url"]
-                    download = self._parse_download_url(url)
+                    download = self._parse_download_url(url, sha256)
                     if download is None:
                         continue
                     if (
@@ -305,6 +311,9 @@ class CPythonFinder(Finder):
         """Fetch the checksums for the given downloads."""
         checksum_urls = set()
         for download in downloads:
+            # Skip the newer releases where we got the hash from the GitHub API
+            if download.sha256:
+                continue
             release_base_url = download.url.rsplit("/", maxsplit=1)[0]
             checksum_url = release_base_url + "/SHA256SUMS"
             checksum_urls.add(checksum_url)
@@ -343,9 +352,13 @@ class CPythonFinder(Finder):
                 checksums[filename] = checksum
 
         for download in downloads:
+            if download.sha256:
+                continue
             download.sha256 = checksums.get(download.filename)
 
-    def _parse_download_url(self, url: str) -> PythonDownload | None:
+    def _parse_download_url(
+        self, url: str, sha256: str | None
+    ) -> PythonDownload | None:
         """Parse an indygreg download URL into a PythonDownload object."""
         # Ex)
         # https://github.com/astral-sh/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst
@@ -391,6 +404,7 @@ class CPythonFinder(Finder):
             url=url,
             build_options=build_options,
             variant=variant,
+            sha256=sha256,
         )
 
     def _normalize_triple(self, triple: str) -> PlatformTriple | None:


### PR DESCRIPTION
We recently ran over the file limit and had to drop hash file from the releases page (https://github.com/astral-sh/python-build-standalone/pull/691). Conveniently, GitHub has recently started to add a SHA256 digest to the API. GitHub did not backfill the hashes for the old releases, so use the API hashes for newer assets, while we use our own hash files for older releases.