### PR TITLE
Update trampoline to ~1.87 nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,13 +382,15 @@ jobs:
     timeout-minutes: 10
     needs: determine_changes
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     name: "test windows trampoline | ${{ matrix.target-arch }}"
     strategy:
       fail-fast: false
       matrix:
-        # Note, we exclude `aarch64` because it's not supported by the GitHub runner
-        target-arch: ["x86_64", "i686"]
+        include:
+          - { runner: windows-latest, target-arch: "x86_64" }
+          - { runner: windows-latest, target-arch: "i686" }
+          - { runner: windows-11-arm, target-arch: "aarch64" }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Dev Drive

--- a/crates/uv-trampoline/README.md
+++ b/crates/uv-trampoline/README.md
@@ -13,19 +13,19 @@ LLD and add the `rustup` targets:
 ```shell
 sudo apt install llvm clang lld
 cargo install cargo-xwin
-rustup toolchain install nightly-2025-02-16
-rustup component add rust-src --toolchain nightly-2025-02-16-x86_64-unknown-linux-gnu
-rustup target add --toolchain nightly-2025-02-16 i686-pc-windows-msvc
-rustup target add --toolchain nightly-2025-02-16 x86_64-pc-windows-msvc
-rustup target add --toolchain nightly-2025-02-16 aarch64-pc-windows-msvc
+rustup toolchain install nightly-2025-03-28
+rustup component add rust-src --toolchain nightly-2025-03-28-x86_64-unknown-linux-gnu
+rustup target add --toolchain nightly-2025-03-28 i686-pc-windows-msvc
+rustup target add --toolchain nightly-2025-03-28 x86_64-pc-windows-msvc
+rustup target add --toolchain nightly-2025-03-28 aarch64-pc-windows-msvc
 ```
 
 Then, build the trampolines for all supported architectures:
 
 ```shell
-cargo +nightly-2025-02-16 xwin build --xwin-arch x86 --release --target i686-pc-windows-msvc
-cargo +nightly-2025-02-16 xwin build --release --target x86_64-pc-windows-msvc
-cargo +nightly-2025-02-16 xwin build --release --target aarch64-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --xwin-arch x86 --release --target i686-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --release --target x86_64-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --release --target aarch64-pc-windows-msvc
 ```
 
 ### Cross-compiling from macOS
@@ -36,19 +36,19 @@ LLVM and add the `rustup` targets:
 ```shell
 brew install llvm
 cargo install cargo-xwin
-rustup toolchain install nightly-2025-02-16
-rustup component add rust-src --toolchain nightly-2025-02-16-aarch64-apple-darwin
-rustup target add --toolchain nightly-2025-02-16 i686-pc-windows-msvc
-rustup target add --toolchain nightly-2025-02-16 x86_64-pc-windows-msvc
-rustup target add --toolchain nightly-2025-02-16 aarch64-pc-windows-msvc
+rustup toolchain install nightly-2025-03-28
+rustup component add rust-src --toolchain nightly-2025-03-28-aarch64-apple-darwin
+rustup target add --toolchain nightly-2025-03-28 i686-pc-windows-msvc
+rustup target add --toolchain nightly-2025-03-28 x86_64-pc-windows-msvc
+rustup target add --toolchain nightly-2025-03-28 aarch64-pc-windows-msvc
 ```
 
 Then, build the trampolines for all supported architectures:
 
 ```shell
-cargo +nightly-2025-02-16 xwin build --release --target i686-pc-windows-msvc
-cargo +nightly-2025-02-16 xwin build --release --target x86_64-pc-windows-msvc
-cargo +nightly-2025-02-16 xwin build --release --target aarch64-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --release --target i686-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --release --target x86_64-pc-windows-msvc
+cargo +nightly-2025-03-28 xwin build --release --target aarch64-pc-windows-msvc
 ```
 
 ### Updating the prebuilt executables

--- a/crates/uv-trampoline/build.rs
+++ b/crates/uv-trampoline/build.rs
@@ -9,6 +9,7 @@ fn main() {
         let manifest =
             new_manifest("uv.Trampoline").remove_dependency("Microsoft.Windows.Common-Controls");
         embed_manifest(manifest).expect("unable to embed manifest");
+        println!("cargo::rustc-link-lib=ucrt"); // https://github.com/rust-lang/rust/issues/143172
         println!("cargo:rerun-if-changed=build.rs");
     }
 }

--- a/crates/uv-trampoline/rust-toolchain.toml
+++ b/crates/uv-trampoline/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-02-16"
+channel = "nightly-2025-03-28"

--- a/crates/uv-trampoline/src/bounce.rs
+++ b/crates/uv-trampoline/src/bounce.rs
@@ -416,6 +416,7 @@ fn spawn_child(si: &STARTUPINFOA, child_cmdline: CString) -> HANDLE {
 // processes, by using the .lpReserved2 field. We want to close those file descriptors too.
 // The UCRT source code has details on the memory layout (see also initialize_inherited_file_handles_nolock):
 // https://github.com/huangqinjin/ucrt/blob/10.0.19041.0/lowio/ioinit.cpp#L190-L223
+#[allow(clippy::ptr_eq)]
 fn close_handles(si: &STARTUPINFOA) {
     // See distlib/PC/launcher.c::cleanup_standard_io()
     // Unlike cleanup_standard_io(), we don't close STD_ERROR_HANDLE to retain warn!


### PR DESCRIPTION
## Summary

1. Given the upcoming 1.89 update, this bumps uv-trampoline to "~1.87" (closest nightly) from "~1.86" (closest nightly).
2. Adds additional CI check for arm builds now that runners are available.

I wasn't sure the MSRV policy applies to uv-trampoline, so I didn't go for ~1.89 nightly.
This PR also fixes a build issue starting after 1.87 where fma and fmaf symbols were missing.
Temporarily dded `#[allow(clippy::ptr_eq)]` to `close_handles` as this lint should not trigger anymore in 1.88 and above.

## Test Plan

Existing tests and local build process. I did not commit the built binaries for security purposes.
