### PR TITLE
fix: Use 3.9 compatible zip

### DIFF
--- a/crates/uv/tests/it/python_module.rs
+++ b/crates/uv/tests/it/python_module.rs
@@ -382,3 +382,295 @@ fn find_uv_bin_user_bin() {
     "
     );
 }
+
+#[test]
+fn find_uv_bin_py38() {
+    let context = TestContext::new("3.8")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+      File "[SITE_PACKAGES]/uv/_find_uv.py", line 28, in find_uv_bin
+        _matching_parents(_module_path(), "lib/[PYTHON]*/site-packages/uv"), "bin"
+      File "[SITE_PACKAGES]/uv/_find_uv.py", line 79, in _matching_parents
+        for part, match_part in zip(
+    TypeError: zip() takes no keyword arguments
+    "#
+    );
+}
+
+#[test]
+fn find_uv_bin_py39() {
+    let context = TestContext::new("3.9")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+      File "[SITE_PACKAGES]/uv/_find_uv.py", line 28, in find_uv_bin
+        _matching_parents(_module_path(), "lib/[PYTHON]*/site-packages/uv"), "bin"
+      File "[SITE_PACKAGES]/uv/_find_uv.py", line 79, in _matching_parents
+        for part, match_part in zip(
+    TypeError: zip() takes no keyword arguments
+    "#
+    );
+}
+
+#[test]
+fn find_uv_bin_py310() {
+    let context = TestContext::new("3.10")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/uv
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn find_uv_bin_py311() {
+    let context = TestContext::new("3.11")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/uv
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn find_uv_bin_py312() {
+    let context = TestContext::new("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/uv
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn find_uv_bin_py313() {
+    let context = TestContext::new("3.13")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/uv
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
+fn find_uv_bin_py314() {
+    let context = TestContext::new("3.14")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix()
+        .with_filter(user_scheme_bin_filter())
+        // Target installs always use "bin" on all platforms. On Windows,
+        // `with_filtered_virtualenv_bin` only filters "Scripts", not "bin"
+        .with_filter((r"[\\/]bin".to_string(), "/[BIN]".to_string()));
+
+    // Install in a virtual environment
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg(context.workspace_root.join("scripts/packages/fake-uv")), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv==0.1.0 (from file://[WORKSPACE]/scripts/packages/fake-uv)
+    "
+    );
+
+    // We should find the binary in the virtual environment
+    uv_snapshot!(context.filters(), context.python_command()
+        .arg("-c")
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/uv
+
+    ----- stderr -----
+    "
+    );
+}

--- a/crates/uv/tests/it/python_module.rs
+++ b/crates/uv/tests/it/python_module.rs
@@ -412,20 +412,14 @@ fn find_uv_bin_py38() {
     // We should find the binary in the virtual environment
     uv_snapshot!(context.filters(), context.python_command()
         .arg("-c")
-        .arg("import uv; print(uv.find_uv_bin())"), @r#"
-    success: false
-    exit_code: 1
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    [VENV]/[BIN]/uv
 
     ----- stderr -----
-    Traceback (most recent call last):
-      File "<string>", line 1, in <module>
-      File "[SITE_PACKAGES]/uv/_find_uv.py", line 28, in find_uv_bin
-        _matching_parents(_module_path(), "lib/[PYTHON]*/site-packages/uv"), "bin"
-      File "[SITE_PACKAGES]/uv/_find_uv.py", line 79, in _matching_parents
-        for part, match_part in zip(
-    TypeError: zip() takes no keyword arguments
-    "#
+    "
     );
 }
 
@@ -458,20 +452,14 @@ fn find_uv_bin_py39() {
     // We should find the binary in the virtual environment
     uv_snapshot!(context.filters(), context.python_command()
         .arg("-c")
-        .arg("import uv; print(uv.find_uv_bin())"), @r#"
-    success: false
-    exit_code: 1
+        .arg("import uv; print(uv.find_uv_bin())"), @r"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    [VENV]/[BIN]/uv
 
     ----- stderr -----
-    Traceback (most recent call last):
-      File "<string>", line 1, in <module>
-      File "[SITE_PACKAGES]/uv/_find_uv.py", line 28, in find_uv_bin
-        _matching_parents(_module_path(), "lib/[PYTHON]*/site-packages/uv"), "bin"
-      File "[SITE_PACKAGES]/uv/_find_uv.py", line 79, in _matching_parents
-        for part, match_part in zip(
-    TypeError: zip() takes no keyword arguments
-    "#
+    "
     );
 }
 

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -79,7 +79,7 @@ def _matching_parents(path: str | None, match: str) -> str | None:
         for part, match_part in (
             zip(reversed(parts), reversed(match_parts), strict=False)
             if sys.version_info >= (3, 10)
-            else zip(reversed(parts), reversed(match_parts))
+            else zip(reversed(parts), reversed(match_parts), strict=False)
         )
     ):
         return None

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -79,7 +79,7 @@ def _matching_parents(path: str | None, match: str) -> str | None:
         for part, match_part in (
             zip(reversed(parts), reversed(match_parts), strict=False)
             if sys.version_info >= (3, 10)
-            else zip(reversed(parts), reversed(match_parts))
+            else zip(reversed(parts), reversed(match_parts))  # noqa: B905
         )
     ):
         return None

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -79,7 +79,7 @@ def _matching_parents(path: str | None, match: str) -> str | None:
         for part, match_part in (
             zip(reversed(parts), reversed(match_parts), strict=False)
             if sys.version_info >= (3, 10)
-            else zip(reversed(parts), reversed(match_parts), strict=False)
+            else zip(reversed(parts), reversed(match_parts))
         )
     ):
         return None

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -76,8 +76,10 @@ def _matching_parents(path: str | None, match: str) -> str | None:
 
     if not all(
         fnmatch(part, match_part)
-        for part, match_part in zip(
-            reversed(parts), reversed(match_parts), strict=False
+        for part, match_part in (
+            zip(reversed(parts), reversed(match_parts), strict=False)
+            if sys.version_info >= (3, 10)
+            else zip(reversed(parts), reversed(match_parts))
         )
     ):
         return None


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Uses a <3.10-compatible version of `zip` since the `strict` argument was [added in 3.10](https://docs.python.org/3.10/library/functions.html#zip)

## Test Plan

I executed the `_matching_parents` function in a local 3.9 environment 
