### PR TITLE
Mark `find_uv_bin_py38` test as requiring `python-eol`

### DIFF
--- a/crates/uv/tests/it/python_module.rs
+++ b/crates/uv/tests/it/python_module.rs
@@ -461,6 +461,7 @@ fn find_uv_bin_error_message() {
     );
 }
 
+#[cfg(feature = "python-eol")]
 #[test]
 fn find_uv_bin_py38() {
     let context = TestContext::new("3.8")


### PR DESCRIPTION
## Summary

Mark `find_uv_bin_py38` test as requiring `python-eol`. Resolves one of the issues reported in #15368.

## Test Plan

```
cargo test --profile=dev --features git --features pypi --features python --no-default-features
```

(without Python 3.8 installed)