### PR TITLE
Promote trixie and alpine 3.22 as default tags

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -178,12 +178,12 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.21,alpine3.21,alpine
-          - alpine:3.22,alpine3.22
-          - debian:bookworm-slim,bookworm-slim,debian-slim
-          - buildpack-deps:bookworm,bookworm,debian
-          - debian:trixie-slim,trixie-slim
-          - buildpack-deps:trixie,trixie
+          - alpine:3.22,alpine3.22,alpine
+          - alpine:3.21,alpine3.21
+          - debian:trixie-slim,trixie-slim,debian-slim
+          - buildpack-deps:trixie,trixie,debian
+          - debian:bookworm-slim,bookworm-slim
+          - buildpack-deps:bookworm,bookworm
           - python:3.14-rc-alpine,python3.14-rc-alpine
           - python:3.13-alpine,python3.13-alpine
           - python:3.12-alpine,python3.12-alpine
@@ -191,6 +191,18 @@ jobs:
           - python:3.10-alpine,python3.10-alpine
           - python:3.9-alpine,python3.9-alpine
           - python:3.8-alpine,python3.8-alpine
+          - python:3.14-rc-trixie,python3.14-rc-trixie
+          - python:3.13-trixie,python3.13-trixie
+          - python:3.12-trixie,python3.12-trixie
+          - python:3.11-trixie,python3.11-trixie
+          - python:3.10-trixie,python3.10-trixie
+          - python:3.9-trixie,python3.9-trixie
+          - python:3.14-rc-slim-trixie,python3.14-rc-trixie-slim
+          - python:3.13-slim-trixie,python3.13-trixie-slim
+          - python:3.12-slim-trixie,python3.12-trixie-slim
+          - python:3.11-slim-trixie,python3.11-trixie-slim
+          - python:3.10-slim-trixie,python3.10-trixie-slim
+          - python:3.9-slim-trixie,python3.9-trixie-slim
           - python:3.14-rc-bookworm,python3.14-rc-bookworm
           - python:3.13-bookworm,python3.13-bookworm
           - python:3.12-bookworm,python3.12-bookworm
@@ -205,18 +217,6 @@ jobs:
           - python:3.10-slim-bookworm,python3.10-bookworm-slim
           - python:3.9-slim-bookworm,python3.9-bookworm-slim
           - python:3.8-slim-bookworm,python3.8-bookworm-slim
-          - python:3.14-rc-trixie,python3.14-rc-trixie
-          - python:3.13-trixie,python3.13-trixie
-          - python:3.12-trixie,python3.12-trixie
-          - python:3.11-trixie,python3.11-trixie
-          - python:3.10-trixie,python3.10-trixie
-          - python:3.9-trixie,python3.9-trixie
-          - python:3.14-rc-slim-trixie,python3.14-rc-trixie-slim
-          - python:3.13-slim-trixie,python3.13-trixie-slim
-          - python:3.12-slim-trixie,python3.12-trixie-slim
-          - python:3.11-slim-trixie,python3.11-trixie-slim
-          - python:3.10-slim-trixie,python3.10-trixie-slim
-          - python:3.9-slim-trixie,python3.9-trixie-slim
     steps:
       # Login to DockerHub (when not pushing, it's to avoid rate-limiting)
       - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -38,21 +38,21 @@ The following distroless images are available:
 And the following derived images are available:
 
 <!-- prettier-ignore -->
-- Based on `alpine:3.21`:
-    - `ghcr.io/astral-sh/uv:alpine`
-    - `ghcr.io/astral-sh/uv:alpine3.21`
 - Based on `alpine:3.22`:
+    - `ghcr.io/astral-sh/uv:alpine`
     - `ghcr.io/astral-sh/uv:alpine3.22`
-- Based on `debian:bookworm-slim`:
-    - `ghcr.io/astral-sh/uv:debian-slim`
-    - `ghcr.io/astral-sh/uv:bookworm-slim`
+- Based on `alpine:3.21`:
+    - `ghcr.io/astral-sh/uv:alpine3.21`
 - Based on `debian:trixie-slim`:
+    - `ghcr.io/astral-sh/uv:debian-slim`
     - `ghcr.io/astral-sh/uv:trixie-slim`
-- Based on `buildpack-deps:bookworm`:
-    - `ghcr.io/astral-sh/uv:debian`
-    - `ghcr.io/astral-sh/uv:bookworm`
+- Based on `debian:bookworm-slim`:
+    - `ghcr.io/astral-sh/uv:bookworm-slim`
 - Based on `buildpack-deps:trixie`:
+    - `ghcr.io/astral-sh/uv:debian`
     - `ghcr.io/astral-sh/uv:trixie`
+- Based on `buildpack-deps:bookworm`:
+    - `ghcr.io/astral-sh/uv:bookworm`
 - Based on `python3.x-alpine`:
     - `ghcr.io/astral-sh/uv:python3.14-rc-alpine`
     - `ghcr.io/astral-sh/uv:python3.13-alpine`
@@ -61,6 +61,20 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.10-alpine`
     - `ghcr.io/astral-sh/uv:python3.9-alpine`
     - `ghcr.io/astral-sh/uv:python3.8-alpine`
+- Based on `python3.x-trixie`:
+    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie`
+    - `ghcr.io/astral-sh/uv:python3.13-trixie`
+    - `ghcr.io/astral-sh/uv:python3.12-trixie`
+    - `ghcr.io/astral-sh/uv:python3.11-trixie`
+    - `ghcr.io/astral-sh/uv:python3.10-trixie`
+    - `ghcr.io/astral-sh/uv:python3.9-trixie`
+- Based on `python3.x-slim-trixie`:
+    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.13-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.12-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.11-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.10-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.9-trixie-slim`
 - Based on `python3.x-bookworm`:
     - `ghcr.io/astral-sh/uv:python3.14-rc-bookworm`
     - `ghcr.io/astral-sh/uv:python3.13-bookworm`
@@ -77,20 +91,6 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.10-bookworm-slim`
     - `ghcr.io/astral-sh/uv:python3.9-bookworm-slim`
     - `ghcr.io/astral-sh/uv:python3.8-bookworm-slim`
-- Based on `python3.x-trixie`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie`
-    - `ghcr.io/astral-sh/uv:python3.13-trixie`
-    - `ghcr.io/astral-sh/uv:python3.12-trixie`
-    - `ghcr.io/astral-sh/uv:python3.11-trixie`
-    - `ghcr.io/astral-sh/uv:python3.10-trixie`
-    - `ghcr.io/astral-sh/uv:python3.9-trixie`
-- Based on `python3.x-slim-trixie`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie-slim`
-    - `ghcr.io/astral-sh/uv:python3.13-trixie-slim`
-    - `ghcr.io/astral-sh/uv:python3.12-trixie-slim`
-    - `ghcr.io/astral-sh/uv:python3.11-trixie-slim`
-    - `ghcr.io/astral-sh/uv:python3.10-trixie-slim`
-    - `ghcr.io/astral-sh/uv:python3.9-trixie-slim`
 <!-- prettier-ignore-end -->
 
 As with the distroless image, each derived image is published with uv version tags as


### PR DESCRIPTION
## Summary

Semi related to https://github.com/astral-sh/uv/issues/15270, except there's no removal.

Makes Alpine 3.22 and debian trixie the default tags instead of removing bookworm and alpine 3.21 to minimize churn.

~~This PR is pending https://github.com/astral-sh/uv/pull/15351 merged first.~~ Merged

## Test Plan

No functional changes made besides changing tag pointers.