### PR TITLE
Use freebsd action fork with pinned checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,7 +756,7 @@ jobs:
           cross build --target x86_64-unknown-freebsd
 
       - name: Test in Firecracker VM
-        uses: acj/freebsd-firecracker-action@136ca0bce2adade21e526ceb07db643ad23dd2dd # v0.5.1
+        uses: zanieb/freebsd-firecracker-action@53aafbb470a6f21f8745eae5a6973002cdced262 # v0.5.1
         with:
           verbose: false
           checkout: false


### PR DESCRIPTION
Picks up https://github.com/acj/freebsd-firecracker-action/pull/5 to unblock CI