### PR TITLE
Fix regression where `--require-hashes` applied to build dependencies in `uv pip install`

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -582,7 +582,7 @@ pub(crate) async fn pip_install(
         extra_build_variables,
         link_mode,
         &build_options,
-        &hasher,
+        &build_hasher,
         exclude_newer.clone(),
         sources,
         WorkspaceCache::default(),

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -6693,16 +6693,17 @@ fn require_hashes_build_dependencies() -> Result<()> {
         .arg("-r")
         .arg("requirements.txt")
         .arg("--require-hashes"), @r"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-      × Failed to download and build `idna==3.6`
-      ├─▶ Failed to resolve requirements from `build-system.requires`
-      ├─▶ No solution found when resolving: `flit-core>=3.2, <4`
-      ╰─▶ In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `flit-core`
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.0.0
+     + idna==3.6
+     + sniffio==1.3.1
     "
     );
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/15146
