### PR TITLE
Better error reporting for removing Python versions from the Windows registry

### DIFF
--- a/crates/uv-python/src/windows_registry.rs
+++ b/crates/uv-python/src/windows_registry.rs
@@ -3,6 +3,7 @@
 use crate::managed::ManagedPythonInstallation;
 use crate::platform::Arch;
 use crate::{COMPANY_DISPLAY_NAME, COMPANY_KEY, PythonInstallationKey, PythonVersion};
+use anyhow::anyhow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -238,8 +239,7 @@ pub fn remove_registry_entry<'a>(
             } else {
                 errors.push((
                     installation.key().clone(),
-                    anyhow::Error::new(err)
-                        .context("Failed to clear registry entries under HKCU:\\{python_entry}"),
+                    anyhow!("Failed to clear registry entries under HKCU:\\{python_entry}: {err}"),
                 ));
             }
         }


### PR DESCRIPTION
See https://github.com/astral-sh/uv/actions/runs/16370666070/job/46258004849

We didn't actual use a format string, showing the template instead. We don't show the causes in the error report, so we format it into one error.