### PR TITLE
Improve HTTP response caching log messages

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -517,7 +517,7 @@ impl CachedClient {
             BeforeRequest::NoMatch => {
                 // This shouldn't happen; if it does, we'll override the cache.
                 warn!(
-                    "Cached request doesn't match current request for: {}",
+                    "Cached response doesn't match current request for: {}",
                     req.url()
                 );
                 let (response, cache_policy) = self.fresh_request(req, cache_control).await?;


### PR DESCRIPTION
"Cached request ... is not storable" doesn't make sense from a user perspective, it's leaking our internal `CachedClient` abstraction. I think it makes more sense to talk about this as "Response from ... is not storable"