### PR TITLE
Support Gitlab CI/CD as a trusted publisher

### DIFF
--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -331,9 +331,7 @@ pub async fn check_trusted_publishing(
             }
             // We could check for credentials from the keyring or netrc the auth middleware first, but
             // given that we are in GitHub Actions we check for trusted publishing first.
-            debug!(
-                "Running on CI without explicit credentials, checking for trusted publishing"
-            );
+            debug!("Running on CI without explicit credentials, checking for trusted publishing");
             match trusted_publishing::get_token(registry, client.for_host(registry).raw_client())
                 .await
             {
@@ -364,9 +362,11 @@ pub async fn check_trusted_publishing(
                 return Err(PublishError::MixedCredentials(conflicts.join(" and ")));
             }
 
-            if env::var(EnvVars::GITHUB_ACTIONS) != Ok("true".to_string()) {
+            let in_github = env::var(EnvVars::GITHUB_ACTIONS) == Ok("true".to_string());
+            let in_gitlab = env::var(EnvVars::GITLAB_CI).is_ok();
+            if !(in_github || in_gitlab) {
                 warn_user_once!(
-                    "Trusted publishing was requested, but you're not in GitHub Actions."
+                    "Trusted publishing was requested, but you're not in a supported CI (GitHub Actions or GitLab CI)."
                 );
             }
 

--- a/crates/uv-publish/src/trusted_publishing.rs
+++ b/crates/uv-publish/src/trusted_publishing.rs
@@ -225,7 +225,8 @@ async fn get_publish_token(
     client: &ClientWithMiddleware,
 ) -> Result<TrustedPublishingToken, TrustedPublishingError> {
     let mint_token_url = DisplaySafeUrl::parse(&format!(
-        "https://{}/_/oidc/mint-token",
+        "{}://{}/_/oidc/mint-token",
+        registry.scheme(),
         registry.authority()
     ))?;
     debug!("Querying the trusted publishing upload token from {mint_token_url}");

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -615,6 +615,27 @@ impl EnvVars {
     /// Used for trusted publishing via `uv publish`. Contains the oidc request token.
     pub const ACTIONS_ID_TOKEN_REQUEST_TOKEN: &'static str = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
 
+    /// Indicates that the current process is running in GitLab CI.
+    ///
+    /// When set (typically to `true`), uv may attempt GitLab-specific trusted publishing flows.
+    pub const GITLAB_CI: &'static str = "GITLAB_CI";
+
+    /// GitLab CI/CD-provided JWT for the current job (v2 format).
+    ///
+    /// When using GitLab's `id_tokens` feature with audience set for PyPI, this token can be
+    /// submitted to PyPI's `/_/oidc/mint-token` endpoint to obtain a short-lived publish token.
+    pub const CI_JOB_JWT_V2: &'static str = "CI_JOB_JWT_V2";
+
+    /// GitLab CI/CD-provided JSON Web Token (JWT) for the current job (legacy format).
+    pub const CI_JOB_JWT: &'static str = "CI_JOB_JWT";
+
+    /// Explicit override for passing an OIDC token for trusted publishing.
+    ///
+    /// If set, uv will use this value as an OIDC token and exchange it via the registry's
+    /// `/_/oidc/mint-token` endpoint to obtain a short-lived publish token. This can be used in
+    /// GitLab CI by mapping the `id_tokens` variable (e.g., `$PYPI_ID_TOKEN`) into this variable.
+    pub const UV_TRUSTED_PUBLISHING_OIDC_TOKEN: &'static str = "UV_TRUSTED_PUBLISHING_OIDC_TOKEN";
+
     /// Sets the encoding for standard I/O streams (e.g., PYTHONIOENCODING=utf-8).
     #[attr_hidden]
     pub const PYTHONIOENCODING: &'static str = "PYTHONIOENCODING";

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -500,3 +500,165 @@ async fn read_index_credential_env_vars_for_check_url() {
     "
     );
 }
+
+/// Verify GitLab trusted publishing via explicit OIDC env override.
+#[tokio::test]
+async fn gitlab_trusted_publishing_with_explicit_oidc_env() {
+    let context = TestContext::new("3.12");
+
+    let server = MockServer::start().await;
+
+    // Mint token endpoint
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    // Upload endpoint requires the minted token as Basic auth
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Emulate GitLab CI with explicit OIDC token provided to uv
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::UV_TRUSTED_PUBLISHING_OIDC_TOKEN, "dummy-oidc-token"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    "
+    );
+}
+
+/// Verify GitLab trusted publishing via CI-provided JWT (CI_JOB_JWT_V2).
+#[tokio::test]
+async fn gitlab_trusted_publishing_via_ci_job_jwt_v2() {
+    let context = TestContext::new("3.12");
+
+    let server = MockServer::start().await;
+
+    // Mint token endpoint exchanges the GitLab OIDC JWT for a short-lived API token
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    // Upload endpoint requires the minted token as Basic auth
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Emulate GitLab CI with CI-provided JWT
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::CI, "true")
+        .env(EnvVars::CI_JOB_JWT_V2, "gitlab-oidc-jwt"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    "
+    );
+}
+
+/// Verify GitLab trusted publishing with a named index from pyproject (no CLI publish-url).
+#[tokio::test]
+async fn gitlab_trusted_publishing_with_index_config() {
+    let context = TestContext::new("3.12");
+
+    let server = MockServer::start().await;
+
+    // Create a project config with a named index that includes a publish-url
+    let pyproject_toml = formatdoc! {
+        r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+
+        [[tool.uv.index]]
+        name = "private-index"
+        url = "{index_uri}/simple/"
+        publish-url = "{index_uri}/upload"
+        explicit = true
+        "#,
+        index_uri = server.uri()
+    };
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)
+        .unwrap();
+
+    // Mint token endpoint exchanges the GitLab OIDC JWT for a short-lived API token
+    Mock::given(method("POST"))
+        .and(path("/_/oidc/mint-token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    // Upload endpoint requires the minted token as Basic auth
+    Mock::given(method("POST"))
+        .and(path("/upload"))
+        .and(basic_auth("__token__", "apitoken"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let ok_wheel = current_dir()
+        .unwrap()
+        .join("../../scripts/links/ok-1.0.0-py3-none-any.whl");
+
+    uv_snapshot!(context.filters(), context.publish()
+        .current_dir(context.temp_dir.path())
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("--index")
+        .arg("private-index")
+        .arg(&ok_wheel)
+        // Emulate GitLab CI with explicit OIDC token provided to uv
+        .env(EnvVars::GITLAB_CI, "true")
+        .env(EnvVars::UV_TRUSTED_PUBLISHING_OIDC_TOKEN, "dummy-oidc-token"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    "
+    );
+}

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -512,8 +512,7 @@ async fn gitlab_trusted_publishing_with_explicit_oidc_env() {
     Mock::given(method("POST"))
         .and(path("/_/oidc/mint-token"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+            ResponseTemplate::new(200).set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
         )
         .mount(&server)
         .await;
@@ -557,8 +556,7 @@ async fn gitlab_trusted_publishing_via_ci_job_jwt_v2() {
     Mock::given(method("POST"))
         .and(path("/_/oidc/mint-token"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+            ResponseTemplate::new(200).set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
         )
         .mount(&server)
         .await;
@@ -624,8 +622,7 @@ async fn gitlab_trusted_publishing_with_index_config() {
     Mock::given(method("POST"))
         .and(path("/_/oidc/mint-token"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
+            ResponseTemplate::new(200).set_body_raw("{\"token\":\"apitoken\"}", "application/json"),
         )
         .mount(&server)
         .await;


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

UV supports GitHub Actions as a trusted publisher, but as outlined in #12754, the support for GitLab CI was missing!  @konstin expressed interest in adding the support.

Users running GitLab CI/CD pipelines need to either:
* Manually exchange OIDC tokens for PyPI API tokens before calling uv publish
* Use API keys stored as CI variables (less secure)
This creates friction and security concerns for GitLab users who want the same seamless, trusted publishing experience as GitHub Actions users.

This PR adds native support for GitLab CI/CD as a trusted publisher in uv, allowing users to publish Python packages to PyPI using GitLab's OIDC tokens without manual token exchange or API key management, by :
* Adding GitLab environment detection via `GITLAB_CI` env var, which would automatically be set by GitLab in all CI jobs
* Supporting explicit OIDC token override via `UV_TRUSTED_PUBLISHING_OIDC_TOKEN`, that works with any GitLab `id_tokens` configuration
* Falling back to GitLab's standard OIDC tokens - `CI_JOB_JWT_V2` (preferred) and  `CI_JOB_JWT` (legacy) for runners that support
* Maintaining backward compatibility with existing GitHub Actions flows

following the same OIDC token exchange pattern as GitHub Actions. 

## Test Plan

The following tests were added :
* Explicit OIDC override: `gitlab_trusted_publishing_with_explicit_oidc_env`
* Standard GitLab tokens: `gitlab_trusted_publishing_via_ci_job_jwt_v2`
* Named index configuration: `gitlab_trusted_publishing_with_index_config`

We mock PyPI's OIDC endpoints to avoid external dependencies and use actual wheel files to test the complete publishing flow.

I tested manually as well :
```
harsh@fcr-node:~/uv$ export GITLAB_CI=true
export UV_TRUSTED_PUBLISHING_OIDC_TOKEN="dummy-oidc-token"

# Test with explicit file path
./target/debug/uv publish --trusted-publishing always --publish-url "https://test.pypi.org/legacy/" dist/ok-1.0.0-py3-none-any.whl
Publishing 1 file to https://test.pypi.org/legacy/
error: Failed to obtain token for trusted publishing
  Caused by: PyPI returned error code 422 Unprocessable Entity, and the OIDC has an unexpected format.
Response: {"errors":[{"code":"invalid-payload","description":"malformed JWT"}],"message":"Token request failed"}
```

The error is the expected behaviour when testing locally with a dummy OIDC token. In real GitLab CI:
* GitLab provides a valid OIDC JWT via id_tokens
* uv detects GITLAB_CI=true
* uv exchanges the valid JWT for a PyPI API token
* uv uploads successfully using the minted token

The "malformed JWT" error proves that uv is correctly :

* Detecting GitLab CI
* Finding the OIDC token
* Making the HTTP request to PyPI
* Handling the response appropriately

I have yet to test this using an actual GitLab instance!