### PR TITLE
Fix warnings when running tests with a subset of features

### DIFF
--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1,16 +1,17 @@
 #![allow(clippy::disallowed_types)]
 
-use crate::common::{
-    READ_ONLY_GITHUB_SSH_DEPLOY_KEY, READ_ONLY_GITHUB_TOKEN, TestContext, apply_filters,
-    decode_token, uv_snapshot,
-};
+#[cfg(feature = "git")]
+use crate::common::{READ_ONLY_GITHUB_SSH_DEPLOY_KEY, READ_ONLY_GITHUB_TOKEN, decode_token};
+use crate::common::{TestContext, apply_filters, uv_snapshot};
 use anyhow::{Ok, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
+#[cfg(feature = "git")]
 use std::path::Path;
 use std::process::Stdio;
+#[cfg(feature = "git")]
 use uv_fs::Simplified;
 use uv_static::EnvVars;
 
@@ -1180,6 +1181,7 @@ fn requirements_txt_https_git_credentials() -> Result<()> {
 
 /// SSH blocks too permissive key files, so we need to scope permissions for the file to the current
 /// user.
+#[cfg(feature = "git")]
 fn reduce_ssh_key_file_permissions(key_file: &Path) -> Result<()> {
     #[cfg(unix)]
     {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6,9 +6,11 @@ use insta::assert_snapshot;
 use std::io::BufReader;
 use url::Url;
 
+#[cfg(feature = "git")]
+use crate::common::{READ_ONLY_GITHUB_TOKEN, decode_token};
 use crate::common::{
-    self, TestContext, build_vendor_links_url, decode_token, download_to_disk, packse_index_url,
-    uv_snapshot, venv_bin_path,
+    TestContext, build_vendor_links_url, download_to_disk, packse_index_url, uv_snapshot,
+    venv_bin_path,
 };
 use uv_fs::Simplified;
 use uv_static::EnvVars;
@@ -8053,7 +8055,7 @@ fn lock_redact_https() -> Result<()> {
 #[cfg(feature = "git")]
 fn lock_redact_git_pep508() -> Result<()> {
     let context = TestContext::new("3.12").with_filtered_link_mode_warning();
-    let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
+    let token = decode_token(READ_ONLY_GITHUB_TOKEN);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(&formatdoc! {
@@ -8138,7 +8140,7 @@ fn lock_redact_git_pep508() -> Result<()> {
 #[cfg(feature = "git")]
 fn lock_redact_git_sources() -> Result<()> {
     let context = TestContext::new("3.12").with_filtered_link_mode_warning();
-    let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
+    let token = decode_token(READ_ONLY_GITHUB_TOKEN);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(&formatdoc! {
@@ -8226,7 +8228,7 @@ fn lock_redact_git_sources() -> Result<()> {
 #[cfg(feature = "git")]
 fn lock_redact_git_pep508_non_project() -> Result<()> {
     let context = TestContext::new("3.12").with_filtered_link_mode_warning();
-    let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
+    let token = decode_token(READ_ONLY_GITHUB_TOKEN);
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(&formatdoc! {


### PR DESCRIPTION
We were getting dead code warnings on Windows tests because these were not properly feature gated.