### PR TITLE
Introduce a generic type for list operations

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -32,8 +32,8 @@ pub use marker::{
     CanonicalMarkerValueExtra, CanonicalMarkerValueString, CanonicalMarkerValueVersion,
     ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerEnvironment,
     MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree, MarkerTreeContents,
-    MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueString, MarkerValueVersion,
-    MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
+    MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueList, MarkerValueString,
+    MarkerValueVersion, MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
 };
 pub use origin::RequirementOrigin;
 #[cfg(feature = "non-pep508-extensions")]

--- a/crates/uv-pep508/src/marker/mod.rs
+++ b/crates/uv-pep508/src/marker/mod.rs
@@ -23,8 +23,8 @@ pub use lowering::{
 pub use tree::{
     ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerExpression,
     MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeDebugGraph, MarkerTreeKind,
-    MarkerValue, MarkerValueExtra, MarkerValueString, MarkerValueVersion, MarkerWarningKind,
-    StringMarkerTree, StringVersion, VersionMarkerTree,
+    MarkerValue, MarkerValueExtra, MarkerValueList, MarkerValueString, MarkerValueVersion,
+    MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
 };
 
 /// `serde` helpers for [`MarkerTree`].

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -16,12 +16,12 @@ use super::algebra::{Edges, INTERNER, NodeId, Variable};
 use super::simplify;
 use crate::cursor::Cursor;
 use crate::marker::lowering::{
-    CanonicalMarkerValueDependencyGroup, CanonicalMarkerValueExtra, CanonicalMarkerValueString,
-    CanonicalMarkerValueVersion,
+    CanonicalMarkerListPair, CanonicalMarkerValueString, CanonicalMarkerValueVersion,
 };
 use crate::marker::parse;
 use crate::{
-    MarkerEnvironment, Pep508Error, Pep508ErrorSource, Pep508Url, Reporter, TracingReporter,
+    CanonicalMarkerValueExtra, MarkerEnvironment, Pep508Error, Pep508ErrorSource, Pep508Url,
+    Reporter, TracingReporter,
 };
 
 /// Ways in which marker evaluation can fail
@@ -126,16 +126,18 @@ impl Display for MarkerValueString {
     }
 }
 
-/// Those markers with exclusively `in` and `not in` operators (PEP 751)
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub enum MarkerValueContains {
+/// Those markers with exclusively `in` and `not in` operators.
+///
+/// Contains PEP 751 lockfile markers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub enum MarkerValueList {
     /// `extras`. This one is special because it's a list, and user-provided
     Extras,
     /// `dependency_groups`. This one is special because it's a list, and user-provided
     DependencyGroups,
 }
 
-impl Display for MarkerValueContains {
+impl Display for MarkerValueList {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Extras => f.write_str("extras"),
@@ -153,10 +155,10 @@ pub enum MarkerValue {
     MarkerEnvVersion(MarkerValueVersion),
     /// Those environment markers with an arbitrary string as value such as `sys_platform`
     MarkerEnvString(MarkerValueString),
+    /// Those markers with exclusively `in` and `not in` operators
+    MarkerEnvList(MarkerValueList),
     /// `extra`. This one is special because it's a list, and user-provided
     Extra,
-    /// Those markers with exclusively `in` and `not in` operators (PEP 751)
-    MarkerEnvContains(MarkerValueContains),
     /// Not a constant, but a user given quoted string with a value inside such as '3.8' or "windows"
     QuotedString(ArcStr),
 }
@@ -196,9 +198,9 @@ impl FromStr for MarkerValue {
             "python_version" => Self::MarkerEnvVersion(MarkerValueVersion::PythonVersion),
             "sys_platform" => Self::MarkerEnvString(MarkerValueString::SysPlatform),
             "sys.platform" => Self::MarkerEnvString(MarkerValueString::SysPlatformDeprecated),
+            "extras" => Self::MarkerEnvList(MarkerValueList::Extras),
+            "dependency_groups" => Self::MarkerEnvList(MarkerValueList::DependencyGroups),
             "extra" => Self::Extra,
-            "extras" => Self::MarkerEnvContains(MarkerValueContains::Extras),
-            "dependency_groups" => Self::MarkerEnvContains(MarkerValueContains::DependencyGroups),
             _ => return Err(format!("Invalid key: {s}")),
         };
         Ok(value)
@@ -210,8 +212,8 @@ impl Display for MarkerValue {
         match self {
             Self::MarkerEnvVersion(marker_value_version) => marker_value_version.fmt(f),
             Self::MarkerEnvString(marker_value_string) => marker_value_string.fmt(f),
+            Self::MarkerEnvList(marker_value_contains) => marker_value_contains.fmt(f),
             Self::Extra => f.write_str("extra"),
-            Self::MarkerEnvContains(marker_value_contains) => marker_value_contains.fmt(f),
             Self::QuotedString(value) => write!(f, "'{value}'"),
         }
     }
@@ -499,24 +501,6 @@ impl Display for MarkerValueExtra {
     }
 }
 
-/// The [`GroupName`] value used in `dependency_group` markers.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub enum MarkerValueDependencyGroup {
-    /// A valid [`GroupName`].
-    Group(GroupName),
-    /// An invalid name, preserved as an arbitrary string.
-    Arbitrary(String),
-}
-
-impl Display for MarkerValueDependencyGroup {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Group(group) => group.fmt(f),
-            Self::Arbitrary(string) => string.fmt(f),
-        }
-    }
-}
-
 /// Represents one clause such as `python_version > "3.8"`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[allow(missing_docs)]
