### PR TITLE
Skip`cargo dev generate-all` test case in CI

### DIFF
--- a/crates/uv-dev/src/generate_options_reference.rs
+++ b/crates/uv-dev/src/generate_options_reference.rs
@@ -387,3 +387,31 @@ impl Visit for CollectOptionsVisitor {
         self.fields.push((name.to_owned(), field));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use anyhow::Result;
+
+    use uv_static::EnvVars;
+
+    use crate::generate_all::Mode;
+
+    use super::{Args, main};
+
+    #[test]
+    fn test_generate_options_reference() -> Result<()> {
+        // Skip this test in CI to avoid redundancy with the dedicated CI job
+        if env::var_os(EnvVars::CI).is_some() {
+            return Ok(());
+        }
+
+        let mode = if env::var(EnvVars::UV_UPDATE_SCHEMA).as_deref() == Ok("1") {
+            Mode::Write
+        } else {
+            Mode::Check
+        };
+        main(&Args { mode })
+    }
+}

--- a/crates/uv-dev/src/generate_options_reference.rs
+++ b/crates/uv-dev/src/generate_options_reference.rs
@@ -387,26 +387,3 @@ impl Visit for CollectOptionsVisitor {
         self.fields.push((name.to_owned(), field));
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use std::env;
-
-    use anyhow::Result;
-
-    use uv_static::EnvVars;
-
-    use crate::generate_all::Mode;
-
-    use super::{Args, main};
-
-    #[test]
-    fn test_generate_options_reference() -> Result<()> {
-        let mode = if env::var(EnvVars::UV_UPDATE_SCHEMA).as_deref() == Ok("1") {
-            Mode::Write
-        } else {
-            Mode::Check
-        };
-        main(&Args { mode })
-    }
-}


### PR DESCRIPTION
This means that CI tests fail in a way that is redundant with the dedicated CI job which can obscure signal on whether actual tests are failing

e.g., https://github.com/astral-sh/uv/actions/runs/16623645930/job/47034116533