### PR TITLE
fix(tests): Ensure show_settings tests don't load user config

### DIFF
--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -18,7 +18,9 @@ fn add_shared_args(mut command: Command, cwd: &Path) -> Command {
         .env(EnvVars::UV_CONCURRENT_BUILDS, "16")
         .env(EnvVars::UV_CONCURRENT_INSTALLS, "8")
         // Set an explicit `XDG_CONFIG_DIRS` to avoid loading system configuration.
-        .env(EnvVars::XDG_CONFIG_DIRS, cwd);
+        .env(EnvVars::XDG_CONFIG_DIRS, cwd)
+        // Set an explicit `XDG_CONFIG_HOME` to avoid loading user configuration.
+        .env(EnvVars::XDG_CONFIG_HOME, cwd);
 
     if cfg!(unix) {
         // Avoid locale issues in tests


### PR DESCRIPTION
## Summary

Ensure show_settings tests set XDG_CONFIG_HOME to avoid loading user configuration

Closes #15403

