### PR TITLE
extra-build-dependencies: Allow version specifiers if match-runtime is explicitly false

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -821,15 +821,17 @@ impl TryFrom<ExtraBuildDependencyWire> for ExtraBuildDependency {
                 requirement,
                 match_runtime,
             } => match requirement.version_or_url {
-                None => Ok(Self {
+                // If `match-runtime = true`, reject additional constraints.
+                Some(VersionOrUrl::VersionSpecifier(..)) if match_runtime => {
+                    Err(ExtraBuildDependencyError::VersionSpecifiersNotAllowed)
+                }
+                Some(VersionOrUrl::Url(..)) if match_runtime => {
+                    Err(ExtraBuildDependencyError::UrlNotAllowed)
+                }
+                _ => Ok(Self {
                     requirement,
                     match_runtime,
                 }),
-                // If `match-runtime = true`, reject additional constraints.
-                Some(VersionOrUrl::VersionSpecifier(..)) => {
-                    Err(ExtraBuildDependencyError::VersionSpecifiersNotAllowed)
-                }
-                Some(VersionOrUrl::Url(..)) => Err(ExtraBuildDependencyError::UrlNotAllowed),
             },
         }
     }

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -13390,6 +13390,35 @@ fn sync_extra_build_dependencies_cache() -> Result<()> {
     Audited 1 package in [TIME]
     ");
 
+    // Adding a version specifier is fine if match-runtime is false
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.9"
+        dependencies = ["child"]
+
+        [tool.uv.sources]
+        child = { path = "child" }
+
+        [tool.uv.extra-build-dependencies]
+        child = [{ requirement = "iniconfig>0", match-runtime = false }]
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: The `extra-build-dependencies` option is experimental and may change without warning. Pass `--preview-features extra-build-dependencies` to disable this warning.
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ child==0.1.0 (from file://[TEMP_DIR]/child)
+    ");
+
     // Remove the build dependency.
     pyproject_toml.write_str(indoc! {r#"
         [project]


### PR DESCRIPTION
## Summary

`match-runtime` can be explicitly specified, and if it's `false` it should behave the same way as if it's omitted.

## Test Plan

Added snapshot test