### PR TITLE
Reject `match-runtime = true` for dynamic packages

### DIFF
--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -91,6 +91,10 @@ pub enum Error {
     NoSourceDistBuilds,
     #[error("Cyclic build dependency detected for `{0}`")]
     CyclicBuildDependency(PackageName),
+    #[error(
+        "Extra build requirement `{0}` was declared with `match-runtime = true`, but `{1}` does not declare static metadata, making runtime-matching impossible"
+    )]
+    UnmatchedRuntime(PackageName, PackageName),
 }
 
 impl IsBuildBackendError for Error {
@@ -106,7 +110,8 @@ impl IsBuildBackendError for Error {
             | Self::Virtualenv(_)
             | Self::NoSourceDistBuild(_)
             | Self::NoSourceDistBuilds
-            | Self::CyclicBuildDependency(_) => false,
+            | Self::CyclicBuildDependency(_)
+            | Self::UnmatchedRuntime(_, _) => false,
             Self::CommandFailed(_, _)
             | Self::BuildBackend(_)
             | Self::MissingHeader(_)

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -480,7 +480,7 @@ impl BuildContext for BuildDispatch<'_> {
             self.workspace_cache(),
             config_settings,
             self.build_isolation,
-            self.extra_build_requires(),
+            self.extra_build_requires,
             &build_stack,
             build_kind,
             environment_variables,


### PR DESCRIPTION
## Summary

If `match-runtime = true`, but we can't resolve a package's metadata statically, then we can't _know_ what the runtime version of the package will be -- because we can't resolve without building it. This PR makes that footgun clearer by raising an error.

Closes https://github.com/astral-sh/uv/issues/15264.
