### PR TITLE
In pylock.toml export, include dependencies (name and version)

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -232,7 +232,9 @@ pub struct PylockTomlPackage {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[allow(clippy::empty_structs_with_brackets)]
-struct PylockTomlDependency {}
+struct PylockTomlDependency {
+    pub name: PackageName,
+}
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -866,12 +868,21 @@ impl<'lock> PylockToml {
                 .filter(|_| directory.is_none())
                 .cloned();
 
+            // Extract dependencies from the package
+            let dependencies = package
+                .dependencies
+                .iter()
+                .map(|dep| PylockTomlDependency {
+                    name: dep.package_id.name.clone(),
+                })
+                .collect();
+
             let package = PylockTomlPackage {
                 name,
                 version,
                 marker: node.marker,
                 requires_python: None,
-                dependencies: vec![],
+                dependencies,
                 index,
                 vcs,
                 directory,

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -234,6 +234,8 @@ pub struct PylockTomlPackage {
 #[allow(clippy::empty_structs_with_brackets)]
 struct PylockTomlDependency {
     pub name: PackageName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<Version>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -874,7 +876,18 @@ impl<'lock> PylockToml {
                 .iter()
                 .map(|dep| PylockTomlDependency {
                     name: dep.package_id.name.clone(),
+                    version: dep.package_id.version.clone(),
                 })
+                .chain(
+                    package
+                        .optional_dependencies
+                        .values()
+                        .flatten()
+                        .map(|dep| PylockTomlDependency {
+                            name: dep.package_id.name.clone(),
+                            version: dep.package_id.version.clone(),
+                        })
+                )
                 .collect();
 
             let package = PylockTomlPackage {


### PR DESCRIPTION
## Summary

In the code for export a lock file to `pylock.toml`, I added the `[[packages.dependencies]]` field (https://packaging.python.org/en/latest/specifications/pylock-toml/#packages-dependencies). The goal of this change is to utilize `uv` to generate lockfiles for use with Pants and PEX (see https://github.com/pantsbuild/pants/issues/22201).

Fixes #13032.

Details:
- Because this dependency field is not fully specified, I only include the package's name and version, which seems sufficient for integrating the resulting files with Pants and Pex.
- I didn't add the dependencies to `from_resolution`, because I don't need it, and because it wasn't immediately clear to me how the edges and nodes in the resolution graph would have to be filetered.


## Test Plan

I manually tested this code. I couldn't find a test suite to add to. I'm open to suggestions on how to add testing.