### PR TITLE
Respect `--with` versions over base environment versions

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1068,8 +1068,8 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
 
             ephemeral_env.set_overlay(format!(
                 "import site; site.addsitedir(\"{}\"); site.addsitedir(\"{}\");",
-                base_site_packages.escape_for_python(),
                 requirements_site_packages.escape_for_python(),
+                base_site_packages.escape_for_python(),
             ))?;
 
             // N.B. The order here matters — earlier interpreters take precedence over the

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -1167,14 +1167,17 @@ fn run_with() -> Result<()> {
     let test_script = context.temp_dir.child("main.py");
     test_script.write_str(indoc! { r"
         import sniffio
+
+        print(sniffio.__version__)
        "
     })?;
 
     // Requesting an unsatisfied requirement should install it.
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
+    1.3.0
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -1186,24 +1189,26 @@ fn run_with() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
-    "###);
+    ");
 
     // Requesting a satisfied requirement should use the base environment.
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("sniffio").arg("main.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--with").arg("sniffio").arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
+    1.3.0
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
     Audited 2 packages in [TIME]
-    "###);
+    ");
 
     // Unless the user requests a different version.
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("sniffio<1.3.0").arg("main.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--with").arg("sniffio<1.3.0").arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
+    1.2.0
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -1212,15 +1217,16 @@ fn run_with() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + sniffio==1.2.0
-    "###);
+    ");
 
     // If we request a dependency that isn't in the base environment, we should still respect any
     // other dependencies. In this case, `sniffio==1.3.0` is not the latest-compatible version, but
     // we should use it anyway.
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("anyio").arg("main.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--with").arg("anyio").arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
+    1.3.0
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
@@ -1231,13 +1237,14 @@ fn run_with() -> Result<()> {
      + anyio==4.3.0
      + idna==3.6
      + sniffio==1.3.0
-    "###);
+    ");
 
     // Even if we run with` --no-sync`.
-    uv_snapshot!(context.filters(), context.run().arg("--with").arg("anyio==4.2.0").arg("--no-sync").arg("main.py"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--with").arg("anyio==4.2.0").arg("--no-sync").arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
+    1.3.0
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
@@ -1246,7 +1253,7 @@ fn run_with() -> Result<()> {
      + anyio==4.2.0
      + idna==3.6
      + sniffio==1.3.0
-    "###);
+    ");
 
     // If the dependencies can't be resolved, we should reference `--with`.
     uv_snapshot!(context.filters(), context.run().arg("--with").arg("add").arg("main.py"), @r###"


### PR DESCRIPTION
## Summary

This fixes a regression from https://github.com/astral-sh/uv/pull/14447 that we seemingly didn't have test coverage for. Specifically, if you have a version of a package in your project, and then install a different version with `--with`, the environment should import the `--with` version.

Closes #14860.