@@ -540,7 +524,7 @@ pub enum MarkerExpression {
     VersionIn {
         key: MarkerValueVersion,
         versions: Vec<Version>,
-        negated: bool,
+        operator: ContainerOperator,
     },
     /// An string marker comparison, e.g. `sys_platform == '...'`.
     ///
@@ -550,20 +534,15 @@ pub enum MarkerExpression {
         operator: MarkerOperator,
         value: ArcStr,
     },
+    /// `'...' in <key>`, a PEP 751 expression.
+    List {
+        pair: CanonicalMarkerListPair,
+        operator: ContainerOperator,
+    },
     /// `extra <extra op> '...'` or `'...' <extra op> extra`.
     Extra {
         name: MarkerValueExtra,
         operator: ExtraOperator,
-    },
-    /// `'...' in extras`
-    Extras {
-        name: MarkerValueExtra,
-        operator: ContainerOperator,
-    },
-    /// `'...' in dependency_groups`
-    DependencyGroups {
-        name: MarkerValueDependencyGroup,
-        operator: ContainerOperator,
     },
 }
 
@@ -572,16 +551,14 @@ pub enum MarkerExpression {
 pub(crate) enum MarkerExpressionKind {
     /// A version expression, e.g. `<version key> <version op> <quoted PEP 440 version>`.
     Version(MarkerValueVersion),
-    /// A version "in" expression, e.g. `<version key> in <quoted list of PEP 440 versions>`.
+    /// A version `in` expression, e.g. `<version key> in <quoted list of PEP 440 versions>`.
     VersionIn(MarkerValueVersion),
     /// A string marker comparison, e.g. `sys_platform == '...'`.
     String(MarkerValueString),
+    /// A list `in` or `not in` expression, e.g. `'...' in dependency_groups`.
+    List(MarkerValueList),
     /// An extra expression, e.g. `extra == '...'`.
     Extra,
-    /// An extras expression, e.g. `'...' in extras`.
-    Extras,
-    /// A dependency groups expression, e.g. `'...' in dependency_groups`.
-    DependencyGroups,
 }
 
 /// The operator for an extra expression, either '==' or '!='.
@@ -624,7 +601,7 @@ impl Display for ExtraOperator {
 }
 
 /// The operator for a container expression, either 'in' or 'not in'.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum ContainerOperator {
     /// `in`
     In,
@@ -641,14 +618,6 @@ impl ContainerOperator {
             MarkerOperator::In => Some(ContainerOperator::In),
             MarkerOperator::NotIn => Some(ContainerOperator::NotIn),
             _ => None,
-        }
-    }
-
-    /// Negates this operator.
-    pub(crate) fn negate(&self) -> ContainerOperator {
-        match *self {
-            ContainerOperator::In => ContainerOperator::NotIn,
-            ContainerOperator::NotIn => ContainerOperator::In,
         }
     }
 }
