### PR TITLE
Update Rust toolchain to 1.89

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -8,6 +8,7 @@ doc-valid-idents = [
   "PyTorch",
   "ROCm",
   "XPU",
+  "PowerShell",
   ".." # Include the defaults
 ]
 

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -564,17 +564,17 @@ pub struct RedirectClientWithMiddleware {
 
 impl RedirectClientWithMiddleware {
     /// Convenience method to make a `GET` request to a URL.
-    pub fn get<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn get<U: IntoUrl>(&self, url: U) -> RequestBuilder<'_> {
         RequestBuilder::new(self.client.get(url), self)
     }
 
     /// Convenience method to make a `POST` request to a URL.
-    pub fn post<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn post<U: IntoUrl>(&self, url: U) -> RequestBuilder<'_> {
         RequestBuilder::new(self.client.post(url), self)
     }
 
     /// Convenience method to make a `HEAD` request to a URL.
-    pub fn head<U: IntoUrl>(&self, url: U) -> RequestBuilder {
+    pub fn head<U: IntoUrl>(&self, url: U) -> RequestBuilder<'_> {
         RequestBuilder::new(self.client.head(url), self)
     }
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -297,7 +297,10 @@ impl RegistryClient {
     }
 
     /// Return the appropriate index URLs for the given [`PackageName`].
