### PR TITLE
Add `--reinstall` flag to `uv python upgrade`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5196,6 +5196,13 @@ pub struct PythonUpgradeArgs {
     #[arg(long, env = EnvVars::UV_PYPY_INSTALL_MIRROR)]
     pub pypy_mirror: Option<String>,
 
+    /// Reinstall the latest Python patch, if it's already installed.
+    ///
+    /// By default, uv will exit successfully if the latest patch is already
+    /// installed.
+    #[arg(long, short)]
+    pub reinstall: bool,
+
     /// URL pointing to JSON of custom Python installations.
     ///
     /// Note that currently, only local paths are supported.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1437,14 +1437,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::PythonUpgradeSettings::resolve(args, filesystem);
             show_settings!(args);
-            let reinstall = false;
             let upgrade = true;
 
             commands::python_install(
                 &project_dir,
                 args.install_dir,
                 args.targets,
-                reinstall,
+                args.reinstall,
                 upgrade,
                 args.bin,
                 args.registry,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1019,6 +1019,7 @@ pub(crate) struct PythonUpgradeSettings {
     pub(crate) registry: Option<bool>,
     pub(crate) python_install_mirror: Option<String>,
     pub(crate) pypy_install_mirror: Option<String>,
+    pub(crate) reinstall: bool,
     pub(crate) python_downloads_json_url: Option<String>,
     pub(crate) default: bool,
     pub(crate) bin: Option<bool>,
@@ -1051,6 +1052,7 @@ impl PythonUpgradeSettings {
             targets,
             mirror: _,
             pypy_mirror: _,
+            reinstall,
             python_downloads_json_url: _,
         } = args;
 
@@ -1061,6 +1063,7 @@ impl PythonUpgradeSettings {
             registry,
             python_install_mirror: python_mirror,
             pypy_install_mirror: pypy_mirror,
+            reinstall,
             python_downloads_json_url,
             default,
             bin,

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -52,6 +52,17 @@ fn python_upgrade() {
 
     ----- stderr -----
     ");
+
+    // Should reinstall on `--reinstall`
+    uv_snapshot!(context.filters(), context.python_upgrade().arg("--preview").arg("3.10").arg("--reinstall"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.10.18 in [TIME]
+     ~ cpython-3.10.18-[PLATFORM] (python3.10)
+    ");
 }
 
 #[test]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2970,6 +2970,8 @@ uv python upgrade [OPTIONS] [TARGETS]...
 <p>Note that currently, only local paths are supported.</p>
 <p>May also be set with the <code>UV_PYTHON_DOWNLOADS_JSON_URL</code> environment variable.</p></dd><dt id="uv-python-upgrade--quiet"><a href="#uv-python-upgrade--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
+</dd><dt id="uv-python-upgrade--reinstall"><a href="#uv-python-upgrade--reinstall"><code>--reinstall</code></a>, <code>-r</code></dt><dd><p>Reinstall the latest Python patch, if it's already installed.</p>
+<p>By default, uv will exit successfully if the latest patch is already installed.</p>
 </dd><dt id="uv-python-upgrade--verbose"><a href="#uv-python-upgrade--verbose"><code>--verbose</code></a>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (<a href="https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives">https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives</a>)</p>
 </dd></dl>


### PR DESCRIPTION
As described in #15179, there are cases where it can be useful to reinstall the latest patch on upgrade if it is already installed. Using this flag, you don't need to know ahead of time if you have the latest patch already.

Closes #15179.