@@ -700,9 +669,8 @@ impl MarkerExpression {
             MarkerExpression::Version { key, .. } => MarkerExpressionKind::Version(*key),
             MarkerExpression::VersionIn { key, .. } => MarkerExpressionKind::VersionIn(*key),
             MarkerExpression::String { key, .. } => MarkerExpressionKind::String(*key),
+            MarkerExpression::List { pair, .. } => MarkerExpressionKind::List(pair.key()),
             MarkerExpression::Extra { .. } => MarkerExpressionKind::Extra,
-            MarkerExpression::Extras { .. } => MarkerExpressionKind::Extras,
-            MarkerExpression::DependencyGroups { .. } => MarkerExpressionKind::DependencyGroups,
         }
     }
 }
@@ -721,11 +689,10 @@ impl Display for MarkerExpression {
             MarkerExpression::VersionIn {
                 key,
                 versions,
-                negated,
+                operator,
             } => {
-                let op = if *negated { "not in" } else { "in" };
                 let versions = versions.iter().map(ToString::to_string).join(" ");
-                write!(f, "{key} {op} '{versions}'")
+                write!(f, "{key} {operator} '{versions}'")
             }
             MarkerExpression::String {
                 key,
@@ -741,14 +708,11 @@ impl Display for MarkerExpression {
 
                 write!(f, "{key} {operator} '{value}'")
             }
+            MarkerExpression::List { pair, operator } => {
+                write!(f, "'{}' {} {}", pair.value(), operator, pair.key())
+            }
             MarkerExpression::Extra { operator, name } => {
                 write!(f, "extra {operator} '{name}'")
-            }
-            MarkerExpression::Extras { operator, name } => {
-                write!(f, "'{name}' {operator} extras")
-            }
-            MarkerExpression::DependencyGroups { operator, name } => {
-                write!(f, "'{name}' {operator} dependency_groups")
             }
         }
     }
@@ -777,24 +741,24 @@ impl<'a> ExtrasEnvironment<'a> {
     /// Returns the `extra` names in this environment.
     fn extra(&self) -> &[ExtraName] {
         match self {
-            ExtrasEnvironment::Extras(extra) => extra,
-            ExtrasEnvironment::Pep751(..) => &[],
+            Self::Extras(extra) => extra,
+            Self::Pep751(..) => &[],
         }
     }
 
     /// Returns the `extras` names in this environment, as in a PEP 751 lockfile.
     fn extras(&self) -> &[ExtraName] {
         match self {
-            ExtrasEnvironment::Extras(..) => &[],
-            ExtrasEnvironment::Pep751(extras, ..) => extras,
+            Self::Extras(..) => &[],
+            Self::Pep751(extras, ..) => extras,
         }
     }
 
     /// Returns the `dependency_group` group names in this environment, as in a PEP 751 lockfile.
     fn dependency_groups(&self) -> &[GroupName] {
         match self {
-            ExtrasEnvironment::Extras(..) => &[],
-            ExtrasEnvironment::Pep751(.., groups) => groups,
+            Self::Extras(..) => &[],
+            Self::Pep751(.., groups) => groups,
         }
     }
 }
@@ -1006,31 +970,21 @@ impl MarkerTree {
                     low: low.negate(self.0),
                 })
             }
