### PR TITLE
Complete PEP 751 multi-use lock file for pylock.toml export

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -32,11 +32,12 @@ use uv_normalize::{ExtraName, PackageName};
 
 use crate::cursor::Cursor;
 pub use crate::marker::{
-    CanonicalMarkerValueExtra, CanonicalMarkerValueString, CanonicalMarkerValueVersion,
-    ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerEnvironment,
-    MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree, MarkerTreeContents,
-    MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueList, MarkerValueString,
-    MarkerValueVersion, MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
+    CanonicalMarkerListPair, CanonicalMarkerValueExtra, CanonicalMarkerValueString,
+    CanonicalMarkerValueVersion, ContainerOperator, ContainsMarkerTree, ExtraMarkerTree,
+    ExtraOperator, InMarkerTree, MarkerEnvironment, MarkerEnvironmentBuilder, MarkerExpression,
+    MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeKind, MarkerValue, MarkerValueExtra,
+    MarkerValueList, MarkerValueString, MarkerValueVersion, MarkerWarningKind, StringMarkerTree,
+    StringVersion, VersionMarkerTree,
 };
 pub use crate::origin::RequirementOrigin;
 #[cfg(feature = "non-pep508-extensions")]

--- a/crates/uv-pep508/src/marker/lowering.rs
+++ b/crates/uv-pep508/src/marker/lowering.rs
@@ -170,7 +170,12 @@ pub enum CanonicalMarkerListPair {
     /// A valid [`GroupName`].
     DependencyGroup(GroupName),
     /// For leniency, preserve invalid values.
-    Arbitrary { key: MarkerValueList, value: String },
+    Arbitrary {
+        /// The list key (e.g., `extras` or `dependency_groups`).
+        key: MarkerValueList,
+        /// The string value being checked for containment.
+        value: String,
+    },
 }
 
 impl CanonicalMarkerListPair {

--- a/crates/uv-pep508/src/marker/mod.rs
+++ b/crates/uv-pep508/src/marker/mod.rs
@@ -18,13 +18,14 @@ mod tree;
 
 pub use environment::{MarkerEnvironment, MarkerEnvironmentBuilder};
 pub use lowering::{
-    CanonicalMarkerValueExtra, CanonicalMarkerValueString, CanonicalMarkerValueVersion,
+    CanonicalMarkerListPair, CanonicalMarkerValueExtra, CanonicalMarkerValueString,
+    CanonicalMarkerValueVersion,
 };
 pub use tree::{
-    ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerExpression,
-    MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeDebugGraph, MarkerTreeKind,
-    MarkerValue, MarkerValueExtra, MarkerValueList, MarkerValueString, MarkerValueVersion,
-    MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
+    ContainerOperator, ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree,
+    MarkerExpression, MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeDebugGraph,
+    MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueList, MarkerValueString,
+    MarkerValueVersion, MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
 };
 
 /// `serde` helpers for [`MarkerTree`].

--- a/crates/uv-resolver/src/lock/export/marker_conversion.rs
+++ b/crates/uv-resolver/src/lock/export/marker_conversion.rs
@@ -1,0 +1,287 @@
+use uv_normalize::PackageName;
+use uv_pep508::{CanonicalMarkerListPair, ContainerOperator, MarkerExpression, MarkerTree};
+use uv_pypi_types::{ConflictKind, Conflicts};
+
+use crate::universal_marker::{ParsedRawExtra, conflict_marker_to_pep751};
+
+/// Converts uv's internal conflict-encoded markers into PEP 751 marker syntax.
+///
+/// uv encodes extras and dependency groups as synthetic `extra == 'extra-{len}-{pkg}-{name}'` /
+/// `extra == 'group-{len}-{pkg}-{name}'` expressions. This function decodes those back into PEP 751's native
+/// `'name' in extras` / `'name' in dependency_groups` list membership syntax.
+///
+/// Algorithm:
+///   1. Expand the marker into disjunctive normal form (DNF) — a list of clauses OR'd together, each clause being a
+///      conjunction (AND) of expressions.
+///   2. For each clause, convert every expression via [`convert_expression`]: decode conflict-encoded extras/groups into
+///      PEP 751 list expressions; drop expressions that are valid conflict markers but belong to a different root
+///      package (they carry no meaning in the exported file); pass all other expressions through unchanged.
+///   3. Check for impossible clauses: if a clause contains two `'x' in extras` (or `dependency_groups`) expressions
+///      where both `x` and `y` belong to the same `ConflictSet`, the clause is always FALSE (mutual exclusion) and is
+///      dropped.
+///   4. AND the surviving expressions back into a clause, then OR all surviving clauses into the final result.
+///
+/// Example — given conflicts `{cpu, gpu}` for package `pkg`, and input marker:
+///
+///   `(extra == 'extra-3-pkg-cpu' AND extra == 'extra-3-pkg-gpu')
+///     OR extra == 'extra-3-pkg-cpu'
+///     OR (python_version >= '3.10' AND extra == 'extra-3-pkg-gpu')`
+///
+///   Step 1 — DNF yields three clauses:
+///     clause A: `extra == 'extra-3-pkg-cpu' AND extra == 'extra-3-pkg-gpu'`
+///     clause B: `extra == 'extra-3-pkg-cpu'`
+///     clause C: `python_version >= '3.10' AND extra == 'extra-3-pkg-gpu'`
+///
+///   Step 2 — convert each expression to PEP 751 syntax:
+///     clause A: `'cpu' in extras AND 'gpu' in extras`
+///     clause B: `'cpu' in extras`
+///     clause C: `python_full_version >= '3.10' AND 'gpu' in extras`
+///
+///   Step 3 — clause A has `'cpu' in extras` and `'gpu' in extras`, both from conflict set `{cpu, gpu}` → impossible,
+///     drop it. Clauses B and C survive.
+///
+///   Step 4 — reassemble: `'cpu' in extras OR (python_full_version >= '3.10' AND 'gpu' in extras)`
+pub(crate) fn to_pep751_marker(
+    marker: MarkerTree,
+    root_name: Option<&PackageName>,
+    conflicts: Option<&Conflicts>,
+) -> MarkerTree {
+    if marker.is_true() {
+        return MarkerTree::TRUE;
+    }
+    if marker.is_false() {
+        return MarkerTree::FALSE;
+    }
+
+    let dnf = marker.to_dnf();
+    if dnf.is_empty() {
+        return MarkerTree::TRUE;
+    }
+
+    let mut result = MarkerTree::FALSE;
+    for clause in dnf {
+        let converted: Vec<MarkerExpression> = clause
+            .into_iter()
+            .filter_map(|expr| convert_expression(expr, root_name))
+            .collect();
+
+        if let Some((root, conflicts)) = root_name.zip(conflicts) {
+            if has_conflict_pair(&converted, root, conflicts) {
+                continue;
+            }
+        }
+
+        let mut clause_result = MarkerTree::TRUE;
+        for expr in converted {
+            clause_result.and(MarkerTree::expression(expr));
+        }
+        result.or(clause_result);
+    }
+
+    result
+}
+
+fn convert_expression(
+    expr: MarkerExpression,
+    root_name: Option<&PackageName>,
+) -> Option<MarkerExpression> {
+    match &expr {
+        MarkerExpression::Extra { name, operator } => {
+            if let Some(extra_name) = name.as_extra() {
+                if let Some(pep751_expr) =
+                    conflict_marker_to_pep751(extra_name, operator, root_name)
+                {
+                    Some(pep751_expr)
+                } else if ParsedRawExtra::parse(extra_name).is_ok() {
+                    None
+                } else {
+                    Some(expr)
+                }
+            } else {
+                Some(expr)
+            }
+        }
+        _ => Some(expr),
+    }
+}
+
+fn has_conflict_pair(
+    exprs: &[MarkerExpression],
+    root_name: &PackageName,
+    conflicts: &Conflicts,
+) -> bool {
+    let in_pairs: Vec<&CanonicalMarkerListPair> = exprs
+        .iter()
+        .filter_map(|expr| match expr {
+            MarkerExpression::List {
+                pair,
+                operator: ContainerOperator::In,
+            } => Some(pair),
+            _ => None,
+        })
+        .collect();
+
+    for i in 0..in_pairs.len() {
+        for j in (i + 1)..in_pairs.len() {
+            if conflict_set_contains_pair(conflicts, root_name, in_pairs[i], in_pairs[j]) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn conflict_set_contains_pair(
+    conflicts: &Conflicts,
+    root_name: &PackageName,
+    a: &CanonicalMarkerListPair,
+    b: &CanonicalMarkerListPair,
+) -> bool {
+    conflicts.iter().any(|set| {
+        let contains = |pair: &CanonicalMarkerListPair| -> bool {
+            match pair {
+                CanonicalMarkerListPair::Extras(extra) => set.iter().any(|item| {
+                    item.package() == root_name
+                        && matches!(item.kind(), ConflictKind::Extra(e) if e == extra)
+                }),
+                CanonicalMarkerListPair::DependencyGroup(group) => set.iter().any(|item| {
+                    item.package() == root_name
+                        && matches!(item.kind(), ConflictKind::Group(g) if g == group)
+                }),
+                CanonicalMarkerListPair::Arbitrary { .. } => false,
+            }
+        };
+        contains(a) && contains(b)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use uv_normalize::{ExtraName, GroupName, PackageName};
+    use uv_pypi_types::{ConflictItem, ConflictSet, Conflicts};
+
+    use super::to_pep751_marker;
+
+    fn create_package(name: &str) -> PackageName {
+        PackageName::from_str(name).unwrap()
+    }
+
+    fn create_extra(name: &str) -> ExtraName {
+        ExtraName::from_str(name).unwrap()
+    }
+
+    fn create_group(name: &str) -> GroupName {
+        GroupName::from_str(name).unwrap()
+    }
+
+    fn create_conflicts(it: impl IntoIterator<Item = ConflictSet>) -> Conflicts {
+        let mut conflicts = Conflicts::empty();
+        for set in it {
+            conflicts.push(set);
+        }
+        conflicts
+    }
+
+    fn create_set<'a>(it: impl IntoIterator<Item = &'a str>) -> ConflictSet {
+        let items = it
+            .into_iter()
+            .map(|extra| (create_package("pkg"), create_extra(extra)))
+            .map(ConflictItem::from)
+            .collect::<Vec<ConflictItem>>();
+        ConflictSet::try_from(items).unwrap()
+    }
+
+    fn create_group_set<'a>(it: impl IntoIterator<Item = &'a str>) -> ConflictSet {
+        let items = it
+            .into_iter()
+            .map(|group| (create_package("pkg"), create_group(group)))
+            .map(ConflictItem::from)
+            .collect::<Vec<ConflictItem>>();
+        ConflictSet::try_from(items).unwrap()
+    }
+
+    fn to_str(marker: uv_pep508::MarkerTree) -> String {
+        marker.try_to_string().unwrap_or_else(|| "true".to_string())
+    }
+
+    #[test]
+    fn drops_impossible_extra_clause() {
+        let root = create_package("pkg");
+        let conflicts = create_conflicts([create_set(["cpu", "gpu"])]);
+        let marker = uv_pep508::MarkerTree::from_str(
+            "(extra == 'extra-3-pkg-cpu' and extra == 'extra-3-pkg-gpu') \
+             or extra == 'extra-3-pkg-cpu'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), Some(&conflicts));
+        insta::assert_snapshot!(to_str(result), @"'cpu' in extras");
+    }
+
+    #[test]
+    fn preserves_clause_from_different_conflict_sets() {
+        let root = create_package("pkg");
+        let conflicts = create_conflicts([create_set(["cpu", "gpu"]), create_set(["dev", "test"])]);
+        let marker = uv_pep508::MarkerTree::from_str(
+            "extra == 'extra-3-pkg-cpu' and extra == 'extra-3-pkg-dev'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), Some(&conflicts));
+        insta::assert_snapshot!(to_str(result), @"'cpu' in extras and 'dev' in extras");
+    }
+
+    #[test]
+    fn not_in_same_conflict_set_is_not_impossible() {
+        let root = create_package("pkg");
+        let conflicts = create_conflicts([create_set(["cpu", "gpu"])]);
+        let marker = uv_pep508::MarkerTree::from_str(
+            "extra != 'extra-3-pkg-cpu' and extra != 'extra-3-pkg-gpu'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), Some(&conflicts));
+        insta::assert_snapshot!(to_str(result), @"'cpu' not in extras and 'gpu' not in extras");
+    }
+
+    #[test]
+    fn drops_impossible_group_clause() {
+        let root = create_package("pkg");
+        let conflicts = create_conflicts([create_group_set(["black22", "black23", "black24"])]);
+        let marker = uv_pep508::MarkerTree::from_str(
+            "(extra == 'group-3-pkg-black22' and extra == 'group-3-pkg-black23') \
+             or extra == 'group-3-pkg-black22'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), Some(&conflicts));
+        insta::assert_snapshot!(to_str(result), @"'black22' in dependency_groups");
+    }
+
+    #[test]
+    fn no_conflicts_preserves_all_clauses() {
+        let root = create_package("pkg");
+        let marker = uv_pep508::MarkerTree::from_str(
+            "extra == 'extra-3-pkg-cpu' or extra == 'extra-3-pkg-gpu'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), None);
+        insta::assert_snapshot!(to_str(result), @"'cpu' in extras or 'gpu' in extras");
+    }
+
+    #[test]
+    fn empty_conflicts_preserves_all_clauses() {
+        let root = create_package("pkg");
+        let conflicts = Conflicts::empty();
+        let marker = uv_pep508::MarkerTree::from_str(
+            "extra == 'extra-3-pkg-cpu' and extra == 'extra-3-pkg-gpu'",
+        )
+        .unwrap();
+
+        let result = to_pep751_marker(marker, Some(&root), Some(&conflicts));
+        insta::assert_snapshot!(to_str(result), @"'cpu' in extras and 'gpu' in extras");
+    }
+}

--- a/crates/uv-resolver/src/lock/export/mod.rs
+++ b/crates/uv-resolver/src/lock/export/mod.rs
@@ -24,6 +24,7 @@ use crate::universal_marker::resolve_conflicts;
 use crate::{Installable, LockError, Package};
 
 pub mod cyclonedx_json;
+mod marker_conversion;
 mod pylock_toml;
 mod requirements_txt;
 

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -32,6 +32,12 @@ pub trait Installable<'lock> {
     /// Return the [`PackageName`] of the target, if available.
     fn project_name(&self) -> Option<&PackageName>;
 
+    /// Return the available extras from the project metadata.
+    fn available_extras(&self) -> Vec<ExtraName>;
+
+    /// Return the available dependency groups from the project metadata.
+    fn available_dependency_groups(&self) -> Vec<GroupName>;
+
     /// Convert the [`Lock`] to a [`Resolution`] using the given marker environment, tags, and root.
     fn to_resolution(
         &self,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6065,7 +6065,7 @@ fn each_element_on_its_line_array(elements: impl Iterator<Item = impl Into<Value
 ///
 /// Note that the marker strings returned will include conflict markers if they
 /// are present.
-fn simplified_universal_markers(
+pub(crate) fn simplified_universal_markers(
     markers: &[UniversalMarker],
     requires_python: &RequiresPython,
 ) -> Vec<String> {

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -331,8 +331,11 @@ pub(crate) async fn export(
         }
     });
 
-    // Skip conflict detection for CycloneDX exports, as SBOMs are meant to document all dependencies including conflicts.
-    if !matches!(format, ExportFormat::CycloneDX1_5) {
+    // PEP 751 and CycloneDX are multi-use formats that document all dependencies including conflicts.
+    if !matches!(
+        format,
+        ExportFormat::CycloneDX1_5 | ExportFormat::PylockToml
+    ) {
         detect_conflicts(&target, &extras, &groups)?;
     }
 

--- a/crates/uv/src/commands/project/install_target.rs
+++ b/crates/uv/src/commands/project/install_target.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet;
 
 use uv_configuration::{Constraints, DependencyGroupsWithDefaults, ExtrasSpecification};
 use uv_distribution_types::Index;
-use uv_normalize::{ExtraName, PackageName};
+use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pypi_types::{DependencyGroupSpecifier, LenientRequirement, VerbatimParsedUrl};
 use uv_resolver::{Installable, Lock, Package};
 use uv_scripts::Pep723Script;
@@ -108,6 +108,117 @@ impl<'lock> Installable<'lock> for InstallTarget<'lock> {
             }
             Self::NonProjectWorkspace { .. } => None,
             Self::Script { .. } => None,
+        }
+    }
+
+    /// Collects all extra names available across the install target.
+    ///
+    /// Algorithm:
+    ///   1. For `Project`: look up the single member in the workspace, extract `optional-dependencies`
+    ///      keys from its `pyproject.toml`.
+    ///   2. For `Projects`: union the `optional-dependencies` keys from each named member.
+    ///   3. For `Workspace`/`NonProjectWorkspace`: union across all workspace members.
+    ///   4. For `Script`: no extras.
+    ///
+    ///   Results are deduplicated and returned in sorted order.
+    ///
+    /// Example — workspace with members `web` (extras: `[api, cli]`) and `core` (extras: `[dev]`):
+    ///
+    ///   Step 3 → union `{api, cli} ∪ {dev}` → `[api, cli, dev]`
+    fn available_extras(&self) -> Vec<ExtraName> {
+        match self {
+            Self::Project {
+                workspace, name, ..
+            } => workspace
+                .packages()
+                .get(name)
+                .and_then(|member| member.pyproject_toml().project.as_ref())
+                .and_then(|project| project.optional_dependencies.as_ref())
+                .map(|extras| extras.keys().cloned().collect())
+                .unwrap_or_default(),
+            Self::Projects {
+                workspace, names, ..
+            } => {
+                let mut all_extras = std::collections::BTreeSet::new();
+                for name in *names {
+                    if let Some(member) = workspace.packages().get(name) {
+                        if let Some(project) = member.pyproject_toml().project.as_ref() {
+                            if let Some(extras) = project.optional_dependencies.as_ref() {
+                                all_extras.extend(extras.keys().cloned());
+                            }
+                        }
+                    }
+                }
+                all_extras.into_iter().collect()
+            }
+            Self::Workspace { workspace, .. } | Self::NonProjectWorkspace { workspace, .. } => {
+                let mut all_extras = std::collections::BTreeSet::new();
+                for member in workspace.packages().values() {
+                    if let Some(project) = member.pyproject_toml().project.as_ref() {
+                        if let Some(extras) = project.optional_dependencies.as_ref() {
+                            all_extras.extend(extras.keys().cloned());
+                        }
+                    }
+                }
+                all_extras.into_iter().collect()
+            }
+            Self::Script { .. } => vec![],
+        }
+    }
+
+    /// Collects all dependency group names available across the install target.
+    ///
+    /// Algorithm:
+    ///   1. For `Project`: look up the single member, extract `dependency-groups` keys from its
+    ///      `pyproject.toml`.
+    ///   2. For `Projects`: union the `dependency-groups` keys from each named member.
+    ///   3. For `Workspace`/`NonProjectWorkspace`: union across all workspace members.
+    ///   4. For `Script`: no groups.
+    ///
+    ///   Results are deduplicated and returned in sorted order.
+    ///
+    /// Example — workspace with members `web` (groups: `[dev, test]`) and `core` (groups: `[dev, lint]`):
+    ///
+    ///   Step 3 → union `{dev, test} ∪ {dev, lint}` → `[dev, lint, test]`
+    fn available_dependency_groups(&self) -> Vec<GroupName> {
+        match self {
+            Self::Project {
+                workspace, name, ..
+            } => workspace
+                .packages()
+                .get(name)
+                .map(|member| {
+                    member
+                        .pyproject_toml()
+                        .dependency_groups
+                        .as_ref()
+                        .map(|groups| groups.keys().cloned().collect())
+                        .unwrap_or_default()
+                })
+                .unwrap_or_default(),
+            Self::Projects {
+                workspace, names, ..
+            } => {
+                let mut all_groups = std::collections::BTreeSet::new();
+                for name in *names {
+                    if let Some(member) = workspace.packages().get(name) {
+                        if let Some(groups) = member.pyproject_toml().dependency_groups.as_ref() {
+                            all_groups.extend(groups.keys().cloned());
+                        }
+                    }
+                }
+                all_groups.into_iter().collect()
+            }
+            Self::Workspace { workspace, .. } | Self::NonProjectWorkspace { workspace, .. } => {
+                let mut all_groups = std::collections::BTreeSet::new();
+                for member in workspace.packages().values() {
+                    if let Some(groups) = member.pyproject_toml().dependency_groups.as_ref() {
+                        all_groups.extend(groups.keys().cloned());
+                    }
+                }
+                all_groups.into_iter().collect()
+            }
+            Self::Script { .. } => vec![],
         }
     }
 }

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -3709,6 +3709,10 @@ fn pep_751_dependency() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -3722,6 +3726,7 @@ fn pep_751_dependency() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0" }]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -3770,6 +3775,10 @@ fn pep_751_export_no_header() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -3783,6 +3792,7 @@ fn pep_751_export_no_header() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0" }]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -3833,6 +3843,10 @@ fn pep_751_export_no_editable() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -3846,6 +3860,7 @@ fn pep_751_export_no_editable() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0" }]
     directory = { path = "." }
 
     [[packages]]
@@ -3903,6 +3918,7 @@ fn pep_751_dependency_extra() -> Result<()> {
     [[packages]]
     name = "click"
     version = "8.1.7"
+    dependencies = [{ name = "colorama", version = "0.4.6", marker = "sys_platform == 'win32'" }]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", upload-time = 2023-08-17T17:29:11Z, size = 336121, hashes = { sha256 = "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", upload-time = 2023-08-17T17:29:10Z, size = 97941, hashes = { sha256 = "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28" } }]
@@ -3918,6 +3934,14 @@ fn pep_751_dependency_extra() -> Result<()> {
     [[packages]]
     name = "flask"
     version = "3.0.2"
+    dependencies = [
+        { name = "blinker", version = "1.7.0" },
+        { name = "click", version = "8.1.7" },
+        { name = "itsdangerous", version = "2.1.2" },
+        { name = "jinja2", version = "3.1.3" },
+        { name = "python-dotenv", version = "1.0.1", marker = "extra == 'dotenv'" },
+        { name = "werkzeug", version = "3.0.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", upload-time = 2024-02-03T21:11:44Z, size = 675248, hashes = { sha256 = "822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", upload-time = 2024-02-03T21:11:42Z, size = 101300, hashes = { sha256 = "3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e" } }]
@@ -3932,6 +3956,7 @@ fn pep_751_dependency_extra() -> Result<()> {
     [[packages]]
     name = "jinja2"
     version = "3.1.3"
+    dependencies = [{ name = "markupsafe", version = "2.1.5" }]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", upload-time = 2024-01-10T23:12:21Z, size = 268261, hashes = { sha256 = "ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90" } }
     wheels = [{ name = "jinja2-3.1.3-py3-none-any.whl", url = "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl", upload-time = 2024-01-10T23:12:19Z, size = 133236, hashes = { sha256 = "7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa" } }]
@@ -3956,6 +3981,7 @@ fn pep_751_dependency_extra() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "flask", version = "3.0.2", extras = ["dotenv"] }]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -3968,6 +3994,7 @@ fn pep_751_dependency_extra() -> Result<()> {
     [[packages]]
     name = "werkzeug"
     version = "3.0.1"
+    dependencies = [{ name = "markupsafe", version = "2.1.5" }]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz", upload-time = 2023-10-24T20:57:50Z, size = 801436, hashes = { sha256 = "507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl", upload-time = 2023-10-24T20:57:47Z, size = 226669, hashes = { sha256 = "90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10" } }]
@@ -4013,9 +4040,18 @@ fn pep_751_project_extra() -> Result<()> {
     lock-version = "1.0"
     created-by = "uv"
     requires-python = ">=3.12"
+    extras = [
+        "async",
+        "pytest",
+    ]
 
     [[packages]]
     name = "project"
+    dependencies = [
+        { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+        { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+        { name = "typing-extensions", version = "4.10.0" },
+    ]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4038,10 +4074,18 @@ fn pep_751_project_extra() -> Result<()> {
     lock-version = "1.0"
     created-by = "uv"
     requires-python = ">=3.12"
+    extras = [
+        "async",
+        "pytest",
+    ]
 
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -4055,6 +4099,11 @@ fn pep_751_project_extra() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [
+        { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+        { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+        { name = "typing-extensions", version = "4.10.0" },
+    ]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4084,6 +4133,10 @@ fn pep_751_project_extra() -> Result<()> {
     lock-version = "1.0"
     created-by = "uv"
     requires-python = ">=3.12"
+    extras = [
+        "async",
+        "pytest",
+    ]
 
     [[packages]]
     name = "iniconfig"
@@ -4094,6 +4147,11 @@ fn pep_751_project_extra() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [
+        { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+        { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+        { name = "typing-extensions", version = "4.10.0" },
+    ]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4116,10 +4174,18 @@ fn pep_751_project_extra() -> Result<()> {
     lock-version = "1.0"
     created-by = "uv"
     requires-python = ">=3.12"
+    extras = [
+        "async",
+        "pytest",
+    ]
 
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -4140,6 +4206,11 @@ fn pep_751_project_extra() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [
+        { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+        { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+        { name = "typing-extensions", version = "4.10.0" },
+    ]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4169,10 +4240,18 @@ fn pep_751_project_extra() -> Result<()> {
     lock-version = "1.0"
     created-by = "uv"
     requires-python = ">=3.12"
+    extras = [
+        "async",
+        "pytest",
+    ]
 
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -4186,6 +4265,11 @@ fn pep_751_project_extra() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [
+        { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+        { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+        { name = "typing-extensions", version = "4.10.0" },
+    ]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4241,6 +4325,11 @@ fn pep_751_git_dependency() -> Result<()> {
     requires-python = ">=3.12"
 
     [[packages]]
+    name = "project"
+    dependencies = [{ name = "uv-public-pypackage", version = "0.1.0" }]
+    directory = { path = ".", editable = false }
+
+    [[packages]]
     name = "uv-public-pypackage"
     version = "0.1.0"
     vcs = { type = "git", url = "https://github.com/astral-test/uv-public-pypackage", commit-id = "b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }
@@ -4282,6 +4371,10 @@ fn pep_751_wheel_url() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     archive = { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }
 
     [[packages]]
@@ -4290,6 +4383,11 @@ fn pep_751_wheel_url() -> Result<()> {
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
+
+    [[packages]]
+    name = "project"
+    dependencies = [{ name = "anyio", version = "4.3.0" }]
+    directory = { path = ".", editable = false }
 
     [[packages]]
     name = "sniffio"
@@ -4335,6 +4433,10 @@ fn pep_751_sdist_url() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     archive = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
 
     [[packages]]
@@ -4343,6 +4445,11 @@ fn pep_751_sdist_url() -> Result<()> {
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
+
+    [[packages]]
+    name = "project"
+    dependencies = [{ name = "anyio", version = "4.3.0" }]
+    directory = { path = ".", editable = false }
 
     [[packages]]
     name = "sniffio"
@@ -4391,6 +4498,10 @@ fn pep_751_sdist_url_subdirectory() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", upload-time = 2024-02-19T08:36:28Z, size = 159642, hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", upload-time = 2024-02-19T08:36:26Z, size = 85584, hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }]
@@ -4403,8 +4514,14 @@ fn pep_751_sdist_url_subdirectory() -> Result<()> {
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
+    name = "project"
+    dependencies = [{ name = "root", version = "0.0.1" }]
+    directory = { path = ".", editable = false }
+
+    [[packages]]
     name = "root"
     version = "0.0.1"
+    dependencies = [{ name = "anyio", version = "4.3.0" }]
     archive = { url = "https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz#subdirectory=packages/root", subdirectory = "packages/root", hashes = { sha256 = "24b55efee28d08ad3cdc58903e359e820601baa6a4a4b3424311541ebcfb09d3" } }
 
     [[packages]]
@@ -4479,6 +4596,10 @@ fn pep_751_infer_output_format() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -4492,6 +4613,7 @@ fn pep_751_infer_output_format() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0" }]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4518,6 +4640,10 @@ fn pep_751_infer_output_format() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.7.0"
+    dependencies = [
+        { name = "idna", version = "3.6" },
+        { name = "sniffio", version = "1.3.1" },
+    ]
     index = "https://pypi.org/simple"
     sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
@@ -4531,6 +4657,7 @@ fn pep_751_infer_output_format() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0" }]
     directory = { path = ".", editable = true }
 
     [[packages]]
@@ -4620,6 +4747,11 @@ fn pep_751_https_git_credentials() -> Result<()> {
     requires-python = ">=3.12"
 
     [[packages]]
+    name = "project"
+    dependencies = [{ name = "uv-private-pypackage", version = "0.1.0" }]
+    directory = { path = ".", editable = false }
+
+    [[packages]]
     name = "uv-private-pypackage"
     version = "0.1.0"
     vcs = { type = "git", url = "https://github.com/astral-test/uv-private-pypackage", commit-id = "d780faf0ac91257d4d5a4f0c5a0e4509608c0071" }
@@ -4663,6 +4795,11 @@ async fn pep_751_https_credentials() -> Result<()> {
     name = "iniconfig"
     version = "2.0.0"
     archive = { url = "http://public:heron@[LOCALHOST]/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }
+
+    [[packages]]
+    name = "project"
+    dependencies = [{ name = "iniconfig", version = "2.0.0" }]
+    directory = { path = ".", editable = false }
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -8473,16 +8610,30 @@ fn cyclonedx_export_all_packages_conflicting_workspace_members() -> Result<()> {
     error: Package `child` and package `project` are incompatible with the declared conflicts: {child, project}
     ");
 
-    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--all-packages"), @"
-    success: false
-    exit_code: 2
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--all-packages"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --all-packages
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+
+    [[packages]]
+    name = "child"
+    dependencies = [{ name = "sortedcontainers", version = "2.4.0" }]
+    directory = { path = "child", editable = true }
+
+    [[packages]]
+    name = "project"
+    dependencies = [{ name = "sortedcontainers", version = "2.3.0" }]
+    directory = { path = ".", editable = true }
 
     ----- stderr -----
     warning: Declaring conflicts for packages (`package = ...`) is experimental and may change without warning. Pass `--preview-features package-conflicts` to disable this warning.
     Resolved 4 packages in [TIME]
-    error: Package `child` and package `project` are incompatible with the declared conflicts: {child, project}
-    ");
+    "#);
     Ok(())
 }
 
@@ -8939,10 +9090,584 @@ fn pylock_toml_filter_by_requires_python() -> Result<()> {
 
     [[packages]]
     name = "project"
+    dependencies = [{ name = "numpy", version = "1.26.4" }]
     directory = { path = ".", editable = true }
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_extras_transitive() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["requests[socks]"]
+
+        [project.optional-dependencies]
+        dev = ["iniconfig"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--extra").arg("dev"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --extra dev
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+    extras = [
+        "dev",
+    ]
+
+    [[packages]]
+    name = "certifi"
+    version = "2024.2.2"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz", upload-time = 2024-02-02T01:22:17Z, size = 164886, hashes = { sha256 = "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl", upload-time = 2024-02-02T01:22:14Z, size = 163774, hashes = { sha256 = "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1" } }]
+
+    [[packages]]
+    name = "charset-normalizer"
+    version = "3.3.2"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz", upload-time = 2023-11-01T04:04:59Z, size = 104809, hashes = { sha256 = "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5" } }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/d1/b2/fcedc8255ec42afee97f9e6f0145c734bbe104aac28300214593eb326f1d/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", upload-time = 2023-11-01T04:03:24Z, size = 192892, hashes = { sha256 = "0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8" } },
+        { url = "https://files.pythonhosted.org/packages/2e/7d/2259318c202f3d17f3fe6438149b3b9e706d1070fe3fcbb28049730bb25c/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", upload-time = 2023-11-01T04:03:25Z, size = 122213, hashes = { sha256 = "ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b" } },
+        { url = "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", upload-time = 2023-11-01T04:03:27Z, size = 119404, hashes = { sha256 = "55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6" } },
+        { url = "https://files.pythonhosted.org/packages/99/b0/9c365f6d79a9f0f3c379ddb40a256a67aa69c59609608fe7feb6235896e1/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = 2023-11-01T04:03:28Z, size = 137275, hashes = { sha256 = "8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a" } },
+        { url = "https://files.pythonhosted.org/packages/91/33/749df346e93d7a30cdcb90cbfdd41a06026317bfbfb62cd68307c1a3c543/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", upload-time = 2023-11-01T04:03:29Z, size = 147518, hashes = { sha256 = "a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389" } },
+        { url = "https://files.pythonhosted.org/packages/72/1a/641d5c9f59e6af4c7b53da463d07600a695b9824e20849cb6eea8a627761/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", upload-time = 2023-11-01T04:03:31Z, size = 140182, hashes = { sha256 = "8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa" } },
+        { url = "https://files.pythonhosted.org/packages/ee/fb/14d30eb4956408ee3ae09ad34299131fb383c47df355ddb428a7331cfa1e/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2023-11-01T04:03:32Z, size = 141869, hashes = { sha256 = "90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b" } },
+        { url = "https://files.pythonhosted.org/packages/df/3e/a06b18788ca2eb6695c9b22325b6fde7dde0f1d1838b1792a0076f58fe9d/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2023-11-01T04:03:34Z, size = 144042, hashes = { sha256 = "6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed" } },
+        { url = "https://files.pythonhosted.org/packages/45/59/3d27019d3b447a88fe7e7d004a1e04be220227760264cc41b405e863891b/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", upload-time = 2023-11-01T04:03:35Z, size = 138275, hashes = { sha256 = "7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26" } },
+        { url = "https://files.pythonhosted.org/packages/7b/ef/5eb105530b4da8ae37d506ccfa25057961b7b63d581def6f99165ea89c7e/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", upload-time = 2023-11-01T04:03:37Z, size = 144819, hashes = { sha256 = "8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d" } },
+        { url = "https://files.pythonhosted.org/packages/a2/51/e5023f937d7f307c948ed3e5c29c4b7a3e42ed2ee0b8cdf8f3a706089bf0/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", upload-time = 2023-11-01T04:03:38Z, size = 149415, hashes = { sha256 = "6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068" } },
+        { url = "https://files.pythonhosted.org/packages/24/9d/2e3ef673dfd5be0154b20363c5cdcc5606f35666544381bee15af3778239/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", upload-time = 2023-11-01T04:03:40Z, size = 141212, hashes = { sha256 = "b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143" } },
+        { url = "https://files.pythonhosted.org/packages/5b/ae/ce2c12fcac59cb3860b2e2d76dc405253a4475436b1861d95fe75bdea520/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", upload-time = 2023-11-01T04:03:41Z, size = 142167, hashes = { sha256 = "efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4" } },
+        { url = "https://files.pythonhosted.org/packages/ed/3a/a448bf035dce5da359daf9ae8a16b8a39623cc395a2ffb1620aa1bce62b0/charset_normalizer-3.3.2-cp312-cp312-win32.whl", upload-time = 2023-11-01T04:03:42Z, size = 93041, hashes = { sha256 = "d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7" } },
+        { url = "https://files.pythonhosted.org/packages/b6/7c/8debebb4f90174074b827c63242c23851bdf00a532489fba57fef3416e40/charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", upload-time = 2023-11-01T04:03:44Z, size = 100397, hashes = { sha256 = "96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001" } },
+        { url = "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl", upload-time = 2023-11-01T04:04:58Z, size = 48543, hashes = { sha256 = "3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc" } },
+    ]
+
+    [[packages]]
+    name = "idna"
+    version = "3.6"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
+
+    [[packages]]
+    name = "iniconfig"
+    version = "2.0.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
+
+    [[packages]]
+    name = "project"
+    dependencies = [
+        { name = "iniconfig", version = "2.0.0", marker = "'dev' in extras" },
+        { name = "requests", version = "2.31.0", extras = ["socks"] },
+    ]
+    directory = { path = ".", editable = true }
+
+    [[packages]]
+    name = "pysocks"
+    version = "1.7.1"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", upload-time = 2019-09-20T02:07:35Z, size = 284429, hashes = { sha256 = "3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0" } }
+    wheels = [{ name = "pysocks-1.7.1-py3-none-any.whl", url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", upload-time = 2019-09-20T02:06:22Z, size = 16725, hashes = { sha256 = "2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5" } }]
+
+    [[packages]]
+    name = "requests"
+    version = "2.31.0"
+    dependencies = [
+        { name = "certifi", version = "2024.2.2" },
+        { name = "charset-normalizer", version = "3.3.2" },
+        { name = "idna", version = "3.6" },
+        { name = "pysocks", version = "1.7.1", marker = "extra == 'socks'" },
+        { name = "urllib3", version = "2.2.1" },
+    ]
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", upload-time = 2023-05-22T15:12:44Z, size = 110794, hashes = { sha256 = "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", upload-time = 2023-05-22T15:12:42Z, size = 62574, hashes = { sha256 = "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f" } }]
+
+    [[packages]]
+    name = "urllib3"
+    version = "2.2.1"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/7a/50/7fd50a27caa0652cd4caf224aa87741ea41d3265ad13f010886167cfcc79/urllib3-2.2.1.tar.gz", upload-time = 2024-02-18T03:55:57Z, size = 291020, hashes = { sha256 = "d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl", upload-time = 2024-02-18T03:55:54Z, size = 121067, hashes = { sha256 = "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d" } }]
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_dependency_groups() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [dependency-groups]
+        test = ["pytest"]
+        coverage = ["covdefaults"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--group").arg("test").arg("--group").arg("coverage"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --group test --group coverage
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+    dependency-groups = [
+        "coverage",
+        "test",
+    ]
+
+    [[packages]]
+    name = "colorama"
+    version = "0.4.6"
+    marker = "sys_platform == 'win32'"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", upload-time = 2022-10-25T02:36:22Z, size = 27697, hashes = { sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", upload-time = 2022-10-25T02:36:20Z, size = 25335, hashes = { sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" } }]
+
+    [[packages]]
+    name = "covdefaults"
+    version = "2.3.0"
+    dependencies = [{ name = "coverage", version = "7.4.4" }]
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/44/ee/9a6f2611f72e4c5657ae5542a510cf4164d2c673687c0ea73bb1cbd85b4d/covdefaults-2.3.0.tar.gz", upload-time = 2023-03-05T16:43:34Z, size = 4835, hashes = { sha256 = "4e99f679f12d792bc62e5510fa3eb59546ed47bd569e36e4fddc4081c9c3ebf7" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/76/4c/823bc951445aa97e5a1b7e337690db3abf85212c8d138e170922e7916ac8/covdefaults-2.3.0-py2.py3-none-any.whl", upload-time = 2023-03-05T16:43:33Z, size = 5144, hashes = { sha256 = "2832961f6ffcfe4b57c338bc3418a3526f495c26fb9c54565409c5532f7c41be" } }]
+
+    [[packages]]
+    name = "coverage"
+    version = "7.4.4"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/d5/f809d8b630cf4c11fe490e20037a343d12a74ec2783c6cdb5aee725e7137/coverage-7.4.4.tar.gz", upload-time = 2024-03-14T19:11:17Z, size = 783727, hashes = { sha256 = "c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49" } }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/a0/de/a54b245e781bfd6f3fd7ce5566a695686b5c25ee7c743f514e7634428972/coverage-7.4.4-cp312-cp312-macosx_10_9_x86_64.whl", upload-time = 2024-03-14T19:09:59Z, size = 206409, hashes = { sha256 = "201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76" } },
+        { url = "https://files.pythonhosted.org/packages/88/92/07f9c593cd27e3c595b8cb83b95adad8c9ba3d611debceed097a5fd6be4b/coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl", upload-time = 2024-03-14T19:10:01Z, size = 206568, hashes = { sha256 = "41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818" } },
+        { url = "https://files.pythonhosted.org/packages/41/6d/e142c823e5d4b24481f990da4cf9d2d577a6f4e1fb6faf39d9a4e42b1d43/coverage-7.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = 2024-03-14T19:10:04Z, size = 238920, hashes = { sha256 = "d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978" } },
+        { url = "https://files.pythonhosted.org/packages/30/1a/105f0139df6a2adbcaa0c110711a46dbd9f59e93a09ca15a97d59c2564f2/coverage-7.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2024-03-14T19:10:07Z, size = 236288, hashes = { sha256 = "3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70" } },
+        { url = "https://files.pythonhosted.org/packages/98/79/185cb42910b6a2b2851980407c8445ac0da0750dff65e420e86f973c8396/coverage-7.4.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2024-03-14T19:10:10Z, size = 238223, hashes = { sha256 = "ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51" } },
+        { url = "https://files.pythonhosted.org/packages/92/12/2303d1c543a11ea060dbc7144ed3174fc09107b5dd333649415c95ede58b/coverage-7.4.4-cp312-cp312-musllinux_1_1_aarch64.whl", upload-time = 2024-03-14T19:10:12Z, size = 245161, hashes = { sha256 = "00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c" } },
+        { url = "https://files.pythonhosted.org/packages/96/5a/7d0e945c4759fe9d19aad1679dd3096aeb4cb9fcf0062fe24554dc4787b8/coverage-7.4.4-cp312-cp312-musllinux_1_1_i686.whl", upload-time = 2024-03-14T19:10:14Z, size = 243066, hashes = { sha256 = "fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48" } },
+        { url = "https://files.pythonhosted.org/packages/f4/1b/79cdb7b11bbbd6540a536ac79412904b5c1f8903d5c1330084212afa8ceb/coverage-7.4.4-cp312-cp312-musllinux_1_1_x86_64.whl", upload-time = 2024-03-14T19:10:16Z, size = 244805, hashes = { sha256 = "69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9" } },
+        { url = "https://files.pythonhosted.org/packages/af/7f/54dc676e7e63549838a3a7b95a8e11df80441bf7d64c6ce8f1cdbc0d1ff0/coverage-7.4.4-cp312-cp312-win32.whl", upload-time = 2024-03-14T19:10:18Z, size = 208590, hashes = { sha256 = "137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0" } },
+        { url = "https://files.pythonhosted.org/packages/46/c4/1dfe76d96034a347d717a2392b004d42d45934cb94efa362ad41ca871f6e/coverage-7.4.4-cp312-cp312-win_amd64.whl", upload-time = 2024-03-14T19:10:20Z, size = 209415, hashes = { sha256 = "d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e" } },
+    ]
+
+    [[packages]]
+    name = "iniconfig"
+    version = "2.0.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
+
+    [[packages]]
+    name = "packaging"
+    version = "24.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", upload-time = 2024-03-10T09:39:28Z, size = 147882, hashes = { sha256 = "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", upload-time = 2024-03-10T09:39:25Z, size = 53488, hashes = { sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5" } }]
+
+    [[packages]]
+    name = "pluggy"
+    version = "1.4.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/54/c6/43f9d44d92aed815e781ca25ba8c174257e27253a94630d21be8725a2b59/pluggy-1.4.0.tar.gz", upload-time = 2024-01-24T13:45:15Z, size = 65812, hashes = { sha256 = "8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl", upload-time = 2024-01-24T13:45:14Z, size = 20120, hashes = { sha256 = "7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981" } }]
+
+    [[packages]]
+    name = "project"
+    dependencies = [
+        { name = "covdefaults", version = "2.3.0", marker = "'coverage' in dependency_groups" },
+        { name = "iniconfig", version = "2.0.0" },
+        { name = "pytest", version = "8.1.1", marker = "'test' in dependency_groups" },
+    ]
+    directory = { path = ".", editable = true }
+
+    [[packages]]
+    name = "pytest"
+    version = "8.1.1"
+    dependencies = [
+        { name = "colorama", version = "0.4.6", marker = "sys_platform == 'win32'" },
+        { name = "iniconfig", version = "2.0.0" },
+        { name = "packaging", version = "24.0" },
+        { name = "pluggy", version = "1.4.0" },
+    ]
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/30/b7/7d44bbc04c531dcc753056920e0988032e5871ac674b5a84cb979de6e7af/pytest-8.1.1.tar.gz", upload-time = 2024-03-09T11:51:08Z, size = 1409703, hashes = { sha256 = "ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl", upload-time = 2024-03-09T11:51:04Z, size = 337359, hashes = { sha256 = "2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7" } }]
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+/// Test that the `environments` field is populated from `tool.uv.environments`
+#[test]
+fn pep_751_environments() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+
+        [tool.uv]
+        environments = [
+            "sys_platform == 'darwin'",
+            "sys_platform == 'linux'",
+        ]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml
+    lock-version = "1.0"
+    created-by = "uv"
+    environments = [
+        "sys_platform == 'darwin'",
+        "sys_platform == 'linux'",
+    ]
+    requires-python = ">=3.12"
+
+    [[packages]]
+    name = "anyio"
+    version = "3.7.0"
+    marker = "sys_platform == 'darwin' or sys_platform == 'linux'"
+    dependencies = [
+        { name = "idna", version = "3.6", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+        { name = "sniffio", version = "1.3.1", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    ]
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", upload-time = 2023-05-27T11:12:46Z, size = 142737, hashes = { sha256 = "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", upload-time = 2023-05-27T11:12:44Z, size = 80873, hashes = { sha256 = "eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0" } }]
+
+    [[packages]]
+    name = "idna"
+    version = "3.6"
+    marker = "sys_platform == 'darwin' or sys_platform == 'linux'"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
+
+    [[packages]]
+    name = "project"
+    dependencies = [{ name = "anyio", version = "3.7.0", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" }]
+    directory = { path = ".", editable = true }
+
+    [[packages]]
+    name = "sniffio"
+    version = "1.3.1"
+    marker = "sys_platform == 'darwin' or sys_platform == 'linux'"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+/// Test conflicting extras with transitive extra dependencies in PEP 751 multi-use lock files.
+///
+/// Scenario:
+/// - Root project `a` has conflicting extras `extra-a-1` and `extra-a-2`
+/// - `extra-a-1` depends on `b[extra-b-1]`
+/// - `extra-a-2` depends on `b[extra-b-2]`
+/// - Package `b` has conflicting extras `extra-b-1` and `extra-b-2` with different versions of sortedcontainers
+///
+/// The exported pylock.toml contains all packages (a, b, sortedcontainers 2.3.0, and sortedcontainers
+/// 2.4.0) with markers.
+#[test]
+fn pep_751_extras_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        conflicts = [
+            [
+              { extra = "extra-a-1" },
+              { extra = "extra-a-2" },
+            ],
+        ]
+
+        [tool.uv.workspace]
+        members = ["b"]
+
+        [tool.uv.sources]
+        b = { workspace = true }
+
+        [project.optional-dependencies]
+        extra-a-1 = ["b[extra-b-1]"]
+        extra-a-2 = ["b[extra-b-2]"]
+        "#,
+    )?;
+
+    let b = context.temp_dir.child("b");
+    b.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        conflicts = [
+            [
+              { extra = "extra-b-1" },
+              { extra = "extra-b-2" },
+            ],
+        ]
+
+        [project.optional-dependencies]
+        extra-b-1 = ["sortedcontainers==2.3.0"]
+        extra-b-2 = ["sortedcontainers==2.4.0"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    // Export a single multi-use lock file containing both conflicting versions
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--all-extras"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --all-extras
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+    extras = [
+        "extra-a-1",
+        "extra-a-2",
+    ]
+
+    [[packages]]
+    name = "a"
+    dependencies = [
+        { name = "b", version = "0.1.0", marker = "'extra-a-1' in extras" },
+        { name = "b", version = "0.1.0", marker = "'extra-a-2' in extras" },
+        { name = "b", version = "0.1.0", extras = ["extra-b-1"], marker = "'extra-a-1' in extras" },
+        { name = "b", version = "0.1.0", extras = ["extra-b-2"], marker = "'extra-a-2' in extras" },
+    ]
+    directory = { path = ".", editable = false }
+
+    [[packages]]
+    name = "b"
+    dependencies = [
+        { name = "sortedcontainers", version = "2.3.0", marker = "extra == 'extra-b-1'" },
+        { name = "sortedcontainers", version = "2.4.0", marker = "extra == 'extra-b-2'" },
+    ]
+    directory = { path = "b", editable = true }
+
+    [[packages]]
+    name = "sortedcontainers"
+    version = "2.3.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/14/10/6a9481890bae97da9edd6e737c9c3dec6aea3fc2fa53b0934037b35c89ea/sortedcontainers-2.3.0.tar.gz", upload-time = 2020-11-09T00:03:52Z, size = 30509, hashes = { sha256 = "59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/20/4d/a7046ae1a1a4cc4e9bbed194c387086f06b25038be596543d026946330c9/sortedcontainers-2.3.0-py2.py3-none-any.whl", upload-time = 2020-11-09T00:03:50Z, size = 29479, hashes = { sha256 = "37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f" } }]
+
+    [[packages]]
+    name = "sortedcontainers"
+    version = "2.4.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", upload-time = 2021-05-16T22:03:42Z, size = 30594, hashes = { sha256 = "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", upload-time = 2021-05-16T22:03:41Z, size = 29575, hashes = { sha256 = "a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0" } }]
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    Ok(())
+}
+
+/// Test that user-defined extras with prefix-like names (e.g., `extra-feature`, `group-utils`,
+/// `project-tools`) are preserved in PEP 751 export and not incorrectly dropped as internal
+/// conflict markers.
+///
+/// This test demonstrates a bug where `is_encoded_extra` uses `starts_with("extra-")`,
+/// `starts_with("group-")`, and `starts_with("project-")` which incorrectly matches user extras.
+#[test]
+fn pep_751_user_extras_with_prefix_names() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "myproject"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.optional-dependencies]
+        extra-feature = ["iniconfig"]
+        group-utils = ["typing-extensions"]
+        project-tools = ["packaging"]
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    // Export with all extras - the extras should appear in the output with their markers
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--all-extras"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --all-extras
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+    extras = [
+        "extra-feature",
+        "group-utils",
+        "project-tools",
+    ]
+
+    [[packages]]
+    name = "iniconfig"
+    version = "2.0.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
+
+    [[packages]]
+    name = "myproject"
+    dependencies = [
+        { name = "iniconfig", version = "2.0.0", marker = "'extra-feature' in extras" },
+        { name = "packaging", version = "24.0", marker = "'project-tools' in extras" },
+        { name = "typing-extensions", version = "4.10.0", marker = "'group-utils' in extras" },
+    ]
+    directory = { path = ".", editable = false }
+
+    [[packages]]
+    name = "packaging"
+    version = "24.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", upload-time = 2024-03-10T09:39:28Z, size = 147882, hashes = { sha256 = "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", upload-time = 2024-03-10T09:39:25Z, size = 53488, hashes = { sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5" } }]
+
+    [[packages]]
+    name = "typing-extensions"
+    version = "4.10.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8814b960f8a36c3b0d07c323176620b7b483e44/typing_extensions-4.10.0.tar.gz", upload-time = 2024-02-25T22:12:49Z, size = 77558, hashes = { sha256 = "b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", upload-time = 2024-02-25T22:12:47Z, size = 33926, hashes = { sha256 = "69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475" } }]
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "#);
+
+    // Export with only one extra - the package should have a marker showing when it's needed
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("pylock.toml").arg("--extra").arg("extra-feature"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    # This file was autogenerated by uv via the following command:
+    #    uv export --cache-dir [CACHE_DIR] --format pylock.toml --extra extra-feature
+    lock-version = "1.0"
+    created-by = "uv"
+    requires-python = ">=3.12"
+    extras = [
+        "extra-feature",
+        "group-utils",
+        "project-tools",
+    ]
+
+    [[packages]]
+    name = "iniconfig"
+    version = "2.0.0"
+    index = "https://pypi.org/simple"
+    sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
+    wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
+
+    [[packages]]
+    name = "myproject"
+    dependencies = [
+        { name = "iniconfig", version = "2.0.0", marker = "'extra-feature' in extras" },
+        { name = "packaging", version = "24.0", marker = "'project-tools' in extras" },
+        { name = "typing-extensions", version = "4.10.0", marker = "'group-utils' in extras" },
+    ]
+    directory = { path = ".", editable = false }
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
     "#);
 
     Ok(())

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -16549,6 +16549,7 @@ fn pep_751_compile_registry_wheel() -> Result<()> {
     [[packages]]
     name = "iniconfig"
     version = "2.0.0"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
 
@@ -16598,6 +16599,7 @@ fn pep_751_compile_registry_sdist() -> Result<()> {
     [[packages]]
     name = "source-distribution"
     version = "0.0.3"
+    requires-python = ">=3.10"
     sdist = { url = "https://files.pythonhosted.org/packages/1f/e5/5b016c945d745f8b108e759d428341488a6aee8f51f07c6c4e33498bb91f/source_distribution-0.0.3.tar.gz", upload-time = 2024-11-03T02:35:36Z, size = 2166, hashes = { sha256 = "be5895c175dbca2d91709a6ab7d5f28e1794272db551ae9a5faf3ae2ed74c3d8" } }
 
     ----- stderr -----
@@ -16682,6 +16684,7 @@ fn pep_751_compile_directory() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", upload-time = 2024-02-19T08:36:28Z, size = 159642, hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", upload-time = 2024-02-19T08:36:26Z, size = 85584, hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }]
 
@@ -16692,12 +16695,14 @@ fn pep_751_compile_directory() -> Result<()> {
     [[packages]]
     name = "idna"
     version = "3.6"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -16808,12 +16813,14 @@ fn pep_751_compile_url_wheel() -> Result<()> {
     [[packages]]
     name = "idna"
     version = "3.6"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -16872,12 +16879,14 @@ fn pep_751_compile_url_sdist() -> Result<()> {
     [[packages]]
     name = "idna"
     version = "3.6"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -17091,18 +17100,21 @@ fn pep_751_compile_preferences() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.0.0"
+    requires-python = ">=3.6.2"
     sdist = { url = "https://files.pythonhosted.org/packages/99/0d/65165f99e5f4f3b4c43a5ed9db0fb7aa655f5a58f290727a30528a87eb45/anyio-3.0.0.tar.gz", upload-time = 2021-04-20T14:02:14Z, size = 116952, hashes = { sha256 = "b553598332c050af19f7d41f73a7790142f5bc3d5eb8bd82f5e515ec22019bd9" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/3b/49/ebee263b69fe243bd1fd0a88bc6bb0f7732bf1794ba3273cb446351f9482/anyio-3.0.0-py3-none-any.whl", upload-time = 2021-04-20T14:02:13Z, size = 72182, hashes = { sha256 = "e71c3d9d72291d12056c0265d07c6bbedf92332f78573e278aeb116f24f30395" } }]
 
     [[packages]]
     name = "idna"
     version = "3.0"
+    requires-python = ">=3.4"
     sdist = { url = "https://files.pythonhosted.org/packages/2f/2e/bfe821bd26194fb474e0932df8ed82e24bd312ba628a8644d93c5a28b5d4/idna-3.0.tar.gz", upload-time = 2021-01-01T05:58:25Z, size = 180786, hashes = { sha256 = "c9a26e10e5558412384fac891eefb41957831d31be55f1e2c98ed97a70abb969" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/0f/6b/3a878f15ef3324754bf4780f8f047d692d9860be894ff8fb3135cef8bed8/idna-3.0-py2.py3-none-any.whl", upload-time = 2021-01-01T05:58:22Z, size = 58618, hashes = { sha256 = "320229aadbdfc597bc28876748cc0c9d04d476e0fe6caacaaddea146365d9f63" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -17132,18 +17144,21 @@ fn pep_751_compile_preferences() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.0.0"
+    requires-python = ">=3.6.2"
     sdist = { url = "https://files.pythonhosted.org/packages/99/0d/65165f99e5f4f3b4c43a5ed9db0fb7aa655f5a58f290727a30528a87eb45/anyio-3.0.0.tar.gz", upload-time = 2021-04-20T14:02:14Z, size = 116952, hashes = { sha256 = "b553598332c050af19f7d41f73a7790142f5bc3d5eb8bd82f5e515ec22019bd9" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/3b/49/ebee263b69fe243bd1fd0a88bc6bb0f7732bf1794ba3273cb446351f9482/anyio-3.0.0-py3-none-any.whl", upload-time = 2021-04-20T14:02:13Z, size = 72182, hashes = { sha256 = "e71c3d9d72291d12056c0265d07c6bbedf92332f78573e278aeb116f24f30395" } }]
 
     [[packages]]
     name = "idna"
     version = "3.0"
+    requires-python = ">=3.4"
     sdist = { url = "https://files.pythonhosted.org/packages/2f/2e/bfe821bd26194fb474e0932df8ed82e24bd312ba628a8644d93c5a28b5d4/idna-3.0.tar.gz", upload-time = 2021-01-01T05:58:25Z, size = 180786, hashes = { sha256 = "c9a26e10e5558412384fac891eefb41957831d31be55f1e2c98ed97a70abb969" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/0f/6b/3a878f15ef3324754bf4780f8f047d692d9860be894ff8fb3135cef8bed8/idna-3.0-py2.py3-none-any.whl", upload-time = 2021-01-01T05:58:22Z, size = 58618, hashes = { sha256 = "320229aadbdfc597bc28876748cc0c9d04d476e0fe6caacaaddea146365d9f63" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -17172,18 +17187,21 @@ fn pep_751_compile_preferences() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "3.0.0"
+    requires-python = ">=3.6.2"
     sdist = { url = "https://files.pythonhosted.org/packages/99/0d/65165f99e5f4f3b4c43a5ed9db0fb7aa655f5a58f290727a30528a87eb45/anyio-3.0.0.tar.gz", upload-time = 2021-04-20T14:02:14Z, size = 116952, hashes = { sha256 = "b553598332c050af19f7d41f73a7790142f5bc3d5eb8bd82f5e515ec22019bd9" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/3b/49/ebee263b69fe243bd1fd0a88bc6bb0f7732bf1794ba3273cb446351f9482/anyio-3.0.0-py3-none-any.whl", upload-time = 2021-04-20T14:02:13Z, size = 72182, hashes = { sha256 = "e71c3d9d72291d12056c0265d07c6bbedf92332f78573e278aeb116f24f30395" } }]
 
     [[packages]]
     name = "idna"
     version = "3.6"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -17211,18 +17229,21 @@ fn pep_751_compile_preferences() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", upload-time = 2024-02-19T08:36:28Z, size = 159642, hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", upload-time = 2024-02-19T08:36:26Z, size = 85584, hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }]
 
     [[packages]]
     name = "idna"
     version = "3.6"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 
@@ -17259,6 +17280,7 @@ fn pep_751_compile_warn() -> Result<()> {
     [[packages]]
     name = "iniconfig"
     version = "2.0.0"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
 
@@ -17297,6 +17319,7 @@ fn pep_751_compile_non_universal() -> Result<()> {
     [[packages]]
     name = "black"
     version = "24.3.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/8f/5f/bac24a952668c7482cfdb4ebf91ba57a796c9da8829363a772040c1a3312/black-24.3.0.tar.gz", upload-time = 2024-03-15T19:35:43Z, size = 634292, hashes = { sha256 = "a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f" } }
     wheels = [
         { url = "https://files.pythonhosted.org/packages/a8/05/8dd038e30caadab7120176d4bc109b7ca2f4457f12eef746b0560a583458/black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2024-03-15T19:38:24Z, size = 1755319, hashes = { sha256 = "c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4" } },
@@ -17306,30 +17329,35 @@ fn pep_751_compile_non_universal() -> Result<()> {
     [[packages]]
     name = "click"
     version = "8.1.7"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", upload-time = 2023-08-17T17:29:11Z, size = 336121, hashes = { sha256 = "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", upload-time = 2023-08-17T17:29:10Z, size = 97941, hashes = { sha256 = "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28" } }]
 
     [[packages]]
     name = "mypy-extensions"
     version = "1.0.0"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", upload-time = 2023-02-04T12:11:27Z, size = 4433, hashes = { sha256 = "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", upload-time = 2023-02-04T12:11:25Z, size = 4695, hashes = { sha256 = "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d" } }]
 
     [[packages]]
     name = "packaging"
     version = "24.0"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", upload-time = 2024-03-10T09:39:28Z, size = 147882, hashes = { sha256 = "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", upload-time = 2024-03-10T09:39:25Z, size = 53488, hashes = { sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5" } }]
 
     [[packages]]
     name = "pathspec"
     version = "0.12.1"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", upload-time = 2023-12-10T22:30:45Z, size = 51043, hashes = { sha256 = "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", upload-time = 2023-12-10T22:30:43Z, size = 31191, hashes = { sha256 = "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08" } }]
 
     [[packages]]
     name = "platformdirs"
     version = "4.2.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz", upload-time = 2024-01-31T01:00:36Z, size = 20055, hashes = { sha256 = "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl", upload-time = 2024-01-31T01:00:34Z, size = 17717, hashes = { sha256 = "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068" } }]
 
@@ -17357,6 +17385,7 @@ fn pep_751_compile_non_universal() -> Result<()> {
     [[packages]]
     name = "black"
     version = "24.3.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/8f/5f/bac24a952668c7482cfdb4ebf91ba57a796c9da8829363a772040c1a3312/black-24.3.0.tar.gz", upload-time = 2024-03-15T19:35:43Z, size = 634292, hashes = { sha256 = "a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f" } }
     wheels = [
         { url = "https://files.pythonhosted.org/packages/71/9d/e5fa1ff4ef1940be15a64883c0bb8d2fcf626efec996eab4ae5a8c691d2c/black-24.3.0-cp312-cp312-win_amd64.whl", upload-time = 2024-03-15T19:39:37Z, size = 1385180, hashes = { sha256 = "56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5" } },
@@ -17366,6 +17395,7 @@ fn pep_751_compile_non_universal() -> Result<()> {
     [[packages]]
     name = "click"
     version = "8.1.7"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", upload-time = 2023-08-17T17:29:11Z, size = 336121, hashes = { sha256 = "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", upload-time = 2023-08-17T17:29:10Z, size = 97941, hashes = { sha256 = "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28" } }]
 
@@ -17373,30 +17403,35 @@ fn pep_751_compile_non_universal() -> Result<()> {
     name = "colorama"
     version = "0.4.6"
     marker = "sys_platform == 'win32'"
+    requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
     sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", upload-time = 2022-10-25T02:36:22Z, size = 27697, hashes = { sha256 = "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", upload-time = 2022-10-25T02:36:20Z, size = 25335, hashes = { sha256 = "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" } }]
 
     [[packages]]
     name = "mypy-extensions"
     version = "1.0.0"
+    requires-python = ">=3.5"
     sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", upload-time = 2023-02-04T12:11:27Z, size = 4433, hashes = { sha256 = "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", upload-time = 2023-02-04T12:11:25Z, size = 4695, hashes = { sha256 = "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d" } }]
 
     [[packages]]
     name = "packaging"
     version = "24.0"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", upload-time = 2024-03-10T09:39:28Z, size = 147882, hashes = { sha256 = "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", upload-time = 2024-03-10T09:39:25Z, size = 53488, hashes = { sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5" } }]
 
     [[packages]]
     name = "pathspec"
     version = "0.12.1"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", upload-time = 2023-12-10T22:30:45Z, size = 51043, hashes = { sha256 = "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", upload-time = 2023-12-10T22:30:43Z, size = 31191, hashes = { sha256 = "a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08" } }]
 
     [[packages]]
     name = "platformdirs"
     version = "4.2.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz", upload-time = 2024-01-31T01:00:36Z, size = 20055, hashes = { sha256 = "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/55/72/4898c44ee9ea6f43396fbc23d9bfaf3d06e01b83698bdf2e4c919deceb7c/platformdirs-4.2.0-py3-none-any.whl", upload-time = 2024-01-31T01:00:34Z, size = 17717, hashes = { sha256 = "0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068" } }]
 
@@ -17436,6 +17471,7 @@ fn pep_751_compile_only_binary() -> Result<()> {
     [[packages]]
     name = "iniconfig"
     version = "2.0.0"
+    requires-python = ">=3.7"
     wheels = [{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", upload-time = 2023-01-07T11:08:09Z, size = 5892, hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }]
 
     ----- stderr -----
@@ -17474,6 +17510,7 @@ fn pep_751_compile_no_binary() -> Result<()> {
     [[packages]]
     name = "iniconfig"
     version = "2.0.0"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", upload-time = 2023-01-07T11:08:11Z, size = 4646, hashes = { sha256 = "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3" } }
 
     ----- stderr -----
@@ -17510,12 +17547,14 @@ fn pep_751_compile_no_emit_package() -> Result<()> {
     [[packages]]
     name = "anyio"
     version = "4.3.0"
+    requires-python = ">=3.8"
     sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", upload-time = 2024-02-19T08:36:28Z, size = 159642, hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", upload-time = 2024-02-19T08:36:26Z, size = 85584, hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }]
 
     [[packages]]
     name = "sniffio"
     version = "1.3.1"
+    requires-python = ">=3.7"
     sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
     wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2273,7 +2273,8 @@ async fn install_git_public_rate_limited_by_github_rest_api_429_response() {
         .pip_install()
         .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage")
         .env(EnvVars::UV_GITHUB_FAST_PATH_URL, server.uri())
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @"
+        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true")
+        .env_remove(EnvVars::UV_HTTP_RETRIES), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -11335,9 +11336,10 @@ fn pep_751_install_registry_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
      + iniconfig==2.0.0
+     + project==0.1.0 (from file://[TEMP_DIR]/)
     "
     );
 
@@ -11350,7 +11352,7 @@ fn pep_751_install_registry_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "
     );
 
@@ -11388,8 +11390,9 @@ fn pep_751_install_registry_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + source-distribution==0.0.3
     "
     );
@@ -11403,7 +11406,7 @@ fn pep_751_install_registry_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "
     );
 
@@ -11447,8 +11450,18 @@ fn pep_751_install_directory() -> Result<()> {
 
         [tool.uv.sources]
         foo = { path = "foo" }
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
         "#,
     )?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
 
     context
         .export()
@@ -11466,11 +11479,12 @@ fn pep_751_install_directory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 4 packages in [TIME]
-    Installed 4 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
      + anyio==4.3.0
      + foo==1.0.0 (from file://[TEMP_DIR]/foo)
      + idna==3.6
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
     "
     );
@@ -11484,7 +11498,7 @@ fn pep_751_install_directory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 4 packages in [TIME]
+    Audited 5 packages in [TIME]
     "
     );
 
@@ -11523,8 +11537,9 @@ fn pep_751_install_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage.git@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "
     );
@@ -11538,7 +11553,7 @@ fn pep_751_install_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "
     );
 
@@ -11576,10 +11591,11 @@ fn pep_751_install_url_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 2 packages in [TIME]
-    Installed 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
+    Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
      + idna==3.6
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
     "
     );
@@ -11593,7 +11609,7 @@ fn pep_751_install_url_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 3 packages in [TIME]
+    Audited 4 packages in [TIME]
     "
     );
 
@@ -11631,10 +11647,11 @@ fn pep_751_install_url_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
      + idna==3.6
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
     "
     );
@@ -11648,7 +11665,7 @@ fn pep_751_install_url_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 3 packages in [TIME]
+    Audited 4 packages in [TIME]
     "
     );
 
@@ -11704,6 +11721,11 @@ fn pep_751_install_path_wheel() -> Result<()> {
         name = "iniconfig"
         version = "2.0.0"
         archive = { path = "iniconfig-2.0.0-py3-none-any.whl", hashes = { sha256 = "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" } }
+
+        [[packages]]
+        name = "project"
+        dependencies = [{ name = "iniconfig", version = "2.0.0" }]
+        directory = { path = ".", editable = false }
         "#
         );
     });
@@ -11717,8 +11739,10 @@ fn pep_751_install_path_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Installed 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 2 packages in [TIME]
      + iniconfig==2.0.0 (from file://[TEMP_DIR]/iniconfig-2.0.0-py3-none-any.whl)
+     + project==0.1.0 (from file://[TEMP_DIR]/)
     "
     );
 
@@ -11731,7 +11755,7 @@ fn pep_751_install_path_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "
     );
 
@@ -11779,9 +11803,10 @@ fn pep_751_install_path_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
      + iniconfig==2.0.0 (from file://[TEMP_DIR]/iniconfig-2.0.0.tar.gz)
+     + project==0.1.0 (from file://[TEMP_DIR]/)
     "
     );
 
@@ -11794,7 +11819,7 @@ fn pep_751_install_path_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "
     );
 

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -5779,10 +5779,11 @@ fn pep_751() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
     "
     );
@@ -5795,7 +5796,7 @@ fn pep_751() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Audited 3 packages in [TIME]
+    Audited 4 packages in [TIME]
     "
     );
 
@@ -5825,12 +5826,13 @@ fn pep_751() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Uninstalled 3 packages in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 4 packages in [TIME]
+    Installed 2 packages in [TIME]
      - anyio==4.3.0
      - idna==3.6
      + iniconfig==2.0.0
+     ~ project==0.1.0 (from file://[TEMP_DIR]/)
      - sniffio==1.3.1
     "
     );
@@ -5877,14 +5879,15 @@ fn pep_751_wheel_only() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Would download 9 packages
-    Would install 9 packages
+    Would download 10 packages
+    Would install 10 packages
      + filelock==3.13.1
      + fsspec==2024.3.1
      + jinja2==3.1.3
      + markupsafe==2.1.5
      + mpmath==1.3.0
      + networkx==3.2.1
+     + project @ file://[TEMP_DIR]/
      + sympy==1.12
      + torch==2.2.1
      + typing-extensions==4.10.0
@@ -5948,10 +5951,11 @@ fn pep_751_build_options() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 4 packages in [TIME]
-    Installed 4 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
      + anyio==4.8.0
      + idna==3.10
+     + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
      + typing-extensions==4.12.2
     "
@@ -6031,11 +6035,12 @@ fn pep_751_build_options() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Prepared 1 package in [TIME]
-    Uninstalled 4 packages in [TIME]
-    Installed 1 package in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 5 packages in [TIME]
+    Installed 2 packages in [TIME]
      - anyio==4.8.0
      - idna==3.10
+     ~ project==0.1.0 (from file://[TEMP_DIR]/)
      - sniffio==1.3.1
      + source-distribution==0.0.3
      - typing-extensions==4.12.2
@@ -6094,8 +6099,10 @@ fn pep_751_direct_url_tags() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Installed 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 2 packages in [TIME]
      + markupsafe==3.0.2 (from https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl)
+     + project==0.1.0 (from file://[TEMP_DIR]/)
     "
     );
 


### PR DESCRIPTION
When exporting to `pylock.toml`, uv previously generated single-use lock files that omitted extras, dependency groups, environment forks, and per-package dependency lists. This made the exported file less useful for tools consuming PEP 751 format.

This change produces a complete multi-use lock file. Internally, uv represents extras and dependency groups as synthetic extra names (e.g., `extra == 'extra-3-pkg-feat'` for an extra, `extra == 'group-3-pkg-dev'` for a group). During export, these are converted to PEP 751 syntax:

- **Root package:** `extra-3-pkg-feat` becomes `'feat' in extras`; `group-3-pkg-dev` becomes `'dev' in dependency_groups`
- **Other packages:** Synthetic markers are removed (they'd silently suppress dependencies since no real package declares them). Real markers like `sys_platform == 'win32'` or `extra == 'dotenv'` pass through unchanged.

The conversion normalizes markers to DNF (OR of ANDs), transforms each term, removes clauses that can never be true (e.g., two mutually exclusive extras in a single AND), and rebuilds the result.

```mermaid
flowchart TB
    subgraph Input["Input: uv Lock File"]
        L1["Markers with<br/>conflict encoding"]
        L2["Fork markers"]
        L3["Extras and groups"]
        L4["Resolution graph"]
    end

    subgraph Convert["Marker Conversion (NEW)"]
        style C1 fill:#87CEEB,color:#000
        style C2 fill:#87CEEB,color:#000
        style C3 fill:#87CEEB,color:#000
        style C4 fill:#87CEEB,color:#000
        style C5 fill:#87CEEB,color:#000
        style C6 fill:#87CEEB,color:#000
        style C7 fill:#87CEEB,color:#000
        C1["Normalize<br/>to DNF"] --> C2["Transform<br/>expressions"]
        C2 --> C3{"Is root<br/>package?"}
        C3 -->|Yes| C4["extra-pkg-feat -><br/>feat in extras"]
        C3 -->|Yes| C5["group-pkg-dev -><br/>dev in dependency_groups"]
        C3 -->|No| C6["Filter conflict markers,<br/>keep real PEP 508"]
        C4 --> C7["Drop impossible clauses<br/>& rebuild"]
        C5 --> C7
        C6 --> C7
    end

    subgraph Assemble["Dependency Assembly (NEW)"]
        style A1 fill:#87CEEB,color:#000
        style A2 fill:#87CEEB,color:#000
        style A3 fill:#87CEEB,color:#000
        style A4 fill:#87CEEB,color:#000
        A1["Regular<br/>deps"] --> A4["Sort +<br/>dedup"]
        A2["Optional deps<br/>per extra"] --> A4
        A3["Dep groups<br/>root only"] --> A4
    end

    subgraph Output["Output: pylock.toml"]
        style O1 fill:#87CEEB,color:#000
        style O2 fill:#87CEEB,color:#000
        style O3 fill:#87CEEB,color:#000
        style O4 fill:#90EE90,color:#000
        style O5 fill:#87CEEB,color:#000
        style O7 fill:#87CEEB,color:#000
        O1["environments"]
        O2["extras"]
        O3["dependency-groups"]
        O7["root package<br/>entry"]
        O4["packages with<br/>markers"]
        O5["dependencies<br/>array"]
        O6["name, version,<br/>wheels, sdist..."]
    end

    L1 --> C1
    L2 --> O1
    L3 --> O2
    L3 --> O3
    L4 --> Assemble
    C7 --> Assemble
    A4 --> O5
    C7 --> O4
    L4 --> O7
```

> Blue = new in this PR. Green = significantly changed. Default = existed before.

## New Fields

The exported `pylock.toml` now includes several new top-level and package-level fields:

**Top-level fields:**
```diff
  lock-version = "1.0"
  created-by = "uv"
+ environments = [
+     "sys_platform == 'darwin'",
+     "sys_platform == 'linux'",
+ ]
  requires-python = ">=3.12"
+ extras = ["async", "pytest"]
+ dependency-groups = ["coverage", "test"]
```

**Package dependencies with markers:**
```diff
  [[packages]]
  name = "project"
+ dependencies = [
+     { name = "anyio", version = "3.7.0", marker = "'async' in extras" },
+     { name = "iniconfig", version = "2.0.0", marker = "'pytest' in extras" },
+     { name = "typing-extensions", version = "4.10.0" },
+ ]
  directory = { path = ".", editable = true }
```

**Transitive dependencies preserve their real markers:**
```diff
  [[packages]]
  name = "flask"
  version = "3.0.2"
+ dependencies = [
+     { name = "blinker", version = "1.7.0" },
+     { name = "click", version = "8.1.7" },
+     { name = "python-dotenv", version = "1.0.1", marker = "extra == 'dotenv'" },
+     { name = "werkzeug", version = "3.0.1" },
+ ]
```

## Root Package Now Included

The pylock.toml now includes the root project as a `[[packages]]` entry with its dependencies:

```toml
[[packages]]
name = "project"
dependencies = [{ name = "iniconfig", version = "2.0.0" }]
directory = { path = ".", editable = true }
```

Previously only third-party packages were listed. Including the root captures the full dependency graph from root to leaves. This is why `pip install` tests show an increased package count (`+1`).

## Per-Package Dependency Assembly

Each package's `dependencies` array is built from three sources, each needing different marker treatment:

**Regular dependencies** (`[project.dependencies]`) are always-required. Their markers may contain platform conditions (`sys_platform == 'win32'`) and, in forked resolutions, conflict markers from the resolver. `to_pep751_marker()` converts or filters the conflict markers (see below) and passes platform markers through unchanged. No extra-gating marker is added. The `extras` field on each dependency entry (e.g., `extras = ["http2"]`) tells the installer which extras to activate on the *target* package; it's separate from the marker.

**Optional dependencies** (`[project.optional-dependencies]`) are conditional on an extra. Each dependency gets an additional marker combined with its own:
- **Root package** → `'extra_name' in extras` (PEP 751 syntax). These map to the lock file's top-level `extras` list — they're install-time choices the user selects.
- **Non-root package** → `extra == 'extra_name'` (standard PEP 508 syntax). These are activated through the dependency graph: when a parent depends on `pkg[socks]`, it sets `extras = ["socks"]` on its dependency entry. The installer sees `extra == 'socks'` on the child's dependencies and knows to pull them in.

The `extras` field on the parent's dependency entry bridges the two: it translates the user's `'socks' in extras` selection into an extra activation that the child's `extra == 'socks'` condition evaluates against.

**Dependency groups** (`[dependency-groups]`, PEP 735) are root-only. Each dependency gets `'group_name' in dependency_groups` combined with its own marker, the same way root extras work. Non-root packages don't get group markers — dependency groups are a project-level concept that only exists in `pyproject.toml`, not in published package metadata.

## Conflict Marker Handling

uv's internal conflict markers use synthetic extra names like `extra-9-myproject-cpu` that don't exist in any real package. In pylock.toml, a consumer would evaluate these as FALSE, silently dropping dependencies. The conversion handles this differently for root and non-root packages:

- **Root package:** Conflict markers are converted to PEP 751 syntax (`'cpu' in extras`, `'dev' in dependency_groups`). After conversion, any AND clause containing two mutually exclusive items (e.g., `'cpu' in extras AND 'gpu' in extras` — the user can't select both) is dropped. This is cosmetic: those clauses already evaluate to FALSE, so removing them doesn't change behavior.
- **Non-root packages:** Conflict markers are removed entirely, making the dependency unconditional. This may install a few extra packages but is safe — better to over-include than silently miss dependencies.

Example with conflicts `{black22, black23, black24}`:

```
Input:  ('black22' in dependency_groups and 'black23' in dependency_groups) or 'black22' in dependency_groups
Output: 'black22' in dependency_groups
```

## Marker Conversion Examples

Root package extras use PEP 751 list syntax:
```toml
# Root package dependency on optional extra
{ name = "anyio", marker = "'async' in extras" }

# Root package dependency on dependency group
{ name = "pytest", marker = "'test' in dependency_groups" }
```

Transitive dependencies keep standard PEP 508 syntax (conflict markers filtered out):
```toml
# Flask's optional dependency on python-dotenv
{ name = "python-dotenv", marker = "extra == 'dotenv'" }

# Click's platform-specific dependency
{ name = "colorama", marker = "sys_platform == 'win32'" }
```

### Why Two Different Syntaxes?

PEP 751 introduces `extras` and `dependency_groups` as new marker variables for lock files, distinct from PEP 508's `extra`:

| Context | Marker Variable | Type | Example |
|---------|----------------|------|---------|
| Lock file (root) | `extras` | set | `'async' in extras` |
| Lock file (root) | `dependency_groups` | set | `'dev' in dependency_groups` |
| Package metadata | `extra` | string | `extra == 'dotenv'` |

- **`'x' in extras`** — "did the user select extra `x` when installing?" (install-time choice)
- **`extra == 'x'`** — "was this package requested with extra `x`?" (dependency graph condition)

PEP 751 states these new markers are only valid within lock files — using them in regular package metadata would raise an error.

## Other Changes

- **`Dist::requires_python()`** — new method on `Dist` in `uv-distribution-types` that extracts `Requires-Python` from registry distribution metadata, returning `Option<RequiresPython>` directly
- **`marker_conversion.rs`** — new module for marker conversion logic with unit tests, separated from `pylock_toml.rs`
- **`install_target.rs`** — `available_extras()` and `available_dependency_groups()` methods added to `InstallTarget`
- **`export.rs`** — PEP 751 and CycloneDX now both skip conflict detection (both are multi-use formats)

## Real World Tests

Tested export on [datamodel-code-generator](https://github.com/koxudaxi/datamodel-code-generator) with `--all-extras`:

[**Before/After Comparison Gist**](https://gist.github.com/gaborbernat/e217cac3505b3abad02361e7c2d612e3) — includes:
- `1-pylock-diff.patch` (656 lines) — unified diff
- `2-pylock-after.toml` (2203 lines) — this PR
- `3-pylock-before.toml` (1899 lines) — upstream/main

Key differences: root package now included, `extras` field added, `dependencies` arrays on all packages.

## Backwards Compatibility

| Direction | Compatible? | Notes |
|-----------|-------------|-------|
| Old pylock.toml → new uv | Yes | New fields (`dependencies`, `extras`, etc.) default to empty |
| New pylock.toml → old uv | Yes | serde ignores unknown fields; old uv skips unrecognized keys |

## Future Work

The marker conversion doesn't attempt boolean simplification across clauses. For example, with conflict set `{black22, black23, black24}`, the output currently includes:

```
('black22' in dependency_groups and 'dev' in dependency_groups)
  or ('black23' in dependency_groups and 'dev' in dependency_groups)
  or ('black24' in dependency_groups and 'dev' in dependency_groups)
  or ('black22' not in dependency_groups and 'black23' not in dependency_groups and 'black24' not in dependency_groups)
```

This could simplify to:

```
'dev' in dependency_groups
  or ('black22' not in dependency_groups and 'black23' not in dependency_groups and 'black24' not in dependency_groups)
```

Since `'dev' in dependency_groups` is a common factor across the first three clauses, it can be factored out using the mutual exclusion of the conflict set. However, this is a general marker simplification concern orthogonal to PEP 751 export — the DNF-to-string formatting doesn't perform this kind of reduction today. Left for a future improvement.
