### PR TITLE
Use consistent workspace inheritance

### DIFF
--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-build-backend"
 version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-build"
 version = "0.8.4"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 uv-build-backend = { workspace = true }

--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "uv-console"
 version = "0.0.1"
-edition = { workspace = true }
 description = "Utilities for interacting with the terminal"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -2,13 +2,13 @@
 name = "uv-globfilter"
 version = "0.1.0"
 readme = "README.md"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 globset = { workspace = true }

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -2,6 +2,12 @@
 name = "uv-macros"
 version = "0.0.1"
 edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-metadata"
 version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "uv-normalize"
 version = "0.0.1"
-edition = { workspace = true }
 description = "Normalization for distribution, package and extra names."
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-publish"
 version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-requirements"
 version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "uv-torch"
 version = "0.1.0"
-edition.workspace = true
-rust-version.workspace = true
-homepage.workspace = true
-documentation.workspace = true
-repository.workspace = true
-authors.workspace = true
-license.workspace = true
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 uv-distribution-types = { workspace = true }


### PR DESCRIPTION
Following a CI failure in https://github.com/astral-sh/uv/pull/15028, ensure that all workspace crates are inheriting the MSRV and other workspace configuration from the workspace root.