### PR TITLE
Implement -C as short hand for --project

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -349,7 +349,7 @@ pub struct GlobalArgs {
     /// See `--directory` to change the working directory entirely.
     ///
     /// This setting has no effect when used in the `uv pip` interface.
-    #[arg(global = true, long, env = EnvVars::UV_PROJECT)]
+    #[arg(global = true, long, short = 'C', env = EnvVars::UV_PROJECT)]
     pub project: Option<PathBuf>,
 }
 
@@ -4753,12 +4753,7 @@ pub struct ToolUpgradeArgs {
     pub fork_strategy: Option<ForkStrategy>,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
-    #[arg(
-        long,
-        short = 'C',
-        alias = "config-settings",
-        help_heading = "Build options"
-    )]
+    #[arg(long, alias = "config-settings", help_heading = "Build options")]
     pub config_setting: Option<Vec<ConfigSettingEntry>>,
 
     /// Settings to pass to the PEP 517 build backend for a specific package, specified as `PACKAGE:KEY=VALUE` pairs.
@@ -5575,12 +5570,7 @@ pub struct InstallerArgs {
     pub keyring_provider: Option<KeyringProviderType>,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
-    #[arg(
-        long,
-        short = 'C',
-        alias = "config-settings",
-        help_heading = "Build options"
-    )]
+    #[arg(long, alias = "config-settings", help_heading = "Build options")]
     pub config_setting: Option<Vec<ConfigSettingEntry>>,
 
     /// Settings to pass to the PEP 517 build backend for a specific package, specified as `PACKAGE:KEY=VALUE` pairs.
@@ -5784,12 +5774,7 @@ pub struct ResolverArgs {
     pub fork_strategy: Option<ForkStrategy>,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
-    #[arg(
-        long,
-        short = 'C',
-        alias = "config-settings",
-        help_heading = "Build options"
-    )]
+    #[arg(long, alias = "config-settings", help_heading = "Build options")]
     pub config_setting: Option<Vec<ConfigSettingEntry>>,
 
     /// Settings to pass to the PEP 517 build backend for a specific package, specified as `PACKAGE:KEY=VALUE` pairs.
@@ -5995,12 +5980,7 @@ pub struct ResolverInstallerArgs {
     pub fork_strategy: Option<ForkStrategy>,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
-    #[arg(
-        long,
-        short = 'C',
-        alias = "config-settings",
-        help_heading = "Build options"
-    )]
+    #[arg(long, alias = "config-settings", help_heading = "Build options")]
     pub config_setting: Option<Vec<ConfigSettingEntry>>,
 
     /// Settings to pass to the PEP 517 build backend for a specific package, specified as `PACKAGE:KEY=VALUE` pairs.

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -65,7 +65,7 @@ fn help() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -144,7 +144,7 @@ fn help_flag() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -222,7 +222,7 @@ fn help_short_flag() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -408,7 +408,7 @@ fn help_subcommand() {
               
               See `--project` to only change the project root directory.
 
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory.
               
               All `pyproject.toml`, `uv.toml`, and `.python-version` files will be discovered by walking
@@ -675,7 +675,7 @@ fn help_subsubcommand() {
               
               See `--project` to only change the project root directory.
 
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory.
               
               All `pyproject.toml`, `uv.toml`, and `.python-version` files will be discovered by walking
@@ -766,7 +766,7 @@ fn help_flag_subcommand() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -847,7 +847,7 @@ fn help_flag_subsubcommand() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -1003,7 +1003,7 @@ fn help_with_global_option() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
@@ -1124,7 +1124,7 @@ fn help_with_no_pager() {
               Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command
-          --project <PROJECT>
+      -C, --project <PROJECT>
               Run the command within the given project directory [env: UV_PROJECT=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This MR implements the shorthand option `-C` for `--project`, so you can call

```
uv -C my/project/ run python
```

Many other prominent tools use this, like `make`, `git`, `cargo`, `poetry`, `meson`, `ninja` etc., and it would be great to see `uv` follow that convention, as proposed in #12040.

However, there is one small-ish technical hurdle: `-C` was recently also picked up as a shorthand for `uv pip install --config-settings` (#1460). These two options clash, because `clap` cannot disambiguate between global and subcommand options.

I could not find a way to deprecate `clap` options, so I simply removed the other occurrences for now, just to get started. Please understand that this was only done to get this MR out, and I see this MR as a conversation starter, not a s a finished proposal.

If you would like to adopt `-C/--project` (and I 100% think you should), what would be the best way forward to integrate this feature? I'd be happy to amend this MR to implement them.

## Test Plan

The corresponding tests strings were adjusted, no additional tests were added.
