### PR TITLE
Add missing periods (`.`) to list elements in `Features` docs page

### DIFF
--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -22,8 +22,8 @@ See the [guide on installing Python](../guides/install-python.md) to get started
 Executing standalone Python scripts, e.g., `example.py`.
 
 - `uv run`: Run a script.
-- `uv add --script`: Add a dependency to a script
-- `uv remove --script`: Remove a dependency from a script
+- `uv add --script`: Add a dependency to a script.
+- `uv remove --script`: Remove a dependency from a script.
 
 See the [guide on running scripts](../guides/scripts.md) to get started.
 


### PR DESCRIPTION
The [**Features**](https://docs.astral.sh/uv/getting-started/features/) page of docs contains a lot of markdown lists, elements of which end with `.`.

For example:

<img width="571" height="267" alt="image" src="https://github.com/user-attachments/assets/b485f310-fece-4da4-acb9-ebc68b9df7d3" />

---

Out of tens of list elements, just two are outliers and do not use `.` at the end.

So this small PR fixes this little inconsistency :)