### PR TITLE
Update pypa/gh-action-pypi-publish to version with pinned hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1872,7 +1872,7 @@ jobs:
           ../uv build
 
       - name: "Publish astral-test-pypa-gh-action"
-        uses: pypa/gh-action-pypi-publish@db8f07d3871a0a180efa06b95d467625c19d5d5f # release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           # With this GitHub action, we can't do as rigid checks as with our custom Python script, so we publish more
           # leniently


### PR DESCRIPTION
Use a version of the GitHub Action that uses a pinned hash, to fix the publish test.

See https://github.com/astral-sh/uv/pull/15324 and https://github.com/pypa/gh-action-pypi-publish/pull/378 for details.