### PR TITLE
Add `rkyv` implementation for Core Metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5915,6 +5915,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "regex",
+ "rkyv",
  "rustc-hash",
  "schemars",
  "serde",

--- a/crates/uv-normalize/src/extra_name.rs
+++ b/crates/uv-normalize/src/extra_name.rs
@@ -97,8 +97,21 @@ impl Default for DefaultExtras {
 /// See:
 /// - <https://peps.python.org/pep-0685/#specification/>
 /// - <https://packaging.python.org/en/latest/specifications/name-normalization/>
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[rkyv(derive(Debug))]
 pub struct ExtraName(SmallString);
 
 impl ExtraName {

--- a/crates/uv-normalize/src/group_name.rs
+++ b/crates/uv-normalize/src/group_name.rs
@@ -17,8 +17,20 @@ use crate::{
 /// See:
 /// - <https://peps.python.org/pep-0735/>
 /// - <https://packaging.python.org/en/latest/specifications/name-normalization/>
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[rkyv(derive(Debug))]
 pub struct GroupName(SmallString);
 
 impl GroupName {

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -30,6 +30,7 @@ boxcar = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 regex = { workspace = true }
+rkyv = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
@@ -56,5 +57,6 @@ schemars = ["dep:schemars"]
 # be supported.
 non-pep508-extensions = []
 default = []
+rkyv = ["dep:rkyv"]
 # Match the API of the published crate, for compatibility.
 serde = []

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -21,7 +21,7 @@ uv-distribution-filename = { workspace = true }
 uv-git-types = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
-uv-pep508 = { workspace = true }
+uv-pep508 = { workspace = true, features = ["rkyv"] }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
 

--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -19,8 +19,11 @@ use crate::{LenientVersionSpecifiers, MetadataError, VerbatimParsedUrl, metadata
 /// fields that are relevant to dependency resolution.
 ///
 /// Core Metadata 2.3 is specified in <https://packaging.python.org/specifications/core-metadata/>.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(
+    Serialize, Deserialize, Debug, Clone, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
+)]
 #[serde(rename_all = "kebab-case")]
+#[rkyv(derive(Debug))]
 pub struct ResolutionMetadata {
     // Mandatory fields
     pub name: PackageName,

--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -141,6 +141,18 @@ impl<'de> Deserialize<'de> for CoreMetadata {
     }
 }
 
+impl Serialize for CoreMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Bool(is_available) => serializer.serialize_bool(*is_available),
+            Self::Hashes(hashes) => hashes.serialize(serializer),
+        }
+    }
+}
+
 impl CoreMetadata {
     pub fn is_available(&self) -> bool {
         match self {
@@ -166,6 +178,18 @@ impl<'de> Deserialize<'de> for Yanked {
             .bool(|bool| Ok(Self::Bool(bool)))
             .string(|string| Ok(Self::Reason(SmallString::from(string))))
             .deserialize(deserializer)
+    }
+}
+
+impl Serialize for Yanked {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Bool(is_yanked) => serializer.serialize_bool(*is_yanked),
+            Self::Reason(reason) => serializer.serialize_str(reason.as_ref()),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Enables us to store Core Metadata in zero-copy format.
