### PR TITLE
Gracefully handle entrypoint permission errors

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1102,6 +1102,14 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                                 &entry.path().display()
                             );
                         }
+                        Err(CopyEntrypointError::Io(err))
+                            if err.kind() == std::io::ErrorKind::PermissionDenied =>
+                        {
+                            trace!(
+                                "Skipping copy of entrypoint `{}`: permission denied",
+                                &entry.path().display()
+                            );
+                        }
                         Err(err) => return Err(err.into()),
                     }
                 }


### PR DESCRIPTION
Gracefully handle entrypoint permission errors

`uv run --with` could fail with a "permission denied" error when it
tried to copy an entrypoint with restrictive permissions.

For instance:

```sh
$ stat -c '%A' /usr/bin/groupmems
-rwxr-s---

$ uv python find
/usr/bin/python

$ uv run --with dummy_test
error: failed to open file `/usr/bin/groupmems`: Permission denied (os error 13)
```

The entrypoint copying logic now catches these permission errors and
skips the file, making `uv` more resilient on systems with binaries that
have restrictive permissions.