### PR TITLE
replace manual venv removal with remove_virtualenv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5958,7 +5958,6 @@ version = "0.0.1"
 dependencies = [
  "fs-err",
  "pathdiff",
- "self-replace",
  "serde",
  "thiserror 2.0.12",
  "toml",

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -39,6 +39,3 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-self-replace = { workspace = true }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -189,16 +189,6 @@ impl InstalledTools {
             environment_path.user_display()
         );
 
-        // On Windows, if the current executable is in the directory, guard against self-deletion.
-        #[cfg(windows)]
-        if let Ok(itself) = std::env::current_exe() {
-            let target = std::path::absolute(&environment_path)?;
-            if itself.starts_with(&target) {
-                debug!("Detected self-delete of executable: {}", itself.display());
-                self_replace::self_delete_outside_path(&environment_path)?;
-            }
-        }
-
         remove_virtualenv(environment_path.as_path())?;
 
         Ok(())

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -24,6 +24,7 @@ use uv_installer::SitePackages;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_state::{StateBucket, StateStore};
 use uv_static::EnvVars;
+use uv_virtualenv::remove_virtualenv;
 
 mod receipt;
 mod tool;
@@ -198,7 +199,7 @@ impl InstalledTools {
             }
         }
 
-        fs_err::remove_dir_all(environment_path)?;
+        remove_virtualenv(environment_path.as_path())?;
 
         Ok(())
     }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1572,7 +1572,7 @@ impl ScriptEnvironment {
                 }
 
                 // Remove the existing virtual environment.
-                let replaced = match fs_err::remove_dir_all(&root) {
+                let replaced = match remove_virtualenv(&root) {
                     Ok(()) => {
                         debug!(
                             "Removed virtual environment at: {}",
@@ -1580,7 +1580,11 @@ impl ScriptEnvironment {
                         );
                         true
                     }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(uv_virtualenv::Error::Io(err))
+                        if err.kind() == std::io::ErrorKind::NotFound =>
+                    {
+                        false
+                    }
                     Err(err) => return Err(err.into()),
                 };
 

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -110,8 +110,9 @@ async fn do_uninstall(
                         )?;
                         continue;
                     }
-                    // Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                    Err(uv_tool::Error::VirtualEnvError(_err)) => {
+                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                        if err.kind() == std::io::ErrorKind::NotFound =>
+                    {
                         bail!("`{name}` is not installed");
                     }
                     Err(err) => {
@@ -136,8 +137,9 @@ async fn do_uninstall(
                         )?;
                         return Ok(());
                     }
-                    // Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                    Err(uv_tool::Error::VirtualEnvError(_err)) => {
+                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                        if err.kind() == std::io::ErrorKind::NotFound =>
+                    {
                         bail!("`{name}` is not installed");
                     }
                     Err(err) => {

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -110,7 +110,8 @@ async fn do_uninstall(
                         )?;
                         continue;
                     }
-                    Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                    // Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                    Err(uv_tool::Error::VirtualEnvError(_err)) => {
                         bail!("`{name}` is not installed");
                     }
                     Err(err) => {
@@ -135,7 +136,8 @@ async fn do_uninstall(
                         )?;
                         return Ok(());
                     }
-                    Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                    // Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                    Err(uv_tool::Error::VirtualEnvError(_err)) => {
                         bail!("`{name}` is not installed");
                     }
                     Err(err) => {


### PR DESCRIPTION

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
At some places the virtualenv directory was manually removed instead of using `remove_virtualenv`.
I also adjusted the error type.
#14985 

## Test Plan

<!-- How was it tested? -->
