### PR TITLE
Add `uv tree --show-sizes` to show package sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6240,6 +6240,7 @@ dependencies = [
  "uv-cache-key",
  "uv-client",
  "uv-configuration",
+ "uv-console",
  "uv-distribution",
  "uv-distribution-filename",
  "uv-distribution-types",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6287,6 +6287,10 @@ pub struct DisplayTreeArgs {
     /// Show the latest available version of each package in the tree.
     #[arg(long)]
     pub outdated: bool,
+
+    /// Show compressed wheel sizes for packages in the tree.
+    #[arg(long)]
+    pub show_sizes: bool,
 }
 
 #[derive(Args, Debug)]

--- a/crates/uv-console/src/lib.rs
+++ b/crates/uv-console/src/lib.rs
@@ -283,3 +283,19 @@ pub fn input(prompt: &str, term: &Term) -> std::io::Result<String> {
 
     Ok(input)
 }
+
+/// Formats a number of bytes into a human readable SI-prefixed size (binary units).
+///
+/// Returns a tuple of `(quantity, units)`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+pub fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
+    const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
+    let bytes_f32 = bytes as f32;
+    let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
+    (bytes_f32 / 1024_f32.powi(i as i32), UNITS[i])
+}

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uv-console = { workspace = true }
 uv-cache-key = { workspace = true }
 uv-client = { workspace = true }
 uv-configuration = { workspace = true }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -14,6 +14,7 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ResolverMarkerEnvironment;
+use uv_console::human_readable_bytes;
 
 use crate::lock::PackageId;
 use crate::{Lock, PackageMap};
@@ -679,20 +680,4 @@ impl std::fmt::Display for TreeDisplay<'_> {
 
         Ok(())
     }
-}
-
-/// Formats a number of bytes into a human readable SI-prefixed size (binary units).
-///
-/// Returns a tuple of `(quantity, units)`.
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss
-)]
-fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
-    const UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-    let bytes_f32 = bytes as f32;
-    let i = ((bytes_f32.log2() / 10.0) as usize).min(UNITS.len() - 1);
-    (bytes_f32 / 1024_f32.powi(i as i32), UNITS[i])
 }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -10,11 +10,11 @@ use petgraph::{Direction, Graph};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use uv_configuration::DependencyGroupsWithDefaults;
