### PR TITLE
Use `\n` instead of linesep in not found error message

### DIFF
--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -48,7 +48,7 @@ def find_uv_bin() -> str:
 
     raise UvNotFound(
         f"Could not find the uv binary in any of the following locations:\n"
-        f"{os.linesep.join(f' - {target}' for target in seen)}\n"
+        f"{'\n'.join(f' - {target}' for target in seen)}\n"
     )
 
 


### PR DESCRIPTION
https://github.com/astral-sh/uv/pull/14182#discussion_r2262979815