### PR TITLE
Lock the credentials store when reading or writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,6 +5095,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "uv-fs",
  "uv-keyring",
  "uv-once-map",
  "uv-redacted",

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uv-fs = { workspace = true }
 uv-keyring = { workspace = true, features = ["apple-native", "secret-service", "windows-native"] }
 uv-once-map = { workspace = true }
 uv-redacted = { workspace = true }

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -71,8 +71,8 @@ impl Default for TextStoreMode {
                 })
                 .ok()?;
 
-            match TextCredentialStore::from_file(&path) {
-                Ok(store) => {
+            match TextCredentialStore::read(&path) {
+                Ok((store, _lock)) => {
                     debug!("Loaded credential file {}", path.display());
                     Some(store)
                 }

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -115,9 +115,9 @@ pub(crate) async fn login(
         AuthBackend::Keyring(provider) => {
             provider.store(&url, &credentials).await?;
         }
-        AuthBackend::TextStore(mut text_store) => {
-            text_store.insert(service.clone(), credentials);
-            text_store.write(TextCredentialStore::default_file()?)?;
+        AuthBackend::TextStore(mut store, _lock) => {
+            store.insert(service.clone(), credentials);
+            store.write(TextCredentialStore::default_file()?, _lock)?;
         }
     }
 

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -61,12 +61,12 @@ pub(crate) async fn logout(
                 .await
                 .with_context(|| format!("Unable to remove credentials for {display_url}"))?;
         }
-        AuthBackend::TextStore(mut text_store) => {
-            if text_store.remove(&service).is_none() {
+        AuthBackend::TextStore(mut store, _lock) => {
+            if store.remove(&service).is_none() {
                 bail!("No matching entry found for {display_url}");
             }
-            text_store
-                .write(TextCredentialStore::default_file()?)
+            store
+                .write(TextCredentialStore::default_file()?, _lock)
                 .with_context(|| "Failed to persist changes to credentials after removal")?;
         }
     }

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -47,7 +47,7 @@ pub(crate) async fn token(
             .fetch(url, Some(&username))
             .await
             .ok_or_else(|| anyhow::anyhow!("Failed to fetch credentials for {display_url}"))?,
-        AuthBackend::TextStore(text_store) => text_store
+        AuthBackend::TextStore(store, _lock) => store
             .get_credentials(url)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("Failed to fetch credentials for {display_url}"))?,


### PR DESCRIPTION
Adds locking of the credentials store for concurrency safety. It's important to hold the lock from read -> write so credentials are not dropped during concurrent writes.

I opted not to attach the lock to the store itself. Instead, I return the lock on read and require it on write to encourage safe use. Maybe attaching the source path to the store struct and adding a `lock(&self)` method would make sense? but then you can forget to take the lock at the right time. The main problem with the interface here is to write a _new_ store you have to take the lock yourself, and you could make a mistake by taking a lock for the wrong path or something. The fix for that would be to introduce a new `CredentialStoreHandle` type or something, but that seems overzealous rn. We also don't eagerly drop the lock on token read, although we could.