### PR TITLE
Use "option" instead of "setting" in `pylock` warning

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -147,7 +147,7 @@ pub(crate) async fn pip_install(
     if pylock.is_some() {
         if !preview.is_enabled(PreviewFeatures::PYLOCK) {
             warn_user!(
-                "The `--pylock` setting is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+                "The `--pylock` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
                 PreviewFeatures::PYLOCK
             );
         }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -140,7 +140,7 @@ pub(crate) async fn pip_sync(
     if pylock.is_some() {
         if !preview.is_enabled(PreviewFeatures::PYLOCK) {
             warn_user!(
-                "The `--pylock` setting is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+                "The `--pylock` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
                 PreviewFeatures::PYLOCK
             );
         }


### PR DESCRIPTION
## Summary

We use "option" everywhere else (though I don't have a strong opinion on which is "better").
