### PR TITLE
Include build settings in cache key for registry source distribution lookups

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -64,8 +64,16 @@ impl<'a> Planner<'a> {
         tags: &Tags,
     ) -> Result<Plan> {
         // Index all the already-downloaded wheels in the cache.
-        let mut registry_index =
-            RegistryWheelIndex::new(cache, tags, index_locations, hasher, config_settings);
+        let mut registry_index = RegistryWheelIndex::new(
+            cache,
+            tags,
+            index_locations,
+            hasher,
+            config_settings,
+            config_settings_package,
+            extra_build_requires,
+            extra_build_variables,
+        );
         let built_index = BuiltWheelIndex::new(
             cache,
             tags,

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -3927,7 +3927,6 @@ fn config_settings_registry() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "


### PR DESCRIPTION
## Summary

Like #15030, but for source distributions built from a registry.
