### PR TITLE
Improve visibility of copy and line separator in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -24,6 +24,7 @@
 
 [data-md-color-scheme="astral-light"] {
   --md-default-bg-color--dark: var(--black);
+  --md-default-fg-color--lightest: rgba(0, 0, 0, 0.14);
   --md-primary-fg-color: var(--galaxy);
   --md-typeset-a-color: var(--flare);
   --md-accent-fg-color: var(--cosmic);
@@ -34,6 +35,7 @@
   --md-default-fg-color: var(--white);
   --md-default-fg-color--light: var(--white);
   --md-default-fg-color--lighter: var(--white);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.5);
   --md-primary-fg-color: var(--space);
   --md-primary-bg-color: var(--white);
   --md-accent-fg-color: var(--cosmic);


### PR DESCRIPTION
## Summary

Same as https://github.com/astral-sh/ruff/pull/19630/ but for uv's documentation

## Test Plan
<img width="884" height="667" alt="Screenshot 2025-07-31 at 08 50 09" src="https://github.com/user-attachments/assets/ad3a0ad3-b791-416d-865d-a6b618bf6d11" />
