### PR TITLE
Remove retry wrapper when matching on error kind

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -176,20 +176,12 @@ impl<E: Into<Self> + std::error::Error + 'static> From<CachedClientError<E>> for
             CachedClientError::Client {
                 retries: Some(retries),
                 err,
-            } => ErrorKind::RequestWithRetries {
-                source: Box::new(err.into_kind()),
-                retries,
-            }
-            .into(),
+            } => Error::new(err.into_kind(), retries),
             CachedClientError::Client { retries: None, err } => err,
             CachedClientError::Callback {
                 retries: Some(retries),
                 err,
-            } => ErrorKind::RequestWithRetries {
-                source: Box::new(err.into().into_kind()),
-                retries,
-            }
-            .into(),
+            } => Error::new(err.into().into_kind(), retries),
             CachedClientError::Callback { retries: None, err } => err.into(),
         }
     }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -549,11 +549,11 @@ impl RegistryClient {
 
         match result {
             Ok(metadata) => Ok(SimpleMetadataSearchOutcome::Found(metadata)),
-            Err(err) => match err.into_kind() {
+            Err(err) => match err.kind() {
                 // The package could not be found in the remote index.
-                ErrorKind::WrappedReqwestError(url, err) => {
-                    let Some(status_code) = err.status() else {
-                        return Err(ErrorKind::WrappedReqwestError(url, err).into());
+                ErrorKind::WrappedReqwestError(.., reqwest_err) => {
+                    let Some(status_code) = reqwest_err.status() else {
+                        return Err(err);
                     };
                     let decision =
                         status_code_strategy.handle_status_code(status_code, index, capabilities);
@@ -562,7 +562,7 @@ impl RegistryClient {
                             status_code,
                             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
                         ) {
-                            return Err(ErrorKind::WrappedReqwestError(url, err).into());
+                            return Err(err);
                         }
                     }
                     Ok(SimpleMetadataSearchOutcome::from(decision))
@@ -574,7 +574,7 @@ impl RegistryClient {
                 // The package could not be found in the local index.
                 ErrorKind::FileNotFound(_) => Ok(SimpleMetadataSearchOutcome::NotFound),
 
-                err => Err(err.into()),
+                _ => Err(err),
             },
         }
     }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -501,7 +501,7 @@ pub async fn check_url(
     {
         Ok(response) => response,
         Err(err) => {
-            return match err.into_kind() {
+            return match err.kind() {
                 uv_client::ErrorKind::PackageNotFound(_) => {
                     // The package doesn't exist, so we can't have uploaded it.
                     warn!(
@@ -509,7 +509,7 @@ pub async fn check_url(
                     );
                     Ok(false)
                 }
-                kind => Err(PublishError::CheckUrlIndex(kind.into())),
+                _ => Err(PublishError::CheckUrlIndex(err)),
             };
         }
     };

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -199,7 +199,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                     })
                     .collect(),
             )),
-            Err(err) => match err.into_kind() {
+            Err(err) => match err.kind() {
                 uv_client::ErrorKind::PackageNotFound(_) => {
                     if let Some(flat_index) = flat_index
                         .and_then(|flat_index| flat_index.get(package_name))
@@ -232,7 +232,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                         Ok(VersionsResponse::Offline)
                     }
                 }
-                kind => Err(kind.into()),
+                _ => Err(err),
             },
         }
     }

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -45,11 +45,11 @@ impl LatestClient<'_> {
         {
             Ok(archives) => archives,
             Err(err) => {
-                return match err.into_kind() {
+                return match err.kind() {
                     uv_client::ErrorKind::PackageNotFound(_) => Ok(None),
                     uv_client::ErrorKind::NoIndex(_) => Ok(None),
                     uv_client::ErrorKind::Offline(_) => Ok(None),
-                    kind => Err(kind.into()),
+                    _ => Err(err),
                 };
             }
         };


### PR DESCRIPTION
## Summary

We often match on `ErrorKind` to figure out how to handle an error (e.g., to treat a 404 as "Not found" rather than aborting the program). Unfortunately, if we retry, we wrap the error in a new kind that includes the retry count. This PR adds an unwrapping mechanism to ensure that callers always look at the underlying error.

Closes https://github.com/astral-sh/uv/issues/14941.

Closes https://github.com/astral-sh/uv/issues/14989.
