### PR TITLE
Move Resolver to new Internals section in the Reference

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -540,8 +540,8 @@ installation of Excel parsers and `matplotlib` unless someone explicitly require
 requested with the `package[<extra>]` syntax, e.g., `pandas[plot, excel]`.
 
 Optional dependencies are specified in `[project.optional-dependencies]`, a TOML table that maps
-from extra name to its dependencies, following
-[dependency specifiers](#dependency-specifiers-pep-508) syntax.
+from extra name to its dependencies, following [dependency specifiers](#dependency-specifiers)
+syntax.
 
 Optional dependencies can have entries in `tool.uv.sources` the same as normal dependencies.
 

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -611,4 +611,4 @@ versions of uv to error.
 ## Learn more
 
 For more details about the internals of the resolver, see the
-[resolver reference](../reference/resolver-internals.md) documentation.
+[resolver reference](../reference/internals/resolver.md) documentation.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,7 +4,7 @@ The reference section provides information about specific parts of uv:
 
 - [Commands](./cli.md): A reference for uv's command line interface.
 - [Settings](./settings.md): A reference for uv's configuration schema.
-- [Resolver](./resolver-internals.md): Details about the internals of uv's resolver.
+- [Resolver](./internals/resolver.md): Details about the internals of uv's resolver.
 - [Policies](./policies/index.md): uv's versioning policy, platform support policy, and license.
 
 Looking for a broader overview? Check out the [concepts](../concepts/index.md) documentation.

--- a/docs/reference/internals/index.md
+++ b/docs/reference/internals/index.md
@@ -1,0 +1,5 @@
+# Internals
+
+The internals section provides details about uv's internal components and implementation details.
+
+- [Resolver](./resolver.md)

--- a/docs/reference/internals/resolver.md
+++ b/docs/reference/internals/resolver.md
@@ -3,7 +3,7 @@
 !!! tip
 
     This document focuses on the internal workings of uv's resolver. For using uv, see the
-    [resolution concept](../concepts/resolution.md) documentation.
+    [resolution concept](../../concepts/resolution.md) documentation.
 
 ## Resolver
 
@@ -42,7 +42,7 @@ works in the following steps:
   requirements in the partial solution and must not be previously marked as incompatible. The
   resolver prefers versions from a lockfile (`uv.lock` or `-o requirements.txt`) and those installed
   in the current environment. Versions are checked from highest to lowest (unless using an
-  alternative [resolution strategy](../concepts/resolution.md#resolution-strategy)).
+  alternative [resolution strategy](../../concepts/resolution.md#resolution-strategy)).
 - All requirements of the selected package version are added to the undecided packages. uv
   prefetches their metadata in the background to improve performance.
 - The process is either repeated with the next package unless a conflict is detected, in which the

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -75,6 +75,7 @@ plugins:
         "reference/versioning.md": "reference/policies/versioning.md"
         "reference/platforms.md": "reference/policies/platforms.md"
         "reference/build_failures.md": "reference/troubleshooting/build-failures.md"
+        "reference/resolver-internals.md": "reference/internals/resolver.md"
         "configuration/installer.md": "reference/installer.md"
         "configuration/authentication.md": "concepts/authentication.md"
         "configuration/build-backend.md": "concepts/build-backend.md"
@@ -232,7 +233,9 @@ nav:
           - reference/troubleshooting/index.md
           - Build failures: reference/troubleshooting/build-failures.md
           - Reproducible examples: reference/troubleshooting/reproducible-examples.md
-      - Resolver: reference/resolver-internals.md
+      - Internals:
+          - reference/internals/index.md
+          - Resolver: reference/internals/resolver.md
       - Benchmarks: reference/benchmarks.md
       - Policies:
           - reference/policies/index.md


### PR DESCRIPTION
## Summary

Move the Resolver reference into a new Internals section in the reference. Add the new nav item, fix internal linking to the new path, fix server side redirect to the new path for external traffic via redirect_maps, fix non existent anchor in "docs/concepts/projects/dependencies.md"

Closes #15412
