### PR TITLE
Update `setup-uv` docs for Github Actions integration guide (re-order python and uv setup)

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -92,13 +92,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 ```
 
 Or, specify the `pyproject.toml` file to ignore the pin and use the latest version compatible with
@@ -115,13 +115,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:
           python-version-file: "pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 ```
 
 ## Multiple Python versions


### PR DESCRIPTION
I updated the Github Actions integration guide to run Github's `setup-python` before Astral's `setup-uv`, as `setup-uv`'s `activate-environment: true` doesn't work with the original ordering. There is a discussion about this behavior in the `setup-uv` repo [here](https://github.com/astral-sh/setup-uv/issues/479).

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Update the documentation for the Github Actions integration. Caveat: I'm unsure if there are any other reasons where the original ordering (that is,`setup-uv` before `setup-python`) might be preferred.

## Test Plan

Tested in a private Github Actions push, as documented in the aforementioned discussion on `setup-uv`'s repo. Confirmed that removing `source .venv/bin/activate` and replacing it with `activate-environment: true` now works in this ordering (but didn't work with the original ordering where `uv` installs before Github's `python`).