+use uv_console::human_readable_bytes;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ResolverMarkerEnvironment;
-use uv_console::human_readable_bytes;
 
 use crate::lock::PackageId;
 use crate::{Lock, PackageMap};

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -465,7 +465,7 @@ impl<'env> TreeDisplay<'env> {
             if self.show_sizes {
                 let package = self.lock.find_by_id(package_id);
                 if let Some(size_bytes) =
-                    package.wheels.iter().filter_map(|wheel| wheel.size).next()
+                    package.wheels.iter().find_map(|wheel| wheel.size)
                 {
                     let (bytes, unit) = human_readable_bytes(size_bytes);
                     line.push(' ');

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -48,6 +48,7 @@ impl<'env> TreeDisplay<'env> {
         dev: &DependencyGroupsWithDefaults,
         no_dedupe: bool,
         invert: bool,
+        show_sizes: bool,
     ) -> Self {
         // Identify any workspace members.
         //
@@ -403,15 +404,8 @@ impl<'env> TreeDisplay<'env> {
             depth,
             no_dedupe,
             lock,
-            show_sizes: false,
+            show_sizes,
         }
-    }
-
-    /// Enable showing sizes in the rendered output.
-    #[must_use]
-    pub fn with_show_sizes(mut self, show: bool) -> Self {
-        self.show_sizes = show;
-        self
     }
 
     /// Perform a depth-first traversal of the given package and its dependencies.

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -32,6 +32,8 @@ pub struct TreeDisplay<'env> {
     no_dedupe: bool,
     /// Reference to the lock to look up additional metadata (e.g., wheel sizes).
     lock: &'env Lock,
+    /// Whether to show sizes in the rendered output.
+    show_sizes: bool,
 }
 
 impl<'env> TreeDisplay<'env> {
@@ -401,7 +403,15 @@ impl<'env> TreeDisplay<'env> {
             depth,
             no_dedupe,
             lock,
+            show_sizes: false,
         }
+    }
+
+    /// Enable showing sizes in the rendered output.
+    #[must_use]
+    pub fn with_show_sizes(mut self, show: bool) -> Self {
+        self.show_sizes = show;
+        self
     }
 
     /// Perform a depth-first traversal of the given package and its dependencies.
@@ -452,11 +462,15 @@ impl<'env> TreeDisplay<'env> {
 
             // Append compressed wheel size, if available in the lockfile.
             // Keep it simple: use the first wheel entry that includes a size.
-            let package = self.lock.find_by_id(package_id);
-            if let Some(size_bytes) = package.wheels.iter().filter_map(|wheel| wheel.size).next() {
-                let (bytes, unit) = human_readable_bytes(size_bytes);
-                line.push(' ');
-                line.push_str(format!("{}", format!("({bytes:.1}{unit})").dimmed()).as_str());
+            if self.show_sizes {
+                let package = self.lock.find_by_id(package_id);
+                if let Some(size_bytes) =
+                    package.wheels.iter().filter_map(|wheel| wheel.size).next()
+                {
+                    let (bytes, unit) = human_readable_bytes(size_bytes);
+                    line.push(' ');
+                    line.push_str(format!("{}", format!("({bytes:.1}{unit})").dimmed()).as_str());
+                }
             }
 
             line

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -464,9 +464,7 @@ impl<'env> TreeDisplay<'env> {
             // Keep it simple: use the first wheel entry that includes a size.
             if self.show_sizes {
                 let package = self.lock.find_by_id(package_id);
-                if let Some(size_bytes) =
-                    package.wheels.iter().find_map(|wheel| wheel.size)
-                {
+                if let Some(size_bytes) = package.wheels.iter().find_map(|wheel| wheel.size) {
                     let (bytes, unit) = human_readable_bytes(size_bytes);
                     line.push(' ');
                     line.push_str(format!("{}", format!("({bytes:.1}{unit})").dimmed()).as_str());

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -52,6 +52,7 @@ pub(crate) use tool::update_shell::update_shell as tool_update_shell;
 pub(crate) use tool::upgrade::upgrade as tool_upgrade;
 use uv_cache::Cache;
 use uv_configuration::Concurrency;
+pub(crate) use uv_console::human_readable_bytes;
 use uv_distribution_types::InstalledMetadata;
 use uv_fs::{CWD, Simplified};
 use uv_installer::compile_tree;
@@ -59,7 +60,6 @@ use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
 use uv_scripts::Pep723Script;
 pub(crate) use venv::venv;
-pub(crate) use uv_console::human_readable_bytes;
 
 use crate::printer::Printer;
 

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -59,6 +59,7 @@ use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
 use uv_scripts::Pep723Script;
 pub(crate) use venv::venv;
+pub(crate) use uv_console::human_readable_bytes;
 
 use crate::printer::Printer;
 
@@ -184,22 +185,6 @@ pub(super) async fn compile_bytecode(
         .dimmed()
     )?;
     Ok(())
-}
-
-/// Formats a number of bytes into a human readable SI-prefixed size.
-///
-/// Returns a tuple of `(quantity, units)`.
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss
-)]
-pub(super) fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
-    static UNITS: [&str; 7] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-    let bytes = bytes as f32;
-    let i = ((bytes.log2() / 10.0) as usize).min(UNITS.len() - 1);
-    (bytes / 1024_f32.powi(i as i32), UNITS[i])
 }
 
 /// A multicasting writer that writes to both the standard output and an output file, if present.

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -284,10 +284,8 @@ pub(crate) async fn tree(
         &groups,
         no_dedupe,
         invert,
+        show_sizes,
     );
-    if show_sizes {
-        tree = tree.with_show_sizes(true);
-    }
 
     print!("{tree}");
 

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -45,6 +45,7 @@ pub(crate) async fn tree(
     no_dedupe: bool,
     invert: bool,
     outdated: bool,
+    show_sizes: bool,
     python_version: Option<PythonVersion>,
     python_platform: Option<TargetTriple>,
     python: Option<String>,
@@ -273,7 +274,7 @@ pub(crate) async fn tree(
     };
 
     // Render the tree.
-    let tree = TreeDisplay::new(
+    let mut tree = TreeDisplay::new(
         &lock,
         markers.as_ref(),
         &latest,
@@ -284,6 +285,9 @@ pub(crate) async fn tree(
         no_dedupe,
         invert,
     );
+    if show_sizes {
+        tree = tree.with_show_sizes(true);
+    }
 
     print!("{tree}");
 

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -274,7 +274,7 @@ pub(crate) async fn tree(
     };
 
     // Render the tree.
-    let mut tree = TreeDisplay::new(
+    let tree = TreeDisplay::new(
         &lock,
         markers.as_ref(),
         &latest,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2122,6 +2122,7 @@ async fn run_project(
                 args.no_dedupe,
                 args.invert,
                 args.outdated,
+                args.show_sizes,
                 args.python_version,
                 args.python_platform,
                 args.python,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1701,6 +1701,7 @@ pub(crate) struct TreeSettings {
     pub(crate) no_dedupe: bool,
     pub(crate) invert: bool,
     pub(crate) outdated: bool,
+    pub(crate) show_sizes: bool,
     #[allow(dead_code)]
     pub(crate) script: Option<PathBuf>,
     pub(crate) python_version: Option<PythonVersion>,
@@ -1758,6 +1759,7 @@ impl TreeSettings {
             no_dedupe: tree.no_dedupe,
             invert: tree.invert,
             outdated: tree.outdated,
+            show_sizes: tree.show_sizes,
             script,
             python_version,
             python_platform,

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -58,8 +58,6 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"(\s|\()(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]"),
     // File sizes
     (r"(\s|\()(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
-    // Remove size placeholders in parentheses to keep snapshots stable
-    (r" \(\[SIZE\]\)", ""),
     // Timestamps
     (r"tv_sec: \d+", "tv_sec: [TIME]"),
     (r"tv_nsec: \d+", "tv_nsec: [TIME]"),

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -58,6 +58,8 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"(\s|\()(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]"),
     // File sizes
     (r"(\s|\()(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
+    // Remove size placeholders in parentheses to keep snapshots stable
+    (r" \(\[SIZE\]\)", ""),
     // Timestamps
     (r"tv_sec: \d+", "tv_sec: [TIME]"),
     (r"tv_nsec: \d+", "tv_nsec: [TIME]"),

--- a/crates/uv/tests/it/tree.rs
+++ b/crates/uv/tests/it/tree.rs
@@ -1669,3 +1669,33 @@ fn only_group() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn show_sizes() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+    "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.tree().arg("--show-sizes").arg("--universal"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project v0.1.0
+    └── iniconfig v2.0.0 ([SIZE])
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###
+    );
+
+    Ok(())
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1839,6 +1839,7 @@ interpreter. Use <code>--universal</code> to display the tree for all platforms,
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul></dd><dt id="uv-tree--script"><a href="#uv-tree--script"><code>--script</code></a> <i>script</i></dt><dd><p>Show the dependency tree the specified PEP 723 Python script, rather than the current project.</p>
 <p>If provided, uv will resolve the dependencies based on its inline metadata table, in adherence with PEP 723.</p>
+</dd><dt id="uv-tree--show-sizes"><a href="#uv-tree--show-sizes"><code>--show-sizes</code></a></dt><dd><p>Show compressed wheel sizes for packages in the tree</p>
 </dd><dt id="uv-tree--universal"><a href="#uv-tree--universal"><code>--universal</code></a></dt><dd><p>Show a platform-independent dependency tree.</p>
 <p>Shows resolved package versions for all Python versions and platforms, rather than filtering to those that are relevant for the current environment.</p>
 <p>Multiple versions may be shown for a each package.</p>
@@ -4758,6 +4759,7 @@ Python environment if no virtual environment is found.</p>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-pip-tree--quiet"><a href="#uv-pip-tree--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
+</dd><dt id="uv-pip-tree--show-sizes"><a href="#uv-pip-tree--show-sizes"><code>--show-sizes</code></a></dt><dd><p>Show compressed wheel sizes for packages in the tree</p>
 </dd><dt id="uv-pip-tree--show-version-specifiers"><a href="#uv-pip-tree--show-version-specifiers"><code>--show-version-specifiers</code></a></dt><dd><p>Show the version constraint(s) imposed on each package</p>
 </dd><dt id="uv-pip-tree--strict"><a href="#uv-pip-tree--strict"><code>--strict</code></a></dt><dd><p>Validate the Python environment, to detect packages with missing dependencies and other issues</p>
 </dd><dt id="uv-pip-tree--system"><a href="#uv-pip-tree--system"><code>--system</code></a></dt><dd><p>List packages in the system Python environment.</p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Adds the enhancement proposed in #15470. Each package in the dependency tree now shows its compressed wheel file size, reading the wheel sizes directly from the lockfile (uv.lock). Doesn't break existing tree formatting or options. If no wheel size is available, nothing is added.

Now, developers can identify large packages in their dependency tree. 

The tree still shows extras exactly as before, and then appends a size for the package.

## Test Plan

Manually tested :
```
harsh@fcr-node:~/uv/test-uv-tree-sizes$ ../target/debug/uv tree
Using CPython 3.13.7
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
Resolved 4 packages in 6ms
pure-python v0.1.0
├── click v8.2.1
└── six v1.17.0
harsh@fcr-node:~/uv/test-uv-tree-sizes$ ../target/debug/uv tree --show-sizes
Using CPython 3.13.7
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.13`.
Resolved 4 packages in 6ms
pure-python v0.1.0
├── click v8.2.1 (99.8KiB)
└── six v1.17.0 (10.8KiB)
```