-    fn index_urls_for(&self, package_name: &PackageName) -> impl Iterator<Item = IndexMetadataRef> {
+    fn index_urls_for(
+        &self,
+        package_name: &PackageName,
+    ) -> impl Iterator<Item = IndexMetadataRef<'_>> {
         self.torch_backend
             .as_ref()
             .and_then(|torch_backend| {

--- a/crates/uv-configuration/src/dependency_groups.rs
+++ b/crates/uv-configuration/src/dependency_groups.rs
@@ -252,7 +252,7 @@ impl DependencyGroupsHistory {
     /// Conceptually this being an empty list should be equivalent to
     /// [`DependencyGroups::is_empty`][] when there aren't any defaults set.
     /// When there are defaults the two will disagree, and rightfully so!
-    pub fn as_flags_pretty(&self) -> Vec<Cow<str>> {
+    pub fn as_flags_pretty(&self) -> Vec<Cow<'_, str>> {
         let Self {
             dev_mode,
             group,
@@ -378,7 +378,7 @@ impl IncludeGroups {
     }
 
     /// Iterate over all groups referenced in the [`IncludeGroups`].
-    pub fn names(&self) -> std::slice::Iter<GroupName> {
+    pub fn names(&self) -> std::slice::Iter<'_, GroupName> {
         match self {
             Self::Some(groups) => groups.iter(),
             Self::All => [].iter(),

--- a/crates/uv-configuration/src/extras.rs
+++ b/crates/uv-configuration/src/extras.rs
@@ -213,7 +213,7 @@ impl ExtrasSpecificationHistory {
     /// Conceptually this being an empty list should be equivalent to
     /// [`ExtrasSpecification::is_empty`][] when there aren't any defaults set.
     /// When there are defaults the two will disagree, and rightfully so!
-    pub fn as_flags_pretty(&self) -> Vec<Cow<str>> {
+    pub fn as_flags_pretty(&self) -> Vec<Cow<'_, str>> {
         let Self {
             extra,
             no_extra,
@@ -312,7 +312,7 @@ impl IncludeExtras {
     }
 
     /// Iterate over all extras referenced in the [`IncludeExtras`].
-    pub fn names(&self) -> std::slice::Iter<ExtraName> {
+    pub fn names(&self) -> std::slice::Iter<'_, ExtraName> {
         match self {
             Self::Some(extras) => extras.iter(),
             Self::All => [].iter(),

--- a/crates/uv-distribution-types/src/any.rs
+++ b/crates/uv-distribution-types/src/any.rs
@@ -38,7 +38,7 @@ impl Name for LocalDist {
 }
 
 impl InstalledMetadata for LocalDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         match self {
             Self::Cached(dist, _) => dist.installed_version(),
             Self::Installed(dist, _) => dist.installed_version(),

--- a/crates/uv-distribution-types/src/cached.rs
+++ b/crates/uv-distribution-types/src/cached.rs
@@ -183,19 +183,19 @@ impl Name for CachedDist {
 }
 
 impl DistributionMetadata for CachedRegistryDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Version(&self.filename.version)
     }
 }
 
 impl DistributionMetadata for CachedDirectUrlDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url.verbatim)
     }
 }
 
 impl DistributionMetadata for CachedDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::Url(dist) => dist.version_or_url(),
@@ -204,19 +204,19 @@ impl DistributionMetadata for CachedDist {
 }
 
 impl InstalledMetadata for CachedRegistryDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Version(&self.filename.version)
     }
 }
 
 impl InstalledMetadata for CachedDirectUrlDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Url(&self.url.verbatim, &self.filename.version)
     }
 }
 
 impl InstalledMetadata for CachedDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         match self {
             Self::Registry(dist) => dist.installed_version(),
             Self::Url(dist) => dist.installed_version(),

--- a/crates/uv-distribution-types/src/dist_error.rs
+++ b/crates/uv-distribution-types/src/dist_error.rs
@@ -153,7 +153,7 @@ impl DerivationChain {
     }
 
     /// Returns an iterator over the steps in the derivation chain.
-    pub fn iter(&self) -> std::slice::Iter<DerivationStep> {
+    pub fn iter(&self) -> std::slice::Iter<'_, DerivationStep> {
         self.0.iter()
     }
 }

--- a/crates/uv-distribution-types/src/installed.rs
+++ b/crates/uv-distribution-types/src/installed.rs
@@ -403,7 +403,7 @@ impl InstalledDist {
 }
 
 impl DistributionMetadata for InstalledDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Version(self.version())
     }
 }
@@ -451,37 +451,37 @@ impl Name for InstalledDist {
 }
 
 impl InstalledMetadata for InstalledRegistryDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Version(&self.version)
     }
 }
 
 impl InstalledMetadata for InstalledDirectUrlDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Url(&self.url, &self.version)
     }
 }
 
 impl InstalledMetadata for InstalledEggInfoFile {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Version(&self.version)
     }
 }
 
 impl InstalledMetadata for InstalledEggInfoDirectory {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Version(&self.version)
     }
 }
 
 impl InstalledMetadata for InstalledLegacyEditable {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         InstalledVersion::Version(&self.version)
     }
 }
 
 impl InstalledMetadata for InstalledDist {
-    fn installed_version(&self) -> InstalledVersion {
+    fn installed_version(&self) -> InstalledVersion<'_> {
         match self {
             Self::Registry(dist) => dist.installed_version(),
             Self::Url(dist) => dist.installed_version(),

--- a/crates/uv-distribution-types/src/lib.rs
+++ b/crates/uv-distribution-types/src/lib.rs
@@ -568,7 +568,7 @@ impl Dist {
     }
 
     /// Convert this distribution into a reference.
-    pub fn as_ref(&self) -> DistRef {
+    pub fn as_ref(&self) -> DistRef<'_> {
         match self {
             Self::Built(dist) => DistRef::Built(dist),
             Self::Source(dist) => DistRef::Source(dist),
@@ -874,61 +874,61 @@ impl Name for CompatibleDist<'_> {
 }
 
 impl DistributionMetadata for RegistryBuiltWheel {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Version(&self.filename.version)
     }
 }
 
 impl DistributionMetadata for RegistryBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         self.best_wheel().version_or_url()
     }
 }
 
 impl DistributionMetadata for DirectUrlBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for PathBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for RegistrySourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Version(&self.version)
     }
 }
 
 impl DistributionMetadata for DirectUrlSourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for GitSourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for PathSourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for DirectorySourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for SourceDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::DirectUrl(dist) => dist.version_or_url(),
@@ -940,7 +940,7 @@ impl DistributionMetadata for SourceDist {
 }
 
 impl DistributionMetadata for BuiltDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::DirectUrl(dist) => dist.version_or_url(),
@@ -950,7 +950,7 @@ impl DistributionMetadata for BuiltDist {
 }
 
 impl DistributionMetadata for Dist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Built(dist) => dist.version_or_url(),
             Self::Source(dist) => dist.version_or_url(),

