### PR TITLE
feat(ci): build loongarch64 binaries in CI

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -842,6 +842,115 @@ jobs:
           name: wheels_uv_build-${{ matrix.platform.target }}
           path: crates/uv-build/dist
 
+  linux-loongarch64:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: loongarch64-unknown-linux-gnu
+            arch: loong64
+            base_image: --platform=linux/loong64 ghcr.io/loong64/debian:trixie
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+
+      # uv
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: auto
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
+          args: --release --locked --out dist --features self-update
+      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+        name: "Test wheel"
+        with:
+          base_image: ${{ matrix.platform.base_image }}
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends python3 python3-pip python-is-python3 python3-venv
+          run: |
+            python3 -m venv .venv
+            .venv/bin/pip install -U pip
+            source .venv/bin/activate
+            pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
+            ${MODULE_NAME} --help
+            # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
+            # python -m ${MODULE_NAME} --help
+            uvx --help
+          env: |
+            PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+            MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wheels_uv-${{ matrix.platform.target }}
+          path: dist
+      - name: "Archive binary"
+        shell: bash
+        run: |
+          ARCHIVE_NAME=uv-$TARGET
+          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
+
+          mkdir -p $ARCHIVE_NAME
+          cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
+          cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+        env:
+          TARGET: ${{ matrix.platform.target }}
+      - name: "Upload binary"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: artifacts-${{ matrix.platform.target }}
+          path: |
+            *.tar.gz
+            *.sha256
+
+      # uv-build
+      - name: "Build wheels uv-build"
+        uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: auto
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
+          args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml
+      - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
+        name: "Test wheel uv-build"
+        with:
+          base_image: ${{ matrix.platform.base_image }}
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends python3 python3-pip python-is-python3 python3-venv
+          run: |
+            python3 -m venv .venv
+            .venv/bin/pip install -U pip
+            source .venv/bin/activate
+            pip install ${PACKAGE_NAME}-build --no-index --find-links crates/uv-build/dist --force-reinstall
+            ${MODULE_NAME}-build --help
+            # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
+            # python -m ${MODULE_NAME}-build --help
+          env: |
+            PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+            MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Upload wheels uv-build"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wheels_uv_build-${{ matrix.platform.target }}
+          path: crates/uv-build/dist
+
   musllinux:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,6 +28,8 @@ jobs:
           pattern: wheels_uv-*
           path: wheels_uv
           merge-multiple: true
+      - name: Remove wheels unsupported by PyPI
+        run: rm wheels_uv/*loong*
       - name: Publish to PyPI
         run: uv publish -v wheels_uv/*
 
@@ -47,5 +49,7 @@ jobs:
           pattern: wheels_uv_build-*
           path: wheels_uv_build
           merge-multiple: true
+      - name: Remove wheels unsupported by PyPI
+        run: rm wheels_uv/*loong*
       - name: Publish to PyPI
         run: uv publish -v wheels_uv_build/*

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,6 +29,7 @@ targets = [
     "powerpc64le-unknown-linux-gnu",
     "riscv64gc-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",
+    "loongarch64-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
@@ -72,6 +73,7 @@ global = "depot-ubuntu-latest-4"
 # Override glibc version for specific target triplets.
 aarch64-unknown-linux-gnu = "2.28"
 riscv64gc-unknown-linux-gnu = "2.31"
+loongarch64-unknown-linux-gnu = "2.36"
 # Override all remaining glibc versions.
 "*" = "2.17"
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR adds support for building loongarch64 binaries in CI. As uv itself runs perfectly well on loongarch64 and with the latter's userbase steadily growing, it would be a good idea to ship prebuilt binaries to help them out.

Please note that as Ubuntu is not yet available for loongarch64, I have elected to use a Debian Trixie container maintained by community members. In addition, as Debian's pip does not allow installing modules system-wide, the workflow for loongarch64 installs additional modules in a virtual environment.

## Test Plan

<!-- How was it tested? -->

Tests are included in CI and the loongarch64 artifacts built in [this workflow](https://github.com/SkyBird233/uv/actions/runs/17091637376/job/48466486690) has been smoke tested.