### PR TITLE
Update messaging for `uv auth`

### DIFF
--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -1,7 +1,9 @@
-use anyhow::{Result, bail};
 use std::fmt::Write;
 
+use anyhow::{Result, bail};
 use console::Term;
+use owo_colors::OwoColorize;
+
 use uv_auth::Credentials;
 use uv_configuration::{KeyringProviderType, Service};
 use uv_preview::Preview;
@@ -116,6 +118,10 @@ pub(crate) async fn login(
     let credentials = Credentials::basic(Some(username), Some(password));
     provider.store(url, &credentials).await?;
 
-    writeln!(printer.stderr(), "Logged in to {display_url}")?;
+    writeln!(
+        printer.stderr(),
+        "Stored credentials for {}",
+        display_url.cyan()
+    )?;
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -1,5 +1,8 @@
-use anyhow::{Context, Result, bail};
 use std::fmt::Write;
+
+use anyhow::{Context, Result, bail};
+use owo_colors::OwoColorize;
+
 use uv_auth::Credentials;
 use uv_configuration::{KeyringProviderType, Service};
 use uv_preview::Preview;
@@ -59,7 +62,11 @@ pub(crate) async fn logout(
         .await
         .with_context(|| format!("Unable to remove credentials for {display_url}"))?;
 
-    writeln!(printer.stderr(), "Logged out of {display_url}")?;
+    writeln!(
+        printer.stderr(),
+        "Removed credentials for {}",
+        display_url.cyan()
+    )?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -60,7 +60,7 @@ fn add_package_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -93,7 +93,7 @@ fn add_package_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged out of public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Removed credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -199,7 +199,7 @@ fn token_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -264,7 +264,7 @@ fn token_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -493,7 +493,7 @@ fn login_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -525,7 +525,7 @@ fn login_token_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -568,7 +568,7 @@ fn logout_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged out of https://pypi-proxy.fly.dev/basic-auth/simple
+    Removed credentials for https://pypi-proxy.fly.dev/basic-auth/simple
     ");
 
     // Logout before logging in (without a username)
@@ -618,7 +618,7 @@ fn logout_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -651,7 +651,7 @@ fn logout_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged out of public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Removed credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     ");
 
     // Login again
@@ -678,7 +678,7 @@ fn logout_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged out of public@https://pypi-proxy.fly.dev/basic-auth/simple
+    Removed credentials for public@https://pypi-proxy.fly.dev/basic-auth/simple
     ");
 
     // Conflict between --username and a URL username is rejected
@@ -738,7 +738,7 @@ fn logout_token_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to https://pypi-proxy.fly.dev/basic-auth/simple
+    Stored credentials for https://pypi-proxy.fly.dev/basic-auth/simple
     "
     );
 
@@ -753,7 +753,7 @@ fn logout_token_native_keyring() -> Result<()> {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged out of https://pypi-proxy.fly.dev/basic-auth/simple
+    Removed credentials for https://pypi-proxy.fly.dev/basic-auth/simple
     ");
 
     Ok(())
@@ -778,7 +778,7 @@ fn login_native_keyring_url() {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to test@https://example.com/
+    Stored credentials for test@https://example.com/
     ");
 
     // HTTP URLs are not allowed - only HTTPS
@@ -814,7 +814,7 @@ fn login_native_keyring_url() {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to test@https://example.com/
+    Stored credentials for test@https://example.com/
     ");
 
     // A domain-only service with a path also gets https:// prepended
@@ -832,7 +832,7 @@ fn login_native_keyring_url() {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to test@https://example.com/simple
+    Stored credentials for test@https://example.com/simple
     ");
 
     // An invalid URL is rejected
@@ -865,7 +865,7 @@ fn login_native_keyring_url() {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to test@https://example.com/simple
+    Stored credentials for test@https://example.com/simple
     ");
 
     // URL with embedded username and separate password works
@@ -881,7 +881,7 @@ fn login_native_keyring_url() {
 
     ----- stderr -----
     warning: The native keyring provider is experimental and may change without warning. Pass `--preview-features native-keyring` to disable this warning.
-    Logged in to test@https://example.com/simple
+    Stored credentials for test@https://example.com/simple
     ");
 
     // Conflict between --username and URL username is rejected


### PR DESCRIPTION
To clarify that we are not validating the credentials
