### PR TITLE
Use a unified variant cache across resolver and installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5213,6 +5213,7 @@ dependencies = [
  "uv-git-types",
  "uv-metadata",
  "uv-normalize",
+ "uv-once-map",
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6080,6 +6080,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "uv-once-map",
  "uv-pep508",
  "uv-pypi-types",
 ]

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -711,7 +711,6 @@ impl RegistryClient {
                 .map_err(|err| ErrorKind::VariantsJsonFormat(url, err))?
         } else {
             let cache_entry = self.cache.entry(
-                // TODO(konsti): Get our own bucket?
                 CacheBucket::Wheels,
                 WheelCache::Index(&variants_json.index)
                     .wheel_dir(variants_json.filename.name.as_ref()),

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -40,6 +40,7 @@ use uv_types::{
     HashStrategy, InFlight,
 };
 use uv_variant_frontend::VariantBuild;
+use uv_variants::cache::VariantProviderCache;
 use uv_variants::variants_json::Provider;
 use uv_workspace::WorkspaceCache;
 
@@ -184,6 +185,10 @@ impl BuildContext for BuildDispatch<'_> {
 
     fn git(&self) -> &GitResolver {
         &self.shared_state.git
+    }
+
+    fn variants(&self) -> &VariantProviderCache {
+        self.shared_state.index.variant_providers()
     }
 
     fn build_arena(&self) -> &BuildArena<SourceBuild> {

--- a/crates/uv-distribution-types/src/id.rs
+++ b/crates/uv-distribution-types/src/id.rs
@@ -2,12 +2,12 @@ use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
 use uv_cache_key::{CanonicalUrl, RepositoryUrl};
-
-use crate::IndexUrl;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pypi_types::HashDigest;
 use uv_redacted::DisplaySafeUrl;
+
+use crate::IndexUrl;
 
 /// A unique identifier for a package. A package can either be identified by a name (e.g., `black`)
 /// or a URL (e.g., `git+https://github.com/psf/black`).

--- a/crates/uv-distribution-types/src/id.rs
+++ b/crates/uv-distribution-types/src/id.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use uv_cache_key::{CanonicalUrl, RepositoryUrl};
 
+use crate::IndexUrl;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_pypi_types::HashDigest;
@@ -66,6 +67,25 @@ impl Display for VersionId {
             Self::NameVersion(name, version) => write!(f, "{name}-{version}"),
             Self::Url(url) => write!(f, "{url}"),
         }
+    }
+}
+
+/// A unique identifier for a package version at a specific index (e.g., `black==23.10.0 @ https://pypi.org/simple`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GlobalVersionId {
+    version: VersionId,
+    index: IndexUrl,
+}
+
+impl GlobalVersionId {
+    pub fn new(version: VersionId, index: IndexUrl) -> Self {
+        Self { version, index }
+    }
+}
+
+impl Display for GlobalVersionId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} @ {}", self.version, self.index)
     }
 }
 

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -1481,6 +1481,16 @@ pub struct RegistryVariantsJson {
     pub index: IndexUrl,
 }
 