+            Variable::List(key) => {
+                let Edges::Boolean { low, high } = node.children else {
+                    unreachable!()
+                };
+                MarkerTreeKind::List(ListMarkerTree {
+                    pair: key,
+                    high: high.negate(self.0),
+                    low: low.negate(self.0),
+                })
+            }
             Variable::Extra(name) => {
                 let Edges::Boolean { low, high } = node.children else {
                     unreachable!()
                 };
                 MarkerTreeKind::Extra(ExtraMarkerTree {
-                    name,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
-                })
-            }
-            Variable::Extras(name) => {
-                let Edges::Boolean { low, high } = node.children else {
-                    unreachable!()
-                };
-                MarkerTreeKind::Extras(ExtrasMarkerTree {
-                    name,
-                    high: high.negate(self.0),
-                    low: low.negate(self.0),
-                })
-            }
-            Variable::DependencyGroups(name) => {
-                let Edges::Boolean { low, high } = node.children else {
-                    unreachable!()
-                };
-                MarkerTreeKind::DependencyGroups(DependencyGroupsMarkerTree {
                     name,
                     high: high.negate(self.0),
                     low: low.negate(self.0),
@@ -1160,14 +1114,18 @@ impl MarkerTree {
                     .edge(extras.extra().contains(marker.name().extra()))
                     .evaluate_reporter_impl(env, extras, reporter);
             }
-            MarkerTreeKind::Extras(marker) => {
+            MarkerTreeKind::List(marker) => {
+                let edge = match marker.pair() {
+                    CanonicalMarkerListPair::Extras(extra) => extras.extras().contains(extra),
+                    CanonicalMarkerListPair::DependencyGroup(dependency_group) => {
+                        extras.dependency_groups().contains(dependency_group)
+                    }
+                    // Invalid marker expression
+                    CanonicalMarkerListPair::Arbitrary { .. } => return false,
+                };
+
                 return marker
-                    .edge(extras.extras().contains(marker.name().extra()))
-                    .evaluate_reporter_impl(env, extras, reporter);
-            }
-            MarkerTreeKind::DependencyGroups(marker) => {
-                return marker
-                    .edge(extras.dependency_groups().contains(marker.name().group()))
+                    .edge(edge)
                     .evaluate_reporter_impl(env, extras, reporter);
             }
         }
@@ -1194,15 +1152,12 @@ impl MarkerTree {
             MarkerTreeKind::Contains(marker) => marker
                 .children()
                 .any(|(_, tree)| tree.evaluate_extras(extras)),
+            MarkerTreeKind::List(marker) => marker
+                .children()
+                .any(|(_, tree)| tree.evaluate_extras(extras)),
             MarkerTreeKind::Extra(marker) => marker
                 .edge(extras.contains(marker.name().extra()))
                 .evaluate_extras(extras),
-            MarkerTreeKind::Extras(marker) => marker
-                .children()
-                .any(|(_, tree)| tree.evaluate_extras(extras)),
-            MarkerTreeKind::DependencyGroups(marker) => marker
-                .children()
-                .any(|(_, tree)| tree.evaluate_extras(extras)),
         }
     }
 
@@ -1430,22 +1385,17 @@ impl MarkerTree {
                         imp(tree, f);
                     }
                 }
+                MarkerTreeKind::List(kind) => {
+                    for (_, tree) in kind.children() {
+                        imp(tree, f);
+                    }
+                }
                 MarkerTreeKind::Extra(kind) => {
                     if kind.low.is_false() {
                         f(MarkerOperator::Equal, kind.name().extra());
                     } else {
                         f(MarkerOperator::NotEqual, kind.name().extra());
                     }
-                    for (_, tree) in kind.children() {
-                        imp(tree, f);
-                    }
-                }
-                MarkerTreeKind::Extras(kind) => {
-                    for (_, tree) in kind.children() {
-                        imp(tree, f);
-                    }
-                }
-                MarkerTreeKind::DependencyGroups(kind) => {
                     for (_, tree) in kind.children() {
                         imp(tree, f);
                     }
@@ -1557,6 +1507,21 @@ impl MarkerTree {
                 write!(f, "{} not in {} -> ", kind.value(), kind.key())?;
                 kind.edge(false).fmt_graph(f, level + 1)?;
             }
+            MarkerTreeKind::List(kind) => {
+                writeln!(f)?;
+                for _ in 0..level {
+                    write!(f, "  ")?;
+                }
+                write!(f, "{} in {} -> ", kind.value(), kind.key())?;
+                kind.edge(true).fmt_graph(f, level + 1)?;
+
+                writeln!(f)?;
+                for _ in 0..level {
+                    write!(f, "  ")?;
+                }
+                write!(f, "{} not in {} -> ", kind.value(), kind.key())?;
+                kind.edge(false).fmt_graph(f, level + 1)?;
+            }
             MarkerTreeKind::Extra(kind) => {
                 writeln!(f)?;
                 for _ in 0..level {
@@ -1570,36 +1535,6 @@ impl MarkerTree {
                     write!(f, "  ")?;
                 }
                 write!(f, "extra != {} -> ", kind.name())?;
-                kind.edge(false).fmt_graph(f, level + 1)?;
-            }
-            MarkerTreeKind::Extras(kind) => {
-                writeln!(f)?;
-                for _ in 0..level {
-                    write!(f, "  ")?;
-                }
-                write!(f, "{} in extras -> ", kind.name())?;
-                kind.edge(true).fmt_graph(f, level + 1)?;
-
-                writeln!(f)?;
-                for _ in 0..level {
-                    write!(f, "  ")?;
-                }
-                write!(f, "{} not in extras -> ", kind.name())?;
-                kind.edge(false).fmt_graph(f, level + 1)?;
-            }
-            MarkerTreeKind::DependencyGroups(kind) => {
-                writeln!(f)?;
-                for _ in 0..level {
-                    write!(f, "  ")?;
-                }
-                write!(f, "{} in dependency_groups -> ", kind.name())?;
-                kind.edge(true).fmt_graph(f, level + 1)?;
-
-                writeln!(f)?;
-                for _ in 0..level {
-                    write!(f, "  ")?;
-                }
-                write!(f, "{} not in dependency_groups -> ", kind.name())?;
                 kind.edge(false).fmt_graph(f, level + 1)?;
             }
         }
@@ -1671,12 +1606,10 @@ pub enum MarkerTreeKind<'a> {
     In(InMarkerTree<'a>),
     /// A string expression with the `contains` operator.
     Contains(ContainsMarkerTree<'a>),
-    /// A string expression (e.g., `extra == 'dev'`).
+    /// A `in` or `not in` expression.
+    List(ListMarkerTree<'a>),
+    /// An extra expression (e.g., `extra == 'dev'`).
     Extra(ExtraMarkerTree<'a>),
-    /// A string expression (e.g., `'dev' in extras`).
-    Extras(ExtrasMarkerTree<'a>),
-    /// A string expression (e.g., `'dev' in dependency_groups`).
-    DependencyGroups(DependencyGroupsMarkerTree<'a>),
 }
 
 /// A version marker node, such as `python_version < '3.7'`.
@@ -1851,6 +1784,59 @@ impl Ord for ContainsMarkerTree<'_> {
     }
 }
 
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ListMarkerTree<'a> {
+    // No separate canonical type, the type is already canonical.
+    pair: &'a CanonicalMarkerListPair,
+    high: NodeId,
+    low: NodeId,
+}
+
+impl ListMarkerTree<'_> {
+    /// The key-value pair for this expression
+    pub fn pair(&self) -> &CanonicalMarkerListPair {
+        self.pair
+    }
+
+    /// The key (RHS) for this expression.
+    pub fn key(&self) -> MarkerValueList {
+        self.pair.key()
+    }
+
+    /// The value (LHS) for this expression.
+    pub fn value(&self) -> String {
+        self.pair.value()
+    }
+
+    /// The edges of this node, corresponding to the boolean evaluation of the expression.
+    pub fn children(&self) -> impl Iterator<Item = (bool, MarkerTree)> {
+        [(true, MarkerTree(self.high)), (false, MarkerTree(self.low))].into_iter()
+    }
+
+    /// Returns the subtree associated with the given edge value.
+    pub fn edge(&self, value: bool) -> MarkerTree {
+        if value {
+            MarkerTree(self.high)
+        } else {
+            MarkerTree(self.low)
+        }
+    }
+}
+
+impl PartialOrd for ListMarkerTree<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ListMarkerTree<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.pair()
+            .cmp(other.pair())
+            .then_with(|| self.children().cmp(other.children()))
+    }
+}
+
 /// A node representing the existence or absence of a given extra, such as `extra == 'bar'`.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ExtraMarkerTree<'a> {
@@ -1887,93 +1873,6 @@ impl PartialOrd for ExtraMarkerTree<'_> {
 }
 
 impl Ord for ExtraMarkerTree<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.name()
