### PR TITLE
Add a hint to use uv self version in workspace.rs

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -44,7 +44,7 @@ pub struct WorkspaceCache(Arc<Mutex<FxHashMap<WorkspaceCacheKey, WorkspaceMember
 #[derive(thiserror::Error, Debug)]
 pub enum WorkspaceError {
     // Workspace structure errors.
-    #[error("No `pyproject.toml` found in current directory or any parent directory. \nhint: If you meant to view uv's version, use `uv self version` instead.")]
+    #[error("No `pyproject.toml` found in current directory or any parent directory\n\nhint: If you meant to view uv's version, use `uv self version` instead")]
     MissingPyprojectToml,
     #[error("Workspace member `{}` is missing a `pyproject.toml` (matches: `{}`)", _0.simplified_display(), _1)]
     MissingPyprojectTomlMember(PathBuf, String),

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -44,7 +44,7 @@ pub struct WorkspaceCache(Arc<Mutex<FxHashMap<WorkspaceCacheKey, WorkspaceMember
 #[derive(thiserror::Error, Debug)]
 pub enum WorkspaceError {
     // Workspace structure errors.
-    #[error("No `pyproject.toml` found in current directory or any parent directory")]
+    #[error("No `pyproject.toml` found in current directory or any parent directory. \nhint: If you meant to view uv's version, use `uv self version` instead.")]
     MissingPyprojectToml,
     #[error("Workspace member `{}` is missing a `pyproject.toml` (matches: `{}`)", _0.simplified_display(), _1)]
     MissingPyprojectTomlMember(PathBuf, String),


### PR DESCRIPTION
## Summary
Fixes #14730 by adding the required hint in workspace.rs

## Test Plan

"cargo nextest run -p workspace-uv" passed all checks
"uv version" returned the appropriate hint when pyproject.toml was missing

This is my first pull request - if additional details are needed, please let me know!