### PR TITLE
Support `extras` and `dependency_groups` markers in PEP 508 grammar

### DIFF
--- a/crates/uv-pep508/src/marker/lowering.rs
+++ b/crates/uv-pep508/src/marker/lowering.rs
@@ -1,7 +1,8 @@
 use std::fmt::{Display, Formatter};
 
-use uv_normalize::ExtraName;
+use uv_normalize::{ExtraName, GroupName};
 
+use crate::marker::tree::MarkerValueDependencyGroup;
 use crate::{MarkerValueExtra, MarkerValueString, MarkerValueVersion};
 
 /// Those environment markers with a PEP 440 version as value such as `python_version`
@@ -128,7 +129,7 @@ impl Display for CanonicalMarkerValueString {
     }
 }
 
-/// The [`ExtraName`] value used in `extra` markers.
+/// The [`ExtraName`] value used in `extra` and `extras` markers.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum CanonicalMarkerValueExtra {
     /// A valid [`ExtraName`].
@@ -156,6 +157,38 @@ impl Display for CanonicalMarkerValueExtra {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Extra(extra) => extra.fmt(f),
+        }
+    }
+}
+
+/// The [`GroupName`] value used in `dependency_group` markers.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum CanonicalMarkerValueDependencyGroup {
+    /// A valid [`GroupName`].
+    Group(GroupName),
+}
+
+impl CanonicalMarkerValueDependencyGroup {
+    /// Returns the [`GroupName`] value.
+    pub fn group(&self) -> &GroupName {
+        match self {
+            Self::Group(group) => group,
+        }
+    }
+}
+
+impl From<CanonicalMarkerValueDependencyGroup> for MarkerValueDependencyGroup {
+    fn from(value: CanonicalMarkerValueDependencyGroup) -> Self {
+        match value {
+            CanonicalMarkerValueDependencyGroup::Group(group) => Self::Group(group),
+        }
+    }
+}
+
+impl Display for CanonicalMarkerValueDependencyGroup {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Group(group) => group.fmt(f),
         }
     }
 }

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -54,6 +54,16 @@ pub(crate) fn requires_python(tree: MarkerTree) -> Option<RequiresPythonRange> {
                     collect_python_markers(tree, markers, range);
                 }
             }
+            MarkerTreeKind::Extras(marker) => {
+                for (_, tree) in marker.children() {
+                    collect_python_markers(tree, markers, range);
+                }
+            }
+            MarkerTreeKind::DependencyGroups(marker) => {
+                for (_, tree) in marker.children() {
+                    collect_python_markers(tree, markers, range);
+                }
+            }
         }
     }
 

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -698,6 +698,16 @@ impl ResolverOutput {
                         add_marker_params_from_tree(tree, set);
                     }
                 }
+                MarkerTreeKind::Extras(marker) => {
+                    for (_, tree) in marker.children() {
+                        add_marker_params_from_tree(tree, set);
+                    }
+                }
+                MarkerTreeKind::DependencyGroups(marker) => {
+                    for (_, tree) in marker.children() {
+                        add_marker_params_from_tree(tree, set);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

We always evaluate these to `false` right now, but we can at least parse them.

See: https://peps.python.org/pep-0751/#dependency-groups.
