### PR TITLE
Include cycle error message in `uv pip` CLI

### DIFF
--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -215,11 +215,10 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch.workspace_cache(),
             )
             .await
-            .map_err(|e| {
-                anyhow!(
-                    "Failed to read dependency groups from: {}\n{}",
-                    pyproject_path.display(),
-                    e
+            .with_context(|| {
+                format!(
+                    "Failed to read dependency groups from: {}",
+                    pyproject_path.display()
                 )
             })?;
 


### PR DESCRIPTION
## Summary

The use of `format!` was dropping the error chain.

Closes https://github.com/astral-sh/uv/issues/15397.
