### PR TITLE
Create (e.g.) `python3.13t` executables in `uv venv`

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -242,6 +242,16 @@ pub(crate) fn create(
                 interpreter.python_minor(),
             )),
         )?;
+        if interpreter.gil_disabled() {
+            uv_fs::replace_symlink(
+                "python",
+                scripts.join(format!(
+                    "python{}.{}t",
+                    interpreter.python_major(),
+                    interpreter.python_minor(),
+                )),
+            )?;
+        }
 
         if interpreter.markers().implementation_name() == "pypy" {
             uv_fs::replace_symlink(

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -277,6 +277,14 @@ pub(crate) fn create(
             let targetw = scripts.join(WindowsExecutable::Pythonw.exe(interpreter));
             create_link_to_executable(targetw.as_path(), &executable_target)
                 .map_err(Error::Python)?;
+            if interpreter.gil_disabled() {
+                let targett = scripts.join(WindowsExecutable::PythonMajorMinort.exe(interpreter));
+                create_link_to_executable(targett.as_path(), &executable_target)
+                    .map_err(Error::Python)?;
+                let targetwt = scripts.join(WindowsExecutable::PythonwMajorMinort.exe(interpreter));
+                create_link_to_executable(targetwt.as_path(), &executable_target)
+                    .map_err(Error::Python)?;
+            }
         } else {
             // Always copy `python.exe`.
             copy_launcher_windows(
@@ -373,6 +381,24 @@ pub(crate) fn create(
                         &scripts,
                         python_home,
                     )?;
+
+                    // If the GIL is disabled, copy `venvlaunchert.exe` and `venvwlaunchert.exe`.
+                    if interpreter.gil_disabled() {
+                        copy_launcher_windows(
+                            WindowsExecutable::PythonMajorMinort,
+                            interpreter,
+                            &base_python,
+                            &scripts,
+                            python_home,
+                        )?;
+                        copy_launcher_windows(
+                            WindowsExecutable::PythonwMajorMinort,
+                            interpreter,
+                            &base_python,
+                            &scripts,
+                            python_home,
+                        )?;
+                    }
                 }
             }
         }
@@ -590,8 +616,12 @@ enum WindowsExecutable {
     PythonMajor,
     /// The `python3.<minor>.exe` executable (or `venvlauncher.exe` launcher shim).
     PythonMajorMinor,
+    /// The `python3.<minor>t.exe` executable (or `venvlaunchert.exe` launcher shim).
+    PythonMajorMinort,
     /// The `pythonw.exe` executable (or `venvwlauncher.exe` launcher shim).
     Pythonw,
+    /// The `pythonw3.<minor>t.exe` executable (or `venvwlaunchert.exe` launcher shim).
+    PythonwMajorMinort,
     /// The `pypy.exe` executable.
     PyPy,
     /// The `pypy3.exe` executable.
@@ -602,7 +632,7 @@ enum WindowsExecutable {
     PyPyw,
     /// The `pypy3.<minor>w.exe` executable.
     PyPyMajorMinorw,
-    // The `graalpy.exe` executable
+    /// The `graalpy.exe` executable.
     GraalPy,
 }
 
@@ -621,7 +651,21 @@ impl WindowsExecutable {
                     interpreter.python_minor()
                 )
             }
+            WindowsExecutable::PythonMajorMinort => {
+                format!(
+                    "python{}.{}t.exe",
+                    interpreter.python_major(),
+                    interpreter.python_minor()
+                )
+            }
             WindowsExecutable::Pythonw => String::from("pythonw.exe"),
+            WindowsExecutable::PythonwMajorMinort => {
+                format!(
+                    "pythonw{}.{}t.exe",
+                    interpreter.python_major(),
+                    interpreter.python_minor()
+                )
+            }
             WindowsExecutable::PyPy => String::from("pypy.exe"),
             WindowsExecutable::PyPyMajor => {
                 format!("pypy{}.exe", interpreter.python_major())
@@ -656,6 +700,8 @@ impl WindowsExecutable {
             Self::Python | Self::PythonMajor | Self::PythonMajorMinor => "venvlauncher.exe",
             Self::Pythonw if interpreter.gil_disabled() => "venvwlaunchert.exe",
             Self::Pythonw => "venvwlauncher.exe",
+            Self::PythonMajorMinort => "venvlaunchert.exe",
+            Self::PythonwMajorMinort => "venvwlaunchert.exe",
             // From 3.13 on these should replace the `python.exe` and `pythonw.exe` shims.
             // These are not relevant as of now for PyPy as it doesn't yet support Python 3.13.
             Self::PyPy | Self::PyPyMajor | Self::PyPyMajorMinor => "venvlauncher.exe",

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1087,6 +1087,65 @@ fn python_install_freethreaded() {
     ----- stderr -----
     "###);
 
+    // Create a virtual environment with the freethreaded Python
+    uv_snapshot!(context.filters(), context.venv().arg("--python").arg("3.13t"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.13.5
+    Creating virtual environment at: .venv
+    Activate with: source .venv/[BIN]/activate
+    ");
+
+    // `python`, `python3`, `python3.13`, and `python3.13t` should all be present
+    let scripts = context
+        .venv
+        .join(if cfg!(windows) { "Scripts" } else { "bin" });
+    assert!(
+        scripts
+            .join(format!("python{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    #[cfg(windows)]
+    assert!(
+        scripts
+            .join(format!("pythonw{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    #[cfg(unix)]
+    assert!(
+        scripts
+            .join(format!("python3{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    #[cfg(unix)]
+    assert!(
+        scripts
+            .join(format!("python3.13{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    assert!(
+        scripts
+            .join(format!("python3.13t{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    #[cfg(windows)]
+    assert!(
+        scripts
+            .join(format!("pythonw3.13t{}", std::env::consts::EXE_SUFFIX))
+            .exists()
+    );
+
+    // Remove the virtual environment
+    fs_err::remove_dir_all(&context.venv).unwrap();
+
     // Should be distinct from 3.13
     uv_snapshot!(context.filters(), context.python_install().arg("3.13"), @r"
     success: true
@@ -1099,14 +1158,14 @@ fn python_install_freethreaded() {
     ");
 
     // Should not work with older Python versions
-    uv_snapshot!(context.filters(), context.python_install().arg("3.12t"), @r###"
+    uv_snapshot!(context.filters(), context.python_install().arg("3.12t"), @r"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     error: No download found for request: cpython-3.12t-[PLATFORM]
-    "###);
+    ");
 
     uv_snapshot!(context.filters(), context.python_uninstall().arg("--all"), @r"
     success: true


### PR DESCRIPTION
## Summary

CPython's `venv` module creates these, so we should too.

On non-Windows, we add `python3.13t`.

On Windows, we add `python3.13t.exe` and `pythonw3.13t.exe` (see: https://github.com/python/cpython/blob/65d2c51c10425dcfacc0a13810d58c41240d7ff9/Lib/venv/__init__.py#L362).

Closes https://github.com/astral-sh/uv/issues/14760.
