### PR TITLE
Fix missed stabilization of removal of registry entry during Python uninstall

### DIFF
--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -112,13 +112,11 @@ async fn do_uninstall(
         }
         if !found {
             // Clear any remnants in the registry
-            if preview.is_enabled() {
-                #[cfg(windows)]
-                {
-                    uv_python::windows_registry::remove_orphan_registry_entries(
-                        &installed_installations,
-                    );
-                }
+            #[cfg(windows)]
+            {
+                uv_python::windows_registry::remove_orphan_registry_entries(
+                    &installed_installations,
+                );
             }
 
             if matches!(requests.as_slice(), [PythonRequest::Default]) {


### PR DESCRIPTION
Funny enough, I caught this via https://github.com/astral-sh/uv/pull/14823