### PR TITLE
Update astral-tokio-tar to v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,8 @@ dependencies = [
 [[package]]
 name = "astral-tokio-tar"
 version = "0.5.3"
-source = "git+https://github.com/astral-sh/tokio-tar?rev=f1488188f1d1b54a73eb0c42a8b8f4b9ee87d688#f1488188f1d1b54a73eb0c42a8b8f4b9ee87d688"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0036af73142caf1291d4ec8ed667d3a1145bd55c8189517bd5aa07b3167ae1e1"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ anstream = { version = "0.6.15" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }
 arrayvec = { version = "0.7.6" }
-astral-tokio-tar = { git = "https://github.com/astral-sh/tokio-tar", rev = "f1488188f1d1b54a73eb0c42a8b8f4b9ee87d688" }
+astral-tokio-tar = { version = "0.5.3" }
 async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = ["bzip2", "gzip", "xz", "zstd"] }
 async-trait = { version = "0.1.82" }


### PR DESCRIPTION
This is not actually an update, we're just updating the commit tag to a crates.io release for https://github.com/astral-sh/uv/pull/15202#issuecomment-3200209608