### PR TITLE
support `--no-project` in `uv format`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4367,6 +4367,14 @@ pub struct FormatArgs {
     /// `uv format -- src/module/foo.py` to format a specific file.
     #[arg(last = true)]
     pub extra_args: Vec<String>,
+
+    /// Avoid discovering a project or workspace.
+    ///
+    /// Instead of running the formatter in the context of the current project, run it in the
+    /// context of the current directory. This is useful when the current directory is not a
+    /// project.
+    #[arg(long)]
+    pub no_project: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -7,10 +7,11 @@ use tokio::process::Command;
 use uv_bin_install::{Binary, bin_install};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
+use uv_fs::Simplified;
 use uv_pep440::Version;
 use uv_preview::{Preview, PreviewFeatures};
 use uv_warnings::warn_user;
-use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
+use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceError};
 
 use crate::child::run_to_completion;
 use crate::commands::ExitStatus;
@@ -29,6 +30,7 @@ pub(crate) async fn format(
     cache: Cache,
     printer: Printer,
     preview: Preview,
+    no_project: bool,
 ) -> Result<ExitStatus> {
     // Check if the format feature is in preview
     if !preview.is_enabled(PreviewFeatures::FORMAT) {
@@ -39,9 +41,30 @@ pub(crate) async fn format(
     }
 
     let workspace_cache = WorkspaceCache::default();
-    let project =
-        VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
-            .await?;
+    let project = if no_project {
+        None
+    } else {
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+            .await
+        {
+            Ok(project) => Some(project),
+            Err(WorkspaceError::MissingProject(_)) => None,
+            Err(WorkspaceError::MissingPyprojectToml) => None,
+            Err(WorkspaceError::NonWorkspace(_)) => None,
+            Err(WorkspaceError::Toml(path, err)) => {
+                warn_user!(
+                    "Failed to parse `{}` during formatting:\n{}",
+                    path.user_display().cyan(),
+                    textwrap::indent(&err.to_string(), "  ")
+                );
+                None
+            }
+            Err(err) => {
+                warn_user!("{err}");
+                None
+            }
+        }
+    };
 
     // Parse version if provided
     let version = version.as_deref().map(Version::from_str).transpose()?;
@@ -62,8 +85,11 @@ pub(crate) async fn format(
         .with_context(|| format!("Failed to install ruff {version}"))?;
 
     let mut command = Command::new(&ruff_path);
+
     // Run ruff in the project root
-    command.current_dir(project.root());
+    if let Some(project) = project {
+        command.current_dir(project.root());
+    }
     command.arg("format");
 
     if check {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2206,6 +2206,7 @@ async fn run_project(
                 cache,
                 printer,
                 globals.preview,
+                args.no_project,
             ))
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1892,6 +1892,7 @@ pub(crate) struct FormatSettings {
     pub(crate) diff: bool,
     pub(crate) extra_args: Vec<String>,
     pub(crate) version: Option<String>,
+    pub(crate) no_project: bool,
 }
 
 impl FormatSettings {
@@ -1902,6 +1903,7 @@ impl FormatSettings {
             diff,
             extra_args,
             version,
+            no_project,
         } = args;
 
         Self {
@@ -1909,6 +1911,7 @@ impl FormatSettings {
             diff,
             extra_args,
             version,
+            no_project,
         }
     }
 }

--- a/crates/uv/tests/it/format.rs
+++ b/crates/uv/tests/it/format.rs
@@ -86,6 +86,34 @@ fn format_from_project_root() -> Result<()> {
 }
 
 #[test]
+fn format_no_project() -> Result<()> {
+    let context = TestContext::new_with_versions(&[]);
+
+    let main_py = context.temp_dir.child("main.py");
+    main_py.write_str(indoc! {r"
+        x    = 1
+    "})?;
+
+    uv_snapshot!(context.filters(), context.format().arg("--no-project"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    1 file reformatted
+
+    ----- stderr -----
+    warning: `uv format` is experimental and may change without warning. Pass `--preview-features format` to disable this warning.
+    ");
+
+    // Check that the file was formatted
+    let formatted_content = fs_err::read_to_string(&main_py)?;
+    assert_snapshot!(formatted_content, @r"
+        x = 1
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn format_relative_project() -> Result<()> {
     let context = TestContext::new_with_versions(&[]);
 


### PR DESCRIPTION
When a user passes `--no-project` argument to `uv format` command, instead of running the formatter in the context of the current project, run it in the context of the current directory. This is useful when the current directory is not a project.

Closes https://github.com/astral-sh/uv/issues/15462