### PR TITLE
Fix some nightly lints

### DIFF
--- a/crates/uv-console/src/lib.rs
+++ b/crates/uv-console/src/lib.rs
@@ -137,7 +137,7 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
                 chars.remove(position);
                 let line_size = term.size().1 as usize;
                 // Case we want to delete last char of a line so the cursor is at the beginning of the next line
-                if (position + prompt_len) % (line_size - 1) == 0 {
+                if (position + prompt_len).is_multiple_of(line_size - 1) {
                     term.clear_line()?;
                     term.move_cursor_up(1)?;
                     term.move_cursor_right(line_size + 1)?;
@@ -170,7 +170,7 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
                 term.flush()?;
             }
             Key::ArrowLeft if position > 0 => {
-                if (position + prompt_len) % term.size().1 as usize == 0 {
+                if (position + prompt_len).is_multiple_of(term.size().1 as usize) {
                     term.move_cursor_up(1)?;
                     term.move_cursor_right(term.size().1 as usize)?;
                 } else {
@@ -180,7 +180,7 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
                 term.flush()?;
             }
             Key::ArrowRight if position < chars.len() => {
-                if (position + prompt_len) % (term.size().1 as usize - 1) == 0 {
+                if (position + prompt_len).is_multiple_of(term.size().1 as usize - 1) {
                     term.move_cursor_down(1)?;
                     term.move_cursor_left(term.size().1 as usize)?;
                 } else {

--- a/crates/uv-platform-tags/src/language_tag.rs
+++ b/crates/uv-platform-tags/src/language_tag.rs
@@ -140,12 +140,10 @@ impl FromStr for LanguageTag {
             Ok(Self::None)
         } else if let Some(py) = s.strip_prefix("py") {
             match py.len() {
-                0 => {
-                    return Err(ParseLanguageTagError::MissingMajorVersion {
-                        implementation: "Python",
-                        tag: s.to_string(),
-                    });
-                }
+                0 => Err(ParseLanguageTagError::MissingMajorVersion {
+                    implementation: "Python",
+                    tag: s.to_string(),
+                }),
                 1 => {
                     // Ex) `py3`
                     let major = py

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1606,7 +1606,7 @@ impl PylockTomlArchive {
                 }
             }
         } else {
-            return Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()));
+            Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()))
         }
     }
 
@@ -1631,7 +1631,7 @@ impl PylockTomlArchive {
             let ext = DistExtension::from_path(filename)?;
             Ok(matches!(ext, DistExtension::Wheel))
         } else {
-            return Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()));
+            Err(PylockTomlErrorKind::ArchiveMissingPathUrl(name.clone()))
         }
     }
 }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;
@@ -3907,7 +3906,7 @@ struct SourceDistMetadata {
 /// future, so this should be treated as only a hint to where to look
 /// and/or recording where the source dist file originally came from.
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
-#[serde(try_from = "SourceDistWire")]
+#[serde(from = "SourceDistWire")]
 enum SourceDist {
     Url {
         url: UrlString,
@@ -4206,17 +4205,15 @@ impl SourceDist {
     }
 }
 
-impl TryFrom<SourceDistWire> for SourceDist {
-    type Error = Infallible;
-
-    fn try_from(wire: SourceDistWire) -> Result<SourceDist, Infallible> {
+impl From<SourceDistWire> for SourceDist {
+    fn from(wire: SourceDistWire) -> SourceDist {
         match wire {
-            SourceDistWire::Url { url, metadata } => Ok(SourceDist::Url { url, metadata }),
-            SourceDistWire::Path { path, metadata } => Ok(SourceDist::Path {
+            SourceDistWire::Url { url, metadata } => SourceDist::Url { url, metadata },
+            SourceDistWire::Path { path, metadata } => SourceDist::Path {
                 path: path.into(),
                 metadata,
-            }),
-            SourceDistWire::Metadata { metadata } => Ok(SourceDist::Metadata { metadata }),
+            },
+            SourceDistWire::Metadata { metadata } => SourceDist::Metadata { metadata },
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -523,39 +523,36 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     )?;
 
                     // Pick the next compatible version.
-                    let version = match decision {
-                        None => {
-                            debug!("No compatible version found for: {next_package}");
+                    let Some(version) = decision else {
+                        debug!("No compatible version found for: {next_package}");
 
-                            let term_intersection = state
-                                .pubgrub
-                                .partial_solution
-                                .term_intersection_for_package(next_id)
-                                .expect("a package was chosen but we don't have a term");
+                        let term_intersection = state
+                            .pubgrub
+                            .partial_solution
+                            .term_intersection_for_package(next_id)
+                            .expect("a package was chosen but we don't have a term");
 
-                            if let PubGrubPackageInner::Package { name, .. } = &**next_package {
-                                // Check if the decision was due to the package being unavailable
-                                if let Some(entry) = self.unavailable_packages.get(name) {
-                                    state.pubgrub.add_incompatibility(
-                                        Incompatibility::custom_term(
-                                            next_id,
-                                            term_intersection.clone(),
-                                            UnavailableReason::Package(entry.clone()),
-                                        ),
-                                    );
-                                    continue;
-                                }
+                        if let PubGrubPackageInner::Package { name, .. } = &**next_package {
+                            // Check if the decision was due to the package being unavailable
+                            if let Some(entry) = self.unavailable_packages.get(name) {
+                                state
+                                    .pubgrub
+                                    .add_incompatibility(Incompatibility::custom_term(
+                                        next_id,
+                                        term_intersection.clone(),
+                                        UnavailableReason::Package(entry.clone()),
+                                    ));
+                                continue;
                             }
-
-                            state
-                                .pubgrub
-                                .add_incompatibility(Incompatibility::no_versions(
-                                    next_id,
-                                    term_intersection.clone(),
-                                ));
-                            continue;
                         }
-                        Some(version) => version,
+
+                        state
+                            .pubgrub
+                            .add_incompatibility(Incompatibility::no_versions(
+                                next_id,
+                                term_intersection.clone(),
+                            ));
+                        continue;
                     };
 
                     let version = match version {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -248,7 +248,7 @@ pub(crate) async fn sync(
                 });
 
             match update_environment(
-                Deref::deref(&environment).clone(),
+                environment.clone(),
                 spec,
                 modifications,
                 build_constraints.unwrap_or_default(),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1437,9 +1437,9 @@ impl AddSettings {
 
         // Warn user if an ambiguous relative path was passed as a value for
         // `--index` or `--default-index`.
-        indexes
-            .iter()
-            .for_each(|index| index.url().warn_on_disambiguated_relative_path());
+        for index in &indexes {
+            index.url().warn_on_disambiguated_relative_path();
+        }
 
         // If the user passed an `--index-url` or `--extra-index-url`, warn.
         if installer


### PR DESCRIPTION
Apply fixes for some `cargo check` and `cargo clippy` lints that are on in nightly Rust.

The following command now passes, the blanket allows had to many false-positives:

```
cargo +nightly clippy -- -A clippy::doc_markdown -A mismatched_lifetime_syntaxes -A clippy::explicit_deref_methods
```

`cargo +nightly check` now passes without warnings.