### PR TITLE
Respect `UV_HTTP_RETRIES` in `uv publish`

### DIFF
--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -1,6 +1,7 @@
 pub use base_client::{
     AuthIntegration, BaseClient, BaseClientBuilder, DEFAULT_RETRIES, ExtraMiddleware,
-    RedirectClientWithMiddleware, RequestBuilder, UvRetryableStrategy, is_extended_transient_error,
+    RedirectClientWithMiddleware, RequestBuilder, RetryParsingError, UvRetryableStrategy,
+    is_extended_transient_error, retries_from_env,
 };
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::{Error, ErrorKind, WrappedReqwestError};

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -263,6 +263,9 @@ pub(crate) enum ProjectError {
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
+    RetryParsing(#[from] uv_client::RetryParsingError),
+
+    #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 }
 
@@ -1708,7 +1711,7 @@ pub(crate) async fn resolve_names(
 
     let client_builder = BaseClientBuilder::new()
         .retries_from_env()
-        .map_err(uv_requirements::Error::ClientError)?
+        .map_err(|err| uv_requirements::Error::ClientError(err.into()))?
         .connectivity(network_settings.connectivity)
         .native_tls(network_settings.native_tls)
         .keyring(*keyring_provider)


### PR DESCRIPTION
Previously, publish would always use the default retries, now it respects `UV_HTTP_RETRIES`

Some awkward error handling to avoid pulling anyhow into uv-publish.