### PR TITLE
Rename `InstalledDist` methods to reflect read operation

### DIFF
--- a/crates/uv-distribution-types/src/installed.rs
+++ b/crates/uv-distribution-types/src/installed.rs
@@ -136,9 +136,9 @@ impl InstalledDist {
 
             let name = PackageName::from_str(name)?;
             let version = Version::from_str(version)?;
-            let cache_info = Self::cache_info(path)?;
+            let cache_info = Self::read_cache_info(path)?;
 
-            return if let Some(direct_url) = Self::direct_url(path)? {
+            return if let Some(direct_url) = Self::read_direct_url(path)? {
                 match Url::try_from(&direct_url) {
                     Ok(url) => Ok(Some(Self::Url(InstalledDirectUrlDist {
                         name,
@@ -304,7 +304,7 @@ impl InstalledDist {
     }
 
     /// Read the `direct_url.json` file from a `.dist-info` directory.
-    pub fn direct_url(path: &Path) -> Result<Option<DirectUrl>, InstalledDistError> {
+    pub fn read_direct_url(path: &Path) -> Result<Option<DirectUrl>, InstalledDistError> {
         let path = path.join("direct_url.json");
         let file = match fs_err::File::open(&path) {
             Ok(file) => file,
@@ -317,7 +317,7 @@ impl InstalledDist {
     }
 
     /// Read the `uv_cache.json` file from a `.dist-info` directory.
-    pub fn cache_info(path: &Path) -> Result<Option<CacheInfo>, InstalledDistError> {
+    pub fn read_cache_info(path: &Path) -> Result<Option<CacheInfo>, InstalledDistError> {
         let path = path.join("uv_cache.json");
         let file = match fs_err::File::open(&path) {
             Ok(file) => file,
@@ -330,7 +330,7 @@ impl InstalledDist {
     }
 
     /// Read the `METADATA` file from a `.dist-info` directory.
-    pub fn metadata(&self) -> Result<uv_pypi_types::ResolutionMetadata, InstalledDistError> {
+    pub fn read_metadata(&self) -> Result<uv_pypi_types::ResolutionMetadata, InstalledDistError> {
         match self {
             Self::Registry(_) | Self::Url(_) => {
                 let path = self.install_path().join("METADATA");
@@ -362,7 +362,7 @@ impl InstalledDist {
     }
 
     /// Return the `INSTALLER` of the distribution.
-    pub fn installer(&self) -> Result<Option<String>, InstalledDistError> {
+    pub fn read_installer(&self) -> Result<Option<String>, InstalledDistError> {
         let path = self.install_path().join("INSTALLER");
         match fs::read_to_string(path) {
             Ok(installer) => Ok(Some(installer.trim().to_owned())),

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -140,7 +140,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         }
 
         let metadata = dist
-            .metadata()
+            .read_metadata()
             .map_err(|err| Error::ReadInstalled(Box::new(dist.clone()), err))?;
 
         Ok(ArchiveMetadata::from_metadata23(metadata))

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -222,7 +222,7 @@ impl SitePackages {
                 };
 
                 // Determine the dependencies for the given package.
-                let Ok(metadata) = distribution.metadata() else {
+                let Ok(metadata) = distribution.read_metadata() else {
                     diagnostics.push(SitePackagesDiagnostic::MetadataUnavailable {
                         package: package.clone(),
                         path: distribution.install_path().to_owned(),
@@ -471,7 +471,7 @@ impl SitePackages {
 
                     // Recurse into the dependencies.
                     let metadata = distribution
-                        .metadata()
+                        .read_metadata()
                         .with_context(|| format!("Failed to read metadata for: {distribution}"))?;
 
                     // Add the dependencies to the queue.

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -98,7 +98,7 @@ pub(crate) fn pip_show(
     let mut requires_map = FxHashMap::default();
     // For Requires field
     for dist in &distributions {
-        if let Ok(metadata) = dist.metadata() {
+        if let Ok(metadata) = dist.read_metadata() {
             requires_map.insert(
                 dist.name(),
                 Box::into_iter(metadata.requires_dist)
@@ -116,7 +116,7 @@ pub(crate) fn pip_show(
             if requires_map.contains_key(installed.name()) {
                 continue;
             }
-            if let Ok(metadata) = installed.metadata() {
+            if let Ok(metadata) = installed.read_metadata() {
                 let requires = Box::into_iter(metadata.requires_dist)
                     .filter(|req| req.evaluate_markers(&markers, &[]))
                     .map(|req| req.name)

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -74,7 +74,7 @@ pub(crate) async fn pip_tree(
             packages
                 .entry(package.name())
                 .or_default()
-                .push(package.metadata()?);
+                .push(package.read_metadata()?);
         }
         packages
     };


### PR DESCRIPTION
## Summary

I found it surprising that these don't "just" return fields from the struct.
