### PR TITLE
Do not replace the Python dylib on macOS if `install_name_tool` fails

### DIFF
--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -2435,7 +2435,7 @@ fn python_install_patch_dylib() {
     let mut cmd = std::process::Command::new("otool");
     cmd.arg("-D").arg(dylib.as_ref());
 
-    uv_snapshot!(context.filters(), cmd, @r###"
+    uv_snapshot!(context.filters(), cmd, @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2443,7 +2443,7 @@ fn python_install_patch_dylib() {
     [TEMP_DIR]/managed/cpython-3.13.1-[PLATFORM]/lib/libpython3.13.dylib
 
     ----- stderr -----
-    "###);
+    ");
 }
 
 #[test]


### PR DESCRIPTION
Attempts to workaround #14843