### PR TITLE
Make `cache_index_credentials()` misuse resistant

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -527,8 +527,6 @@ async fn build_package(
     .await?
     .into_interpreter();
 
-    index_locations.cache_index_credentials();
-
     // Read build constraints.
     let build_constraints =
         operations::read_constraints(build_constraints, &client_builder).await?;
@@ -556,7 +554,7 @@ async fn build_package(
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .keyring(keyring_provider)
         .markers(interpreter.markers())

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -405,8 +405,6 @@ pub(crate) async fn pip_compile(
         no_index,
     );
 
-    index_locations.cache_index_credentials();
-
     // Determine the PyTorch backend.
     let torch_backend = torch_backend
         .map(|mode| {
@@ -424,7 +422,7 @@ pub(crate) async fn pip_compile(
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(&index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -368,8 +368,6 @@ pub(crate) async fn pip_install(
         no_index,
     );
 
-    index_locations.cache_index_credentials();
-
     // Determine the PyTorch backend.
     let torch_backend = torch_backend
         .map(|mode| {
@@ -387,7 +385,7 @@ pub(crate) async fn pip_install(
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(&index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -98,7 +98,7 @@ pub(crate) async fn pip_list(
         // Initialize the registry client.
         let client = RegistryClientBuilder::try_from(client_builder)?
             .cache(cache.clone().with_refresh(Refresh::All(Timestamp::now())))
-            .index_locations(&index_locations)
+            .index_locations(index_locations)
             .index_strategy(index_strategy)
             .markers(environment.interpreter().markers())
             .platform(environment.interpreter().platform())

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -292,8 +292,6 @@ pub(crate) async fn pip_sync(
         no_index,
     );
 
-    index_locations.cache_index_credentials();
-
     // Determine the PyTorch backend.
     let torch_backend = torch_backend
         .map(|mode| {
@@ -311,7 +309,7 @@ pub(crate) async fn pip_sync(
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(&index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -98,7 +98,7 @@ pub(crate) async fn pip_tree(
         // Initialize the registry client.
         let client = RegistryClientBuilder::try_from(client_builder)?
             .cache(cache.clone().with_refresh(Refresh::All(Timestamp::now())))
-            .index_locations(&index_locations)
+            .index_locations(index_locations)
             .index_strategy(index_strategy)
             .markers(environment.interpreter().markers())
             .platform(environment.interpreter().platform())

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -399,11 +399,9 @@ pub(crate) async fn add(
             let hasher = HashStrategy::default();
             let sources = SourceStrategy::Enabled;
 
-            settings.resolver.index_locations.cache_index_credentials();
-
             // Initialize the registry client.
             let client = RegistryClientBuilder::try_from(client_builder)?
-                .index_locations(&settings.resolver.index_locations)
+                .index_locations(settings.resolver.index_locations.clone())
                 .index_strategy(settings.resolver.index_strategy)
                 .markers(target.interpreter().markers())
                 .platform(target.interpreter().platform())

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -628,8 +628,6 @@ async fn do_lock(
         .keyring(*keyring_provider)
         .allow_insecure_host(network_settings.allow_insecure_host.clone());
 
-    index_locations.cache_index_credentials();
-
     for index in target.indexes() {
         if let Some(credentials) = index.credentials() {
             let credentials = Arc::new(credentials);
@@ -643,7 +641,7 @@ async fn do_lock(
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(*index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1728,12 +1728,10 @@ pub(crate) async fn resolve_names(
         .keyring(*keyring_provider)
         .allow_insecure_host(network_settings.allow_insecure_host.clone());
 
-    index_locations.cache_index_credentials();
-
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(*index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
@@ -1904,12 +1902,10 @@ pub(crate) async fn resolve_environment(
     let marker_env = pip::resolution_markers(None, python_platform, interpreter);
     let python_requirement = PythonRequirement::from_interpreter(interpreter);
 
-    index_locations.cache_index_credentials();
-
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(*index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
@@ -2089,12 +2085,10 @@ pub(crate) async fn sync_environment(
     let interpreter = venv.interpreter();
     let tags = venv.interpreter().tags()?;
 
-    index_locations.cache_index_credentials();
-
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
@@ -2318,12 +2312,10 @@ pub(crate) async fn update_environment(
         }
     }
 
-    index_locations.cache_index_credentials();
-
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(*index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -718,15 +718,13 @@ pub(super) async fn do_sync(
     // Constrain any build requirements marked as `match-runtime = true`.
     let extra_build_requires = extra_build_requires.match_runtime(&resolution)?;
 
-    index_locations.cache_index_credentials();
-
     // Populate credentials from the target.
     store_credentials_from_target(target);
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
-        .index_locations(index_locations)
+        .index_locations(index_locations.clone())
         .index_strategy(index_strategy)
         .markers(venv.interpreter().markers())
         .platform(venv.interpreter().platform())

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -223,7 +223,7 @@ pub(crate) async fn tree(
             .native_tls(network_settings.native_tls)
             .connectivity(network_settings.connectivity)
             .allow_insecure_host(network_settings.allow_insecure_host.clone())
-            .index_locations(index_locations)
+            .index_locations(index_locations.clone())
             .keyring(*keyring_provider)
             .build();
             let download_concurrency = Semaphore::new(concurrency.downloads);

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -89,13 +89,12 @@ pub(crate) async fn publish(
 
     // Initialize the registry client.
     let check_url_client = if let Some(index_url) = &check_url {
-        index_locations.cache_index_credentials();
         let registry_client_builder = RegistryClientBuilder::new(cache.clone())
             .retries_from_env()?
             .native_tls(network_settings.native_tls)
             .connectivity(network_settings.connectivity)
             .allow_insecure_host(network_settings.allow_insecure_host.clone())
-            .index_locations(&index_locations)
+            .index_locations(index_locations)
             .keyring(keyring_provider);
         Some(CheckUrlClient {
             index_url: index_url.clone(),

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -176,8 +176,6 @@ pub(crate) async fn venv(
         python.into_interpreter()
     };
 
-    index_locations.cache_index_credentials();
-
     // Check if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {
         match validate_project_requires_python(
@@ -225,13 +223,10 @@ pub(crate) async fn venv(
         // Extract the interpreter.
         let interpreter = venv.interpreter();
 
-        // Add all authenticated sources to the cache.
-        index_locations.cache_index_credentials();
-
         // Instantiate a client.
         let client = RegistryClientBuilder::try_from(client_builder)?
             .cache(cache.clone())
-            .index_locations(index_locations)
+            .index_locations(index_locations.clone())
             .index_strategy(index_strategy)
             .keyring(keyring_provider)
             .allow_insecure_host(network_settings.allow_insecure_host.clone())


### PR DESCRIPTION
https://github.com/astral-sh/uv/issues/11836#issuecomment-3022735011 was caused by a missing `cache_index_credentials()` call. This call was always preceding a registry client builder. We can improve this situation by caching index credentials in the registry client builder.