### PR TITLE
Move all retry tests to `network.rs`

### DIFF
--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -522,66 +522,6 @@ fn install_package() {
     context.assert_command("import flask").success();
 }
 
-#[tokio::test]
-async fn install_http_retries() {
-    let context = TestContext::new("3.12");
-
-    let server = MockServer::start().await;
-
-    // Create a server that always fails, so we can see the number of retries used
-    Mock::given(method("GET"))
-        .respond_with(ResponseTemplate::new(503))
-        .mount(&server)
-        .await;
-
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("anyio")
-        .arg("--index")
-        .arg(server.uri())
-        .env(EnvVars::UV_HTTP_RETRIES, "foo"), @r"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Failed to parse `UV_HTTP_RETRIES`
-      Caused by: invalid digit found in string
-    "
-    );
-
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("anyio")
-        .arg("--index")
-        .arg(server.uri())
-        .env(EnvVars::UV_HTTP_RETRIES, "999999999999"), @r"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Failed to parse `UV_HTTP_RETRIES`
-      Caused by: number too large to fit in target type
-    "
-    );
-
-    uv_snapshot!(context.filters(), context.pip_install()
-        .arg("anyio")
-        .arg("--index")
-        .arg(server.uri())
-        .env(EnvVars::UV_HTTP_RETRIES, "5")
-        .env(EnvVars::UV_TEST_NO_HTTP_RETRY_DELAY, "true"), @r"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Request failed after 5 retries
-      Caused by: Failed to fetch: `http://[LOCALHOST]/anyio/`
-      Caused by: HTTP status server error (503 Service Unavailable) for url (http://[LOCALHOST]/anyio/)
-    "
-    );
-}
-
 /// Install a package from a `requirements.txt` into a virtual environment.
 #[test]
 fn install_requirements_txt() -> Result<()> {
@@ -11842,7 +11782,7 @@ fn strip_shebang_arguments() -> Result<()> {
 
         [tool.setuptools]
         packages = ["shebang_test"]
-        
+
         [tool.setuptools.data-files]
         "scripts" = ["scripts/custom_script", "scripts/custom_gui_script"]
     "#})?;


### PR DESCRIPTION
Retry behavior isn't tied to a specific installation method, but underlies all of them.