--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -420,7 +420,7 @@ impl PrioritizedDist {
     }
 
     /// Return the highest-priority distribution for the package version, if any.
-    pub fn get(&self) -> Option<CompatibleDist> {
+    pub fn get(&self) -> Option<CompatibleDist<'_>> {
         let best_wheel = self.0.best_wheel_index.map(|i| &self.0.wheels[i]);
         match (&best_wheel, &self.0.source) {
             // If both are compatible, break ties based on the hash outcome. For example, prefer a

--- a/crates/uv-distribution-types/src/requested.rs
+++ b/crates/uv-distribution-types/src/requested.rs
@@ -37,7 +37,7 @@ impl Name for RequestedDist {
 }
 
 impl DistributionMetadata for RequestedDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Installed(dist) => dist.version_or_url(),
             Self::Installable(dist) => dist.version_or_url(),

--- a/crates/uv-distribution-types/src/resolved.rs
+++ b/crates/uv-distribution-types/src/resolved.rs
@@ -164,7 +164,7 @@ impl Name for ResolvedDistRef<'_> {
 }
 
 impl DistributionMetadata for ResolvedDistRef<'_> {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Installed { dist } => VersionOrUrlRef::Version(dist.version()),
             Self::InstallableRegistrySourceDist { sdist, .. } => sdist.version_or_url(),
@@ -201,7 +201,7 @@ impl Name for ResolvedDist {
 }
 
 impl DistributionMetadata for ResolvedDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Installed { dist } => dist.version_or_url(),
             Self::Installable { dist, .. } => dist.version_or_url(),

--- a/crates/uv-distribution-types/src/traits.rs
+++ b/crates/uv-distribution-types/src/traits.rs
@@ -23,7 +23,7 @@ pub trait Name {
 pub trait DistributionMetadata: Name {
     /// Return a [`uv_pep440::Version`], for registry-based distributions, or a [`url::Url`],
     /// for URL-based distributions.
-    fn version_or_url(&self) -> VersionOrUrlRef;
+    fn version_or_url(&self) -> VersionOrUrlRef<'_>;
 
     /// Returns a unique identifier for the package at the given version (e.g., `black==23.10.0`).
     ///
@@ -56,7 +56,7 @@ pub trait DistributionMetadata: Name {
 /// Metadata that can be resolved from a built distribution.
 pub trait InstalledMetadata: Name {
     /// Return the resolved version of the installed distribution.
-    fn installed_version(&self) -> InstalledVersion;
+    fn installed_version(&self) -> InstalledVersion<'_>;
 }
 
 pub trait RemoteSource {

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -58,12 +58,12 @@ impl<'a> RegistryWheelIndex<'a> {
     /// Return an iterator over available wheels for a given package.
     ///
     /// If the package is not yet indexed, this will index the package by reading from the cache.
-    pub fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry> {
+    pub fn get(&mut self, name: &'a PackageName) -> impl Iterator<Item = &IndexEntry<'_>> {
         self.get_impl(name).iter().rev()
     }
 
     /// Get an entry in the index.
-    fn get_impl(&mut self, name: &'a PackageName) -> &[IndexEntry] {
+    fn get_impl(&mut self, name: &'a PackageName) -> &[IndexEntry<'_>] {
         (match self.index.entry(name) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(Self::index(

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -207,7 +207,7 @@ pub fn normalize_absolute_path(path: &Path) -> Result<PathBuf, std::io::Error> {
 }
 
 /// Normalize a [`Path`], removing things like `.` and `..`.
-pub fn normalize_path(path: &Path) -> Cow<Path> {
+pub fn normalize_path(path: &Path) -> Cow<'_, Path> {
     // Fast path: if the path is already normalized, return it as-is.
     if path.components().all(|component| match component {
         Component::Prefix(_) | Component::RootDir | Component::Normal(_) => true,

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -45,7 +45,7 @@ impl GitResolver {
     }
 
     /// Returns the [`GitOid`] for the given [`RepositoryReference`], if it exists.
-    fn get(&self, reference: &RepositoryReference) -> Option<Ref<RepositoryReference, GitOid>> {
+    fn get(&self, reference: &RepositoryReference) -> Option<Ref<'_, RepositoryReference, GitOid>> {
         self.0.get(reference)
     }
 

--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -360,7 +360,7 @@ impl Version {
 
     /// Returns the release number part of the version.
     #[inline]
-    pub fn release(&self) -> Release {
+    pub fn release(&self) -> Release<'_> {
         let inner = match &self.inner {
             VersionInner::Small { small } => {
                 // Parse out the version digits.
@@ -423,7 +423,7 @@ impl Version {
 
     /// Returns the local segments in this version, if any exist.
     #[inline]
-    pub fn local(&self) -> LocalVersionSlice {
+    pub fn local(&self) -> LocalVersionSlice<'_> {
         match self.inner {
             VersionInner::Small { ref small } => small.local_slice(),
             VersionInner::Full { ref full } => full.local.as_slice(),
@@ -1405,7 +1405,7 @@ impl VersionSmall {
     }
 
     #[inline]
-    fn local_slice(&self) -> LocalVersionSlice {
+    fn local_slice(&self) -> LocalVersionSlice<'_> {
         if self.suffix_kind() == Self::SUFFIX_LOCAL {
             LocalVersionSlice::Max
         } else {
@@ -2725,7 +2725,7 @@ pub(crate) fn compare_release(this: &[u64], other: &[u64]) -> Ordering {
 /// implementation
 ///
 /// [pep440-suffix-ordering]: https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
-fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersionSlice) {
+fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, LocalVersionSlice<'_>) {
     // If the version is a "max" version, use a post version larger than any possible post version.
     let post = if version.max().is_some() {
         Some(u64::MAX)

--- a/crates/uv-pep440/src/version_specifier.rs
+++ b/crates/uv-pep440/src/version_specifier.rs
@@ -951,7 +951,7 @@ impl<'a> TildeVersionSpecifier<'a> {
     }
 
     /// Construct a new tilde `VersionSpecifier` with the given patch version appended.
-    pub fn with_patch_version(&self, patch: u64) -> TildeVersionSpecifier {
+    pub fn with_patch_version(&self, patch: u64) -> TildeVersionSpecifier<'_> {
         let mut release = self.inner.version.release().to_vec();
         if self.has_patch() {
             release.pop();

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -3693,20 +3693,20 @@ mod test {
         let b = ExtraName::from_str("b").unwrap();
 
         let marker = m("extra == 'a' and extra == 'b'");
-        assert!(!marker.evaluate_only_extras(&[a.clone()]));
-        assert!(!marker.evaluate_only_extras(&[b.clone()]));
+        assert!(!marker.evaluate_only_extras(std::slice::from_ref(&a)));
+        assert!(!marker.evaluate_only_extras(std::slice::from_ref(&b)));
         assert!(marker.evaluate_only_extras(&[a.clone(), b.clone()]));
 
         let marker = m("(platform_machine == 'inapplicable' and extra == 'b') or extra == 'a'");
-        assert!(marker.evaluate_only_extras(&[a.clone()]));
-        assert!(!marker.evaluate_only_extras(&[b.clone()]));
+        assert!(marker.evaluate_only_extras(std::slice::from_ref(&a)));
+        assert!(!marker.evaluate_only_extras(std::slice::from_ref(&b)));
         assert!(marker.evaluate_only_extras(&[a.clone(), b.clone()]));
 
         let marker = m(
             "(platform_machine == 'inapplicable' and extra == 'a') or (platform_machine != 'inapplicable' and extra == 'b')",
         );
-        assert!(!marker.evaluate_only_extras(&[a.clone()]));
-        assert!(!marker.evaluate_only_extras(&[b.clone()]));
+        assert!(!marker.evaluate_only_extras(std::slice::from_ref(&a)));
+        assert!(!marker.evaluate_only_extras(std::slice::from_ref(&b)));
         assert!(marker.evaluate_only_extras(&[a.clone(), b.clone()]));
     }
 }

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -524,7 +524,7 @@ pub fn looks_like_git_repository(url: &Url) -> bool {
 ///
 /// For example, given `file:///home/ferris/project/scripts#hash=somehash`, returns
 /// `("/home/ferris/project/scripts", Some("hash=somehash"))`.
-fn split_fragment(path: &Path) -> (Cow<Path>, Option<&str>) {
+fn split_fragment(path: &Path) -> (Cow<'_, Path>, Option<&str>) {
     let Some(s) = path.to_str() else {
         return (Cow::Borrowed(path), None);
     };

--- a/crates/uv-pypi-types/src/supported_environments.rs
+++ b/crates/uv-pypi-types/src/supported_environments.rs
@@ -25,7 +25,7 @@ impl SupportedEnvironments {
     }
 
     /// Returns an iterator over the marker trees.
-    pub fn iter(&self) -> std::slice::Iter<MarkerTree> {
+    pub fn iter(&self) -> std::slice::Iter<'_, MarkerTree> {
         self.0.iter()
     }
 }

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -302,7 +302,7 @@ impl PythonEnvironment {
     ///
     /// Some distributions also create symbolic links from `purelib` to `platlib`; in such cases, we
     /// still deduplicate the entries, returning a single path.
-    pub fn site_packages(&self) -> impl Iterator<Item = Cow<Path>> {
+    pub fn site_packages(&self) -> impl Iterator<Item = Cow<'_, Path>> {
         self.0.interpreter.site_packages()
     }
 

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -567,7 +567,7 @@ impl Interpreter {
     ///
     /// Some distributions also create symbolic links from `purelib` to `platlib`; in such cases, we
     /// still deduplicate the entries, returning a single path.
-    pub fn site_packages(&self) -> impl Iterator<Item = Cow<Path>> {
+    pub fn site_packages(&self) -> impl Iterator<Item = Cow<'_, Path>> {
         let target = self.target().map(Target::site_packages);
 
         let prefix = self

--- a/crates/uv-python/src/sysconfig/parser.rs
+++ b/crates/uv-python/src/sysconfig/parser.rs
@@ -22,7 +22,7 @@ pub(super) struct SysconfigData(BTreeMap<String, Value>);
 
 impl SysconfigData {
     /// Returns an iterator over the key-value pairs in the map.
-    pub(super) fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<String, Value> {
+    pub(super) fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<'_, String, Value> {
         self.0.iter_mut()
     }
 

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -740,7 +740,7 @@ impl Name for Candidate<'_> {
 }
 
 impl DistributionMetadata for Candidate<'_> {
-    fn version_or_url(&self) -> uv_distribution_types::VersionOrUrlRef {
+    fn version_or_url(&self) -> uv_distribution_types::VersionOrUrlRef<'_> {
         uv_distribution_types::VersionOrUrlRef::Version(self.version)
     }
 }

--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -1306,7 +1306,7 @@ impl PylockTomlPackage {
 
 impl PylockTomlWheel {
     /// Return the [`WheelFilename`] for this wheel.
-    fn filename(&self, name: &PackageName) -> Result<Cow<WheelFilename>, PylockTomlErrorKind> {
+    fn filename(&self, name: &PackageName) -> Result<Cow<'_, WheelFilename>, PylockTomlErrorKind> {
         if let Some(name) = self.name.as_ref() {
             Ok(Cow::Borrowed(name))
         } else if let Some(path) = self.path.as_ref() {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3918,7 +3918,7 @@ enum SourceDist {
 }
 
 impl SourceDist {
-    fn filename(&self) -> Option<Cow<str>> {
+    fn filename(&self) -> Option<Cow<'_, str>> {
         match self {
             Self::Metadata { .. } => None,
             Self::Url { url, .. } => url.filename().ok(),

--- a/crates/uv-resolver/src/pubgrub/distribution.rs
+++ b/crates/uv-resolver/src/pubgrub/distribution.rs
@@ -29,7 +29,7 @@ impl Name for PubGrubDistribution<'_> {
 }
 
 impl DistributionMetadata for PubGrubDistribution<'_> {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         match self {
             Self::Registry(_, version) => VersionOrUrlRef::Version(version),
             Self::Url(_, url) => VersionOrUrlRef::Url(&url.verbatim),

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -75,7 +75,7 @@ impl Name for AnnotatedDist {
 }
 
 impl DistributionMetadata for AnnotatedDist {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         self.dist.version_or_url()
     }
 }

--- a/crates/uv-resolver/src/resolution/requirements_txt.rs
+++ b/crates/uv-resolver/src/resolution/requirements_txt.rs
@@ -36,7 +36,7 @@ impl<'dist> RequirementsTxtDist<'dist> {
         &self,
         requires_python: &RequiresPython,
         include_markers: bool,
-    ) -> Cow<str> {
+    ) -> Cow<'_, str> {
         // If the URL is editable, write it as an editable requirement.
         if self.dist.is_editable() {
             if let VersionOrUrlRef::Url(url) = self.dist.version_or_url() {
@@ -143,7 +143,7 @@ impl<'dist> RequirementsTxtDist<'dist> {
 
     /// Convert the [`RequirementsTxtDist`] to a comparator that can be used to sort the requirements
     /// in a `requirements.txt` file.
-    pub(crate) fn to_comparator(&self) -> RequirementsTxtComparator {
+    pub(crate) fn to_comparator(&self) -> RequirementsTxtComparator<'_> {
         if self.dist.is_editable() {
             if let VersionOrUrlRef::Url(url) = self.dist.version_or_url() {
                 return RequirementsTxtComparator::Url(url.verbatim());
@@ -213,7 +213,7 @@ impl Name for RequirementsTxtDist<'_> {
 }
 
 impl DistributionMetadata for RequirementsTxtDist<'_> {
-    fn version_or_url(&self) -> VersionOrUrlRef {
+    fn version_or_url(&self) -> VersionOrUrlRef<'_> {
         self.dist.version_or_url()
     }
 }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -174,7 +174,7 @@ impl VersionMap {
     pub(crate) fn iter(
         &self,
         range: &Ranges<Version>,
-    ) -> impl DoubleEndedIterator<Item = (&Version, VersionMapDistHandle)> {
+    ) -> impl DoubleEndedIterator<Item = (&Version, VersionMapDistHandle<'_>)> {
         // Performance optimization: If we only have a single version, return that version directly.
         if let Some(version) = range.as_singleton() {
             either::Either::Left(match self.inner {

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -32,7 +32,7 @@ pub enum HashStrategy {
 
 impl HashStrategy {
     /// Return the [`HashPolicy`] for the given distribution.
-    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy {
+    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy<'_> {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
@@ -53,7 +53,7 @@ impl HashStrategy {
     }
 
     /// Return the [`HashPolicy`] for the given registry-based package.
-    pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy {
+    pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
@@ -76,7 +76,7 @@ impl HashStrategy {
     }
 
     /// Return the [`HashPolicy`] for the given direct URL package.
-    pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy {
+    pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),

--- a/crates/uv-workspace/src/dependency_groups.rs
+++ b/crates/uv-workspace/src/dependency_groups.rs
@@ -225,7 +225,7 @@ impl FlatDependencyGroups {
     }
 
     /// Return the entry for a given group, if any.
-    pub fn entry(&mut self, group: GroupName) -> Entry<GroupName, FlatDependencyGroup> {
+    pub fn entry(&mut self, group: GroupName) -> Entry<'_, GroupName, FlatDependencyGroup> {
         self.0.entry(group)
     }
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -546,8 +546,8 @@ impl Deref for SyncEnvironment {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Project(environment) => Deref::deref(environment),
-            Self::Script(environment) => Deref::deref(environment),
+            Self::Project(environment) => environment,
+            Self::Script(environment) => environment,
         }
     }
 }

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -25,9 +25,7 @@ pub(crate) async fn self_update(
             printer.stderr(),
             "{}",
             format_args!(
-                concat!(
-                    "{}{} Self-update is not possible because network connectivity is disabled (i.e., with `--offline`)"
-                ),
+                "{}{} Self-update is not possible because network connectivity is disabled (i.e., with `--offline`)",
                 "error".red().bold(),
                 ":".bold()
             )

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"


### PR DESCRIPTION
## Summary

Bumps Rust toolchain to 1.89, but not the MSRV.

Lifetime changes is related to a new lint rule explained in https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

## Test Plan

Existing Tests