+impl RegistryVariantsJson {
+    /// Return the [`GlobalVersionId`] for this registry variants JSON.
+    pub fn version_id(&self) -> GlobalVersionId {
+        GlobalVersionId::new(
+            VersionId::NameVersion(self.filename.name.clone(), self.filename.version.clone()),
+            self.index.clone(),
+        )
+    }
+}
+
 impl Identifier for RegistryVariantsJson {
     fn distribution_id(&self) -> DistributionId {
         self.file.distribution_id()

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -29,6 +29,7 @@ uv-git = { workspace = true }
 uv-git-types = { workspace = true }
 uv-metadata = { workspace = true }
 uv-normalize = { workspace = true }
+uv-once-map = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -74,6 +74,10 @@ pub enum Error {
         filename: Version,
         metadata: Version,
     },
+    #[error(
+        "Package {name} has no matching wheel for the current platform, but has the following variants: {variants}"
+    )]
+    WheelVariantMismatch { name: PackageName, variants: String },
     #[error("Failed to parse metadata from built wheel")]
     Metadata(#[from] uv_pypi_types::MetadataError),
     #[error("Failed to read metadata: `{}`", _0.user_display())]

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -8,7 +8,7 @@ pub use metadata::{
 };
 pub use reporter::Reporter;
 pub use source::prune;
-pub use variants::{VariantProviderCache, resolve_variants};
+pub use variants::{PackageVariantCache, resolve_variants};
 
 mod archive;
 mod distribution_database;

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -1,7 +1,4 @@
-pub use distribution_database::{
-    DistributionDatabase, HttpArchivePointer, LocalArchivePointer, VariantProviderCache,
-    resolve_variants,
-};
+pub use distribution_database::{DistributionDatabase, HttpArchivePointer, LocalArchivePointer};
 pub use download::LocalWheel;
 pub use error::Error;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
@@ -11,6 +8,7 @@ pub use metadata::{
 };
 pub use reporter::Reporter;
 pub use source::prune;
+pub use variants::{VariantProviderCache, resolve_variants};
 
 mod archive;
 mod distribution_database;
@@ -20,3 +18,4 @@ mod index;
 mod metadata;
 mod reporter;
 mod source;
+mod variants;

--- a/crates/uv-distribution/src/variants.rs
+++ b/crates/uv-distribution/src/variants.rs
@@ -1,0 +1,198 @@
+use std::hash::BuildHasherDefault;
+use std::sync::Arc;
+
+use futures::{StreamExt, TryStreamExt};
+use itertools::Itertools;
+use owo_colors::OwoColorize;
+use rustc_hash::{FxHashMap, FxHasher};
+use tracing::{debug, trace};
+
+use uv_distribution_types::{
+    BuiltDist, Dist, DistributionId, GlobalVersionId, Identifier, Name, Node, RegistryBuiltDist,
+    RegistryVariantsJson, Resolution, ResolvedDist,
+};
+use uv_once_map::OnceMap;
+use uv_types::BuildContext;
+use uv_variants::resolved_variants::ResolvedVariants;
+use uv_variants::score_variant;
+
+use crate::{DistributionDatabase, Error};
+
+type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// A cache for variants.
+// TODO(konsti): Cache by provider provider plugin and `requires` compatibility
+// TODO(konsti): Cache to disk
+#[derive(Default)]
+pub struct VariantProviderCache(FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>);
+
+impl std::ops::Deref for VariantProviderCache {
+    type Target = FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Resolve all variants for the given resolution.
+pub async fn resolve_variants<Context: BuildContext>(
+    resolution: Resolution,
+    distribution_database: DistributionDatabase<'_, Context>,
+    cache: &VariantProviderCache,
+) -> Result<Resolution, Error> {
+    // Fetch variants.json and then query providers, running in parallel for all distributions.
+    let dist_resolved_variants: FxHashMap<GlobalVersionId, Arc<ResolvedVariants>> =
+        futures::stream::iter(
+            resolution
+                .graph()
+                .node_weights()
+                .filter_map(|node| extract_variants(node)),
+        )
+        .map(async |(variants_json, ..)| {
+            let id = variants_json.version_id();
+
+            let resolved_variants = if cache.register(id.clone()) {
+                let resolved_variants = distribution_database
+                    .fetch_and_query_variants(variants_json)
+                    .await?;
+
+                let resolved_variants = Arc::new(resolved_variants);
+                cache.done(id.clone(), resolved_variants.clone());
+                resolved_variants
+            } else {
+                cache
+                    .wait(&id)
+                    .await
+                    .expect("missing value for registered task")
+            };
+
+            Ok::<_, Error>((id, resolved_variants))
+        })
+        // TODO(konsti): Buffer size
+        .buffered(8)
+        .try_collect()
+        .await?;
+
+    // Determine modification to the resolutions to select variant wheels, or error if there
+    // is no matching variant wheel and no matching non-variant wheel.
+    let mut new_best_wheel_index: FxHashMap<DistributionId, usize> = FxHashMap::default();
+    for node in resolution.graph().node_weights() {
+        let Some((json, dist)) = extract_variants(node) else {
+            continue;
+        };
+        let resolved_variants = &dist_resolved_variants[&json.version_id()];
+
+        // Select best wheel
+        let mut highest_priority_variant_wheel: Option<(usize, Vec<usize>)> = None;
+        for (wheel_index, wheel) in dist.wheels.iter().enumerate() {
+            let Some(variant) = wheel.filename.variant() else {
+                // The non-variant wheel is already supported
+                continue;
+            };
+
+            let Some(variants_properties) = resolved_variants.variants_json.variants.get(variant)
+            else {
+                // TODO(konsti): For production, this should be a warning.
+                panic!("Variant {variant} not found in variants.json");
+            };
+
+            let Some(scores) = score_variant(
+                &resolved_variants.variants_json.default_priorities,
+                &resolved_variants.target_variants,
+                variants_properties,
+            ) else {
+                // The wheel is not compatible.
+                continue;
+            };
+
+            if let Some((_, old_scores)) = &highest_priority_variant_wheel {
+                if &scores > old_scores {
+                    highest_priority_variant_wheel = Some((wheel_index, scores));
+                }
+            } else {
+                highest_priority_variant_wheel = Some((wheel_index, scores));
+            }
+        }
+
+        // Determine if we need to modify the resolution
+        if let Some((wheel_index, _scores)) = highest_priority_variant_wheel {
+            debug!(
+                "{} for {}: {}",
+                "Using variant wheel".red(),
+                dist.name(),
+                dist.wheels[wheel_index].filename,
+            );
+            new_best_wheel_index.insert(dist.distribution_id(), wheel_index);
+        } else if dist.best_wheel().filename.variant().is_some() {
+            return Err(Error::WheelVariantMismatch {
+                name: dist.name().clone(),
+                variants: dist
+                    .wheels
+                    .iter()
+                    .filter_map(|wheel| wheel.filename.variant())
+                    .join(", "),
+            });
+        } else {
+            trace!(
+                "No matching variant wheel, but matching non-variant wheel for {}",
+                dist.name()
+            );
+        }
+    }
+    let resolution = resolution.map(|dist| {
+        let ResolvedDist::Installable {
+            dist,
+            version,
+            variants_json,
+        } = dist
+        else {
+            return None;
+        };
+        let Dist::Built(BuiltDist::Registry(dist)) = &**dist else {
+            return None;
+        };
+        // Check whether there is a matching variant wheel we want to use instead of the default.
+        let best_wheel_index = new_best_wheel_index.get(&dist.distribution_id())?;
+        Some(ResolvedDist::Installable {
+            dist: Arc::new(Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                wheels: dist.wheels.clone(),
+                best_wheel_index: *best_wheel_index,
+                sdist: dist.sdist.clone(),
+            }))),
+            variants_json: variants_json.clone(),
+            version: version.clone(),
+        })
+    });
+
+    Ok(resolution)
+}
+
+fn extract_variants(node: &Node) -> Option<(&RegistryVariantsJson, &RegistryBuiltDist)> {
+    let Node::Dist { dist, .. } = node else {
+        // The root node has no variants
+        return None;
+    };
+    let ResolvedDist::Installable {
+        dist,
+        variants_json,
+        ..
+    } = dist
+    else {
+        // TODO(konsti): Installed dists? Or is that not a thing here?
+        return None;
+    };
+    let Some(variants_json) = variants_json else {
+        return None;
+    };
+    let Dist::Built(BuiltDist::Registry(dist)) = &**dist else {
+        return None;
+    };
+    if !dist
+        .wheels
+        .iter()
+        .any(|wheel| wheel.filename.variant().is_some())
+    {
+        return None;
+    }
+    Some((variants_json, dist))
+}