-            .cmp(other.name())
-            .then_with(|| self.children().cmp(other.children()))
-    }
-}
-
-/// A node representing the existence or absence of a given extra, such as `'bar' in extras`.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct ExtrasMarkerTree<'a> {
-    name: &'a CanonicalMarkerValueExtra,
-    high: NodeId,
-    low: NodeId,
-}
-
-impl ExtrasMarkerTree<'_> {
-    /// Returns the name of the extra in this expression.
-    pub fn name(&self) -> &CanonicalMarkerValueExtra {
-        self.name
-    }
-
-    /// The edges of this node, corresponding to the boolean evaluation of the expression.
-    pub fn children(&self) -> impl Iterator<Item = (bool, MarkerTree)> {
-        [(true, MarkerTree(self.high)), (false, MarkerTree(self.low))].into_iter()
-    }
-
-    /// Returns the subtree associated with the given edge value.
-    pub fn edge(&self, value: bool) -> MarkerTree {
-        if value {
-            MarkerTree(self.high)
-        } else {
-            MarkerTree(self.low)
-        }
-    }
-}
-
-impl PartialOrd for ExtrasMarkerTree<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ExtrasMarkerTree<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.name()
-            .cmp(other.name())
-            .then_with(|| self.children().cmp(other.children()))
-    }
-}
-
-/// A node representing the existence or absence of a given dependency group, such as
-/// `'bar' in dependency_groups`.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct DependencyGroupsMarkerTree<'a> {
-    name: &'a CanonicalMarkerValueDependencyGroup,
-    high: NodeId,
-    low: NodeId,
-}
-
-impl DependencyGroupsMarkerTree<'_> {
-    /// Returns the name of the group in this expression.
-    pub fn name(&self) -> &CanonicalMarkerValueDependencyGroup {
-        self.name
-    }
-
-    /// The edges of this node, corresponding to the boolean evaluation of the expression.
-    pub fn children(&self) -> impl Iterator<Item = (bool, MarkerTree)> {
-        [(true, MarkerTree(self.high)), (false, MarkerTree(self.low))].into_iter()
-    }
-
-    /// Returns the subtree associated with the given edge value.
-    pub fn edge(&self, value: bool) -> MarkerTree {
-        if value {
-            MarkerTree(self.high)
-        } else {
-            MarkerTree(self.low)
-        }
-    }
-}
-
-impl PartialOrd for DependencyGroupsMarkerTree<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for DependencyGroupsMarkerTree<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.name()
             .cmp(other.name())
