### PR TITLE
Allow templating the `UV_PROJECT_ENVIRONMENT` path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,6 +6074,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-pypi-types",
+ "uv-python",
  "uv-redacted",
  "uv-static",
  "uv-warnings",

--- a/crates/uv-configuration/src/preview.rs
+++ b/crates/uv-configuration/src/preview.rs
@@ -14,6 +14,7 @@ bitflags::bitflags! {
         const JSON_OUTPUT = 1 << 2;
         const PYLOCK = 1 << 3;
         const ADD_BOUNDS = 1 << 4;
+        const TEMPLATE_PROJECT_ENVIRONMENT = 1 << 5;
     }
 }
 

--- a/crates/uv-configuration/src/preview.rs
+++ b/crates/uv-configuration/src/preview.rs
@@ -29,7 +29,15 @@ impl PreviewFeatures {
             Self::JSON_OUTPUT => "json-output",
             Self::PYLOCK => "pylock",
             Self::ADD_BOUNDS => "add-bounds",
-            _ => panic!("`flag_as_str` can only be used for exactly one feature flag"),
+            Self::TEMPLATE_PROJECT_ENVIRONMENT => "template-project-environment",
+            _ => {
+                let split: Vec<PreviewFeatures> = self.iter().collect();
+                if split.len() > 1 {
+                    panic!("`flag_as_str` can only be used for exactly one feature flag");
+                } else {
+                    panic!("Unhandled preview feature flag in `flag_as_str`: {self:?}");
+                }
+            }
         }
     }
 }
@@ -71,6 +79,7 @@ impl FromStr for PreviewFeatures {
                 "json-output" => Self::JSON_OUTPUT,
                 "pylock" => Self::PYLOCK,
                 "add-bounds" => Self::ADD_BOUNDS,
+                "template-project-environment" => Self::TEMPLATE_PROJECT_ENVIRONMENT,
                 _ => {
                     warn_user_once!("Unknown preview feature: `{part}`");
                     continue;
@@ -233,6 +242,10 @@ mod tests {
         assert_eq!(PreviewFeatures::JSON_OUTPUT.flag_as_str(), "json-output");
         assert_eq!(PreviewFeatures::PYLOCK.flag_as_str(), "pylock");
         assert_eq!(PreviewFeatures::ADD_BOUNDS.flag_as_str(), "add-bounds");
+        assert_eq!(
+            PreviewFeatures::TEMPLATE_PROJECT_ENVIRONMENT.flag_as_str(),
+            "template-project-environment"
+        );
     }
 
     #[test]

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -28,6 +28,7 @@ uv-options-metadata = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
+uv-python = { workspace = true }
 uv-redacted = { workspace = true }
 uv-static = { workspace = true }
 uv-warnings = { workspace = true }

--- a/crates/uv-workspace/src/lib.rs
+++ b/crates/uv-workspace/src/lib.rs
@@ -1,6 +1,7 @@
 pub use workspace::{
-    DiscoveryOptions, MemberDiscovery, ProjectWorkspace, RequiresPythonSources, VirtualProject,
-    Workspace, WorkspaceCache, WorkspaceError, WorkspaceMember,
+    CustomProjectEnvironmentPath, DiscoveryOptions, MemberDiscovery, ProjectWorkspace,
+    RequiresPythonSources, VirtualProject, Workspace, WorkspaceCache, WorkspaceError,
+    WorkspaceMember,
 };
 
 pub mod dependency_groups;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -904,7 +904,7 @@ impl ProjectInterpreter {
         .await?;
 
         // Read from the virtual environment first.
-        let root = workspace.venv(active);
+        let root = workspace.venv(active, preview);
         match PythonEnvironment::from_root(&root, cache) {
             Ok(venv) => {
                 match environment_is_usable(
@@ -1307,7 +1307,7 @@ impl ProjectEnvironment {
 
             // Otherwise, create a virtual environment with the discovered interpreter.
             ProjectInterpreter::Interpreter(interpreter) => {
-                let root = workspace.venv(active);
+                let root = workspace.venv(active, preview);
 
                 // Avoid removing things that are not virtual environments
                 let replace = match (root.try_exists(), root.join("pyvenv.cfg").try_exists()) {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -119,7 +119,7 @@ pub(crate) async fn venv(
                 // This isn't strictly necessary and we may want to change it later, but this
                 // avoids a breaking change when adding project environment support to `uv venv`.
                 (project.workspace().install_path() == project_dir)
-                    .then(|| project.workspace().venv(Some(false)))
+                    .then(|| project.workspace().venv(Some(false), preview))
             })
             .unwrap_or(PathBuf::from(".venv")),
     );

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -7320,7 +7320,7 @@ fn preview_features() {
         show_settings: true,
         preview: Preview {
             flags: PreviewFeatures(
-                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS,
+                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | TEMPLATE_PROJECT_ENVIRONMENT,
             ),
         },
         python_preference: Managed,
@@ -7524,7 +7524,7 @@ fn preview_features() {
         show_settings: true,
         preview: Preview {
             flags: PreviewFeatures(
-                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS,
+                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | TEMPLATE_PROJECT_ENVIRONMENT,
             ),
         },
         python_preference: Managed,


### PR DESCRIPTION
I'm looking at supporting centralized environments, and this feels like a nice incremental step towards that. Basically we can re-use `UV_PROJECT_ENVIRONMENT` to empower centralized storage without adding any more settings. Later, we'd add a toggle that enables centralized storage in the cache using our "canonical" recommended naming scheme. At that point, we'd probably explore things like empowering editor discovery via `.venv` pointers and such.

The "canonical" usage would be something like:

```
UV_PROJECT_ENVIRONMENT=$HOME/.local/share/uv/envs/{project_name}-{python_implementation}{python_version_minor}-{project_path_hash}
```

Unfortunately, templating the Python version (which is a common request) is a little annoying because we determine the path to the environment _before_ discovering a Python interpreter, but I got it working.

The only thing that's missing here is documentation, which I can add if there's consensus this is a good path forward.