--- a/crates/uv-distribution/src/variants.rs
+++ b/crates/uv-distribution/src/variants.rs
@@ -20,13 +20,11 @@ use crate::{DistributionDatabase, Error};
 
 type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
 
-/// A cache for variants.
-// TODO(konsti): Cache by provider provider plugin and `requires` compatibility
-// TODO(konsti): Cache to disk
+/// An in-memory cache from package to resolved variants.
 #[derive(Default)]
-pub struct VariantProviderCache(FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>);
+pub struct PackageVariantCache(FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>);
 
-impl std::ops::Deref for VariantProviderCache {
+impl std::ops::Deref for PackageVariantCache {
     type Target = FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>;
 
     fn deref(&self) -> &Self::Target {
@@ -38,7 +36,7 @@ impl std::ops::Deref for VariantProviderCache {
 pub async fn resolve_variants<Context: BuildContext>(
     resolution: Resolution,
     distribution_database: DistributionDatabase<'_, Context>,
-    cache: &VariantProviderCache,
+    cache: &PackageVariantCache,
 ) -> Result<Resolution, Error> {
     // Fetch variants.json and then query providers, running in parallel for all distributions.
     let dist_resolved_variants: FxHashMap<GlobalVersionId, Arc<ResolvedVariants>> =

--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -11,7 +11,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use uv_configuration::ExtrasSpecificationWithDefaults;
 use uv_configuration::{BuildOptions, DependencyGroupsWithDefaults, InstallOptions};
-use uv_distribution::{DistributionDatabase, VariantProviderCache};
+use uv_distribution::{DistributionDatabase, PackageVariantCache};
 use uv_distribution_types::{Edge, Node, Resolution, ResolvedDist};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerVariantsUniversal;
@@ -48,7 +48,7 @@ pub trait Installable<'lock> {
         build_options: &BuildOptions,
         install_options: &InstallOptions,
         distribution_database: DistributionDatabase<'_, Context>,
-        variants_cache: &VariantProviderCache,
+        variants_cache: &PackageVariantCache,
     ) -> Result<Resolution, LockError> {
         let size_guess = self.lock().packages.len();
         let mut petgraph = Graph::with_capacity(size_guess, size_guess);
@@ -615,7 +615,7 @@ async fn determine_properties<Context: BuildContext>(
     package: &Package,
     workspace_root: &Path,
     distribution_database: &DistributionDatabase<'_, Context>,
-    variants_cache: &VariantProviderCache,
+    variants_cache: &PackageVariantCache,
 ) -> Result<Variant, LockError> {
     let Some(variants_json) = package.to_registry_variants_json(workspace_root)? else {
         // When selecting a non-variant wheel, all variant markers evaluate to false.

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::resolver::provider::{MetadataResponse, VersionsResponse};
 use rustc_hash::FxHasher;
-use uv_distribution_types::{IndexUrl, VersionId};
+use uv_distribution_types::{GlobalVersionId, IndexUrl, VersionId};
 use uv_normalize::PackageName;
 use uv_once_map::OnceMap;
 use uv_variants::resolved_variants::ResolvedVariants;
@@ -24,9 +24,7 @@ struct SharedInMemoryIndex {
     distributions: FxOnceMap<VersionId, Arc<MetadataResponse>>,
 
     /// The resolved variant priorities for a package version.
-    // TODO(konsti): Why is this index url separate in implicit/explicit? should the index url be
-    // an option? ask charlie about implicit vs explicit
-    variant_priorities: FxOnceMap<(VersionId, Option<IndexUrl>), Arc<ResolvedVariants>>,
+    variant_priorities: FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>,
 }
 
 pub(crate) type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
@@ -48,9 +46,7 @@ impl InMemoryIndex {
     }
 
     /// Returns a reference to the variant priorities map.
-    pub fn variant_priorities(
-        &self,
-    ) -> &FxOnceMap<(VersionId, Option<IndexUrl>), Arc<ResolvedVariants>> {
+    pub fn variant_priorities(&self) -> &FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>> {
         &self.0.variant_priorities
     }
 }

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -1,12 +1,14 @@
 use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 
-use crate::resolver::provider::{MetadataResponse, VersionsResponse};
 use rustc_hash::FxHasher;
-use uv_distribution_types::{GlobalVersionId, IndexUrl, VersionId};
+
+use uv_distribution::VariantProviderCache;
+use uv_distribution_types::{IndexUrl, VersionId};
 use uv_normalize::PackageName;
 use uv_once_map::OnceMap;
-use uv_variants::resolved_variants::ResolvedVariants;
+
+use crate::resolver::provider::{MetadataResponse, VersionsResponse};
 
 /// In-memory index of package metadata.
 #[derive(Default, Clone)]
@@ -24,7 +26,7 @@ struct SharedInMemoryIndex {
     distributions: FxOnceMap<VersionId, Arc<MetadataResponse>>,
 
     /// The resolved variant priorities for a package version.
-    variant_priorities: FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>>,
+    variant_priorities: VariantProviderCache,
 }
 
 pub(crate) type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
@@ -46,7 +48,7 @@ impl InMemoryIndex {
     }
 
     /// Returns a reference to the variant priorities map.
-    pub fn variant_priorities(&self) -> &FxOnceMap<GlobalVersionId, Arc<ResolvedVariants>> {
+    pub fn variant_priorities(&self) -> &VariantProviderCache {
         &self.0.variant_priorities
     }
 }

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 
 use rustc_hash::FxHasher;
 
-use uv_distribution::VariantProviderCache;
+use uv_distribution::PackageVariantCache;
 use uv_distribution_types::{IndexUrl, VersionId};
 use uv_normalize::PackageName;
 use uv_once_map::OnceMap;
+use uv_variants::cache::VariantProviderCache;
 
 use crate::resolver::provider::{MetadataResponse, VersionsResponse};
 
@@ -25,8 +26,11 @@ struct SharedInMemoryIndex {
     /// A map from package ID to metadata for that distribution.
     distributions: FxOnceMap<VersionId, Arc<MetadataResponse>>,
 
-    /// The resolved variant priorities for a package version.
-    variant_priorities: VariantProviderCache,
+    /// The resolved variants, indexed by provider.
+    variant_providers: VariantProviderCache,
+
+    /// The resolved variant priorities, indexed by package version.
+    variant_priorities: PackageVariantCache,
 }
 
 pub(crate) type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
@@ -47,8 +51,13 @@ impl InMemoryIndex {
         &self.0.distributions
     }
 
+    /// Returns a reference to the variant providers map.
+    pub fn variant_providers(&self) -> &VariantProviderCache {
+        &self.0.variant_providers
+    }
+
     /// Returns a reference to the variant priorities map.
-    pub fn variant_priorities(&self) -> &VariantProviderCache {
+    pub fn variant_priorities(&self) -> &PackageVariantCache {
         &self.0.variant_priorities
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2038,7 +2038,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         }
 
         // Grab the pinned distribution for the given name and version.
-        let dist = pins.get(name, version).expect("Selected dist has pin");
+        let Some(dist) = pins.get(name, version) else {
+            return Variant::default();
+        };
 
         let Some(filename) = dist.wheel_filename() else {
             // TODO(konsti): Handle installed dists too

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -19,6 +19,7 @@ use uv_git::GitResolver;
 use uv_pep508::PackageName;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_variants::VariantProviderOutput;
+use uv_variants::cache::VariantProviderCache;
 use uv_variants::variants_json::VariantPropertyType;
 use uv_workspace::WorkspaceCache;
 
@@ -73,6 +74,9 @@ pub trait BuildContext {
 
     /// Return a reference to the Git resolver.
     fn git(&self) -> &GitResolver;
+
+    /// Return a reference to the variant cache.
+    fn variants(&self) -> &VariantProviderCache;
 
     /// Return a reference to the build arena.
     fn build_arena(&self) -> &BuildArena<Self::SourceDistBuilder>;
@@ -155,6 +159,7 @@ pub trait BuildContext {
         version_id: Option<&'a str>,
     ) -> impl Future<Output = Result<Option<DistFilename>, impl IsBuildBackendError>> + 'a;
 
+    /// Set up the variants for the given provider.
     fn setup_variants<'a>(
         &'a self,
         backend_name: String,
@@ -193,7 +198,7 @@ pub trait VariantsTrait {
     fn query(
         &self,
         known_properties: &[VariantPropertyType],
-    ) -> impl Future<Output = anyhow::Result<VariantProviderOutput>>;
+    ) -> impl Future<Output = Result<VariantProviderOutput>>;
 }
 
 /// A wrapper for [`uv_installer::SitePackages`]

--- a/crates/uv-variant-frontend/src/lib.rs
+++ b/crates/uv-variant-frontend/src/lib.rs
@@ -95,13 +95,13 @@ impl VariantBuild {
             .resolve(&requirements, &BuildStack::empty())
             .await
             .map_err(|err| {
-                Error::RequirementsResolve("`variant.providers.TODO(konsti).requires`", err.into())
+                Error::RequirementsResolve("`variant.providers.requires`", err.into())
             })?;
         build_context
             .install(&resolved_requirements, &venv, &BuildStack::empty())
             .await
             .map_err(|err| {
-                Error::RequirementsInstall("`variant.providers.TODO(konsti).requires`", err.into())
+                Error::RequirementsInstall("`variant.providers.requires`", err.into())
             })?;
 
         // Figure out what the modified path should be, and remove the PATH variable from the
@@ -181,7 +181,7 @@ impl VariantBuild {
                 with open("{in_file}") as fp:
                     known_properties = json.load(fp)
 
-                # Filter to the namespace of the plugin
+                # Filter to the namespace of the plugin.
                 filtered_properties = []
                 for known_property in known_properties:
                     # We don't know the namespace ahead of time, so the frontend passes all properties.

--- a/crates/uv-variants/Cargo.toml
+++ b/crates/uv-variants/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
+uv-once-map = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
 

--- a/crates/uv-variants/src/cache.rs
+++ b/crates/uv-variants/src/cache.rs
@@ -1,0 +1,23 @@
+use std::hash::BuildHasherDefault;
+use std::sync::Arc;
+
+use rustc_hash::FxHasher;
+
+use uv_once_map::OnceMap;
+
+use crate::VariantProviderOutput;
+use crate::variants_json::Provider;
+
+type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// An in-memory cache for variant provider outputs.
+#[derive(Default)]
+pub struct VariantProviderCache(FxOnceMap<Provider, Arc<VariantProviderOutput>>);
+
+impl std::ops::Deref for VariantProviderCache {
+    type Target = FxOnceMap<Provider, Arc<VariantProviderOutput>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/uv-variants/src/lib.rs
+++ b/crates/uv-variants/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod cache;
 pub mod resolved_variants;
 pub mod variants_json;
 
 use crate::variants_json::{DefaultPriorities, Variant, VariantNamespace};
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 use rustc_hash::FxHashMap;
@@ -36,7 +38,7 @@ pub enum VariantPriority {
 /// Return a priority score for the variant (higher is better) or `None` if it isn't compatible.
 pub fn score_variant(
     default_priorities: &DefaultPriorities,
-    target_namespaces: &FxHashMap<VariantNamespace, VariantProviderOutput>,
+    target_namespaces: &FxHashMap<VariantNamespace, Arc<VariantProviderOutput>>,
     variants_properties: &Variant,
 ) -> Option<Vec<usize>> {
     for (namespace, features) in &**variants_properties {
@@ -113,6 +115,7 @@ mod tests {
         variants_json::{DefaultPriorities, Variant, VariantNamespace},
     };
     use itertools::Itertools;
+    use std::sync::Arc;
 
     use super::score_variant;
 
@@ -120,7 +123,7 @@ mod tests {
     use rustc_hash::FxHashMap;
     use serde_json::json;
 
-    fn host() -> FxHashMap<VariantNamespace, VariantProviderOutput> {
+    fn host() -> FxHashMap<VariantNamespace, Arc<VariantProviderOutput>> {
         serde_json::from_value(json!({
             "gpu": {
                 "namespace": "gpu",

--- a/crates/uv-variants/src/resolved_variants.rs
+++ b/crates/uv-variants/src/resolved_variants.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
+
 use crate::VariantProviderOutput;
 use crate::variants_json::{VariantNamespace, VariantsJsonContent};
-use rustc_hash::FxHashMap;
 
 #[derive(Debug, Clone)]
 pub struct ResolvedVariants {
     pub variants_json: VariantsJsonContent,
-    pub target_variants: FxHashMap<VariantNamespace, VariantProviderOutput>,
+    pub target_variants: FxHashMap<VariantNamespace, Arc<VariantProviderOutput>>,
 }

--- a/crates/uv-variants/src/variants_json.rs
+++ b/crates/uv-variants/src/variants_json.rs
@@ -93,7 +93,7 @@ pub struct VariantPropertyType {
 }
 
 /// Provider information
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Provider {
     /// Object reference to plugin class

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -250,6 +250,9 @@ pub(crate) enum ProjectError {
     Lowering(#[from] uv_distribution::LoweringError),
 
     #[error(transparent)]
+    Distribution(#[from] uv_distribution::Error),
+
+    #[error(transparent)]
     PyprojectMut(#[from] uv_workspace::pyproject_mut::Error),
 
     #[error(transparent)]

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -18,7 +18,7 @@ use uv_configuration::{
     Preview, PreviewFeatures, TargetTriple,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::{DistributionDatabase, VariantProviderCache, resolve_variants};
+use uv_distribution::{DistributionDatabase, resolve_variants};
 use uv_distribution_types::{
     DirectorySourceDist, Dist, Index, Requirement, Resolution, ResolvedDist, SourceDist,
 };
@@ -712,7 +712,6 @@ pub(super) async fn do_sync(
         DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads);
 
     // Read the lockfile.
-    let variants_cache = Arc::new(VariantProviderCache::default());
     let resolution = target
         .to_resolution(
             &marker_env,
@@ -722,7 +721,7 @@ pub(super) async fn do_sync(
             build_options,
             &install_options,
             distribution_database,
-            variants_cache.clone(),
+            state.index().variant_priorities(),
         )
         .await?;
 
@@ -775,7 +774,12 @@ pub(super) async fn do_sync(
     // TODO(konsti): Pass this into operations::install
     let distribution_database =
         DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads);
-    let resolution = resolve_variants(resolution, distribution_database, variants_cache).await?;
+    let resolution = resolve_variants(
+        resolution,
+        distribution_database,
+        state.index().variant_priorities(),
+    )
+    .await?;
 
     let site_packages = SitePackages::from_environment(venv)?;
 

--- a/scripts/packages/torch_user/uv.lock
+++ b/scripts/packages/torch_user/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux' and 'nvidia :: cuda_version_lower_bound :: 12.6' in variant_properties and 'nvidia :: cuda_version_lower_bound :: 12.8' not in variant_properties and 'nvidia :: cuda_version_lower_bound :: 12.9' not in variant_properties",


### PR DESCRIPTION
## Summary

Resolves a couple different TODOs around variant caching. We don't yet cache to disk, though.
