### PR TITLE
document uv version for environment variables

### DIFF
--- a/crates/uv-dev/src/generate_env_vars_reference.rs
+++ b/crates/uv-dev/src/generate_env_vars_reference.rs
@@ -80,27 +80,31 @@ fn generate() -> String {
     // Partition and sort environment variables into UV_ and external variables.
     let (uv_vars, external_vars): (BTreeSet<_>, BTreeSet<_>) = EnvVars::metadata()
         .iter()
-        .partition(|(var, _)| var.starts_with("UV_"));
+        .partition(|(var, _, _)| var.starts_with("UV_"));
 
     output.push_str("uv defines and respects the following environment variables:\n\n");
 
-    for (var, doc) in uv_vars {
-        output.push_str(&render(var, doc));
+    for (var, doc, added_in) in uv_vars {
+        output.push_str(&render(var, doc, added_in));
     }
 
     output.push_str("\n\n## Externally defined variables\n\n");
     output.push_str("uv also reads the following externally defined environment variables:\n\n");
 
-    for (var, doc) in external_vars {
-        output.push_str(&render(var, doc));
+    for (var, doc, added_in) in external_vars {
+        output.push_str(&render(var, doc, added_in));
     }
 
     output
 }
 
 /// Render an environment variable and its documentation.
-fn render(var: &str, doc: &str) -> String {
-    format!("### `{var}`\n\n{doc}\n\n")
+fn render(var: &str, doc: &str, added_in: Option<&str>) -> String {
+    if let Some(added_in) = added_in {
+        format!("### `{var}`\n<small class=\"added-in\">added in `{added_in}`</small>\n\n{doc}\n\n")
+    } else {
+        format!("### `{var}`\n\n{doc}\n\n")
+    }
 }
 
 #[cfg(test)]

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1,4 +1,7 @@
-use uv_macros::{attr_env_var_pattern, attr_hidden, attribute_env_vars_metadata};
+//! Environment variables used or supported by uv.
+//! Used to generate `docs/reference/environment.md`.
+//! NOTICE: Upcoming release functionality should be documented with `#[attr_added_in("next release")]`.
+use uv_macros::{attr_added_in, attr_env_var_pattern, attr_hidden, attribute_env_vars_metadata};
 
 /// Declares all environment variable used throughout `uv` and its crates.
 pub struct EnvVars;
@@ -14,54 +17,67 @@ impl EnvVars {
     ///
     /// See <https://doc.rust-lang.org/std/env/fn.current_exe.html#security> for security
     /// considerations.
+    #[attr_added_in("0.6.0")]
     pub const UV: &'static str = "UV";
 
     /// Equivalent to the `--offline` command-line argument. If set, uv will disable network access.
+    #[attr_added_in("0.5.9")]
     pub const UV_OFFLINE: &'static str = "UV_OFFLINE";
 
     /// Equivalent to the `--default-index` command-line argument. If set, uv will use
     /// this URL as the default index when searching for packages.
+    #[attr_added_in("0.4.23")]
     pub const UV_DEFAULT_INDEX: &'static str = "UV_DEFAULT_INDEX";
 
     /// Equivalent to the `--index` command-line argument. If set, uv will use this
     /// space-separated list of URLs as additional indexes when searching for packages.
+    #[attr_added_in("0.4.23")]
     pub const UV_INDEX: &'static str = "UV_INDEX";
 
     /// Equivalent to the `--index-url` command-line argument. If set, uv will use this
     /// URL as the default index when searching for packages.
     /// (Deprecated: use `UV_DEFAULT_INDEX` instead.)
+    #[attr_added_in("0.0.5")]
     pub const UV_INDEX_URL: &'static str = "UV_INDEX_URL";
 
     /// Equivalent to the `--extra-index-url` command-line argument. If set, uv will
     /// use this space-separated list of URLs as additional indexes when searching for packages.
     /// (Deprecated: use `UV_INDEX` instead.)
+    #[attr_added_in("0.1.3")]
     pub const UV_EXTRA_INDEX_URL: &'static str = "UV_EXTRA_INDEX_URL";
 
     /// Equivalent to the `--find-links` command-line argument. If set, uv will use this
     /// comma-separated list of additional locations to search for packages.
+    #[attr_added_in("0.4.19")]
     pub const UV_FIND_LINKS: &'static str = "UV_FIND_LINKS";
 
     /// Equivalent to the `--cache-dir` command-line argument. If set, uv will use this
     /// directory for caching instead of the default cache directory.
+    #[attr_added_in("0.0.5")]
     pub const UV_CACHE_DIR: &'static str = "UV_CACHE_DIR";
 
     /// The directory for storage of credentials when using a plain text backend.
+    #[attr_added_in("0.8.15")]
     pub const UV_CREDENTIALS_DIR: &'static str = "UV_CREDENTIALS_DIR";
 
     /// Equivalent to the `--no-cache` command-line argument. If set, uv will not use the
     /// cache for any operations.
+    #[attr_added_in("0.1.2")]
     pub const UV_NO_CACHE: &'static str = "UV_NO_CACHE";
 
     /// Equivalent to the `--resolution` command-line argument. For example, if set to
     /// `lowest-direct`, uv will install the lowest compatible versions of all direct dependencies.
+    #[attr_added_in("0.1.27")]
     pub const UV_RESOLUTION: &'static str = "UV_RESOLUTION";
 
     /// Equivalent to the `--prerelease` command-line argument. For example, if set to
     /// `allow`, uv will allow pre-release versions for all dependencies.
+    #[attr_added_in("0.1.16")]
     pub const UV_PRERELEASE: &'static str = "UV_PRERELEASE";
 
     /// Equivalent to the `--fork-strategy` argument. Controls version selection during universal
     /// resolution.
+    #[attr_added_in("0.5.9")]
     pub const UV_FORK_STRATEGY: &'static str = "UV_FORK_STRATEGY";
 
     /// Equivalent to the `--system` command-line argument. If set to `true`, uv will
@@ -70,10 +86,12 @@ impl EnvVars {
     /// WARNING: `UV_SYSTEM_PYTHON=true` is intended for use in continuous integration (CI)
     /// or containerized environments and should be used with caution, as modifying the system
     /// Python can lead to unexpected behavior.
+    #[attr_added_in("0.1.18")]
     pub const UV_SYSTEM_PYTHON: &'static str = "UV_SYSTEM_PYTHON";
 
     /// Equivalent to the `--python` command-line argument. If set to a path, uv will use
     /// this Python interpreter for all operations.
+    #[attr_added_in("0.1.40")]
     pub const UV_PYTHON: &'static str = "UV_PYTHON";
 
     /// Equivalent to the `--break-system-packages` command-line argument. If set to `true`,
@@ -82,10 +100,12 @@ impl EnvVars {
     /// WARNING: `UV_BREAK_SYSTEM_PACKAGES=true` is intended for use in continuous integration
     /// (CI) or containerized environments and should be used with caution, as modifying the system
     /// Python can lead to unexpected behavior.
+    #[attr_added_in("0.1.32")]
     pub const UV_BREAK_SYSTEM_PACKAGES: &'static str = "UV_BREAK_SYSTEM_PACKAGES";
 
     /// Equivalent to the `--native-tls` command-line argument. If set to `true`, uv will
     /// use the system's trust store instead of the bundled `webpki-roots` crate.
+    #[attr_added_in("0.1.19")]
     pub const UV_NATIVE_TLS: &'static str = "UV_NATIVE_TLS";
 
     /// Equivalent to the `--index-strategy` command-line argument.
@@ -93,30 +113,37 @@ impl EnvVars {
     /// For example, if set to `unsafe-best-match`, uv will consider versions of a given package
     /// available across all index URLs, rather than limiting its search to the first index URL
     /// that contains the package.
+    #[attr_added_in("0.1.29")]
     pub const UV_INDEX_STRATEGY: &'static str = "UV_INDEX_STRATEGY";
 
     /// Equivalent to the `--require-hashes` command-line argument. If set to `true`,
     /// uv will require that all dependencies have a hash specified in the requirements file.
+    #[attr_added_in("0.1.34")]
     pub const UV_REQUIRE_HASHES: &'static str = "UV_REQUIRE_HASHES";
 
     /// Equivalent to the `--constraint` command-line argument. If set, uv will use this
     /// file as the constraints file. Uses space-separated list of files.
+    #[attr_added_in("0.1.36")]
     pub const UV_CONSTRAINT: &'static str = "UV_CONSTRAINT";
 
     /// Equivalent to the `--build-constraint` command-line argument. If set, uv will use this file
     /// as constraints for any source distribution builds. Uses space-separated list of files.
+    #[attr_added_in("0.2.34")]
     pub const UV_BUILD_CONSTRAINT: &'static str = "UV_BUILD_CONSTRAINT";
 
     /// Equivalent to the `--override` command-line argument. If set, uv will use this file
     /// as the overrides file. Uses space-separated list of files.
+    #[attr_added_in("0.2.22")]
     pub const UV_OVERRIDE: &'static str = "UV_OVERRIDE";
 
     /// Equivalent to the `--link-mode` command-line argument. If set, uv will use this as
     /// a link mode.
+    #[attr_added_in("0.1.40")]
     pub const UV_LINK_MODE: &'static str = "UV_LINK_MODE";
 
     /// Equivalent to the `--no-build-isolation` command-line argument. If set, uv will
     /// skip isolation when building source distributions.
+    #[attr_added_in("0.1.40")]
     pub const UV_NO_BUILD_ISOLATION: &'static str = "UV_NO_BUILD_ISOLATION";
 
     /// Equivalent to the `--custom-compile-command` command-line argument.
@@ -124,133 +151,167 @@ impl EnvVars {
     /// Used to override uv in the output header of the `requirements.txt` files generated by
     /// `uv pip compile`. Intended for use-cases in which `uv pip compile` is called from within a wrapper
     /// script, to include the name of the wrapper script in the output file.
+    #[attr_added_in("0.1.23")]
     pub const UV_CUSTOM_COMPILE_COMMAND: &'static str = "UV_CUSTOM_COMPILE_COMMAND";
 
     /// Equivalent to the `--keyring-provider` command-line argument. If set, uv
     /// will use this value as the keyring provider.
+    #[attr_added_in("0.1.19")]
     pub const UV_KEYRING_PROVIDER: &'static str = "UV_KEYRING_PROVIDER";
 
     /// Equivalent to the `--config-file` command-line argument. Expects a path to a
     /// local `uv.toml` file to use as the configuration file.
+    #[attr_added_in("0.1.34")]
     pub const UV_CONFIG_FILE: &'static str = "UV_CONFIG_FILE";
 
     /// Equivalent to the `--no-config` command-line argument. If set, uv will not read
     /// any configuration files from the current directory, parent directories, or user configuration
     /// directories.
+    #[attr_added_in("0.2.30")]
     pub const UV_NO_CONFIG: &'static str = "UV_NO_CONFIG";
 
     /// Equivalent to the `--isolated` command-line argument. If set, uv will avoid discovering
     /// a `pyproject.toml` or `uv.toml` file.
+    #[attr_added_in("0.8.14")]
     pub const UV_ISOLATED: &'static str = "UV_ISOLATED";
 
     /// Equivalent to the `--exclude-newer` command-line argument. If set, uv will
     /// exclude distributions published after the specified date.
+    #[attr_added_in("0.2.12")]
     pub const UV_EXCLUDE_NEWER: &'static str = "UV_EXCLUDE_NEWER";
 
     /// Whether uv should prefer system or managed Python versions.
+    #[attr_added_in("0.3.2")]
     pub const UV_PYTHON_PREFERENCE: &'static str = "UV_PYTHON_PREFERENCE";
 
     /// Require use of uv-managed Python versions.
+    #[attr_added_in("0.6.8")]
     pub const UV_MANAGED_PYTHON: &'static str = "UV_MANAGED_PYTHON";
 
     /// Disable use of uv-managed Python versions.
+    #[attr_added_in("0.6.8")]
     pub const UV_NO_MANAGED_PYTHON: &'static str = "UV_NO_MANAGED_PYTHON";
 
     /// Equivalent to the
     /// [`python-downloads`](../reference/settings.md#python-downloads) setting and, when disabled, the
     /// `--no-python-downloads` option. Whether uv should allow Python downloads.
+    #[attr_added_in("0.3.2")]
     pub const UV_PYTHON_DOWNLOADS: &'static str = "UV_PYTHON_DOWNLOADS";
 
     /// Overrides the environment-determined libc on linux systems when filling in the current platform
     /// within Python version requests. Options are: `gnu`, `gnueabi`, `gnueabihf`, `musl`, and `none`.
+    #[attr_added_in("0.7.22")]
     pub const UV_LIBC: &'static str = "UV_LIBC";
 
     /// Equivalent to the `--compile-bytecode` command-line argument. If set, uv
     /// will compile Python source files to bytecode after installation.
+    #[attr_added_in("0.3.3")]
     pub const UV_COMPILE_BYTECODE: &'static str = "UV_COMPILE_BYTECODE";
 
     /// Timeout (in seconds) for bytecode compilation.
+    #[attr_added_in("0.7.22")]
     pub const UV_COMPILE_BYTECODE_TIMEOUT: &'static str = "UV_COMPILE_BYTECODE_TIMEOUT";
 
     /// Equivalent to the `--no-editable` command-line argument. If set, uv
     /// installs or exports any editable dependencies, including the project and any workspace
     /// members, as non-editable.
+    #[attr_added_in("0.6.15")]
     pub const UV_NO_EDITABLE: &'static str = "UV_NO_EDITABLE";
 
     /// Equivalent to the `--dev` command-line argument. If set, uv will include
     /// development dependencies.
+    #[attr_added_in("0.8.7")]
     pub const UV_DEV: &'static str = "UV_DEV";
 
     /// Equivalent to the `--no-dev` command-line argument. If set, uv will exclude
     /// development dependencies.
+    #[attr_added_in("0.8.7")]
     pub const UV_NO_DEV: &'static str = "UV_NO_DEV";
 
     /// Equivalent to the `--no-binary` command-line argument. If set, uv will install
     /// all packages from source. The resolver will still use pre-built wheels to
     /// extract package metadata, if available.
+    #[attr_added_in("0.5.30")]
     pub const UV_NO_BINARY: &'static str = "UV_NO_BINARY";
 
     /// Equivalent to the `--no-binary-package` command line argument. If set, uv will
     /// not use pre-built wheels for the given space-delimited list of packages.
+    #[attr_added_in("0.5.30")]
     pub const UV_NO_BINARY_PACKAGE: &'static str = "UV_NO_BINARY_PACKAGE";
 
     /// Equivalent to the `--no-build` command-line argument. If set, uv will not build
     /// source distributions.
+    #[attr_added_in("0.1.40")]
     pub const UV_NO_BUILD: &'static str = "UV_NO_BUILD";
 
     /// Equivalent to the `--no-build-package` command line argument. If set, uv will
     /// not build source distributions for the given space-delimited list of packages.
+    #[attr_added_in("0.6.5")]
     pub const UV_NO_BUILD_PACKAGE: &'static str = "UV_NO_BUILD_PACKAGE";
 
     /// Equivalent to the `--publish-url` command-line argument. The URL of the upload
     /// endpoint of the index to use with `uv publish`.
+    #[attr_added_in("0.4.16")]
     pub const UV_PUBLISH_URL: &'static str = "UV_PUBLISH_URL";
 
     /// Equivalent to the `--token` command-line argument in `uv publish`. If set, uv
     /// will use this token (with the username `__token__`) for publishing.
+    #[attr_added_in("0.4.16")]
     pub const UV_PUBLISH_TOKEN: &'static str = "UV_PUBLISH_TOKEN";
 
     /// Equivalent to the `--index` command-line argument in `uv publish`. If
     /// set, uv the index with this name in the configuration for publishing.
+    #[attr_added_in("0.5.8")]
     pub const UV_PUBLISH_INDEX: &'static str = "UV_PUBLISH_INDEX";
 
     /// Equivalent to the `--username` command-line argument in `uv publish`. If
     /// set, uv will use this username for publishing.
+    #[attr_added_in("0.4.16")]
     pub const UV_PUBLISH_USERNAME: &'static str = "UV_PUBLISH_USERNAME";
 
     /// Equivalent to the `--password` command-line argument in `uv publish`. If
     /// set, uv will use this password for publishing.
+    #[attr_added_in("0.4.16")]
     pub const UV_PUBLISH_PASSWORD: &'static str = "UV_PUBLISH_PASSWORD";
 
     /// Don't upload a file if it already exists on the index. The value is the URL of the index.
+    #[attr_added_in("0.4.30")]
     pub const UV_PUBLISH_CHECK_URL: &'static str = "UV_PUBLISH_CHECK_URL";
 
     /// Equivalent to the `--no-sync` command-line argument. If set, uv will skip updating
     /// the environment.
+    #[attr_added_in("0.4.18")]
     pub const UV_NO_SYNC: &'static str = "UV_NO_SYNC";
 
     /// Equivalent to the `--locked` command-line argument. If set, uv will assert that the
     /// `uv.lock` remains unchanged.
+    #[attr_added_in("0.4.25")]
     pub const UV_LOCKED: &'static str = "UV_LOCKED";
 
     /// Equivalent to the `--frozen` command-line argument. If set, uv will run without
     /// updating the `uv.lock` file.
+    #[attr_added_in("0.4.25")]
     pub const UV_FROZEN: &'static str = "UV_FROZEN";
 
     /// Equivalent to the `--preview` argument. Enables preview mode.
+    #[attr_added_in("0.1.37")]
     pub const UV_PREVIEW: &'static str = "UV_PREVIEW";
 
     /// Equivalent to the `--preview-features` argument. Enables specific preview features.
+    #[attr_added_in("0.8.4")]
     pub const UV_PREVIEW_FEATURES: &'static str = "UV_PREVIEW_FEATURES";
 
     /// Equivalent to the `--token` argument for self update. A GitHub token for authentication.
+    #[attr_added_in("0.4.10")]
     pub const UV_GITHUB_TOKEN: &'static str = "UV_GITHUB_TOKEN";
 
     /// Equivalent to the `--no-verify-hashes` argument. Disables hash verification for
     /// `requirements.txt` files.
+    #[attr_added_in("0.5.3")]
     pub const UV_NO_VERIFY_HASHES: &'static str = "UV_NO_VERIFY_HASHES";
 
     /// Equivalent to the `--allow-insecure-host` argument.
+    #[attr_added_in("0.3.5")]
     pub const UV_INSECURE_HOST: &'static str = "UV_INSECURE_HOST";
 
     /// Disable ZIP validation for streamed wheels and ZIP-based source distributions.
@@ -259,50 +320,63 @@ impl EnvVars {
     /// integrity checks and allowing uv to install potentially malicious ZIP files. If uv rejects
     /// a ZIP file due to failing validation, it is likely that the file is malformed; consider
     /// filing an issue with the package maintainer.
+    #[attr_added_in("0.8.6")]
     pub const UV_INSECURE_NO_ZIP_VALIDATION: &'static str = "UV_INSECURE_NO_ZIP_VALIDATION";
 
     /// Sets the maximum number of in-flight concurrent downloads that uv will
     /// perform at any given time.
+    #[attr_added_in("0.1.43")]
     pub const UV_CONCURRENT_DOWNLOADS: &'static str = "UV_CONCURRENT_DOWNLOADS";
 
     /// Sets the maximum number of source distributions that uv will build
     /// concurrently at any given time.
+    #[attr_added_in("0.1.43")]
     pub const UV_CONCURRENT_BUILDS: &'static str = "UV_CONCURRENT_BUILDS";
 
     /// Controls the number of threads used when installing and unzipping
     /// packages.
+    #[attr_added_in("0.1.45")]
     pub const UV_CONCURRENT_INSTALLS: &'static str = "UV_CONCURRENT_INSTALLS";
 
     /// Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
     /// example, spinners and progress bars.
+    #[attr_added_in("0.2.28")]
     pub const UV_NO_PROGRESS: &'static str = "UV_NO_PROGRESS";
 
     /// Specifies the directory where uv stores managed tools.
+    #[attr_added_in("0.2.16")]
     pub const UV_TOOL_DIR: &'static str = "UV_TOOL_DIR";
 
     /// Specifies the "bin" directory for installing tool executables.
+    #[attr_added_in("0.3.0")]
     pub const UV_TOOL_BIN_DIR: &'static str = "UV_TOOL_BIN_DIR";
 
     /// Equivalent to the `--build-backend` argument for `uv init`. Determines the default backend
     /// to use when creating a new project.
+    #[attr_added_in("0.8.2")]
     pub const UV_INIT_BUILD_BACKEND: &'static str = "UV_INIT_BUILD_BACKEND";
 
     /// Specifies the path to the directory to use for a project virtual environment.
     ///
     /// See the [project documentation](../concepts/projects/config.md#project-environment-path)
     /// for more details.
+    #[attr_added_in("0.4.4")]
     pub const UV_PROJECT_ENVIRONMENT: &'static str = "UV_PROJECT_ENVIRONMENT";
 
     /// Specifies the directory to place links to installed, managed Python executables.
+    #[attr_added_in("0.4.29")]
     pub const UV_PYTHON_BIN_DIR: &'static str = "UV_PYTHON_BIN_DIR";
 
     /// Specifies the directory for storing managed Python installations.
+    #[attr_added_in("0.2.22")]
     pub const UV_PYTHON_INSTALL_DIR: &'static str = "UV_PYTHON_INSTALL_DIR";
 
     /// Whether to install the Python executable into the `UV_PYTHON_BIN_DIR` directory.
+    #[attr_added_in("0.8.0")]
     pub const UV_PYTHON_INSTALL_BIN: &'static str = "UV_PYTHON_INSTALL_BIN";
 
     /// Whether to install the Python executable into the Windows registry.
+    #[attr_added_in("0.8.0")]
     pub const UV_PYTHON_INSTALL_REGISTRY: &'static str = "UV_PYTHON_INSTALL_REGISTRY";
 
     /// Managed Python installations information is hardcoded in the `uv` binary.
@@ -311,10 +385,12 @@ impl EnvVars {
     /// This will allow for setting each property of the Python installation, mostly the url part for offline mirror.
     ///
     /// Note that currently, only local paths are supported.
+    #[attr_added_in("0.6.13")]
     pub const UV_PYTHON_DOWNLOADS_JSON_URL: &'static str = "UV_PYTHON_DOWNLOADS_JSON_URL";
 
     /// Specifies the directory for caching the archives of managed Python installations before
     /// installation.
+    #[attr_added_in("0.7.0")]
     pub const UV_PYTHON_CACHE_DIR: &'static str = "UV_PYTHON_CACHE_DIR";
 
     /// Managed Python installations are downloaded from the Astral
@@ -324,6 +400,7 @@ impl EnvVars {
     /// The provided URL will replace `https://github.com/astral-sh/python-build-standalone/releases/download` in, e.g.,
     /// `https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
     /// Distributions can be read from a local directory by using the `file://` URL scheme.
+    #[attr_added_in("0.2.35")]
     pub const UV_PYTHON_INSTALL_MIRROR: &'static str = "UV_PYTHON_INSTALL_MIRROR";
 
     /// Managed PyPy installations are downloaded from [python.org](https://downloads.python.org/).
@@ -333,57 +410,69 @@ impl EnvVars {
     /// `https://downloads.python.org/pypy` in, e.g.,
     /// `https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2`.
     /// Distributions can be read from a local directory by using the `file://` URL scheme.
+    #[attr_added_in("0.2.35")]
     pub const UV_PYPY_INSTALL_MIRROR: &'static str = "UV_PYPY_INSTALL_MIRROR";
 
     /// Pin managed CPython versions to a specific build version.
     ///
     /// For CPython, this should be the build date (e.g., "20250814").
+    #[attr_added_in("0.8.14")]
     pub const UV_PYTHON_CPYTHON_BUILD: &'static str = "UV_PYTHON_CPYTHON_BUILD";
 
     /// Pin managed PyPy versions to a specific build version.
     ///
     /// For PyPy, this should be the PyPy version (e.g., "7.3.20").
+    #[attr_added_in("0.8.14")]
     pub const UV_PYTHON_PYPY_BUILD: &'static str = "UV_PYTHON_PYPY_BUILD";
 
     /// Pin managed GraalPy versions to a specific build version.
     ///
     /// For GraalPy, this should be the GraalPy version (e.g., "24.2.2").
+    #[attr_added_in("0.8.14")]
     pub const UV_PYTHON_GRAALPY_BUILD: &'static str = "UV_PYTHON_GRAALPY_BUILD";
 
     /// Pin managed Pyodide versions to a specific build version.
     ///
     /// For Pyodide, this should be the Pyodide version (e.g., "0.28.1").
+    #[attr_added_in("0.8.14")]
     pub const UV_PYTHON_PYODIDE_BUILD: &'static str = "UV_PYTHON_PYODIDE_BUILD";
 
     /// Equivalent to the `--clear` command-line argument. If set, uv will remove any
     /// existing files or directories at the target path.
+    #[attr_added_in("0.8.0")]
     pub const UV_VENV_CLEAR: &'static str = "UV_VENV_CLEAR";
 
     /// Install seed packages (one or more of: `pip`, `setuptools`, and `wheel`) into the virtual environment
     /// created by `uv venv`.
     ///
     /// Note that `setuptools` and `wheel` are not included in Python 3.12+ environments.
+    #[attr_added_in("0.5.21")]
     pub const UV_VENV_SEED: &'static str = "UV_VENV_SEED";
 
     /// Used to override `PATH` to limit Python executable availability in the test suite.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const UV_TEST_PYTHON_PATH: &'static str = "UV_TEST_PYTHON_PATH";
 
     /// Include resolver and installer output related to environment modifications.
     #[attr_hidden]
+    #[attr_added_in("0.2.32")]
     pub const UV_SHOW_RESOLUTION: &'static str = "UV_SHOW_RESOLUTION";
 
     /// Use to update the json schema files.
     #[attr_hidden]
+    #[attr_added_in("0.1.34")]
     pub const UV_UPDATE_SCHEMA: &'static str = "UV_UPDATE_SCHEMA";
 
     /// Use to disable line wrapping for diagnostics.
+    #[attr_added_in("0.0.5")]
     pub const UV_NO_WRAP: &'static str = "UV_NO_WRAP";
 
     /// Provides the HTTP Basic authentication username for a named index.
     ///
     /// The `name` parameter is the name of the index. For example, given an index named `foo`,
     /// the environment variable key would be `UV_INDEX_FOO_USERNAME`.
+    #[attr_added_in("0.4.23")]
     #[attr_env_var_pattern("UV_INDEX_{name}_USERNAME")]
     pub fn index_username(name: &str) -> String {
         format!("UV_INDEX_{name}_USERNAME")
@@ -393,6 +482,7 @@ impl EnvVars {
     ///
     /// The `name` parameter is the name of the index. For example, given an index named `foo`,
     /// the environment variable key would be `UV_INDEX_FOO_PASSWORD`.
+    #[attr_added_in("0.4.23")]
     #[attr_env_var_pattern("UV_INDEX_{name}_PASSWORD")]
     pub fn index_password(name: &str) -> String {
         format!("UV_INDEX_{name}_PASSWORD")
@@ -400,220 +490,280 @@ impl EnvVars {
 
     /// Used to set the uv commit hash at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const UV_COMMIT_HASH: &'static str = "UV_COMMIT_HASH";
 
     /// Used to set the uv commit short hash at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const UV_COMMIT_SHORT_HASH: &'static str = "UV_COMMIT_SHORT_HASH";
 
     /// Used to set the uv commit date at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const UV_COMMIT_DATE: &'static str = "UV_COMMIT_DATE";
 
     /// Used to set the uv tag at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const UV_LAST_TAG: &'static str = "UV_LAST_TAG";
 
     /// Used to set the uv tag distance from head at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const UV_LAST_TAG_DISTANCE: &'static str = "UV_LAST_TAG_DISTANCE";
 
     /// Used to set the spawning/parent interpreter when using --system in the test suite.
     #[attr_hidden]
+    #[attr_added_in("0.2.0")]
     pub const UV_INTERNAL__PARENT_INTERPRETER: &'static str = "UV_INTERNAL__PARENT_INTERPRETER";
 
     /// Used to force showing the derivation tree during resolver error reporting.
     #[attr_hidden]
+    #[attr_added_in("0.3.0")]
     pub const UV_INTERNAL__SHOW_DERIVATION_TREE: &'static str = "UV_INTERNAL__SHOW_DERIVATION_TREE";
 
     /// Used to set a temporary directory for some tests.
     #[attr_hidden]
+    #[attr_added_in("0.3.4")]
     pub const UV_INTERNAL__TEST_DIR: &'static str = "UV_INTERNAL__TEST_DIR";
 
     /// Used to force treating an interpreter as "managed" during tests.
     #[attr_hidden]
+    #[attr_added_in("0.8.0")]
     pub const UV_INTERNAL__TEST_PYTHON_MANAGED: &'static str = "UV_INTERNAL__TEST_PYTHON_MANAGED";
 
     /// Path to system-level configuration directory on Unix systems.
+    #[attr_added_in("0.4.26")]
     pub const XDG_CONFIG_DIRS: &'static str = "XDG_CONFIG_DIRS";
 
     /// Path to system-level configuration directory on Windows systems.
+    #[attr_added_in("0.4.26")]
     pub const SYSTEMDRIVE: &'static str = "SYSTEMDRIVE";
 
     /// Path to user-level configuration directory on Windows systems.
+    #[attr_added_in("0.1.42")]
     pub const APPDATA: &'static str = "APPDATA";
 
     /// Path to root directory of user's profile on Windows systems.
+    #[attr_added_in("0.0.5")]
     pub const USERPROFILE: &'static str = "USERPROFILE";
 
     /// Path to user-level configuration directory on Unix systems.
+    #[attr_added_in("0.1.34")]
     pub const XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
 
     /// Path to cache directory on Unix systems.
+    #[attr_added_in("0.1.17")]
     pub const XDG_CACHE_HOME: &'static str = "XDG_CACHE_HOME";
 
     /// Path to directory for storing managed Python installations and tools.
+    #[attr_added_in("0.2.16")]
     pub const XDG_DATA_HOME: &'static str = "XDG_DATA_HOME";
 
     /// Path to directory where executables are installed.
+    #[attr_added_in("0.2.16")]
     pub const XDG_BIN_HOME: &'static str = "XDG_BIN_HOME";
 
     /// Custom certificate bundle file path for SSL connections.
+    #[attr_added_in("0.1.14")]
     pub const SSL_CERT_FILE: &'static str = "SSL_CERT_FILE";
 
     /// If set, uv will use this file for mTLS authentication.
     /// This should be a single file containing both the certificate and the private key in PEM format.
+    #[attr_added_in("0.2.11")]
     pub const SSL_CLIENT_CERT: &'static str = "SSL_CLIENT_CERT";
 
     /// Proxy for HTTP requests.
+    #[attr_added_in("0.1.38")]
     pub const HTTP_PROXY: &'static str = "HTTP_PROXY";
 
     /// Proxy for HTTPS requests.
+    #[attr_added_in("0.1.38")]
     pub const HTTPS_PROXY: &'static str = "HTTPS_PROXY";
 
     /// General proxy for all network requests.
+    #[attr_added_in("0.1.38")]
     pub const ALL_PROXY: &'static str = "ALL_PROXY";
 
     /// Comma-separated list of hostnames (e.g., `example.com`) and/or patterns (e.g., `192.168.1.0/24`) that should bypass the proxy.
+    #[attr_added_in("0.1.38")]
     pub const NO_PROXY: &'static str = "NO_PROXY";
 
     /// Timeout (in seconds) for HTTP requests. (default: 30 s)
+    #[attr_added_in("0.1.7")]
     pub const UV_HTTP_TIMEOUT: &'static str = "UV_HTTP_TIMEOUT";
 
     /// The number of retries for HTTP requests. (default: 3)
+    #[attr_added_in("0.7.21")]
     pub const UV_HTTP_RETRIES: &'static str = "UV_HTTP_RETRIES";
 
     /// Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
+    #[attr_added_in("0.1.6")]
     pub const UV_REQUEST_TIMEOUT: &'static str = "UV_REQUEST_TIMEOUT";
 
     /// Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
+    #[attr_added_in("0.1.7")]
     pub const HTTP_TIMEOUT: &'static str = "HTTP_TIMEOUT";
 
     /// The validation modes to use when run with `--compile`.
     ///
     /// See [`PycInvalidationMode`](https://docs.python.org/3/library/py_compile.html#py_compile.PycInvalidationMode).
+    #[attr_added_in("0.1.7")]
     pub const PYC_INVALIDATION_MODE: &'static str = "PYC_INVALIDATION_MODE";
 
     /// Used to detect an activated virtual environment.
+    #[attr_added_in("0.0.5")]
     pub const VIRTUAL_ENV: &'static str = "VIRTUAL_ENV";
 
     /// Used to detect the path of an active Conda environment.
+    #[attr_added_in("0.0.5")]
     pub const CONDA_PREFIX: &'static str = "CONDA_PREFIX";
 
     /// Used to determine the name of the active Conda environment.
+    #[attr_added_in("0.5.0")]
     pub const CONDA_DEFAULT_ENV: &'static str = "CONDA_DEFAULT_ENV";
 
     /// Used to determine the root install path of Conda.
+    #[attr_added_in("0.8.18")]
     pub const CONDA_ROOT: &'static str = "_CONDA_ROOT";
 
     /// If set to `1` before a virtual environment is activated, then the
     /// virtual environment name will not be prepended to the terminal prompt.
+    #[attr_added_in("0.0.5")]
     pub const VIRTUAL_ENV_DISABLE_PROMPT: &'static str = "VIRTUAL_ENV_DISABLE_PROMPT";
 
     /// Used to detect the use of the Windows Command Prompt (as opposed to PowerShell).
+    #[attr_added_in("0.1.16")]
     pub const PROMPT: &'static str = "PROMPT";
 
     /// Used to detect `NuShell` usage.
+    #[attr_added_in("0.1.16")]
     pub const NU_VERSION: &'static str = "NU_VERSION";
 
     /// Used to detect Fish shell usage.
+    #[attr_added_in("0.1.28")]
     pub const FISH_VERSION: &'static str = "FISH_VERSION";
 
     /// Used to detect Bash shell usage.
+    #[attr_added_in("0.1.28")]
     pub const BASH_VERSION: &'static str = "BASH_VERSION";
 
     /// Used to detect Zsh shell usage.
+    #[attr_added_in("0.1.28")]
     pub const ZSH_VERSION: &'static str = "ZSH_VERSION";
 
     /// Used to determine which `.zshenv` to use when Zsh is being used.
+    #[attr_added_in("0.2.25")]
     pub const ZDOTDIR: &'static str = "ZDOTDIR";
 
     /// Used to detect Ksh shell usage.
+    #[attr_added_in("0.2.33")]
     pub const KSH_VERSION: &'static str = "KSH_VERSION";
 
     /// Used with `--python-platform macos` and related variants to set the
     /// deployment target (i.e., the minimum supported macOS version).
     ///
     /// Defaults to `13.0`, the least-recent non-EOL macOS version at time of writing.
+    #[attr_added_in("0.1.42")]
     pub const MACOSX_DEPLOYMENT_TARGET: &'static str = "MACOSX_DEPLOYMENT_TARGET";
 
     /// Used with `--python-platform arm64-apple-ios` and related variants to set the
     /// deployment target (i.e., the minimum supported iOS version).
     ///
     /// Defaults to `13.0`.
+    #[attr_added_in("0.8.16")]
     pub const IPHONEOS_DEPLOYMENT_TARGET: &'static str = "IPHONEOS_DEPLOYMENT_TARGET";
 
     /// Used with `--python-platform aarch64-linux-android` and related variants to set the
     /// Android API level. (i.e., the minimum supported Android API level).
     ///
     /// Defaults to `24`.
+    #[attr_added_in("0.8.16")]
     pub const ANDROID_API_LEVEL: &'static str = "ANDROID_API_LEVEL";
 
     /// Disables colored output (takes precedence over `FORCE_COLOR`).
     ///
     /// See [no-color.org](https://no-color.org).
+    #[attr_added_in("0.2.7")]
     pub const NO_COLOR: &'static str = "NO_COLOR";
 
     /// Forces colored output regardless of terminal support.
     ///
     /// See [force-color.org](https://force-color.org).
+    #[attr_added_in("0.2.7")]
     pub const FORCE_COLOR: &'static str = "FORCE_COLOR";
 
     /// Use to control color via `anstyle`.
+    #[attr_added_in("0.1.32")]
     pub const CLICOLOR_FORCE: &'static str = "CLICOLOR_FORCE";
 
     /// The standard `PATH` env var.
+    #[attr_added_in("0.0.5")]
     pub const PATH: &'static str = "PATH";
 
     /// The standard `HOME` env var.
+    #[attr_added_in("0.0.5")]
     pub const HOME: &'static str = "HOME";
 
     /// The standard `SHELL` posix env var.
+    #[attr_added_in("0.1.16")]
     pub const SHELL: &'static str = "SHELL";
 
     /// The standard `PWD` posix env var.
+    #[attr_added_in("0.0.5")]
     pub const PWD: &'static str = "PWD";
 
     /// Used to look for Microsoft Store Pythons installations.
+    #[attr_added_in("0.3.3")]
     pub const LOCALAPPDATA: &'static str = "LOCALAPPDATA";
 
     /// Path to the `.git` directory. Ignored by `uv` when performing fetch.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const GIT_DIR: &'static str = "GIT_DIR";
 
     /// Path to the git working tree. Ignored by `uv` when performing fetch.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const GIT_WORK_TREE: &'static str = "GIT_WORK_TREE";
 
     /// Path to the index file for staged changes. Ignored by `uv` when performing fetch.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const GIT_INDEX_FILE: &'static str = "GIT_INDEX_FILE";
 
     /// Path to where git object files are located. Ignored by `uv` when performing fetch.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const GIT_OBJECT_DIRECTORY: &'static str = "GIT_OBJECT_DIRECTORY";
 
     /// Alternate locations for git objects. Ignored by `uv` when performing fetch.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const GIT_ALTERNATE_OBJECT_DIRECTORIES: &'static str = "GIT_ALTERNATE_OBJECT_DIRECTORIES";
 
     /// Disables SSL verification for git operations.
     #[attr_hidden]
+    #[attr_added_in("0.5.28")]
     pub const GIT_SSL_NO_VERIFY: &'static str = "GIT_SSL_NO_VERIFY";
 
     /// Sets allowed protocols for git operations.
     ///
     /// When uv is in "offline" mode, only the "file" protocol is allowed.
     #[attr_hidden]
+    #[attr_added_in("0.6.13")]
     pub const GIT_ALLOW_PROTOCOL: &'static str = "GIT_ALLOW_PROTOCOL";
 
     /// Sets the SSH command used when Git tries to establish a connection using SSH.
     #[attr_hidden]
+    #[attr_added_in("0.7.11")]
     pub const GIT_SSH_COMMAND: &'static str = "GIT_SSH_COMMAND";
 
     /// Disable interactive git prompts in terminals, e.g., for credentials. Does not disable
     /// GUI prompts.
     #[attr_hidden]
+    #[attr_added_in("0.6.4")]
     pub const GIT_TERMINAL_PROMPT: &'static str = "GIT_TERMINAL_PROMPT";
 
     /// Used in tests for better git isolation.
@@ -625,73 +775,91 @@ impl EnvVars {
     /// prevent git from crawling up the directory tree past that point to find
     /// parent git repositories.
     #[attr_hidden]
+    #[attr_added_in("0.4.29")]
     pub const GIT_CEILING_DIRECTORIES: &'static str = "GIT_CEILING_DIRECTORIES";
 
     /// Indicates that the current process is running in GitHub Actions.
     ///
     /// `uv publish` may attempt trusted publishing flows when set
     /// to `true`.
+    #[attr_added_in("0.4.16")]
     pub const GITHUB_ACTIONS: &'static str = "GITHUB_ACTIONS";
 
     /// Indicates that the current process is running in GitLab CI.
     ///
     /// `uv publish` may attempt trusted publishing flows when set
     /// to `true`.
+    #[attr_added_in("0.8.18")]
     pub const GITLAB_CI: &'static str = "GITLAB_CI";
 
     /// Sets the encoding for standard I/O streams (e.g., PYTHONIOENCODING=utf-8).
     #[attr_hidden]
+    #[attr_added_in("0.4.18")]
     pub const PYTHONIOENCODING: &'static str = "PYTHONIOENCODING";
 
     /// Forces unbuffered I/O streams, equivalent to `-u` in Python.
     #[attr_hidden]
+    #[attr_added_in("0.1.15")]
     pub const PYTHONUNBUFFERED: &'static str = "PYTHONUNBUFFERED";
 
     /// Enables UTF-8 mode for Python, equivalent to `-X utf8`.
     #[attr_hidden]
+    #[attr_added_in("0.4.19")]
     pub const PYTHONUTF8: &'static str = "PYTHONUTF8";
 
     /// Adds directories to Python module search path (e.g., `PYTHONPATH=/path/to/modules`).
+    #[attr_added_in("0.1.22")]
     pub const PYTHONPATH: &'static str = "PYTHONPATH";
 
     /// Used in tests to enforce a consistent locale setting.
     #[attr_hidden]
+    #[attr_added_in("0.4.28")]
     pub const LC_ALL: &'static str = "LC_ALL";
 
     /// Typically set by CI runners, used to detect a CI runner.
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const CI: &'static str = "CI";
 
     /// Azure DevOps build identifier, used to detect CI environments.
     #[attr_hidden]
+    #[attr_added_in("0.1.22")]
     pub const BUILD_BUILDID: &'static str = "BUILD_BUILDID";
 
     /// Generic build identifier, used to detect CI environments.
     #[attr_hidden]
+    #[attr_added_in("0.1.22")]
     pub const BUILD_ID: &'static str = "BUILD_ID";
 
     /// Pip environment variable to indicate CI environment.
     #[attr_hidden]
+    #[attr_added_in("0.1.22")]
     pub const PIP_IS_CI: &'static str = "PIP_IS_CI";
 
     /// Use to set the .netrc file location.
+    #[attr_added_in("0.1.16")]
     pub const NETRC: &'static str = "NETRC";
 
     /// The standard `PAGER` posix env var. Used by `uv` to configure the appropriate pager.
+    #[attr_added_in("0.4.18")]
     pub const PAGER: &'static str = "PAGER";
 
     /// Used to detect when running inside a Jupyter notebook.
+    #[attr_added_in("0.2.6")]
     pub const JPY_SESSION_NAME: &'static str = "JPY_SESSION_NAME";
 
     /// Use to create the tracing root directory via the `tracing-durations-export` feature.
     #[attr_hidden]
+    #[attr_added_in("0.1.32")]
     pub const TRACING_DURATIONS_TEST_ROOT: &'static str = "TRACING_DURATIONS_TEST_ROOT";
 
     /// Use to create the tracing durations file via the `tracing-durations-export` feature.
+    #[attr_added_in("0.0.5")]
     pub const TRACING_DURATIONS_FILE: &'static str = "TRACING_DURATIONS_FILE";
 
     /// Used to set `RUST_HOST_TARGET` at build time via `build.rs`.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const TARGET: &'static str = "TARGET";
 
     /// If set, uv will use this value as the log level for its `--verbose` output. Accepts
@@ -704,6 +872,7 @@ impl EnvVars {
     ///
     /// See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
     /// for more.
+    #[attr_added_in("0.0.5")]
     pub const RUST_LOG: &'static str = "RUST_LOG";
 
     /// If set, it can be used to display more stack trace details when a panic occurs.
@@ -716,11 +885,13 @@ impl EnvVars {
     ///
     /// See the [Rust backtrace documentation](https://doc.rust-lang.org/std/backtrace/index.html)
     /// for more.
+    #[attr_added_in("0.7.22")]
     pub const RUST_BACKTRACE: &'static str = "RUST_BACKTRACE";
 
     /// Add additional context and structure to log messages.
     ///
     /// If logging is not enabled, e.g., with `RUST_LOG` or `-v`, this has no effect.
+    #[attr_added_in("0.6.4")]
     pub const UV_LOG_CONTEXT: &'static str = "UV_LOG_CONTEXT";
 
     /// Use to set the stack size used by uv.
@@ -732,6 +903,7 @@ impl EnvVars {
     /// stack size, because we actually spawn our own main2 thread to work around
     /// the fact that Windows' real main thread is only 1MB. That thread has size
     /// `max(UV_STACK_SIZE, 1MB)`.
+    #[attr_added_in("0.0.5")]
     pub const UV_STACK_SIZE: &'static str = "UV_STACK_SIZE";
 
     /// Use to set the stack size used by uv.
@@ -746,201 +918,254 @@ impl EnvVars {
     /// stack size, because we actually spawn our own main2 thread to work around
     /// the fact that Windows' real main thread is only 1MB. That thread has size
     /// `max(RUST_MIN_STACK, 1MB)`.
+    #[attr_added_in("0.5.19")]
     pub const RUST_MIN_STACK: &'static str = "RUST_MIN_STACK";
 
     /// The directory containing the `Cargo.toml` manifest for a package.
     #[attr_hidden]
+    #[attr_added_in("0.1.11")]
     pub const CARGO_MANIFEST_DIR: &'static str = "CARGO_MANIFEST_DIR";
 
     /// Specifies the directory where Cargo stores build artifacts (target directory).
     #[attr_hidden]
+    #[attr_added_in("0.0.5")]
     pub const CARGO_TARGET_DIR: &'static str = "CARGO_TARGET_DIR";
 
     /// Used in tests for environment substitution testing in `requirements.in`.
     #[attr_hidden]
+    #[attr_added_in("0.1.18")]
     pub const URL: &'static str = "URL";
 
     /// Used in tests for environment substitution testing in `requirements.in`.
     #[attr_hidden]
+    #[attr_added_in("0.1.18")]
     pub const FILE_PATH: &'static str = "FILE_PATH";
 
     /// Used in tests for environment substitution testing in `requirements.in`.
     #[attr_hidden]
+    #[attr_added_in("0.1.25")]
     pub const HATCH_PATH: &'static str = "HATCH_PATH";
 
     /// Used in tests for environment substitution testing in `requirements.in`.
     #[attr_hidden]
+    #[attr_added_in("0.1.25")]
     pub const BLACK_PATH: &'static str = "BLACK_PATH";
 
     /// Used in testing Hatch's root.uri feature
     ///
     /// See: <https://hatch.pypa.io/dev/config/dependency/#local>.
     #[attr_hidden]
+    #[attr_added_in("0.1.22")]
     pub const ROOT_PATH: &'static str = "ROOT_PATH";
 
     /// Used in testing extra build dependencies.
     #[attr_hidden]
+    #[attr_added_in("0.8.5")]
     pub const EXPECTED_ANYIO_VERSION: &'static str = "EXPECTED_ANYIO_VERSION";
 
     /// Used to set test credentials for keyring tests.
     #[attr_hidden]
+    #[attr_added_in("0.1.34")]
     pub const KEYRING_TEST_CREDENTIALS: &'static str = "KEYRING_TEST_CREDENTIALS";
 
     /// Used to disable delay for HTTP retries in tests.
+    #[attr_added_in("0.7.21")]
     pub const UV_TEST_NO_HTTP_RETRY_DELAY: &'static str = "UV_TEST_NO_HTTP_RETRY_DELAY";
 
     /// Used to set a packse index url for tests.
     #[attr_hidden]
+    #[attr_added_in("0.2.12")]
     pub const UV_TEST_PACKSE_INDEX: &'static str = "UV_TEST_PACKSE_INDEX";
 
     /// Used for testing named indexes in tests.
     #[attr_hidden]
+    #[attr_added_in("0.5.21")]
     pub const UV_INDEX_MY_INDEX_USERNAME: &'static str = "UV_INDEX_MY_INDEX_USERNAME";
 
     /// Used for testing named indexes in tests.
     #[attr_hidden]
+    #[attr_added_in("0.5.21")]
     pub const UV_INDEX_MY_INDEX_PASSWORD: &'static str = "UV_INDEX_MY_INDEX_PASSWORD";
 
     /// Used to set the GitHub fast-path url for tests.
     #[attr_hidden]
+    #[attr_added_in("0.7.15")]
     pub const UV_GITHUB_FAST_PATH_URL: &'static str = "UV_GITHUB_FAST_PATH_URL";
 
     /// Hide progress messages with non-deterministic order in tests.
     #[attr_hidden]
+    #[attr_added_in("0.5.29")]
     pub const UV_TEST_NO_CLI_PROGRESS: &'static str = "UV_TEST_NO_CLI_PROGRESS";
 
     /// `.env` files from which to load environment variables when executing `uv run` commands.
+    #[attr_added_in("0.4.30")]
     pub const UV_ENV_FILE: &'static str = "UV_ENV_FILE";
 
     /// Ignore `.env` files when executing `uv run` commands.
+    #[attr_added_in("0.4.30")]
     pub const UV_NO_ENV_FILE: &'static str = "UV_NO_ENV_FILE";
 
     /// The URL from which to download uv using the standalone installer and `self update` feature,
     /// in lieu of the default GitHub URL.
+    #[attr_added_in("0.5.0")]
     pub const UV_INSTALLER_GITHUB_BASE_URL: &'static str = "UV_INSTALLER_GITHUB_BASE_URL";
 
     /// The URL from which to download uv using the standalone installer and `self update` feature,
     /// in lieu of the default GitHub Enterprise URL.
+    #[attr_added_in("0.5.0")]
     pub const UV_INSTALLER_GHE_BASE_URL: &'static str = "UV_INSTALLER_GHE_BASE_URL";
 
     /// The directory in which to install uv using the standalone installer and `self update` feature.
     /// Defaults to `~/.local/bin`.
+    #[attr_added_in("0.5.0")]
     pub const UV_INSTALL_DIR: &'static str = "UV_INSTALL_DIR";
 
     /// Used ephemeral environments like CI to install uv to a specific path while preventing
     /// the installer from modifying shell profiles or environment variables.
+    #[attr_added_in("0.5.0")]
     pub const UV_UNMANAGED_INSTALL: &'static str = "UV_UNMANAGED_INSTALL";
 
     /// The URL from which to download uv using the standalone installer. By default, installs from
     /// uv's GitHub Releases. `INSTALLER_DOWNLOAD_URL` is also supported as an alias, for backwards
     /// compatibility.
+    #[attr_added_in("0.8.4")]
     pub const UV_DOWNLOAD_URL: &'static str = "UV_DOWNLOAD_URL";
 
     /// Avoid modifying the `PATH` environment variable when installing uv using the standalone
     /// installer and `self update` feature. `INSTALLER_NO_MODIFY_PATH` is also supported as an
     /// alias, for backwards compatibility.
+    #[attr_added_in("0.8.4")]
     pub const UV_NO_MODIFY_PATH: &'static str = "UV_NO_MODIFY_PATH";
 
     /// Skip writing `uv` installer metadata files (e.g., `INSTALLER`, `REQUESTED`, and `direct_url.json`) to site-packages `.dist-info` directories.
+    #[attr_added_in("0.5.7")]
     pub const UV_NO_INSTALLER_METADATA: &'static str = "UV_NO_INSTALLER_METADATA";
 
     /// Enables fetching files stored in Git LFS when installing a package from a Git repository.
+    #[attr_added_in("0.5.19")]
     pub const UV_GIT_LFS: &'static str = "UV_GIT_LFS";
 
     /// Number of times that `uv run` has been recursively invoked. Used to guard against infinite
     /// recursion, e.g., when `uv run`` is used in a script shebang.
     #[attr_hidden]
+    #[attr_added_in("0.5.31")]
     pub const UV_RUN_RECURSION_DEPTH: &'static str = "UV_RUN_RECURSION_DEPTH";
 
     /// Number of times that `uv run` will allow recursive invocations, before exiting with an
     /// error.
     #[attr_hidden]
+    #[attr_added_in("0.5.31")]
     pub const UV_RUN_MAX_RECURSION_DEPTH: &'static str = "UV_RUN_MAX_RECURSION_DEPTH";
 
     /// Overrides terminal width used for wrapping. This variable is not read by uv directly.
     ///
     /// This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.
+    #[attr_added_in("0.6.2")]
     pub const COLUMNS: &'static str = "COLUMNS";
 
     /// The CUDA driver version to assume when inferring the PyTorch backend (e.g., `550.144.03`).
     #[attr_hidden]
+    #[attr_added_in("0.6.9")]
     pub const UV_CUDA_DRIVER_VERSION: &'static str = "UV_CUDA_DRIVER_VERSION";
 
     /// The AMD GPU architecture to assume when inferring the PyTorch backend (e.g., `gfx1100`).
     #[attr_hidden]
+    #[attr_added_in("0.7.14")]
     pub const UV_AMD_GPU_ARCHITECTURE: &'static str = "UV_AMD_GPU_ARCHITECTURE";
 
     /// Equivalent to the `--torch-backend` command-line argument (e.g., `cpu`, `cu126`, or `auto`).
+    #[attr_added_in("0.6.9")]
     pub const UV_TORCH_BACKEND: &'static str = "UV_TORCH_BACKEND";
 
     /// Equivalent to the `--project` command-line argument.
+    #[attr_added_in("0.4.4")]
     pub const UV_PROJECT: &'static str = "UV_PROJECT";
 
     /// Disable GitHub-specific requests that allow uv to skip `git fetch` in some circumstances.
+    #[attr_added_in("0.7.13")]
     pub const UV_NO_GITHUB_FAST_PATH: &'static str = "UV_NO_GITHUB_FAST_PATH";
 
     /// Authentication token for Hugging Face requests. When set, uv will use this token
     /// when making requests to `https://huggingface.co/` and any subdomains.
+    #[attr_added_in("0.8.1")]
     pub const HF_TOKEN: &'static str = "HF_TOKEN";
 
     /// Disable Hugging Face authentication, even if `HF_TOKEN` is set.
+    #[attr_added_in("0.8.1")]
     pub const UV_NO_HF_TOKEN: &'static str = "UV_NO_HF_TOKEN";
 
     /// The URL to treat as an S3-compatible storage endpoint. Requests to this endpoint
     /// will be signed using AWS Signature Version 4 based on the `AWS_ACCESS_KEY_ID`,
     /// `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, and `AWS_CONFIG_FILE` environment variables.
+    #[attr_added_in("0.8.21")]
     pub const UV_S3_ENDPOINT_URL: &'static str = "UV_S3_ENDPOINT_URL";
 
     /// The URL of the pyx Simple API server.
+    #[attr_added_in("0.8.15")]
     pub const PYX_API_URL: &'static str = "PYX_API_URL";
 
     /// The domain of the pyx CDN.
+    #[attr_added_in("0.8.15")]
     pub const PYX_CDN_DOMAIN: &'static str = "PYX_CDN_DOMAIN";
 
     /// The pyx API key (e.g., `sk-pyx-...`).
+    #[attr_added_in("0.8.15")]
     pub const PYX_API_KEY: &'static str = "PYX_API_KEY";
 
     /// The pyx API key, for backwards compatibility.
     #[attr_hidden]
+    #[attr_added_in("0.8.15")]
     pub const UV_API_KEY: &'static str = "UV_API_KEY";
 
     /// The pyx authentication token (e.g., `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...`), as output by `uv auth token`.
+    #[attr_added_in("0.8.15")]
     pub const PYX_AUTH_TOKEN: &'static str = "PYX_AUTH_TOKEN";
 
     /// The pyx authentication token, for backwards compatibility.
     #[attr_hidden]
+    #[attr_added_in("0.8.15")]
     pub const UV_AUTH_TOKEN: &'static str = "UV_AUTH_TOKEN";
 
     /// Specifies the directory where uv stores pyx credentials.
+    #[attr_added_in("0.8.15")]
     pub const PYX_CREDENTIALS_DIR: &'static str = "PYX_CREDENTIALS_DIR";
 
     /// The AWS region to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_REGION: &'static str = "AWS_REGION";
 
     /// The default AWS region to use when signing S3 requests, if `AWS_REGION` is not set.
+    #[attr_added_in("0.8.21")]
     pub const AWS_DEFAULT_REGION: &'static str = "AWS_DEFAULT_REGION";
 
     /// The AWS access key ID to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_ACCESS_KEY_ID: &'static str = "AWS_ACCESS_KEY_ID";
 
     /// The AWS secret access key to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_SECRET_ACCESS_KEY: &'static str = "AWS_SECRET_ACCESS_KEY";
 
     /// The AWS session token to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_SESSION_TOKEN: &'static str = "AWS_SESSION_TOKEN";
 
     /// The AWS profile to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_PROFILE: &'static str = "AWS_PROFILE";
 
     /// The AWS config file to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_CONFIG_FILE: &'static str = "AWS_CONFIG_FILE";
 
     /// The AWS shared credentials file to use when signing S3 requests.
+    #[attr_added_in("0.8.21")]
     pub const AWS_SHARED_CREDENTIALS_FILE: &'static str = "AWS_SHARED_CREDENTIALS_FILE";
 
     /// Avoid verifying that wheel filenames match their contents when installing wheels. This
     /// is not recommended, as wheels with inconsistent filenames should be considered invalid and
     /// corrected by the relevant package maintainers; however, this option can be used to work
     /// around invalid artifacts in rare cases.
+    #[attr_added_in("0.8.23")]
     pub const UV_SKIP_WHEEL_FILENAME_CHECK: &'static str = "UV_SKIP_WHEEL_FILENAME_CHECK";
 }

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -3,6 +3,7 @@
 uv defines and respects the following environment variables:
 
 ### `UV_BREAK_SYSTEM_PACKAGES`
+<small class="added-in">added in `0.1.32`</small>
 
 Equivalent to the `--break-system-packages` command-line argument. If set to `true`,
 uv will allow the installation of packages that conflict with system-installed packages.
@@ -12,54 +13,65 @@ WARNING: `UV_BREAK_SYSTEM_PACKAGES=true` is intended for use in continuous integ
 Python can lead to unexpected behavior.
 
 ### `UV_BUILD_CONSTRAINT`
+<small class="added-in">added in `0.2.34`</small>
 
 Equivalent to the `--build-constraint` command-line argument. If set, uv will use this file
 as constraints for any source distribution builds. Uses space-separated list of files.
 
 ### `UV_CACHE_DIR`
+<small class="added-in">added in `0.0.5`</small>
 
 Equivalent to the `--cache-dir` command-line argument. If set, uv will use this
 directory for caching instead of the default cache directory.
 
 ### `UV_COMPILE_BYTECODE`
+<small class="added-in">added in `0.3.3`</small>
 
 Equivalent to the `--compile-bytecode` command-line argument. If set, uv
 will compile Python source files to bytecode after installation.
 
 ### `UV_COMPILE_BYTECODE_TIMEOUT`
+<small class="added-in">added in `0.7.22`</small>
 
 Timeout (in seconds) for bytecode compilation.
 
 ### `UV_CONCURRENT_BUILDS`
+<small class="added-in">added in `0.1.43`</small>
 
 Sets the maximum number of source distributions that uv will build
 concurrently at any given time.
 
 ### `UV_CONCURRENT_DOWNLOADS`
+<small class="added-in">added in `0.1.43`</small>
 
 Sets the maximum number of in-flight concurrent downloads that uv will
 perform at any given time.
 
 ### `UV_CONCURRENT_INSTALLS`
+<small class="added-in">added in `0.1.45`</small>
 
 Controls the number of threads used when installing and unzipping
 packages.
 
 ### `UV_CONFIG_FILE`
+<small class="added-in">added in `0.1.34`</small>
 
 Equivalent to the `--config-file` command-line argument. Expects a path to a
 local `uv.toml` file to use as the configuration file.
 
 ### `UV_CONSTRAINT`
+<small class="added-in">added in `0.1.36`</small>
 
 Equivalent to the `--constraint` command-line argument. If set, uv will use this
 file as the constraints file. Uses space-separated list of files.
 
 ### `UV_CREDENTIALS_DIR`
+<small class="added-in">added in `0.8.15`</small>
 
 The directory for storage of credentials when using a plain text backend.
 
 ### `UV_CUSTOM_COMPILE_COMMAND`
+<small class="added-in">added in `0.1.23`</small>
 
 Equivalent to the `--custom-compile-command` command-line argument.
 
@@ -68,73 +80,88 @@ Used to override uv in the output header of the `requirements.txt` files generat
 script, to include the name of the wrapper script in the output file.
 
 ### `UV_DEFAULT_INDEX`
+<small class="added-in">added in `0.4.23`</small>
 
 Equivalent to the `--default-index` command-line argument. If set, uv will use
 this URL as the default index when searching for packages.
 
 ### `UV_DEV`
+<small class="added-in">added in `0.8.7`</small>
 
 Equivalent to the `--dev` command-line argument. If set, uv will include
 development dependencies.
 
 ### `UV_DOWNLOAD_URL`
+<small class="added-in">added in `0.8.4`</small>
 
 The URL from which to download uv using the standalone installer. By default, installs from
 uv's GitHub Releases. `INSTALLER_DOWNLOAD_URL` is also supported as an alias, for backwards
 compatibility.
 
 ### `UV_ENV_FILE`
+<small class="added-in">added in `0.4.30`</small>
 
 `.env` files from which to load environment variables when executing `uv run` commands.
 
 ### `UV_EXCLUDE_NEWER`
+<small class="added-in">added in `0.2.12`</small>
 
 Equivalent to the `--exclude-newer` command-line argument. If set, uv will
 exclude distributions published after the specified date.
 
 ### `UV_EXTRA_INDEX_URL`
+<small class="added-in">added in `0.1.3`</small>
 
 Equivalent to the `--extra-index-url` command-line argument. If set, uv will
 use this space-separated list of URLs as additional indexes when searching for packages.
 (Deprecated: use `UV_INDEX` instead.)
 
 ### `UV_FIND_LINKS`
+<small class="added-in">added in `0.4.19`</small>
 
 Equivalent to the `--find-links` command-line argument. If set, uv will use this
 comma-separated list of additional locations to search for packages.
 
 ### `UV_FORK_STRATEGY`
+<small class="added-in">added in `0.5.9`</small>
 
 Equivalent to the `--fork-strategy` argument. Controls version selection during universal
 resolution.
 
 ### `UV_FROZEN`
+<small class="added-in">added in `0.4.25`</small>
 
 Equivalent to the `--frozen` command-line argument. If set, uv will run without
 updating the `uv.lock` file.
 
 ### `UV_GITHUB_TOKEN`
+<small class="added-in">added in `0.4.10`</small>
 
 Equivalent to the `--token` argument for self update. A GitHub token for authentication.
 
 ### `UV_GIT_LFS`
+<small class="added-in">added in `0.5.19`</small>
 
 Enables fetching files stored in Git LFS when installing a package from a Git repository.
 
 ### `UV_HTTP_RETRIES`
+<small class="added-in">added in `0.7.21`</small>
 
 The number of retries for HTTP requests. (default: 3)
 
 ### `UV_HTTP_TIMEOUT`
+<small class="added-in">added in `0.1.7`</small>
 
 Timeout (in seconds) for HTTP requests. (default: 30 s)
 
 ### `UV_INDEX`
+<small class="added-in">added in `0.4.23`</small>
 
 Equivalent to the `--index` command-line argument. If set, uv will use this
 space-separated list of URLs as additional indexes when searching for packages.
 
 ### `UV_INDEX_STRATEGY`
+<small class="added-in">added in `0.1.29`</small>
 
 Equivalent to the `--index-strategy` command-line argument.
 
@@ -143,12 +170,14 @@ available across all index URLs, rather than limiting its search to the first in
 that contains the package.
 
 ### `UV_INDEX_URL`
+<small class="added-in">added in `0.0.5`</small>
 
 Equivalent to the `--index-url` command-line argument. If set, uv will use this
 URL as the default index when searching for packages.
 (Deprecated: use `UV_DEFAULT_INDEX` instead.)
 
 ### `UV_INDEX_{name}_PASSWORD`
+<small class="added-in">added in `0.4.23`</small>
 
 Provides the HTTP Basic authentication password for a named index.
 
@@ -156,6 +185,7 @@ The `name` parameter is the name of the index. For example, given an index named
 the environment variable key would be `UV_INDEX_FOO_PASSWORD`.
 
 ### `UV_INDEX_{name}_USERNAME`
+<small class="added-in">added in `0.4.23`</small>
 
 Provides the HTTP Basic authentication username for a named index.
 
@@ -163,15 +193,18 @@ The `name` parameter is the name of the index. For example, given an index named
 the environment variable key would be `UV_INDEX_FOO_USERNAME`.
 
 ### `UV_INIT_BUILD_BACKEND`
+<small class="added-in">added in `0.8.2`</small>
 
 Equivalent to the `--build-backend` argument for `uv init`. Determines the default backend
 to use when creating a new project.
 
 ### `UV_INSECURE_HOST`
+<small class="added-in">added in `0.3.5`</small>
 
 Equivalent to the `--allow-insecure-host` argument.
 
 ### `UV_INSECURE_NO_ZIP_VALIDATION`
+<small class="added-in">added in `0.8.6`</small>
 
 Disable ZIP validation for streamed wheels and ZIP-based source distributions.
 
@@ -181,180 +214,217 @@ a ZIP file due to failing validation, it is likely that the file is malformed; c
 filing an issue with the package maintainer.
 
 ### `UV_INSTALLER_GHE_BASE_URL`
+<small class="added-in">added in `0.5.0`</small>
 
 The URL from which to download uv using the standalone installer and `self update` feature,
 in lieu of the default GitHub Enterprise URL.
 
 ### `UV_INSTALLER_GITHUB_BASE_URL`
+<small class="added-in">added in `0.5.0`</small>
 
 The URL from which to download uv using the standalone installer and `self update` feature,
 in lieu of the default GitHub URL.
 
 ### `UV_INSTALL_DIR`
+<small class="added-in">added in `0.5.0`</small>
 
 The directory in which to install uv using the standalone installer and `self update` feature.
 Defaults to `~/.local/bin`.
 
 ### `UV_ISOLATED`
+<small class="added-in">added in `0.8.14`</small>
 
 Equivalent to the `--isolated` command-line argument. If set, uv will avoid discovering
 a `pyproject.toml` or `uv.toml` file.
 
 ### `UV_KEYRING_PROVIDER`
+<small class="added-in">added in `0.1.19`</small>
 
 Equivalent to the `--keyring-provider` command-line argument. If set, uv
 will use this value as the keyring provider.
 
 ### `UV_LIBC`
+<small class="added-in">added in `0.7.22`</small>
 
 Overrides the environment-determined libc on linux systems when filling in the current platform
 within Python version requests. Options are: `gnu`, `gnueabi`, `gnueabihf`, `musl`, and `none`.
 
 ### `UV_LINK_MODE`
+<small class="added-in">added in `0.1.40`</small>
 
 Equivalent to the `--link-mode` command-line argument. If set, uv will use this as
 a link mode.
 
 ### `UV_LOCKED`
+<small class="added-in">added in `0.4.25`</small>
 
 Equivalent to the `--locked` command-line argument. If set, uv will assert that the
 `uv.lock` remains unchanged.
 
 ### `UV_LOG_CONTEXT`
+<small class="added-in">added in `0.6.4`</small>
 
 Add additional context and structure to log messages.
 
 If logging is not enabled, e.g., with `RUST_LOG` or `-v`, this has no effect.
 
 ### `UV_MANAGED_PYTHON`
+<small class="added-in">added in `0.6.8`</small>
 
 Require use of uv-managed Python versions.
 
 ### `UV_NATIVE_TLS`
+<small class="added-in">added in `0.1.19`</small>
 
 Equivalent to the `--native-tls` command-line argument. If set to `true`, uv will
 use the system's trust store instead of the bundled `webpki-roots` crate.
 
 ### `UV_NO_BINARY`
+<small class="added-in">added in `0.5.30`</small>
 
 Equivalent to the `--no-binary` command-line argument. If set, uv will install
 all packages from source. The resolver will still use pre-built wheels to
 extract package metadata, if available.
 
 ### `UV_NO_BINARY_PACKAGE`
+<small class="added-in">added in `0.5.30`</small>
 
 Equivalent to the `--no-binary-package` command line argument. If set, uv will
 not use pre-built wheels for the given space-delimited list of packages.
 
 ### `UV_NO_BUILD`
+<small class="added-in">added in `0.1.40`</small>
 
 Equivalent to the `--no-build` command-line argument. If set, uv will not build
 source distributions.
 
 ### `UV_NO_BUILD_ISOLATION`
+<small class="added-in">added in `0.1.40`</small>
 
 Equivalent to the `--no-build-isolation` command-line argument. If set, uv will
 skip isolation when building source distributions.
 
 ### `UV_NO_BUILD_PACKAGE`
+<small class="added-in">added in `0.6.5`</small>
 
 Equivalent to the `--no-build-package` command line argument. If set, uv will
 not build source distributions for the given space-delimited list of packages.
 
 ### `UV_NO_CACHE`
+<small class="added-in">added in `0.1.2`</small>
 
 Equivalent to the `--no-cache` command-line argument. If set, uv will not use the
 cache for any operations.
 
 ### `UV_NO_CONFIG`
+<small class="added-in">added in `0.2.30`</small>
 
 Equivalent to the `--no-config` command-line argument. If set, uv will not read
 any configuration files from the current directory, parent directories, or user configuration
 directories.
 
 ### `UV_NO_DEV`
+<small class="added-in">added in `0.8.7`</small>
 
 Equivalent to the `--no-dev` command-line argument. If set, uv will exclude
 development dependencies.
 
 ### `UV_NO_EDITABLE`
+<small class="added-in">added in `0.6.15`</small>
 
 Equivalent to the `--no-editable` command-line argument. If set, uv
 installs or exports any editable dependencies, including the project and any workspace
 members, as non-editable.
 
 ### `UV_NO_ENV_FILE`
+<small class="added-in">added in `0.4.30`</small>
 
 Ignore `.env` files when executing `uv run` commands.
 
 ### `UV_NO_GITHUB_FAST_PATH`
+<small class="added-in">added in `0.7.13`</small>
 
 Disable GitHub-specific requests that allow uv to skip `git fetch` in some circumstances.
 
 ### `UV_NO_HF_TOKEN`
+<small class="added-in">added in `0.8.1`</small>
 
 Disable Hugging Face authentication, even if `HF_TOKEN` is set.
 
 ### `UV_NO_INSTALLER_METADATA`
+<small class="added-in">added in `0.5.7`</small>
 
 Skip writing `uv` installer metadata files (e.g., `INSTALLER`, `REQUESTED`, and `direct_url.json`) to site-packages `.dist-info` directories.
 
 ### `UV_NO_MANAGED_PYTHON`
+<small class="added-in">added in `0.6.8`</small>
 
 Disable use of uv-managed Python versions.
 
 ### `UV_NO_MODIFY_PATH`
+<small class="added-in">added in `0.8.4`</small>
 
 Avoid modifying the `PATH` environment variable when installing uv using the standalone
 installer and `self update` feature. `INSTALLER_NO_MODIFY_PATH` is also supported as an
 alias, for backwards compatibility.
 
 ### `UV_NO_PROGRESS`
+<small class="added-in">added in `0.2.28`</small>
 
 Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
 example, spinners and progress bars.
 
 ### `UV_NO_SYNC`
+<small class="added-in">added in `0.4.18`</small>
 
 Equivalent to the `--no-sync` command-line argument. If set, uv will skip updating
 the environment.
 
 ### `UV_NO_VERIFY_HASHES`
+<small class="added-in">added in `0.5.3`</small>
 
 Equivalent to the `--no-verify-hashes` argument. Disables hash verification for
 `requirements.txt` files.
 
 ### `UV_NO_WRAP`
+<small class="added-in">added in `0.0.5`</small>
 
 Use to disable line wrapping for diagnostics.
 
 ### `UV_OFFLINE`
+<small class="added-in">added in `0.5.9`</small>
 
 Equivalent to the `--offline` command-line argument. If set, uv will disable network access.
 
 ### `UV_OVERRIDE`
+<small class="added-in">added in `0.2.22`</small>
 
 Equivalent to the `--override` command-line argument. If set, uv will use this file
 as the overrides file. Uses space-separated list of files.
 
 ### `UV_PRERELEASE`
+<small class="added-in">added in `0.1.16`</small>
 
 Equivalent to the `--prerelease` command-line argument. For example, if set to
 `allow`, uv will allow pre-release versions for all dependencies.
 
 ### `UV_PREVIEW`
+<small class="added-in">added in `0.1.37`</small>
 
 Equivalent to the `--preview` argument. Enables preview mode.
 
 ### `UV_PREVIEW_FEATURES`
+<small class="added-in">added in `0.8.4`</small>
 
 Equivalent to the `--preview-features` argument. Enables specific preview features.
 
 ### `UV_PROJECT`
+<small class="added-in">added in `0.4.4`</small>
 
 Equivalent to the `--project` command-line argument.
 
 ### `UV_PROJECT_ENVIRONMENT`
+<small class="added-in">added in `0.4.4`</small>
 
 Specifies the path to the directory to use for a project virtual environment.
 
@@ -362,35 +432,42 @@ See the [project documentation](../concepts/projects/config.md#project-environme
 for more details.
 
 ### `UV_PUBLISH_CHECK_URL`
+<small class="added-in">added in `0.4.30`</small>
 
 Don't upload a file if it already exists on the index. The value is the URL of the index.
 
 ### `UV_PUBLISH_INDEX`
+<small class="added-in">added in `0.5.8`</small>
 
 Equivalent to the `--index` command-line argument in `uv publish`. If
 set, uv the index with this name in the configuration for publishing.
 
 ### `UV_PUBLISH_PASSWORD`
+<small class="added-in">added in `0.4.16`</small>
 
 Equivalent to the `--password` command-line argument in `uv publish`. If
 set, uv will use this password for publishing.
 
 ### `UV_PUBLISH_TOKEN`
+<small class="added-in">added in `0.4.16`</small>
 
 Equivalent to the `--token` command-line argument in `uv publish`. If set, uv
 will use this token (with the username `__token__`) for publishing.
 
 ### `UV_PUBLISH_URL`
+<small class="added-in">added in `0.4.16`</small>
 
 Equivalent to the `--publish-url` command-line argument. The URL of the upload
 endpoint of the index to use with `uv publish`.
 
 ### `UV_PUBLISH_USERNAME`
+<small class="added-in">added in `0.4.16`</small>
 
 Equivalent to the `--username` command-line argument in `uv publish`. If
 set, uv will use this username for publishing.
 
 ### `UV_PYPY_INSTALL_MIRROR`
+<small class="added-in">added in `0.2.35`</small>
 
 Managed PyPy installations are downloaded from [python.org](https://downloads.python.org/).
 
@@ -401,32 +478,38 @@ different source for PyPy installations. The provided URL will replace
 Distributions can be read from a local directory by using the `file://` URL scheme.
 
 ### `UV_PYTHON`
+<small class="added-in">added in `0.1.40`</small>
 
 Equivalent to the `--python` command-line argument. If set to a path, uv will use
 this Python interpreter for all operations.
 
 ### `UV_PYTHON_BIN_DIR`
+<small class="added-in">added in `0.4.29`</small>
 
 Specifies the directory to place links to installed, managed Python executables.
 
 ### `UV_PYTHON_CACHE_DIR`
+<small class="added-in">added in `0.7.0`</small>
 
 Specifies the directory for caching the archives of managed Python installations before
 installation.
 
 ### `UV_PYTHON_CPYTHON_BUILD`
+<small class="added-in">added in `0.8.14`</small>
 
 Pin managed CPython versions to a specific build version.
 
 For CPython, this should be the build date (e.g., "20250814").
 
 ### `UV_PYTHON_DOWNLOADS`
+<small class="added-in">added in `0.3.2`</small>
 
 Equivalent to the
 [`python-downloads`](../reference/settings.md#python-downloads) setting and, when disabled, the
 `--no-python-downloads` option. Whether uv should allow Python downloads.
 
 ### `UV_PYTHON_DOWNLOADS_JSON_URL`
+<small class="added-in">added in `0.6.13`</small>
 
 Managed Python installations information is hardcoded in the `uv` binary.
 
@@ -436,20 +519,24 @@ This will allow for setting each property of the Python installation, mostly the
 Note that currently, only local paths are supported.
 
 ### `UV_PYTHON_GRAALPY_BUILD`
+<small class="added-in">added in `0.8.14`</small>
 
 Pin managed GraalPy versions to a specific build version.
 
 For GraalPy, this should be the GraalPy version (e.g., "24.2.2").
 
 ### `UV_PYTHON_INSTALL_BIN`
+<small class="added-in">added in `0.8.0`</small>
 
 Whether to install the Python executable into the `UV_PYTHON_BIN_DIR` directory.
 
 ### `UV_PYTHON_INSTALL_DIR`
+<small class="added-in">added in `0.2.22`</small>
 
 Specifies the directory for storing managed Python installations.
 
 ### `UV_PYTHON_INSTALL_MIRROR`
+<small class="added-in">added in `0.2.35`</small>
 
 Managed Python installations are downloaded from the Astral
 [`python-build-standalone`](https://github.com/astral-sh/python-build-standalone) project.
@@ -460,46 +547,55 @@ The provided URL will replace `https://github.com/astral-sh/python-build-standal
 Distributions can be read from a local directory by using the `file://` URL scheme.
 
 ### `UV_PYTHON_INSTALL_REGISTRY`
+<small class="added-in">added in `0.8.0`</small>
 
 Whether to install the Python executable into the Windows registry.
 
 ### `UV_PYTHON_PREFERENCE`
+<small class="added-in">added in `0.3.2`</small>
 
 Whether uv should prefer system or managed Python versions.
 
 ### `UV_PYTHON_PYODIDE_BUILD`
+<small class="added-in">added in `0.8.14`</small>
 
 Pin managed Pyodide versions to a specific build version.
 
 For Pyodide, this should be the Pyodide version (e.g., "0.28.1").
 
 ### `UV_PYTHON_PYPY_BUILD`
+<small class="added-in">added in `0.8.14`</small>
 
 Pin managed PyPy versions to a specific build version.
 
 For PyPy, this should be the PyPy version (e.g., "7.3.20").
 
 ### `UV_REQUEST_TIMEOUT`
+<small class="added-in">added in `0.1.6`</small>
 
 Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
 
 ### `UV_REQUIRE_HASHES`
+<small class="added-in">added in `0.1.34`</small>
 
 Equivalent to the `--require-hashes` command-line argument. If set to `true`,
 uv will require that all dependencies have a hash specified in the requirements file.
 
 ### `UV_RESOLUTION`
+<small class="added-in">added in `0.1.27`</small>
 
 Equivalent to the `--resolution` command-line argument. For example, if set to
 `lowest-direct`, uv will install the lowest compatible versions of all direct dependencies.
 
 ### `UV_S3_ENDPOINT_URL`
+<small class="added-in">added in `0.8.21`</small>
 
 The URL to treat as an S3-compatible storage endpoint. Requests to this endpoint
 will be signed using AWS Signature Version 4 based on the `AWS_ACCESS_KEY_ID`,
 `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, and `AWS_CONFIG_FILE` environment variables.
 
 ### `UV_SKIP_WHEEL_FILENAME_CHECK`
+<small class="added-in">added in `0.8.23`</small>
 
 Avoid verifying that wheel filenames match their contents when installing wheels. This
 is not recommended, as wheels with inconsistent filenames should be considered invalid and
@@ -507,6 +603,7 @@ corrected by the relevant package maintainers; however, this option can be used 
 around invalid artifacts in rare cases.
 
 ### `UV_STACK_SIZE`
+<small class="added-in">added in `0.0.5`</small>
 
 Use to set the stack size used by uv.
 
@@ -519,6 +616,7 @@ the fact that Windows' real main thread is only 1MB. That thread has size
 `max(UV_STACK_SIZE, 1MB)`.
 
 ### `UV_SYSTEM_PYTHON`
+<small class="added-in">added in `0.1.18`</small>
 
 Equivalent to the `--system` command-line argument. If set to `true`, uv will
 use the first Python interpreter found in the system `PATH`.
@@ -528,32 +626,39 @@ or containerized environments and should be used with caution, as modifying the 
 Python can lead to unexpected behavior.
 
 ### `UV_TEST_NO_HTTP_RETRY_DELAY`
+<small class="added-in">added in `0.7.21`</small>
 
 Used to disable delay for HTTP retries in tests.
 
 ### `UV_TOOL_BIN_DIR`
+<small class="added-in">added in `0.3.0`</small>
 
 Specifies the "bin" directory for installing tool executables.
 
 ### `UV_TOOL_DIR`
+<small class="added-in">added in `0.2.16`</small>
 
 Specifies the directory where uv stores managed tools.
 
 ### `UV_TORCH_BACKEND`
+<small class="added-in">added in `0.6.9`</small>
 
 Equivalent to the `--torch-backend` command-line argument (e.g., `cpu`, `cu126`, or `auto`).
 
 ### `UV_UNMANAGED_INSTALL`
+<small class="added-in">added in `0.5.0`</small>
 
 Used ephemeral environments like CI to install uv to a specific path while preventing
 the installer from modifying shell profiles or environment variables.
 
 ### `UV_VENV_CLEAR`
+<small class="added-in">added in `0.8.0`</small>
 
 Equivalent to the `--clear` command-line argument. If set, uv will remove any
 existing files or directories at the target path.
 
 ### `UV_VENV_SEED`
+<small class="added-in">added in `0.5.21`</small>
 
 Install seed packages (one or more of: `pip`, `setuptools`, and `wheel`) into the virtual environment
 created by `uv venv`.
@@ -567,10 +672,12 @@ Note that `setuptools` and `wheel` are not included in Python 3.12+ environments
 uv also reads the following externally defined environment variables:
 
 ### `ALL_PROXY`
+<small class="added-in">added in `0.1.38`</small>
 
 General proxy for all network requests.
 
 ### `ANDROID_API_LEVEL`
+<small class="added-in">added in `0.8.16`</small>
 
 Used with `--python-platform aarch64-linux-android` and related variants to set the
 Android API level. (i.e., the minimum supported Android API level).
@@ -578,74 +685,91 @@ Android API level. (i.e., the minimum supported Android API level).
 Defaults to `24`.
 
 ### `APPDATA`
+<small class="added-in">added in `0.1.42`</small>
 
 Path to user-level configuration directory on Windows systems.
 
 ### `AWS_ACCESS_KEY_ID`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS access key ID to use when signing S3 requests.
 
 ### `AWS_CONFIG_FILE`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS config file to use when signing S3 requests.
 
 ### `AWS_DEFAULT_REGION`
+<small class="added-in">added in `0.8.21`</small>
 
 The default AWS region to use when signing S3 requests, if `AWS_REGION` is not set.
 
 ### `AWS_PROFILE`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS profile to use when signing S3 requests.
 
 ### `AWS_REGION`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS region to use when signing S3 requests.
 
 ### `AWS_SECRET_ACCESS_KEY`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS secret access key to use when signing S3 requests.
 
 ### `AWS_SESSION_TOKEN`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS session token to use when signing S3 requests.
 
 ### `AWS_SHARED_CREDENTIALS_FILE`
+<small class="added-in">added in `0.8.21`</small>
 
 The AWS shared credentials file to use when signing S3 requests.
 
 ### `BASH_VERSION`
+<small class="added-in">added in `0.1.28`</small>
 
 Used to detect Bash shell usage.
 
 ### `CLICOLOR_FORCE`
+<small class="added-in">added in `0.1.32`</small>
 
 Use to control color via `anstyle`.
 
 ### `COLUMNS`
+<small class="added-in">added in `0.6.2`</small>
 
 Overrides terminal width used for wrapping. This variable is not read by uv directly.
 
 This is a quasi-standard variable, described, e.g., in `ncurses(3x)`.
 
 ### `CONDA_DEFAULT_ENV`
+<small class="added-in">added in `0.5.0`</small>
 
 Used to determine the name of the active Conda environment.
 
 ### `CONDA_PREFIX`
+<small class="added-in">added in `0.0.5`</small>
 
 Used to detect the path of an active Conda environment.
 
 ### `FISH_VERSION`
+<small class="added-in">added in `0.1.28`</small>
 
 Used to detect Fish shell usage.
 
 ### `FORCE_COLOR`
+<small class="added-in">added in `0.2.7`</small>
 
 Forces colored output regardless of terminal support.
 
 See [force-color.org](https://force-color.org).
 
 ### `GITHUB_ACTIONS`
+<small class="added-in">added in `0.4.16`</small>
 
 Indicates that the current process is running in GitHub Actions.
 
@@ -653,6 +777,7 @@ Indicates that the current process is running in GitHub Actions.
 to `true`.
 
 ### `GITLAB_CI`
+<small class="added-in">added in `0.8.18`</small>
 
 Indicates that the current process is running in GitLab CI.
 
@@ -660,27 +785,33 @@ Indicates that the current process is running in GitLab CI.
 to `true`.
 
 ### `HF_TOKEN`
+<small class="added-in">added in `0.8.1`</small>
 
 Authentication token for Hugging Face requests. When set, uv will use this token
 when making requests to `https://huggingface.co/` and any subdomains.
 
 ### `HOME`
+<small class="added-in">added in `0.0.5`</small>
 
 The standard `HOME` env var.
 
 ### `HTTPS_PROXY`
+<small class="added-in">added in `0.1.38`</small>
 
 Proxy for HTTPS requests.
 
 ### `HTTP_PROXY`
+<small class="added-in">added in `0.1.38`</small>
 
 Proxy for HTTP requests.
 
 ### `HTTP_TIMEOUT`
+<small class="added-in">added in `0.1.7`</small>
 
 Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
 
 ### `IPHONEOS_DEPLOYMENT_TARGET`
+<small class="added-in">added in `0.8.16`</small>
 
 Used with `--python-platform arm64-apple-ios` and related variants to set the
 deployment target (i.e., the minimum supported iOS version).
@@ -688,18 +819,22 @@ deployment target (i.e., the minimum supported iOS version).
 Defaults to `13.0`.
 
 ### `JPY_SESSION_NAME`
+<small class="added-in">added in `0.2.6`</small>
 
 Used to detect when running inside a Jupyter notebook.
 
 ### `KSH_VERSION`
+<small class="added-in">added in `0.2.33`</small>
 
 Used to detect Ksh shell usage.
 
 ### `LOCALAPPDATA`
+<small class="added-in">added in `0.3.3`</small>
 
 Used to look for Microsoft Store Pythons installations.
 
 ### `MACOSX_DEPLOYMENT_TARGET`
+<small class="added-in">added in `0.1.42`</small>
 
 Used with `--python-platform macos` and related variants to set the
 deployment target (i.e., the minimum supported macOS version).
@@ -707,70 +842,86 @@ deployment target (i.e., the minimum supported macOS version).
 Defaults to `13.0`, the least-recent non-EOL macOS version at time of writing.
 
 ### `NETRC`
+<small class="added-in">added in `0.1.16`</small>
 
 Use to set the .netrc file location.
 
 ### `NO_COLOR`
+<small class="added-in">added in `0.2.7`</small>
 
 Disables colored output (takes precedence over `FORCE_COLOR`).
 
 See [no-color.org](https://no-color.org).
 
 ### `NO_PROXY`
+<small class="added-in">added in `0.1.38`</small>
 
 Comma-separated list of hostnames (e.g., `example.com`) and/or patterns (e.g., `192.168.1.0/24`) that should bypass the proxy.
 
 ### `NU_VERSION`
+<small class="added-in">added in `0.1.16`</small>
 
 Used to detect `NuShell` usage.
 
 ### `PAGER`
+<small class="added-in">added in `0.4.18`</small>
 
 The standard `PAGER` posix env var. Used by `uv` to configure the appropriate pager.
 
 ### `PATH`
+<small class="added-in">added in `0.0.5`</small>
 
 The standard `PATH` env var.
 
 ### `PROMPT`
+<small class="added-in">added in `0.1.16`</small>
 
 Used to detect the use of the Windows Command Prompt (as opposed to PowerShell).
 
 ### `PWD`
+<small class="added-in">added in `0.0.5`</small>
 
 The standard `PWD` posix env var.
 
 ### `PYC_INVALIDATION_MODE`
+<small class="added-in">added in `0.1.7`</small>
 
 The validation modes to use when run with `--compile`.
 
 See [`PycInvalidationMode`](https://docs.python.org/3/library/py_compile.html#py_compile.PycInvalidationMode).
 
 ### `PYTHONPATH`
+<small class="added-in">added in `0.1.22`</small>
 
 Adds directories to Python module search path (e.g., `PYTHONPATH=/path/to/modules`).
 
 ### `PYX_API_KEY`
+<small class="added-in">added in `0.8.15`</small>
 
 The pyx API key (e.g., `sk-pyx-...`).
 
 ### `PYX_API_URL`
+<small class="added-in">added in `0.8.15`</small>
 
 The URL of the pyx Simple API server.
 
 ### `PYX_AUTH_TOKEN`
+<small class="added-in">added in `0.8.15`</small>
 
 The pyx authentication token (e.g., `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...`), as output by `uv auth token`.
 
 ### `PYX_CDN_DOMAIN`
+<small class="added-in">added in `0.8.15`</small>
 
 The domain of the pyx CDN.
 
 ### `PYX_CREDENTIALS_DIR`
+<small class="added-in">added in `0.8.15`</small>
 
 Specifies the directory where uv stores pyx credentials.
 
 ### `RUST_BACKTRACE`
+<small class="added-in">added in `0.7.22`</small>
 
 If set, it can be used to display more stack trace details when a panic occurs.
 This is used by uv particularly on windows to show more details during a platform exception.
@@ -784,6 +935,7 @@ See the [Rust backtrace documentation](https://doc.rust-lang.org/std/backtrace/i
 for more.
 
 ### `RUST_LOG`
+<small class="added-in">added in `0.0.5`</small>
 
 If set, uv will use this value as the log level for its `--verbose` output. Accepts
 any filter compatible with the `tracing_subscriber` crate.
@@ -797,6 +949,7 @@ See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracin
 for more.
 
 ### `RUST_MIN_STACK`
+<small class="added-in">added in `0.5.19`</small>
 
 Use to set the stack size used by uv.
 
@@ -812,31 +965,38 @@ the fact that Windows' real main thread is only 1MB. That thread has size
 `max(RUST_MIN_STACK, 1MB)`.
 
 ### `SHELL`
+<small class="added-in">added in `0.1.16`</small>
 
 The standard `SHELL` posix env var.
 
 ### `SSL_CERT_FILE`
+<small class="added-in">added in `0.1.14`</small>
 
 Custom certificate bundle file path for SSL connections.
 
 ### `SSL_CLIENT_CERT`
+<small class="added-in">added in `0.2.11`</small>
 
 If set, uv will use this file for mTLS authentication.
 This should be a single file containing both the certificate and the private key in PEM format.
 
 ### `SYSTEMDRIVE`
+<small class="added-in">added in `0.4.26`</small>
 
 Path to system-level configuration directory on Windows systems.
 
 ### `TRACING_DURATIONS_FILE`
+<small class="added-in">added in `0.0.5`</small>
 
 Use to create the tracing durations file via the `tracing-durations-export` feature.
 
 ### `USERPROFILE`
+<small class="added-in">added in `0.0.5`</small>
 
 Path to root directory of user's profile on Windows systems.
 
 ### `UV`
+<small class="added-in">added in `0.6.0`</small>
 
 The path to the binary that was used to invoke uv.
 
@@ -849,43 +1009,53 @@ See <https://doc.rust-lang.org/std/env/fn.current_exe.html#security> for securit
 considerations.
 
 ### `VIRTUAL_ENV`
+<small class="added-in">added in `0.0.5`</small>
 
 Used to detect an activated virtual environment.
 
 ### `VIRTUAL_ENV_DISABLE_PROMPT`
+<small class="added-in">added in `0.0.5`</small>
 
 If set to `1` before a virtual environment is activated, then the
 virtual environment name will not be prepended to the terminal prompt.
 
 ### `XDG_BIN_HOME`
+<small class="added-in">added in `0.2.16`</small>
 
 Path to directory where executables are installed.
 
 ### `XDG_CACHE_HOME`
+<small class="added-in">added in `0.1.17`</small>
 
 Path to cache directory on Unix systems.
 
 ### `XDG_CONFIG_DIRS`
+<small class="added-in">added in `0.4.26`</small>
 
 Path to system-level configuration directory on Unix systems.
 
 ### `XDG_CONFIG_HOME`
+<small class="added-in">added in `0.1.34`</small>
 
 Path to user-level configuration directory on Unix systems.
 
 ### `XDG_DATA_HOME`
+<small class="added-in">added in `0.2.16`</small>
 
 Path to directory for storing managed Python installations and tools.
 
 ### `ZDOTDIR`
+<small class="added-in">added in `0.2.25`</small>
 
 Used to determine which `.zshenv` to use when Zsh is being used.
 
 ### `ZSH_VERSION`
+<small class="added-in">added in `0.1.28`</small>
 
 Used to detect Zsh shell usage.
 
 ### `_CONDA_ROOT`
+<small class="added-in">added in `0.8.18`</small>
 
 Used to determine the root install path of Conda.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -147,7 +147,7 @@ because the nav is in a hamburger menu anyway
       font-weight: normal;
       font-size: 0.85rem;
   }
-  /* Reducing spacing between nav items to fit more content 
+  /* Reducing spacing between nav items to fit more content
   First, disable `nav__link` spacing then use `nav__item` to enforce margins this reduces inconsistencies in the spacing. */
   .md-nav--primary .md-nav__link {
     margin: 0;
@@ -172,11 +172,11 @@ because the nav is in a hamburger menu anyway
   .md-nav__item--section> .md-nav > .md-nav__list > .md-nav__item > .md-nav > .md-nav__list > .md-nav__item:last-of-type {
     margin-bottom: 0.575em;
   }
-  /* Increase the size of the first nav item to match the sections 
+  /* Increase the size of the first nav item to match the sections
   It has no children, so it is not considered a section */
   .md-nav--primary > .md-nav__list > .md-nav__item:first-of-type {
     font-size: 0.85rem;
-    margin-bottom: 0.75em; 
+    margin-bottom: 0.75em;
   }
 }
 
@@ -205,6 +205,14 @@ because the nav is in a hamburger menu anyway
 h3.cli-reference {
   font-size: 1.1em;
   margin: 0 0 0 0;
+}
+h3:has(+ p > small.added-in) {
+  display: inline-block;
+  margin: 0;
+}
+h3 + p:has(> small.added-in) {
+  display: inline;
+  margin: 0;
 }
 
 /* Styling for anchor link headers */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ version_files = [
   "crates/uv-version/Cargo.toml",
   "crates/uv-build/Cargo.toml",
   "crates/uv-build/pyproject.toml",
+  { target = "crates/uv-static/src/env_vars.rs", replace = "next release" },
   "docs/getting-started/installation.md",
   "docs/guides/integration/docker.md",
   "docs/guides/integration/pre-commit.md",
@@ -75,6 +76,7 @@ version_files = [
   "docs/concepts/build-backend.md",
   "docs/concepts/projects/init.md",
   "docs/concepts/projects/workspaces.md",
+  { target = "docs/reference/environment.md", replace = "next release" },
 ]
 
 [tool.rooster.section-labels]


### PR DESCRIPTION
## Summary

As new environment variables get introduced (e.g. `UV_EDITABLE`) I thought it would useful to start tracking which release they were introduced. I think its a common workflow to navigate to the [env var documentation](https://docs.astral.sh/uv/reference/environment) to know what the env var for something is but then end up in a situation where one is using an environment variable with the wrong version of uv and not notice immediately that its not compatible and therefore ignored.

## Test Plan

Existing tests.

The versions in `since` have all been manually reviewed to the best of my ability for correctness. 
