### PR TITLE
Directly ask the NVIDIA kernel driver what version it is

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5942,6 +5942,7 @@ dependencies = [
  "clap",
  "either",
  "fs-err 3.1.1",
+ "nix 0.30.1",
  "schemars",
  "serde",
  "thiserror 2.0.12",

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -19,6 +19,7 @@ uv-static = { workspace = true }
 clap = { workspace = true, optional = true }
 either = { workspace = true }
 fs-err = { workspace = true }
+nix = { workspace = true, features = ["ioctl"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
This is the same API called by `nvidia-smi`, but doing it ourselves is both much faster and more robust to installation conditions (e.g., nvidia-smi not being installed).