### PR TITLE
Allow declaring match-runtime for project's own build dependencies

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -202,6 +202,7 @@ mod resolver {
             workspace_cache,
             concurrency,
             Preview::default(),
+            None,
         );
 
         let markers = if universal {

--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -95,6 +95,8 @@ pub enum Error {
         "Extra build requirement `{0}` was declared with `match-runtime = true`, but `{1}` does not declare static metadata, making runtime-matching impossible"
     )]
     UnmatchedRuntime(PackageName, PackageName),
+    #[error("Build requires for `{0}` missing for metadata declared in `pyproject.toml`")]
+    MissingBuildRequirementForMetadata(PackageName),
 }
 
 impl IsBuildBackendError for Error {
@@ -111,7 +113,8 @@ impl IsBuildBackendError for Error {
             | Self::NoSourceDistBuild(_)
             | Self::NoSourceDistBuilds
             | Self::CyclicBuildDependency(_)
-            | Self::UnmatchedRuntime(_, _) => false,
+            | Self::UnmatchedRuntime(_, _)
+            | Self::MissingBuildRequirementForMetadata(_) => false,
             Self::CommandFailed(_, _)
             | Self::BuildBackend(_)
             | Self::MissingHeader(_)

--- a/crates/uv-build-frontend/src/error.rs
+++ b/crates/uv-build-frontend/src/error.rs
@@ -97,6 +97,10 @@ pub enum Error {
     UnmatchedRuntime(PackageName, PackageName),
     #[error("Build requires for `{0}` missing for metadata declared in `pyproject.toml`")]
     MissingBuildRequirementForMetadata(PackageName),
+    #[error(
+        "Build requirement `{0}` was declared with `match-runtime = true`, but there is no runtime environment to match against"
+    )]
+    UnmatchedRuntimeMetadata(PackageName),
 }
 
 impl IsBuildBackendError for Error {
@@ -114,6 +118,7 @@ impl IsBuildBackendError for Error {
             | Self::NoSourceDistBuilds
             | Self::CyclicBuildDependency(_)
             | Self::UnmatchedRuntime(_, _)
+            | Self::UnmatchedRuntimeMetadata(_)
             | Self::MissingBuildRequirementForMetadata(_) => false,
             Self::CommandFailed(_, _)
             | Self::BuildBackend(_)

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -88,7 +88,7 @@ struct Project {
 }
 
 /// The `[build-system]` section of a pyproject.toml as specified in PEP 517.
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 struct BuildSystem {
     /// PEP 508 dependencies required to execute the build system.
@@ -302,19 +302,25 @@ impl SourceBuild {
             source.to_path_buf()
         };
 
-        let default_backend: Pep517Backend = DEFAULT_BACKEND.clone();
-        // Check if we have a PEP 517 build backend.
-        let (pep517_backend, project) = Self::extract_pep517_backend(
+        let pyproject_toml = if source_tree.join("pyproject.toml").is_file() {
+            Some(Self::parse_pyproject_toml(&source_tree).map_err(|e| *e)?)
+        } else {
+            None
+        };
+        let pep517_backend = Self::extract_pep517_backend(
+            pyproject_toml.as_ref(),
             &source_tree,
             install_path,
             fallback_package_name,
             locations,
             source_strategy,
             workspace_cache,
-            &default_backend,
+            &DEFAULT_BACKEND,
         )
         .await
-        .map_err(|err| *err)?;
+        .map_err(|e| *e)?;
+
+        let project = pyproject_toml.and_then(|pyproj| pyproj.project);
 
         let package_name = project
             .as_ref()
@@ -381,7 +387,7 @@ impl SourceBuild {
             let resolved_requirements = Self::get_resolved_requirements(
                 build_context,
                 source_build_context,
-                &default_backend,
+                &DEFAULT_BACKEND,
                 &pep517_backend,
                 extra_build_dependencies,
                 build_stack,
@@ -550,8 +556,19 @@ impl SourceBuild {
         )
     }
 
+    fn parse_pyproject_toml(source_tree: &Path) -> Result<PyProjectToml, Box<Error>> {
+        let toml = fs::read_to_string(source_tree.join("pyproject.toml"))
+            .map_err(|e| Box::new(e.into()))?;
+        let pyproject_toml =
+            toml_edit::Document::from_str(&toml).map_err(Error::InvalidPyprojectTomlSyntax)?;
+        let pyproject_toml = PyProjectToml::deserialize(pyproject_toml.into_deserializer())
+            .map_err(Error::InvalidPyprojectTomlSchema)?;
+        Ok(pyproject_toml)
+    }
+
     /// Extract the PEP 517 backend from the `pyproject.toml` or `setup.py` file.
     async fn extract_pep517_backend(
+        pyproject_toml: Option<&PyProjectToml>,
         source_tree: &Path,
         install_path: &Path,
         package_name: Option<&PackageName>,
@@ -559,123 +576,114 @@ impl SourceBuild {
         source_strategy: SourceStrategy,
         workspace_cache: &WorkspaceCache,
         default_backend: &Pep517Backend,
-    ) -> Result<(Pep517Backend, Option<Project>), Box<Error>> {
-        match fs::read_to_string(source_tree.join("pyproject.toml")) {
-            Ok(toml) => {
-                let pyproject_toml = toml_edit::Document::from_str(&toml)
-                    .map_err(Error::InvalidPyprojectTomlSyntax)?;
-                let pyproject_toml = PyProjectToml::deserialize(pyproject_toml.into_deserializer())
-                    .map_err(Error::InvalidPyprojectTomlSchema)?;
+    ) -> Result<Pep517Backend, Box<Error>> {
+        if pyproject_toml.is_none() {
+            // We require either a `pyproject.toml` or a `setup.py` file at the top level.
+            if !source_tree.join("setup.py").is_file() {
+                return Err(Box::new(Error::InvalidSourceDist(
+                    source_tree.to_path_buf(),
+                )));
+            }
 
-                let backend = if let Some(build_system) = pyproject_toml.build_system {
-                    // If necessary, lower the requirements.
-                    let requirements = match source_strategy {
-                        SourceStrategy::Enabled => {
-                            if let Some(name) = pyproject_toml
-                                .project
-                                .as_ref()
-                                .map(|project| &project.name)
-                                .or(package_name)
-                            {
-                                let build_requires = uv_pypi_types::BuildRequires {
-                                    name: Some(name.clone()),
-                                    requires_dist: build_system.requires,
-                                };
-                                let build_requires = BuildRequires::from_project_maybe_workspace(
-                                    build_requires,
-                                    install_path,
-                                    locations,
-                                    source_strategy,
-                                    workspace_cache,
-                                )
-                                .await
-                                .map_err(Error::Lowering)?;
-                                build_requires.requires_dist
-                            } else {
-                                build_system
-                                    .requires
-                                    .into_iter()
-                                    .map(Requirement::from)
-                                    .collect()
-                            }
-                        }
-                        SourceStrategy::Disabled => build_system
+            // If no `pyproject.toml` is present, by default, proceed with a PEP 517 build using
+            // the default backend, to match `build`. `pip` uses `setup.py` directly in this
+            // case,  but plans to make PEP 517 builds the default in the future.
+            // See: https://github.com/pypa/pip/issues/9175.
+            return Ok(default_backend.clone());
+        }
+        let pyproject_toml = pyproject_toml.unwrap();
+        let backend = if let Some(build_system) = pyproject_toml.build_system.clone() {
+            // If necessary, lower the requirements.
+            let requirements = match source_strategy {
+                SourceStrategy::Enabled => {
+                    if let Some(name) = pyproject_toml
+                        .project
+                        .as_ref()
+                        .map(|project| &project.name)
+                        .or(package_name)
+                    {
+                        let build_requires = uv_pypi_types::BuildRequires {
+                            name: Some(name.clone()),
+                            requires_dist: build_system.requires,
+                        };
+                        let build_requires = BuildRequires::from_project_maybe_workspace(
+                            build_requires,
+                            install_path,
+                            locations,
+                            source_strategy,
+                            workspace_cache,
+                        )
+                        .await
+                        .map_err(Error::Lowering)?;
+                        build_requires.requires_dist
+                    } else {
+                        build_system
                             .requires
                             .into_iter()
                             .map(Requirement::from)
-                            .collect(),
-                    };
-
-                    Pep517Backend {
-                        // If `build-backend` is missing, inject the legacy setuptools backend, but
-                        // retain the `requires`, to match `pip` and `build`. Note that while PEP 517
-                        // says that in this case we "should revert to the legacy behaviour of running
-                        // `setup.py` (either directly, or by implicitly invoking the
-                        // `setuptools.build_meta:__legacy__` backend)", we found that in practice, only
-                        // the legacy setuptools backend is allowed. See also:
-                        // https://github.com/pypa/build/blob/de5b44b0c28c598524832dff685a98d5a5148c44/src/build/__init__.py#L114-L118
-                        backend: build_system
-                            .build_backend
-                            .unwrap_or_else(|| "setuptools.build_meta:__legacy__".to_string()),
-                        backend_path: build_system.backend_path,
-                        requirements,
+                            .collect()
                     }
-                } else {
-                    // If a `pyproject.toml` is present, but `[build-system]` is missing, proceed
-                    // with a PEP 517 build using the default backend (`setuptools`), to match `pip`
-                    // and `build`.
-                    //
-                    // If there is no build system defined and there is no metadata source for
-                    // `setuptools`, warn. The build will succeed, but the metadata will be
-                    // incomplete (for example, the package name will be `UNKNOWN`).
-                    if pyproject_toml.project.is_none()
-                        && !source_tree.join("setup.py").is_file()
-                        && !source_tree.join("setup.cfg").is_file()
-                    {
-                        // Give a specific hint for `uv pip install .` in a workspace root.
-                        let looks_like_workspace_root = pyproject_toml
-                            .tool
-                            .as_ref()
-                            .and_then(|tool| tool.uv.as_ref())
-                            .and_then(|tool| tool.workspace.as_ref())
-                            .is_some();
-                        if looks_like_workspace_root {
-                            warn_user_once!(
-                                "`{}` appears to be a workspace root without a Python project; \
-                                consider using `uv sync` to install the workspace, or add a \
-                                `[build-system]` table to `pyproject.toml`",
-                                source_tree.simplified_display().cyan(),
-                            );
-                        } else {
-                            warn_user_once!(
-                                "`{}` does not appear to be a Python project, as the `pyproject.toml` \
-                                does not include a `[build-system]` table, and neither `setup.py` \
-                                nor `setup.cfg` are present in the directory",
-                                source_tree.simplified_display().cyan(),
-                            );
-                        }
-                    }
-
-                    default_backend.clone()
-                };
-                Ok((backend, pyproject_toml.project))
-            }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {
-                // We require either a `pyproject.toml` or a `setup.py` file at the top level.
-                if !source_tree.join("setup.py").is_file() {
-                    return Err(Box::new(Error::InvalidSourceDist(
-                        source_tree.to_path_buf(),
-                    )));
                 }
+                SourceStrategy::Disabled => build_system
+                    .requires
+                    .into_iter()
+                    .map(Requirement::from)
+                    .collect(),
+            };
 
-                // If no `pyproject.toml` is present, by default, proceed with a PEP 517 build using
-                // the default backend, to match `build`. `pip` uses `setup.py` directly in this
-                // case,  but plans to make PEP 517 builds the default in the future.
-                // See: https://github.com/pypa/pip/issues/9175.
-                Ok((default_backend.clone(), None))
+            Pep517Backend {
+                // If `build-backend` is missing, inject the legacy setuptools backend, but
+                // retain the `requires`, to match `pip` and `build`. Note that while PEP 517
+                // says that in this case we "should revert to the legacy behaviour of running
+                // `setup.py` (either directly, or by implicitly invoking the
+                // `setuptools.build_meta:__legacy__` backend)", we found that in practice, only
+                // the legacy setuptools backend is allowed. See also:
+                // https://github.com/pypa/build/blob/de5b44b0c28c598524832dff685a98d5a5148c44/src/build/__init__.py#L114-L118
+                backend: build_system
+                    .build_backend
+                    .unwrap_or_else(|| "setuptools.build_meta:__legacy__".to_string()),
+                backend_path: build_system.backend_path,
+                requirements,
             }
-            Err(err) => Err(Box::new(err.into())),
-        }
+        } else {
+            // If a `pyproject.toml` is present, but `[build-system]` is missing, proceed
+            // with a PEP 517 build using the default backend (`setuptools`), to match `pip`
+            // and `build`.
+            //
+            // If there is no build system defined and there is no metadata source for
+            // `setuptools`, warn. The build will succeed, but the metadata will be
+            // incomplete (for example, the package name will be `UNKNOWN`).
+            if pyproject_toml.project.is_none()
+                && !source_tree.join("setup.py").is_file()
+                && !source_tree.join("setup.cfg").is_file()
+            {
+                // Give a specific hint for `uv pip install .` in a workspace root.
+                let looks_like_workspace_root = pyproject_toml
+                    .tool
+                    .as_ref()
+                    .and_then(|tool| tool.uv.as_ref())
+                    .and_then(|tool| tool.workspace.as_ref())
+                    .is_some();
+                if looks_like_workspace_root {
+                    warn_user_once!(
+                        "`{}` appears to be a workspace root without a Python project; \
+                        consider using `uv sync` to install the workspace, or add a \
+                        `[build-system]` table to `pyproject.toml`",
+                        source_tree.simplified_display().cyan(),
+                    );
+                } else {
+                    warn_user_once!(
+                        "`{}` does not appear to be a Python project, as the `pyproject.toml` \
+                        does not include a `[build-system]` table, and neither `setup.py` \
+                        nor `setup.cfg` are present in the directory",
+                        source_tree.simplified_display().cyan(),
+                    );
+                }
+            }
+
+            default_backend.clone()
+        };
+        Ok(backend)
     }
 
     /// Try calling `prepare_metadata_for_build_wheel` to get the metadata without executing the

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -103,6 +103,7 @@ pub struct BuildDispatch<'a> {
     workspace_cache: WorkspaceCache,
     concurrency: Concurrency,
     preview: Preview,
+    top_level_resolution: Option<&'a Resolution>,
 }
 
 impl<'a> BuildDispatch<'a> {
@@ -129,6 +130,7 @@ impl<'a> BuildDispatch<'a> {
         workspace_cache: WorkspaceCache,
         concurrency: Concurrency,
         preview: Preview,
+        top_level_resolution: Option<&'a Resolution>,
     ) -> Self {
         Self {
             client,
@@ -155,6 +157,7 @@ impl<'a> BuildDispatch<'a> {
             workspace_cache,
             concurrency,
             preview,
+            top_level_resolution,
         }
     }
 
@@ -557,6 +560,10 @@ impl BuildContext for BuildDispatch<'_> {
         .await??;
 
         Ok(Some(filename))
+    }
+
+    fn top_level_resolution(&self) -> Option<&Resolution> {
+        self.top_level_resolution
     }
 }
 

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -211,6 +211,7 @@ fn validate_uv_toml(path: &Path, options: &Options) -> Result<(), Error> {
         override_dependencies: _,
         constraint_dependencies: _,
         build_constraint_dependencies: _,
+        build_dependencies_metadata: _,
         environments,
         required_environments,
         conflicts,
@@ -362,6 +363,7 @@ fn warn_uv_toml_masked_fields(options: &Options) {
         managed: _,
         package: _,
         build_backend: _,
+        build_dependencies_metadata: _,
     } = options;
 
     let mut masked_fields = vec![];

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -156,6 +156,9 @@ pub struct Options {
     pub r#package: Option<serde::de::IgnoredAny>,
 
     #[cfg_attr(feature = "schemars", schemars(skip))]
+    pub build_dependencies_metadata: Option<serde::de::IgnoredAny>,
+
+    #[cfg_attr(feature = "schemars", schemars(skip))]
     pub build_backend: Option<serde::de::IgnoredAny>,
 }
 
@@ -2142,6 +2145,7 @@ pub struct OptionsWire {
     default_groups: Option<serde::de::IgnoredAny>,
     dependency_groups: Option<serde::de::IgnoredAny>,
     dev_dependencies: Option<serde::de::IgnoredAny>,
+    build_dependencies_metadata: Option<serde::de::IgnoredAny>,
 
     // Build backend
     build_backend: Option<serde::de::IgnoredAny>,
@@ -2208,6 +2212,7 @@ impl From<OptionsWire> for Options {
             sources,
             default_groups,
             dependency_groups,
+            build_dependencies_metadata,
             extra_build_dependencies,
             extra_build_variables,
             dev_dependencies,
@@ -2293,6 +2298,7 @@ impl From<OptionsWire> for Options {
             dependency_groups,
             managed,
             package,
+            build_dependencies_metadata,
         }
     }
 }

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -111,6 +111,9 @@ pub trait BuildContext {
     /// Get the extra build variables.
     fn extra_build_variables(&self) -> &ExtraBuildVariables;
 
+    /// Get the resolution for the top-level package.
+    fn top_level_resolution(&self) -> Option<&Resolution>;
+
     /// Resolve the given requirements into a ready-to-install set of package versions.
     fn resolve<'a>(
         &'a self,

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -428,6 +428,19 @@ pub struct ToolUv {
     )]
     pub dependency_groups: Option<ToolUvDependencyGroups>,
 
+    /// Metadata for build dependencies.
+    ///
+    /// This allows specifying metadata for build dependencies, such as runtime matching.
+    #[option(
+        default = "None",
+        value_type = "dict",
+        example = r#"
+        [build-dependencies-metadata.package1]
+        match-runtime = true
+    "#
+    )]
+    pub build_dependencies_metadata: Option<BuildDependenciesMetadata>,
+
     /// Additional build dependencies for packages.
     ///
     /// This allows extending the PEP 517 build environment for the project's dependencies with
@@ -844,6 +857,16 @@ impl From<ExtraBuildDependency> for ExtraBuildDependencyWire {
             match_runtime: item.match_runtime,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct BuildDependenciesMetadata(BTreeMap<PackageName, BuildDependencyMetadata>);
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct BuildDependencyMetadata {
+    pub match_runtime: Option<bool>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize)]

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -580,6 +580,7 @@ async fn build_package(
     // Initialize any shared state.
     let state = SharedState::default();
     let workspace_cache = WorkspaceCache::default();
+    let top_level_resolution = None;
 
     let extra_build_requires =
         LoweredExtraBuildDependencies::from_non_lowered(extra_build_dependencies.clone())
@@ -609,6 +610,7 @@ async fn build_package(
         workspace_cache,
         concurrency,
         preview,
+        top_level_resolution,
     );
 
     prepare_output_directory(&output_dir).await?;

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -482,6 +482,8 @@ pub(crate) async fn pip_compile(
         LoweredExtraBuildDependencies::from_non_lowered(extra_build_dependencies.clone())
             .into_inner();
 
+    let top_level_resolution = None;
+
     // Create a build dispatch.
     let build_dispatch = BuildDispatch::new(
         &client,
@@ -506,6 +508,7 @@ pub(crate) async fn pip_compile(
         WorkspaceCache::default(),
         concurrency,
         preview,
+        top_level_resolution,
     );
 
     let options = OptionsBuilder::new()

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -453,6 +453,7 @@ pub(crate) async fn pip_install(
         WorkspaceCache::default(),
         concurrency,
         preview,
+        None,
     );
 
     let (resolution, hasher) = if let Some(pylock) = pylock {
@@ -588,6 +589,7 @@ pub(crate) async fn pip_install(
         WorkspaceCache::default(),
         concurrency,
         preview,
+        Some(&resolution),
     );
 
     // Sync the environment.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -382,6 +382,7 @@ pub(crate) async fn pip_sync(
         WorkspaceCache::default(),
         concurrency,
         preview,
+        None,
     );
 
     // Determine the set of installed packages.
@@ -519,6 +520,7 @@ pub(crate) async fn pip_sync(
         WorkspaceCache::default(),
         concurrency,
         preview,
+        Some(&resolution),
     );
 
     // Sync the environment.

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -469,6 +469,7 @@ pub(crate) async fn add(
                 WorkspaceCache::default(),
                 concurrency,
                 preview,
+                None,
             );
 
             requirements.extend(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -718,6 +718,7 @@ async fn do_lock(
         workspace_cache.clone(),
         concurrency,
         preview,
+        None,
     );
 
     let database = DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads);

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1766,6 +1766,7 @@ pub(crate) async fn resolve_names(
         workspace_cache.clone(),
         concurrency,
         preview,
+        None,
     );
 
     // Resolve the unnamed requirements.
@@ -1977,6 +1978,7 @@ pub(crate) async fn resolve_environment(
         workspace_cache,
         concurrency,
         preview,
+        None,
     );
 
     // Resolve the requirements.
@@ -2115,6 +2117,7 @@ pub(crate) async fn sync_environment(
         workspace_cache,
         concurrency,
         preview,
+        None,
     );
 
     // Sync the environment.
@@ -2344,6 +2347,7 @@ pub(crate) async fn update_environment(
         workspace_cache,
         concurrency,
         preview,
+        None,
     );
 
     // Resolve the requirements.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -774,6 +774,7 @@ pub(super) async fn do_sync(
         workspace_cache.clone(),
         concurrency,
         preview,
+        Some(&resolution),
     );
 
     let site_packages = SitePackages::from_environment(venv)?;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -254,6 +254,8 @@ pub(crate) async fn venv(
         let build_options = BuildOptions::new(NoBinary::None, NoBuild::All);
         let extra_build_requires = ExtraBuildRequires::default();
         let extra_build_variables = uv_distribution_types::ExtraBuildVariables::default();
+        let top_level_resolution = None;
+
         // Prep the build context.
         let build_dispatch = BuildDispatch::new(
             &client,
@@ -278,6 +280,7 @@ pub(crate) async fn venv(
             workspace_cache,
             concurrency,
             preview,
+            top_level_resolution,
         );
 
         // Resolve the seed packages.

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -13571,3 +13571,84 @@ fn sync_extra_build_dependencies_cache() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn sync_match_runtime() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Create a build backend that asserts that `EXPECTED_ANYIO_VERSION` matches the installed version of `anyio`.
+    let build_backend = context.temp_dir.child("child").child("build_backend.py");
+    build_backend.write_str(indoc! {r#"
+        import os
+        import sys
+        from hatchling.build import *
+
+        expected_version = "1.4.0"
+        try:
+            import anyio
+        except ModuleNotFoundError:
+            print("Missing `anyio` module", file=sys.stderr)
+            sys.exit(1)
+
+        from importlib.metadata import version
+        anyio_version = version("anyio")
+
+        if not anyio_version.startswith(expected_version):
+            print(f"Expected `anyio` version {expected_version} but got {anyio_version}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"Found expected `anyio` version {anyio_version}", file=sys.stderr)
+    "#})?;
+
+    // Create a project that wants runtime matching for `anyio`
+    let child_pyproject = context.temp_dir.child("child").child("pyproject.toml");
+    child_pyproject.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling", "anyio"]
+        backend-path = ["."]
+        build-backend = "build_backend"
+
+        [tool.uv.build-dependencies-metadata.anyio]
+        match-runtime = true
+    "#})?;
+    context
+        .temp_dir
+        .child("child/src/child/__init__.py")
+        .touch()?;
+
+    // A parent project that resolves to a non-latest version of `anyio`
+    let parent_pyproject = context.temp_dir.child("pyproject.toml");
+    parent_pyproject.write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child", "anyio==1.4.0"]
+
+        [tool.uv.sources]
+        child = { path = "child" }
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + anyio==1.4.0
+     + async-generator==1.10
+     + child==0.1.0 (from file://[TEMP_DIR]/child)
+     + idna==3.6
+     + sniffio==1.3.1
+    ");
+
+    Ok(())
+}

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -30,6 +30,26 @@ build-constraint-dependencies = ["setuptools==60.0.0"]
 
 ---
 
+### [`build-dependencies-metadata`](#build-dependencies-metadata) {: #build-dependencies-metadata }
+
+Metadata for build dependencies.
+
+This allows specifying metadata for build dependencies, such as runtime matching.
+
+**Default value**: `None`
+
+**Type**: `dict`
+
+**Example usage**:
+
+```toml title="pyproject.toml"
+[tool.uv]
+[build-dependencies-metadata.package1]
+match-runtime = true
+```
+
+---
+
 ### [`conflicts`](#conflicts) {: #conflicts }
 
 Declare collections of extras or dependency groups that are conflicting

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -46,6 +46,17 @@
         "type": "string"
       }
     },
+    "build-dependencies-metadata": {
+      "description": "Metadata for build dependencies.\n\nThis allows specifying metadata for build dependencies, such as runtime matching.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BuildDependenciesMetadata"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "cache-dir": {
       "description": "Path to the cache directory.\n\nDefaults to `$XDG_CACHE_HOME/uv` or `$HOME/.cache/uv` on Linux and macOS, and\n`%LOCALAPPDATA%\\uv\\cache` on Windows.",
       "type": [
@@ -756,6 +767,23 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "BuildDependenciesMetadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/BuildDependencyMetadata"
+      }
+    },
+    "BuildDependencyMetadata": {
+      "type": "object",
+      "properties": {
+        "match_runtime": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

This PR allows specifying:
```toml
[tool.uv.build-dependencies-metadata.foo]
match-runtime = true
```

which when paired with:
```toml
[build-system]
requires = ["foo", "bar"]
# ...
```
will cause the `foo` build-time dependency to be runtime-matched when this is applicable.

A few differences between this approach and triggering runtime-matching via `extra-build-dependencies`:

> [!NOTE]
> It is impossible to introduce new dependencies using `build-dependencies-metadata` (these should simply be added to `build-system.requires` instead), so trying to specify metadata for a package that's not a build-time dependency is an error.

> [!NOTE]
> This PR implements runtime matching slightly differently from the current `extra-build-dependencies` option: the latter takes the (lowered) extra requirements, and mutates them according to the "top-level" resolution to attach the corresponding `source` before passing it into the build frontend, which checks that the extra requirements have been mutated before appending them to the build environment resolution.
> This PR's implementation passes down the entire "top-level" resolution into the frontend, which then does the requirement matching and validation in the same place.



## TODOs

- [ ] Add more docs about how this works
- [x] `tool.uv.build-dependencies-metadata.foo` should fail if `foo` isn't a build-time dependency
- [x] `uv build`ing a wheel should fail if a package tries to runtime match a build dependency

And a future PR should unify how `extra-build-dependencies`'s `match-runtime` works with this approach
