### PR TITLE
Ignore GraalPy devtag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1339,6 +1339,11 @@ jobs:
         run: |
           ./uv pip install anyio
 
+      - name: "Check a GraalPy dev version (different version parsing)"
+        run: |
+          curl -sLf https://github.com/graalvm/graal-languages-ea-builds/releases/download/graalpy-25.0.0-ea.31/graalpy-25.0.0-ea.31-linux-amd64.tar.gz | tar xz
+          ./uv run -p ./graalpy-25.0.0-dev-linux-amd64/bin/python python --version
+
   integration-test-graalpy-windows-x86_64:
     timeout-minutes: 10
     needs: build-binary-windows-x86_64

--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -41,7 +41,9 @@ if hasattr(sys, "implementation"):
         import re
 
         implementation_version = re.sub(
-            r"graalpy(\d)(\d+)-\d+", r"\1.\2", sys.implementation.cache_tag
+            r"graalpy(\d)(\d+)(?:dev[\da-f]+)?-\d+",
+            r"\1.\2",
+            sys.implementation.cache_tag,
         )
     else:
         implementation_version = format_full_version(sys.implementation.version)


### PR DESCRIPTION
Allows [development builds of GraalPy](https://github.com/graalvm/graal-languages-ea-builds) to work with uv.

CC @timfel

