### PR TITLE
Consider pythonw when copying entrypoints in uv run

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1937,7 +1937,15 @@ fn copy_entrypoint(
         return Ok(());
     };
 
-    let launcher = launcher.with_python_path(python_executable.to_path_buf());
+    let is_gui = launcher.python_path.ends_with("pythonw.exe");
+
+    let python_path = if is_gui {
+        python_executable.with_file_name("pythonw.exe")
+    } else {
+        python_executable.to_path_buf()
+    };
+
+    let launcher = launcher.with_python_path(python_path);
     let mut file = fs_err::OpenOptions::new()
         .create_new(true)
         .write(true)


### PR DESCRIPTION

## Summary

Follow up from https://github.com/astral-sh/uv/pull/15068#discussion_r2258586926

It seems when copying entrypoints we're ignoring whether it was pythonw vs not.

## Test Plan

Updated existing test.
