### PR TITLE
Add `triton` to `torch-backend` manifest

### DIFF
--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -267,6 +267,7 @@ impl TorchStrategy {
                 | "torchserve"
                 | "torchtext"
                 | "torchvision"
+                | "triton"
                 | "pytorch-triton"
                 | "pytorch-triton-rocm"
                 | "pytorch-triton-xpu"


### PR DESCRIPTION
## Summary

The PyTorch team publishes ARM Linux wheels for `triton` to the PyTorch index, which aren't available on PyPI.

## Test Plan

```
echo "torch" | cargo run pip compile - --torch-backend=cu128 --python-platform aarch64-unknown-linux-gnu --python-version 3.13
```

Previously failed because it couldn't find a compatible `triton` wheel.