### PR TITLE
Fix: Update smoke test failed cmd count method

### DIFF
--- a/scripts/smoke-test/__main__.py
+++ b/scripts/smoke-test/__main__.py
@@ -45,7 +45,7 @@ def report_result(result: subprocess.CompletedProcess):
 
 def main():
     results = [run_command(command) for command in read_commands()]
-    failed = sum(result.returncode != 0 for result in results)
+    failed = len([result.returncode != 0 for result in results])
     for result in results:
         report_result(result)
 


### PR DESCRIPTION
## Summary

in `scripts/smoke-test/__main__.py.main()`

 In get failed count, We use sum to calc all return code 

```python
failed = sum(result.returncode != 0 for result in results)
```

However, If retuncode is greater than 1, or a negative number, Sum will return a wrong result.

So update to len(),  We can get the exact number of failures


## Test Plan

nothing