### PR TITLE
Refactor code blogs in README for copy/pasting & uniformity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,30 +92,30 @@ Additionally, the command line reference documentation can be viewed with `uv he
 uv manages project dependencies and environments, with support for lockfiles, workspaces, and more,
 similar to `rye` or `poetry`:
 
-```console
-$ uv init example
-Initialized project `example` at `/home/user/example`
+```bash
+uv init example
+# Initialized project `example` at `/home/user/example`
 
 $ cd example
 
-$ uv add ruff
-Creating virtual environment at: .venv
-Resolved 2 packages in 170ms
-   Built example @ file:///home/user/example
-Prepared 2 packages in 627ms
-Installed 2 packages in 1ms
- + example==0.1.0 (from file:///home/user/example)
- + ruff==0.5.0
+uv add ruff
+# Creating virtual environment at: .venv
+# Resolved 2 packages in 170ms
+#    Built example @ file:///home/user/example
+# Prepared 2 packages in 627ms
+# Installed 2 packages in 1ms
+#  + example==0.1.0 (from file:///home/user/example)
+#  + ruff==0.5.0
 
-$ uv run ruff check
-All checks passed!
+uv run ruff check
+# All checks passed!
 
-$ uv lock
-Resolved 2 packages in 0.33ms
+uv lock
+# Resolved 2 packages in 0.33ms
 
-$ uv sync
-Resolved 2 packages in 0.70ms
-Audited 1 package in 0.02ms
+uv sync
+# Resolved 2 packages in 0.70ms
+# Audited 1 package in 0.02ms
 ```
 
 See the [project documentation](https://docs.astral.sh/uv/guides/projects/) to get started.
@@ -129,20 +129,20 @@ uv manages dependencies and environments for single-file scripts.
 
 Create a new script and add inline metadata declaring its dependencies:
 
-```console
-$ echo 'import requests; print(requests.get("https://astral.sh"))' > example.py
+```bash
+echo 'import requests; print(requests.get("https://astral.sh"))' > example.py
 
-$ uv add --script example.py requests
-Updated `example.py`
+uv add --script example.py requests
+# Updated `example.py`
 ```
 
 Then, run the script in an isolated virtual environment:
 
-```console
-$ uv run example.py
-Reading inline script metadata from: example.py
-Installed 5 packages in 12ms
-<Response [200]>
+```bash
+uv run example.py
+# Reading inline script metadata from: example.py
+# Installed 5 packages in 12ms
+# <Response [200]>
 ```
 
 See the [scripts documentation](https://docs.astral.sh/uv/guides/scripts/) to get started.
@@ -153,34 +153,34 @@ uv executes and installs command-line tools provided by Python packages, similar
 
 Run a tool in an ephemeral environment using `uvx` (an alias for `uv tool run`):
 
-```console
-$ uvx pycowsay 'hello world!'
-Resolved 1 package in 167ms
-Installed 1 package in 9ms
- + pycowsay==0.0.0.2
-  """
+```bash
+uvx pycowsay 'hello world!'
+# Resolved 1 package in 167ms
+# Installed 1 package in 9ms
+#  + pycowsay==0.0.0.2
+#   """
 
-  ------------
-< hello world! >
-  ------------
-   \   ^__^
-    \  (oo)\_______
-       (__)\       )\/\
-           ||----w |
-           ||     ||
+#   ------------
+# < hello world! >
+#   ------------
+#    \   ^__^
+#     \  (oo)\_______
+#        (__)\       )\/\
+#            ||----w |
+#            ||     ||
 ```
 
 Install a tool with `uv tool install`:
 
-```console
-$ uv tool install ruff
-Resolved 1 package in 6ms
-Installed 1 package in 2ms
- + ruff==0.5.0
-Installed 1 executable: ruff
+```bash
+uv tool install ruff
+# Resolved 1 package in 6ms
+# Installed 1 package in 2ms
+#  + ruff==0.5.0
+# Installed 1 executable: ruff
 
-$ ruff --version
-ruff 0.5.0
+ruff --version
+# ruff 0.5.0
 ```
 
 See the [tools documentation](https://docs.astral.sh/uv/guides/tools/) to get started.
@@ -191,37 +191,37 @@ uv installs Python and allows quickly switching between versions.
 
 Install multiple Python versions:
 
-```console
-$ uv python install 3.10 3.11 3.12
-Searching for Python versions matching: Python 3.10
-Searching for Python versions matching: Python 3.11
-Searching for Python versions matching: Python 3.12
-Installed 3 versions in 3.42s
- + cpython-3.10.14-macos-aarch64-none
- + cpython-3.11.9-macos-aarch64-none
- + cpython-3.12.4-macos-aarch64-none
+```bash
+uv python install 3.10 3.11 3.12
+# Searching for Python versions matching: Python 3.10
+# Searching for Python versions matching: Python 3.11
+# Searching for Python versions matching: Python 3.12
+# Installed 3 versions in 3.42s
+#  + cpython-3.10.14-macos-aarch64-none
+#  + cpython-3.11.9-macos-aarch64-none
+#  + cpython-3.12.4-macos-aarch64-none
 ```
 
 Download Python versions as needed:
 
-```console
-$ uv venv --python 3.12.0
-Using Python 3.12.0
-Creating virtual environment at: .venv
-Activate with: source .venv/bin/activate
+```bash
+uv venv --python 3.12.0
+# Using Python 3.12.0
+# Creating virtual environment at: .venv
+# Activate with: source .venv/bin/activate
 
-$ uv run --python pypy@3.8 -- python --version
-Python 3.8.16 (a9dbdca6fc3286b0addd2240f11d97d8e8de187a, Dec 29 2022, 11:45:30)
-[PyPy 7.3.11 with GCC Apple LLVM 13.1.6 (clang-1316.0.21.2.5)] on darwin
-Type "help", "copyright", "credits" or "license" for more information.
->>>>
+uv run --python pypy@3.8 -- python --version
+# Python 3.8.16 (a9dbdca6fc3286b0addd2240f11d97d8e8de187a, Dec 29 2022, 11:45:30)
+# [PyPy 7.3.11 with GCC Apple LLVM 13.1.6 (clang-1316.0.21.2.5)] on darwin
+# Type "help", "copyright", "credits" or "license" for more information.
+# >>>>
 ```
 
 Use a specific Python version in the current directory:
 
-```console
-$ uv python pin 3.11
-Pinned `.python-version` to `3.11`
+```bash
+uv python pin 3.11
+# Pinned `.python-version` to `3.11`
 ```
 
 See the [Python installation documentation](https://docs.astral.sh/uv/guides/install-python/) to get
@@ -240,32 +240,32 @@ Migrate to uv without changing your existing workflows — and experience a 10-1
 
 Compile requirements into a platform-independent requirements file:
 
-```console
-$ uv pip compile docs/requirements.in \
+```bash
+uv pip compile docs/requirements.in \
    --universal \
    --output-file docs/requirements.txt
-Resolved 43 packages in 12ms
+   # Resolved 43 packages in 12ms
 ```
 
 Create a virtual environment:
 
-```console
-$ uv venv
-Using Python 3.12.3
-Creating virtual environment at: .venv
-Activate with: source .venv/bin/activate
+```bash
+uv venv
+# Using Python 3.12.3
+# Creating virtual environment at: .venv
+# Activate with: source .venv/bin/activate
 ```
 
 Install the locked requirements:
 
-```console
-$ uv pip sync docs/requirements.txt
-Resolved 43 packages in 11ms
-Installed 43 packages in 208ms
- + babel==2.15.0
- + black==24.4.2
- + certifi==2024.7.4
- ...
+```bash
+uv pip sync docs/requirements.txt
+# Resolved 43 packages in 11ms
+# Installed 43 packages in 208ms
+#  + babel==2.15.0
+#  + black==24.4.2
+#  + certifi==2024.7.4
+#  ...
 ```
 
 See the [pip interface documentation](https://docs.astral.sh/uv/pip/index/) to get started.


### PR DESCRIPTION
Allows readers to copy/paste commands from the README.md file by:
1. Changing code blocks to from "console" to "bash".
2. Commenting out the outputs from the code block.

This prevents excess "command not found" errors and enables quicker configuration.