### PR TITLE
Fix clippy warnings in downloads.rs

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -552,13 +552,13 @@ impl FromStr for PythonDownloadRequest {
         impl Position {
             pub(crate) fn next(&self) -> Self {
                 match self {
-                    Position::Start => Position::Implementation,
-                    Position::Implementation => Position::Version,
-                    Position::Version => Position::Os,
-                    Position::Os => Position::Arch,
-                    Position::Arch => Position::Libc,
-                    Position::Libc => Position::End,
-                    Position::End => Position::End,
+                    Self::Start => Self::Implementation,
+                    Self::Implementation => Self::Version,
+                    Self::Version => Self::Os,
+                    Self::Os => Self::Arch,
+                    Self::Arch => Self::Libc,
+                    Self::Libc => Self::End,
+                    Self::End => Self::End,
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes clippy warnings on main.

## Test Plan

`cargo clippy`
