### PR TITLE
Add --editable flag to `uv build`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2505,6 +2505,10 @@ pub struct BuildArgs {
     #[arg(long)]
     pub wheel: bool,
 
+    /// Build an editable ("wheel") from the given directory.
+    #[arg(long)]
+    pub editable: bool,
+
     /// When using the uv build backend, list the files that would be included when building.
     ///
     /// Skips building the actual distribution, except when the source distribution is needed to

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -963,6 +963,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.out_dir,
                 args.sdist,
                 args.wheel,
+                args.editable,
                 args.list,
                 args.build_logs,
                 args.force_pep517,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2562,6 +2562,7 @@ pub(crate) struct BuildSettings {
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) sdist: bool,
     pub(crate) wheel: bool,
+    pub(crate) editable: bool,
     pub(crate) list: bool,
     pub(crate) build_logs: bool,
     pub(crate) force_pep517: bool,
@@ -2583,6 +2584,7 @@ impl BuildSettings {
             all_packages,
             sdist,
             wheel,
+            editable,
             list,
             force_pep517,
             build_constraints,
@@ -2610,6 +2612,7 @@ impl BuildSettings {
             out_dir,
             sdist,
             wheel,
+            editable,
             list,
             build_logs: flag(build_logs, no_build_logs, "build-logs").unwrap_or(true),
             build_constraints: build_constraints

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4875,6 +4875,7 @@ uv build [OPTIONS] [SRC]
 <p>May also be set with the <code>UV_DEFAULT_INDEX</code> environment variable.</p></dd><dt id="uv-build--directory"><a href="#uv-build--directory"><code>--directory</code></a> <i>directory</i></dt><dd><p>Change to the given directory prior to running the command.</p>
 <p>Relative paths are resolved with the given directory as the base.</p>
 <p>See <code>--project</code> to only change the project root directory.</p>
+</dd><dt id="uv-build--editable"><a href="#uv-build--editable"><code>--editable</code></a></dt><dd><p>Build an editable (&quot;wheel&quot;) from the given directory</p>
 </dd><dt id="uv-build--exclude-newer"><a href="#uv-build--exclude-newer"><code>--exclude-newer</code></a> <i>exclude-newer</i></dt><dd><p>Limit candidate packages to those that were uploaded prior to the given date.</p>
 <p>Accepts both RFC 3339 timestamps (e.g., <code>2006-12-02T02:07:43Z</code>) and local dates in the same format (e.g., <code>2006-12-02</code>) in your system's configured time zone.</p>
 <p>May also be set with the <code>UV_EXCLUDE_NEWER</code> environment variable.</p></dd><dt id="uv-build--extra-index-url"><a href="#uv-build--extra-index-url"><code>--extra-index-url</code></a> <i>extra-index-url</i></dt><dd><p>(Deprecated: use <code>--index</code> instead) Extra URLs of package indexes to use, in addition to <code>--index-url</code>.</p>


### PR DESCRIPTION
## Summary

- Force recompilation of packages installed in editable mode

It can often be useful to force building of packages with native extensions, for example when working on a package with dynamic recompilation managed by import hooks, such as `meson-python` where the underlying build system has it's own build caches that may not always work properly and needs some kicking.

Setuptools used to support `python setup.py build_ext -i` to accomplish this, but in the PEP-517/PEP-660 worlds we don't have an equivalent CLI.

- Use in low level packaging tooling

When building packages with Nix the build process is running inside a sandbox with no file system access and no internet access. This is great for security and reproducibility, but it breaks assumptions in the Python ecosystem:

  - Baking of absolute paths

    Python build systems often (always?) bake in absolute paths pointing to the source directory. where build systems will bake in the absolute path to the build directory.

    This patching is currently handled by a [Python script](https://github.com/pyproject-nix/pyproject.nix/blob/d8355c7/build/hooks/editable_hook/editable_hook/patch_editable.py).

    Note: Script absolute paths are not relevant to this PR, I'm just bringing it up to explain the overall build process of an editable within a Nix context.

  - We want to install the wheel into a custom prefix (the Nix store)

    Within Nix we build each Python package in isolation and install them into their own Nix store prefixes (a requirement for per-package incremental builds). For example the `requests` package in one of my projects is installed into `/nix/store/xhd2c62gj3b5ikwbpsp5kzyb88jc56g5-requests-2.32.3`. This directory contains _only_ the installed files from requests, and not their dependencies.

    In the case of editable packages that means we have to produce a wheel to be able to run `uv pip install --prefix /nix/store/...` on it. Building a wheel is currently handled by a small/janky [Python script](https://github.com/pyproject-nix/pyproject.nix/blob/3db43c7/build/hooks/editable_hook/editable_hook/build_editable.py).

  - Build system side effects

    Some build systems, notably `cython` & `meson-python`, uses [`build_editable`](https://peps.python.org/pep-0660/#build-editable) side effects to place build results in-place into the source tree. Since the editable wheel was built inside the Nix sandbox with a temporary build directory those side effects are discarded.

    This means that we need a mechanism to trigger an editable build, similarly to the "force recompilation" use case outlined above.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Automated test included.
Also extended the `build_wheel` test to ensure that it outputs a regular non-editable wheel.
