### PR TITLE
Move wheel tag methods to `WheelTag`

### DIFF
--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -134,34 +134,22 @@ impl WheelFilename {
 
     /// Return the wheel's Python tags.
     pub fn python_tags(&self) -> &[LanguageTag] {
-        match &self.tags {
-            WheelTag::Small { small } => std::slice::from_ref(&small.python_tag),
-            WheelTag::Large { large } => large.python_tag.as_slice(),
-        }
+        self.tags.python_tags()
     }
 
     /// Return the wheel's ABI tags.
     pub fn abi_tags(&self) -> &[AbiTag] {
-        match &self.tags {
-            WheelTag::Small { small } => std::slice::from_ref(&small.abi_tag),
-            WheelTag::Large { large } => large.abi_tag.as_slice(),
-        }
+        self.tags.abi_tags()
     }
 
     /// Return the wheel's platform tags.
     pub fn platform_tags(&self) -> &[PlatformTag] {
-        match &self.tags {
-            WheelTag::Small { small } => std::slice::from_ref(&small.platform_tag),
-            WheelTag::Large { large } => large.platform_tag.as_slice(),
-        }
+        self.tags.platform_tags()
     }
 
     /// Return the wheel's build tag, if present.
     pub fn build_tag(&self) -> Option<&BuildTag> {
-        match &self.tags {
-            WheelTag::Small { .. } => None,
-            WheelTag::Large { large } => large.build_tag.as_ref(),
-        }
+        self.tags.build_tag()
     }
 
     /// Parse a wheel filename from the stem (e.g., `foo-1.2.3-py3-none-any`).

--- a/crates/uv-distribution-filename/src/wheel_tag.rs
+++ b/crates/uv-distribution-filename/src/wheel_tag.rs
@@ -37,6 +37,40 @@ pub(crate) enum WheelTag {
     Large { large: Box<WheelTagLarge> },
 }
 
+impl WheelTag {
+    /// Return the Python tags.
+    pub(crate) fn python_tags(&self) -> &[LanguageTag] {
+        match self {
+            Self::Small { small } => std::slice::from_ref(&small.python_tag),
+            Self::Large { large } => large.python_tag.as_slice(),
+        }
+    }
+
+    /// Return the ABI tags.
+    pub(crate) fn abi_tags(&self) -> &[AbiTag] {
+        match self {
+            Self::Small { small } => std::slice::from_ref(&small.abi_tag),
+            Self::Large { large } => large.abi_tag.as_slice(),
+        }
+    }
+
+    /// Return the platform tags.
+    pub(crate) fn platform_tags(&self) -> &[PlatformTag] {
+        match self {
+            Self::Small { small } => std::slice::from_ref(&small.platform_tag),
+            Self::Large { large } => large.platform_tag.as_slice(),
+        }
+    }
+
+    /// Return the build tag, if present.
+    pub(crate) fn build_tag(&self) -> Option<&BuildTag> {
+        match self {
+            Self::Small { .. } => None,
+            Self::Large { large } => large.build_tag.as_ref(),
+        }
+    }
+}
+
 impl Display for WheelTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Summary

Lowering these out of `WheelFilename`.
