### PR TITLE
Copy entrypoints that have a shebang that differs in `python` vs `python3`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1803,8 +1803,15 @@ fn copy_entrypoint(
 ' '''
 "#,
         )
-        // Or an absolute path shebang
+        // Or, an absolute path shebang
         .or_else(|| contents.strip_prefix(&format!("#!{}\n", previous_executable.display())))
+        // If the previous executable ends with `python3`, check for a shebang with `python` too
+        .or_else(|| {
+            previous_executable
+                .to_str()
+                .and_then(|path| path.strip_suffix("3"))
+                .and_then(|path| contents.strip_prefix(&format!("#!{path}\n")))
+        })
     else {
         // If it's not a Python shebang, we'll skip it
         trace!(


### PR DESCRIPTION
In https://github.com/astral-sh/uv/issues/14919 it was reported that uv's behavior differed after the first invocation. I noticed we weren't copying entrypoints after the first invocation. It turns out the shebangs were written with `.../python` but on a subsequent invocation the `sys.executable` was `.../python3` so we didn't detect these as matching.

This is a pretty naive fix, but it seems much easier than ensuring the entry point path exactly matches the subsequent `sys.executable` we find.

I guess we should fix this in reverse too? but I think we might always prefer `python3` when loading interpreters from environments.

See #14790 for more background.