### PR TITLE
 Better warning chain styling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5113,6 +5113,7 @@ dependencies = [
  "uv-python",
  "uv-settings",
  "uv-static",
+ "uv-warnings",
  "uv-workspace",
  "walkdir",
 ]

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -31,6 +31,7 @@ uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-settings = { workspace = true, features = ["schemars"] }
 uv-static = { workspace = true }
+uv-warnings = { workspace = true }
 uv-workspace = { workspace = true, features = ["schemars"] }
 
 # Any dependencies that are exclusively used in `uv-dev` should be listed as non-workspace

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -1,11 +1,10 @@
 use std::fmt::Write;
-use std::iter;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use console::Term;
-use owo_colors::OwoColorize;
+use owo_colors::{AnsiColors, OwoColorize};
 use tokio::sync::Semaphore;
 use tracing::{debug, info};
 use uv_auth::Credentials;
@@ -17,7 +16,7 @@ use uv_publish::{
     CheckUrlClient, TrustedPublishResult, check_trusted_publishing, files_for_publishing, upload,
 };
 use uv_redacted::DisplaySafeUrl;
-use uv_warnings::warn_user_once;
+use uv_warnings::{warn_user_once, write_error_chain};
 
 use crate::commands::reporters::PublishReporter;
 use crate::commands::{ExitStatus, human_readable_bytes};
@@ -274,19 +273,15 @@ async fn gather_credentials(
                 fetching the trusted publishing token. If you don't want to use trusted \
                 publishing, you can ignore this error, but you need to provide credentials."
             )?;
-            writeln!(
+
+            write_error_chain(
+                anyhow::Error::from(err)
+                    .context("Trusted publishing error")
+                    .as_ref(),
                 printer.stderr(),
-                "{}: {err}",
-                "Trusted publishing error".red().bold()
+                "error",
+                AnsiColors::Red,
             )?;
-            for source in iter::successors(std::error::Error::source(&err), |&err| err.source()) {
-                writeln!(
-                    printer.stderr(),
-                    "  {}: {}",
-                    "Caused by".red().bold(),
-                    source.to_string().trim()
-                )?;
-            }
         }
     }
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use indexmap::IndexSet;
 use itertools::{Either, Itertools};
-use owo_colors::OwoColorize;
+use owo_colors::{AnsiColors, OwoColorize};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
@@ -30,7 +30,7 @@ use uv_python::{
 };
 use uv_shell::Shell;
 use uv_trampoline_builder::{Launcher, LauncherKind};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, write_error_chain};
 
 use crate::commands::python::{ChangeEvent, ChangeEventKind};
 use crate::commands::reporters::PythonDownloadReporter;
@@ -139,7 +139,7 @@ impl Changelog {
 enum InstallErrorKind {
     DownloadUnpack,
     Bin,
-    #[cfg(windows)]
+    #[cfg_attr(not(windows), allow(dead_code))]
     Registry,
 }
 
@@ -667,7 +667,6 @@ pub(crate) async fn install(
         // to warn
         let fatal = !errors.iter().all(|(kind, _, _)| match kind {
             InstallErrorKind::Bin => bin.is_none(),
-            #[cfg(windows)]
             InstallErrorKind::Registry => registry.is_none(),
             InstallErrorKind::DownloadUnpack => false,
         });
@@ -676,40 +675,45 @@ pub(crate) async fn install(
             .into_iter()
             .sorted_unstable_by(|(_, key_a, _), (_, key_b, _)| key_a.cmp(key_b))
         {
-            let (level, verb) = match kind {
-                InstallErrorKind::DownloadUnpack => ("error".red().bold().to_string(), "install"),
+            match kind {
+                InstallErrorKind::DownloadUnpack => {
+                    write_error_chain(
+                        err.context(format!("Failed to install {key}")).as_ref(),
+                        printer.stderr(),
+                        "error",
+                        AnsiColors::Red,
+                    )?;
+                }
                 InstallErrorKind::Bin => {
-                    let level = match bin {
-                        None => "warning".yellow().bold().to_string(),
+                    let (level, color) = match bin {
+                        None => ("warning", AnsiColors::Yellow),
                         Some(false) => continue,
-                        Some(true) => "error".red().bold().to_string(),
+                        Some(true) => ("error", AnsiColors::Red),
                     };
-                    (level, "install executable for")
-                }
-                #[cfg(windows)]
-                InstallErrorKind::Registry => {
-                    let level = match registry {
-                        None => "warning".yellow().bold().to_string(),
-                        Some(false) => continue,
-                        Some(true) => "error".red().bold().to_string(),
-                    };
-                    (level, "install registry entry for")
-                }
-            };
 
-            writeln!(
-                printer.stderr(),
-                "{level}{} Failed to {verb} {}",
-                ":".bold(),
-                key.green()
-            )?;
-            for err in err.chain() {
-                writeln!(
-                    printer.stderr(),
-                    "  {}: {}",
-                    "Caused by".red().bold(),
-                    err.to_string().trim()
-                )?;
+                    write_error_chain(
+                        err.context(format!("Failed to install executable for {key}"))
+                            .as_ref(),
+                        printer.stderr(),
+                        level,
+                        color,
+                    )?;
+                }
+                InstallErrorKind::Registry => {
+                    let (level, color) = match registry {
+                        None => ("warning", AnsiColors::Yellow),
+                        Some(false) => continue,
+                        Some(true) => ("error", AnsiColors::Red),
+                    };
+
+                    write_error_chain(
+                        err.context(format!("Failed to create registry entry for {key}"))
+                            .as_ref(),
+                        printer.stderr(),
+                        level,
+                        color,
+                    )?;
+                }
             }
         }
 


### PR DESCRIPTION
Improve the styling of warning chains for Python installation errors. Apply the same logic to other internal warning and error formatting locations.

**Before**

<img width="1232" height="364" alt="Screenshot from 2025-07-28 10-06-41" src="https://github.com/user-attachments/assets/e3befe14-ad4c-44ed-8b0a-57d9c9a3b815" />

**After**

<img width="1232" height="364" alt="Screenshot from 2025-07-28 10-23-49" src="https://github.com/user-attachments/assets/1bd890c1-5dbb-4662-93bd-14430c060a69" />
