### PR TITLE
Remove prioritized dist duplication

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -91,13 +91,21 @@ impl CompatibleDist<'_> {
         }
     }
 
+    // For installable distributions, return the prioritized distribution it was derived from.
+    pub fn prioritized(&self) -> Option<&PrioritizedDist> {
+        match self {
+            CompatibleDist::InstalledDist(_) => None,
+            CompatibleDist::SourceDist { prioritized, .. }
+            | CompatibleDist::CompatibleWheel { prioritized, .. }
+            | CompatibleDist::IncompatibleWheel { prioritized, .. } => Some(prioritized),
+        }
+    }
+
     /// Return the set of supported platform the distribution, in terms of their markers.
     pub fn implied_markers(&self) -> MarkerTree {
-        match self {
-            CompatibleDist::InstalledDist(_) => MarkerTree::TRUE,
-            CompatibleDist::SourceDist { prioritized, .. } => prioritized.0.markers,
-            CompatibleDist::CompatibleWheel { prioritized, .. } => prioritized.0.markers,
-            CompatibleDist::IncompatibleWheel { prioritized, .. } => prioritized.0.markers,
+        match self.prioritized() {
+            Some(prioritized) => prioritized.0.markers,
+            None => MarkerTree::TRUE,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1271,7 +1271,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
         let dist = match candidate.dist() {
             CandidateDist::Compatible(dist) => dist,
-            CandidateDist::Incompatible(incompatibility) => {
+            CandidateDist::Incompatible {
+                incompatible_dist: incompatibility,
+                prioritized_dist: _,
+            } => {
                 // If the version is incompatible because no distributions are compatible, exit early.
                 return Ok(Some(ResolverVersion::Unavailable(
                     candidate.version().clone(),


### PR DESCRIPTION
`Candidate` has an optional field `prioritized`, which was mostly redundant with `CandidateDist`. Specifically, it was only `None`, if `CandidateDist` was `Installed`. This commit removes this duplication.
