### PR TITLE
Fix uv_build upper bound formatting

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -680,7 +680,7 @@ mod tests {
             license = { file = "license.txt" }
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
         "#
             },
@@ -748,7 +748,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
         "#
             },
@@ -812,7 +812,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
 
             [tool.uv.build-backend]
@@ -854,7 +854,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
 
             [tool.uv.build-backend]
@@ -879,7 +879,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
 
             [tool.uv.build-backend]
@@ -928,7 +928,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
 
             [tool.uv.build-backend]
@@ -959,7 +959,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1010,7 +1010,7 @@ mod tests {
             version = "1.0.0"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
 
             [tool.uv.build-backend]
@@ -1036,7 +1036,7 @@ mod tests {
             module-name = "simple_namespace.part"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1104,7 +1104,7 @@ mod tests {
             namespace = true
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1127,7 +1127,7 @@ mod tests {
             namespace = true
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1188,7 +1188,7 @@ mod tests {
             namespace = true
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1211,7 +1211,7 @@ mod tests {
             module-name = "cloud-stubs.db.schema"
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };
@@ -1261,7 +1261,7 @@ mod tests {
             module-name = ["foo", "simple_namespace.part_a", "simple_namespace.part_b"]
 
             [build-system]
-            requires = ["uv_build>=0.5.15,<0.6"]
+            requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
             "#
         };

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -171,7 +171,7 @@ impl PyProjectToml {
     ///
     /// ```toml
     /// [build-system]
-    /// requires = ["uv_build>=0.4.15,<0.5"]
+    /// requires = ["uv_build>=0.4.15,<0.5.0"]
     /// build-backend = "uv_build"
     /// ```
     pub fn check_build_system(&self, uv_version: &str) -> Vec<String> {
@@ -826,7 +826,7 @@ mod tests {
             {payload}
 
             [build-system]
-            requires = ["uv_build>=0.4.15,<0.5"]
+            requires = ["uv_build>=0.4.15,<0.5.0"]
             build-backend = "uv_build"
         "#
         }
@@ -909,7 +909,7 @@ mod tests {
             foo-bar = "foo:bar"
 
             [build-system]
-            requires = ["uv_build>=0.4.15,<0.5"]
+            requires = ["uv_build>=0.4.15,<0.5.0"]
             build-backend = "uv_build"
         "#
         };
@@ -1036,7 +1036,7 @@ mod tests {
             foo-bar = "foo:bar"
 
             [build-system]
-            requires = ["uv_build>=0.4.15,<0.5"]
+            requires = ["uv_build>=0.4.15,<0.5.0"]
             build-backend = "uv_build"
         "#
         };
@@ -1135,7 +1135,7 @@ mod tests {
             version = "0.1.0"
 
             [build-system]
-            requires = ["uv_build>=0.4.15,<0.5", "wheel"]
+            requires = ["uv_build>=0.4.15,<0.5.0", "wheel"]
             build-backend = "uv_build"
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();
@@ -1171,7 +1171,7 @@ mod tests {
             version = "0.1.0"
 
             [build-system]
-            requires = ["uv_build>=0.4.15,<0.5"]
+            requires = ["uv_build>=0.4.15,<0.5.0"]
             build-backend = "setuptools"
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -944,7 +944,7 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 min_version.release()[0] == 0,
                 "migrate to major version bumps"
             );
-            let max_version = Version::new([0, min_version.release()[1] + 1]);
+            let max_version = Version::new([0, min_version.release()[1] + 1, 0]);
             indoc::formatdoc! {r#"
                 [build-system]
                 requires = ["uv_build>={min_version},<{max_version}"]

--- a/scripts/packages/built-by-uv/pyproject.toml
+++ b/scripts/packages/built-by-uv/pyproject.toml
@@ -24,5 +24,5 @@ data = "assets"
 headers = "header"
 
 [build-system]
-requires = ["uv_build>=0.8,<0.9"]
+requires = ["uv_build>=0.8,<0.9.0"]
 build-backend = "uv_build"


### PR DESCRIPTION
## Summary
- include patch number when generating uv_build upper bounds
- use `<0.x.0` in example project and backend tests

## Testing
- `cargo test -p uv-build-backend`
- `cargo test -p uv --lib --tests` *(fails: blocked by pypi-proxy.fly.dev)*

------
https://chatgpt.com/codex/tasks/task_e_687a53ba646c8331baa4140c5b2bec70