### PR TITLE
Use 'get -o' in nushell activate script

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate.nu
+++ b/crates/uv-virtualenv/src/activator/activate.nu
@@ -46,7 +46,7 @@ export-env {
         if ($parsed | describe) == 'bool' {
           $parsed
         } else {
-          not ($env | get -i $name | is-empty)
+          not ($env | get -o $name | is-empty)
         }
       } else {
         false


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix [activate.nu is incompatible with nushell 0.106.0 · Issue #14888 · astral-sh/uv](https://github.com/astral-sh/uv/issues/14888)
