### PR TITLE
Accept `&Path` when creating executable links

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -262,10 +262,10 @@ pub(crate) fn create(
     if cfg!(windows) {
         if using_minor_version_link {
             let target = scripts.join(WindowsExecutable::Python.exe(interpreter));
-            create_link_to_executable(target.as_path(), executable_target.clone())
+            create_link_to_executable(target.as_path(), &executable_target)
                 .map_err(Error::Python)?;
             let targetw = scripts.join(WindowsExecutable::Pythonw.exe(interpreter));
-            create_link_to_executable(targetw.as_path(), executable_target)
+            create_link_to_executable(targetw.as_path(), &executable_target)
                 .map_err(Error::Python)?;
         } else {
             // Always copy `python.exe`.

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -768,7 +768,7 @@ fn create_bin_links(
             installation.executable(false)
         };
 
-        match create_link_to_executable(&target, executable.clone()) {
+        match create_link_to_executable(&target, &executable) {
             Ok(()) => {
                 debug!(
                     "Installed executable at `{}` for {}",
@@ -925,7 +925,7 @@ fn create_bin_links(
                         .remove(&target);
                 }
 
-                if let Err(err) = create_link_to_executable(&target, executable) {
+                if let Err(err) = create_link_to_executable(&target, &executable) {
                     errors.push((
                         InstallErrorKind::Bin,
                         installation.key().clone(),
@@ -953,7 +953,7 @@ fn create_bin_links(
                 errors.push((
                     InstallErrorKind::Bin,
                     installation.key().clone(),
-                    anyhow::Error::new(err),
+                    Error::new(err),
                 ));
             }
         }


### PR DESCRIPTION
## Summary

I don't see a great reason for this to take an owned value. It only needs an owned value for error cases.