### PR TITLE
Remove Python 3.9.18 from `.python-versions`

### DIFF
--- a/.python-versions
+++ b/.python-versions
@@ -6,7 +6,6 @@
 3.8.20
 # The following are required for packse scenarios
 3.9.20
-3.9.18
 3.9.12
 # The following is needed for `==3.13` request tests
 3.13.0


### PR DESCRIPTION
Python 3.9.18 is not used in the tests anymore.
