### PR TITLE
 Fix format of {version} on `uv format` failure

### DIFF
--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -59,7 +59,7 @@ pub(crate) async fn format(
     let version = version.as_ref().unwrap_or(&default_version);
     let ruff_path = bin_install(Binary::Ruff, version, &client, &cache, &reporter)
         .await
-        .context("Failed to install ruff {version}")?;
+        .with_context(|| format!("Failed to install ruff {version}"))?;
 
     let mut command = Command::new(&ruff_path);
     // Run ruff in the project root


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #15512 

## Test Plan

Manually tested :
```
~/uv/target/release/uv format --version 999.999.999 --preview-features format
error: Failed to install ruff 999.999.999
  Caused by: Failed to download from: https://github.com/astral-sh/ruff/releases/download/999.999.999/ruff-x86_64-unknown-linux-gnu.tar.gz
  Caused by: HTTP status client error (404 Not Found) for url (https://github.com/astral-sh/ruff/releases/download/999.999.999/ruff-x86_64-unknown-linux-gnu.tar.gz)
  ```