@@ -2090,7 +1989,7 @@ mod test {
             implementation_name: "",
             implementation_version: "3.7",
             os_name: "linux",
-            platform_machine: "",
+            platform_machine: "x86_64",
             platform_python_implementation: "",
             platform_release: "",
             platform_system: "",

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -62,6 +62,7 @@ impl VerbatimUrl {
     ///
     /// If no root directory is provided, relative paths are resolved against the current working
     /// directory.
+    #[cfg(feature = "non-pep508-extensions")] // PEP 508 arguably only allows absolute file URLs.
     pub fn from_url_or_path(
         input: &str,
         root_dir: Option<&Path>,

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -54,12 +54,7 @@ pub(crate) fn requires_python(tree: MarkerTree) -> Option<RequiresPythonRange> {
                     collect_python_markers(tree, markers, range);
                 }
             }
-            MarkerTreeKind::Extras(marker) => {
-                for (_, tree) in marker.children() {
-                    collect_python_markers(tree, markers, range);
-                }
-            }
-            MarkerTreeKind::DependencyGroups(marker) => {
+            MarkerTreeKind::List(marker) => {
                 for (_, tree) in marker.children() {
                     collect_python_markers(tree, markers, range);
                 }

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -698,12 +698,7 @@ impl ResolverOutput {
                         add_marker_params_from_tree(tree, set);
                     }
                 }
-                MarkerTreeKind::Extras(marker) => {
-                    for (_, tree) in marker.children() {
-                        add_marker_params_from_tree(tree, set);
-                    }
-                }
-                MarkerTreeKind::DependencyGroups(marker) => {
+                MarkerTreeKind::List(marker) => {
                     for (_, tree) in marker.children() {
                         add_marker_params_from_tree(tree, set);
                     }


### PR DESCRIPTION
We currently have two marker keys that a list, `extras` and `dependency_groups`, both from PEP 751. With the variants PEP, we will add three more. This change is broken out of the wheel variants PR to introduce generic marker list support, plus a change to use `ContainerOperator` in more places.
