### PR TITLE
Stop setting `CLICOLOR_FORCE=1` when calling build backends

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -1159,7 +1159,10 @@ impl PythonRunner {
             .envs(environment_variables)
             .env(EnvVars::PATH, modified_path)
             .env(EnvVars::VIRTUAL_ENV, venv.root())
-            .env(EnvVars::CLICOLOR_FORCE, "1")
+            // NOTE: it would be nice to get colored output from build backends,
+            // but setting CLICOLOR_FORCE=1 changes the output of underlying
+            // tools, which might mess with wrappers trying to parse their
+            // output.
             .env(EnvVars::PYTHONIOENCODING, "utf-8:backslashreplace")
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary

`CLICOLOR_FORCE` changes the output of underlying build commands, which messes with wrapper tools trying to parse their output.

Closes #12564, closes #15415. 