### PR TITLE
Update the target Python version for Ruff to 3.7 in the `uv` module

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,2 +1,2 @@
-# It is important retain compatibility here
+# It is important to retain compatibility here.
 target-version = "py37"

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,0 +1,2 @@
+# It is important retain compatibility here
+target-version = "py37"

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -76,11 +76,7 @@ def _matching_parents(path: str | None, match: str) -> str | None:
 
     if not all(
         fnmatch(part, match_part)
-        for part, match_part in (
-            zip(reversed(parts), reversed(match_parts), strict=False)
-            if sys.version_info >= (3, 10)
-            else zip(reversed(parts), reversed(match_parts))
-        )
+        for part, match_part in zip(reversed(parts), reversed(match_parts))
     ):
         return None
 

--- a/python/uv/_find_uv.py
+++ b/python/uv/_find_uv.py
@@ -79,7 +79,7 @@ def _matching_parents(path: str | None, match: str) -> str | None:
         for part, match_part in (
             zip(reversed(parts), reversed(match_parts), strict=False)
             if sys.version_info >= (3, 10)
-            else zip(reversed(parts), reversed(match_parts))  # noqa: B905
+            else zip(reversed(parts), reversed(match_parts))
         )
     ):
         return None


### PR DESCRIPTION
This fixes our Ruff target Python version for our Python module, which avoids it enforcing things that break compatibility like https://github.com/astral-sh/uv/issues/15176