### PR TITLE
Remove the native system store from the keyring providers

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,5 +7,5 @@ slow-timeout =  { period = "10s", terminate-after = 12 }
 serial = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'test(native_keyring)'
+filter = 'test(native_auth)'
 test-group = 'serial'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           UV_HTTP_RETRIES: 5
         run: |
           cargo nextest run \
-            --features python-patch,keyring-tests,secret-service \
+            --features python-patch,native-auth,secret-service \
             --workspace \
             --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
@@ -293,7 +293,7 @@ jobs:
         run: |
           cargo nextest run \
             --no-default-features \
-            --features python,python-managed,pypi,git,performance,crates-io,keyring-tests,apple-native \
+            --features python,python-managed,pypi,git,performance,crates-io,native-auth,apple-native \
             --workspace \
             --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
 
@@ -345,7 +345,7 @@ jobs:
         run: |
           cargo nextest run \
             --no-default-features \
-            --features python,pypi,python-managed,keyring-tests,windows-native \
+            --features python,pypi,python-managed,native-auth,windows-native \
             --workspace \
             --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5098,6 +5098,7 @@ dependencies = [
  "uv-fs",
  "uv-keyring",
  "uv-once-map",
+ "uv-preview",
  "uv-redacted",
  "uv-small-str",
  "uv-state",
@@ -5415,9 +5416,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
- "uv-preview",
  "uv-static",
- "uv-warnings",
 ]
 
 [[package]]

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 uv-fs = { workspace = true }
 uv-keyring = { workspace = true, features = ["apple-native", "secret-service", "windows-native"] }
 uv-once-map = { workspace = true }
+uv-preview = { workspace = true }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
 uv-static = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -489,13 +489,15 @@ impl<'a> BaseClientBuilder<'a> {
                     AuthIntegration::Default => {
                         let auth_middleware = AuthMiddleware::new()
                             .with_indexes(self.indexes.clone())
-                            .with_keyring(self.keyring.to_provider(&self.preview));
+                            .with_keyring(self.keyring.to_provider())
+                            .with_preview(self.preview);
                         client = client.with(auth_middleware);
                     }
                     AuthIntegration::OnlyAuthenticated => {
                         let auth_middleware = AuthMiddleware::new()
                             .with_indexes(self.indexes.clone())
-                            .with_keyring(self.keyring.to_provider(&self.preview))
+                            .with_keyring(self.keyring.to_provider())
+                            .with_preview(self.preview)
                             .with_only_authenticated(true);
 
                         client = client.with(auth_middleware);

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -25,9 +25,7 @@ uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true, features = ["schemars"] }
 uv-platform-tags = { workspace = true }
-uv-preview = { workspace = true }
 uv-static = { workspace = true }
-uv-warnings = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 either = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-configuration/src/authentication.rs
+++ b/crates/uv-configuration/src/authentication.rs
@@ -1,6 +1,4 @@
 use uv_auth::{self, KeyringProvider};
-use uv_preview::{Preview, PreviewFeatures};
-use uv_warnings::warn_user_once;
 
 /// Keyring provider type to use for credential lookup.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -11,8 +9,6 @@ pub enum KeyringProviderType {
     /// Do not use keyring for credential lookup.
     #[default]
     Disabled,
-    /// Use a native integration with the system keychain for credential lookup.
-    Native,
     /// Use the `keyring` command for credential lookup.
     Subprocess,
     // /// Not yet implemented
@@ -23,18 +19,9 @@ pub enum KeyringProviderType {
 // See <https://pip.pypa.io/en/stable/topics/authentication/#keyring-support> for details.
 
 impl KeyringProviderType {
-    pub fn to_provider(&self, preview: &Preview) -> Option<KeyringProvider> {
+    pub fn to_provider(&self) -> Option<KeyringProvider> {
         match self {
             Self::Disabled => None,
-            Self::Native => {
-                if !preview.is_enabled(PreviewFeatures::NATIVE_KEYRING) {
-                    warn_user_once!(
-                        "The native keyring provider is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
-                        PreviewFeatures::NATIVE_KEYRING
-                    );
-                }
-                Some(KeyringProvider::native())
-            }
             Self::Subprocess => Some(KeyringProvider::subprocess()),
         }
     }
@@ -44,7 +31,6 @@ impl std::fmt::Display for KeyringProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Disabled => write!(f, "disabled"),
-            Self::Native => write!(f, "native"),
             Self::Subprocess => write!(f, "subprocess"),
         }
     }

--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [features]
 default = ["apple-native", "secret-service", "windows-native"]
-keyring-tests = []
+native-auth = []
 
 ## Use the built-in Keychain Services on macOS
 apple-native = ["dep:security-framework"]

--- a/crates/uv-keyring/src/lib.rs
+++ b/crates/uv-keyring/src/lib.rs
@@ -407,12 +407,12 @@ doc_comment::doctest!("../README.md", readme);
 /// passing their store-specific parameters for the generic ones.
 mod tests {
     use super::{Entry, Error};
-    #[cfg(feature = "keyring-tests")]
+    #[cfg(feature = "native-auth")]
     use super::{Result, credential::CredentialApi};
     use std::collections::HashMap;
 
     /// Create a platform-specific credential given the constructor, service, and user
-    #[cfg(feature = "keyring-tests")]
+    #[cfg(feature = "native-auth")]
     pub(crate) fn entry_from_constructor<F, T>(f: F, service: &str, user: &str) -> Entry
     where
         F: FnOnce(Option<&str>, &str, &str) -> Result<T>,

--- a/crates/uv-keyring/src/macos.rs
+++ b/crates/uv-keyring/src/macos.rs
@@ -331,7 +331,7 @@ pub fn decode_error(err: Error) -> ErrorCode {
     }
 }
 
-#[cfg(feature = "keyring-tests")]
+#[cfg(feature = "native-auth")]
 #[cfg(not(miri))]
 #[cfg(test)]
 mod tests {

--- a/crates/uv-keyring/src/secret_service.rs
+++ b/crates/uv-keyring/src/secret_service.rs
@@ -634,7 +634,7 @@ fn wrap(err: Error) -> Box<dyn std::error::Error + Send + Sync> {
     Box::new(err)
 }
 
-#[cfg(feature = "keyring-tests")]
+#[cfg(feature = "native-auth")]
 #[cfg(test)]
 mod tests {
     use crate::credential::CredentialPersistence;

--- a/crates/uv-keyring/src/windows.rs
+++ b/crates/uv-keyring/src/windows.rs
@@ -513,7 +513,7 @@ impl std::error::Error for Error {
     }
 }
 
-#[cfg(feature = "keyring-tests")]
+#[cfg(feature = "native-auth")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/uv-keyring/tests/basic.rs
+++ b/crates/uv-keyring/tests/basic.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "keyring-tests")]
+#![cfg(feature = "native-auth")]
 
 use common::{generate_random_bytes_of_len, generate_random_string, init_logger};
 use uv_keyring::{Entry, Error};

--- a/crates/uv-keyring/tests/threading.rs
+++ b/crates/uv-keyring/tests/threading.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "keyring-tests")]
+#![cfg(feature = "native-auth")]
 
 use common::{generate_random_string, init_logger};
 use uv_keyring::{Entry, Error};

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -18,7 +18,7 @@ bitflags::bitflags! {
         const EXTRA_BUILD_DEPENDENCIES = 1 << 6;
         const DETECT_MODULE_CONFLICTS = 1 << 7;
         const FORMAT = 1 << 8;
-        const NATIVE_KEYRING = 1 << 9;
+        const NATIVE_AUTH = 1 << 9;
     }
 }
 
@@ -37,7 +37,7 @@ impl PreviewFeatures {
             Self::EXTRA_BUILD_DEPENDENCIES => "extra-build-dependencies",
             Self::DETECT_MODULE_CONFLICTS => "detect-module-conflicts",
             Self::FORMAT => "format",
-            Self::NATIVE_KEYRING => "native-keyring",
+            Self::NATIVE_AUTH => "native-auth",
             _ => panic!("`flag_as_str` can only be used for exactly one feature flag"),
         }
     }
@@ -84,7 +84,7 @@ impl FromStr for PreviewFeatures {
                 "extra-build-dependencies" => Self::EXTRA_BUILD_DEPENDENCIES,
                 "detect-module-conflicts" => Self::DETECT_MODULE_CONFLICTS,
                 "format" => Self::FORMAT,
-                "native-keyring" => Self::NATIVE_KEYRING,
+                "native-auth" => Self::NATIVE_AUTH,
                 _ => {
                     warn_user_once!("Unknown preview feature: `{part}`");
                     continue;

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -152,7 +152,7 @@ ignored = [
 
 [features]
 default = ["performance", "uv-distribution/static", "default-tests"]
-keyring-tests = []
+native-auth = []
 # Use better memory allocators, etc.
 performance = ["performance-memory-allocator"]
 performance-memory-allocator = ["dep:uv-performance-memory-allocator"]

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -5,13 +5,12 @@ use console::Term;
 use owo_colors::OwoColorize;
 
 use uv_auth::Service;
+use uv_auth::store::AuthBackend;
 use uv_auth::{Credentials, TextCredentialStore};
-use uv_configuration::KeyringProviderType;
 use uv_distribution_types::IndexUrl;
 use uv_pep508::VerbatimUrl;
 use uv_preview::Preview;
 
-use crate::commands::auth::AuthBackend;
 use crate::{commands::ExitStatus, printer::Printer};
 
 /// Login to a service.
@@ -20,11 +19,10 @@ pub(crate) async fn login(
     username: Option<String>,
     password: Option<String>,
     token: Option<String>,
-    keyring_provider: Option<KeyringProviderType>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    let backend = AuthBackend::from_settings(keyring_provider.as_ref(), preview)?;
+    let backend = AuthBackend::from_settings(preview)?;
 
     // If the URL includes a known index URL suffix, strip it
     // TODO(zanieb): Use a shared abstraction across `login` and `logout`?
@@ -112,7 +110,7 @@ pub(crate) async fn login(
     // TODO(zanieb): Add support for other authentication schemes here, e.g., `Credentials::Bearer`
     let credentials = Credentials::basic(Some(username), Some(password));
     match backend {
-        AuthBackend::Keyring(provider) => {
+        AuthBackend::System(provider) => {
             provider.store(&url, &credentials).await?;
         }
         AuthBackend::TextStore(mut store, _lock) => {

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -4,13 +4,12 @@ use anyhow::{Context, Result, bail};
 use owo_colors::OwoColorize;
 
 use uv_auth::Service;
+use uv_auth::store::AuthBackend;
 use uv_auth::{Credentials, TextCredentialStore};
-use uv_configuration::KeyringProviderType;
 use uv_distribution_types::IndexUrl;
 use uv_pep508::VerbatimUrl;
 use uv_preview::Preview;
 
-use crate::commands::auth::AuthBackend;
 use crate::{commands::ExitStatus, printer::Printer};
 
 /// Logout from a service.
@@ -19,11 +18,10 @@ use crate::{commands::ExitStatus, printer::Printer};
 pub(crate) async fn logout(
     service: Service,
     username: Option<String>,
-    keyring_provider: Option<KeyringProviderType>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    let backend = AuthBackend::from_settings(keyring_provider.as_ref(), preview)?;
+    let backend = AuthBackend::from_settings(preview)?;
 
     // TODO(zanieb): Use a shared abstraction across `login` and `logout`?
     let url = service.url().clone();
@@ -55,7 +53,7 @@ pub(crate) async fn logout(
 
     // TODO(zanieb): Consider exhaustively logging out from all backends
     match backend {
-        AuthBackend::Keyring(provider) => {
+        AuthBackend::System(provider) => {
             provider
                 .remove(&url, &username)
                 .await

--- a/crates/uv/src/commands/auth/mod.rs
+++ b/crates/uv/src/commands/auth/mod.rs
@@ -1,43 +1,4 @@
-use uv_auth::{KeyringProvider, TextCredentialStore, TomlCredentialError};
-use uv_configuration::KeyringProviderType;
-use uv_fs::LockedFile;
-use uv_preview::Preview;
-
 pub(crate) mod dir;
 pub(crate) mod login;
 pub(crate) mod logout;
 pub(crate) mod token;
-
-/// The storage backend to use in `uv auth` commands.
-enum AuthBackend {
-    Keyring(KeyringProvider),
-    TextStore(TextCredentialStore, LockedFile),
-}
-
-impl AuthBackend {
-    fn from_settings(
-        keyring: Option<&KeyringProviderType>,
-        preview: Preview,
-    ) -> Result<Self, TomlCredentialError> {
-        // For keyring providers, we only support persistence via the native keyring right now
-        if let Some(keyring) = match keyring {
-            Some(provider @ KeyringProviderType::Native) => provider.to_provider(&preview),
-            _ => None,
-        } {
-            return Ok(Self::Keyring(keyring));
-        }
-
-        // Otherwise, we'll use the plain text credential store
-        let path = TextCredentialStore::default_file()?;
-        match TextCredentialStore::read(&path) {
-            Ok((store, lock)) => Ok(Self::TextStore(store, lock)),
-            Err(TomlCredentialError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                Ok(Self::TextStore(
-                    TextCredentialStore::default(),
-                    TextCredentialStore::lock(&path)?,
-                ))
-            }
-            Err(err) => Err(err),
-        }
-    }
-}

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -4,21 +4,19 @@ use anyhow::{Result, bail};
 
 use uv_auth::Credentials;
 use uv_auth::Service;
-use uv_configuration::KeyringProviderType;
+use uv_auth::store::AuthBackend;
 use uv_preview::Preview;
 
-use crate::commands::auth::AuthBackend;
 use crate::{commands::ExitStatus, printer::Printer};
 
 /// Show the token that will be used for a service.
 pub(crate) async fn token(
     service: Service,
     username: Option<String>,
-    keyring_provider: Option<KeyringProviderType>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    let backend = AuthBackend::from_settings(keyring_provider.as_ref(), preview)?;
+    let backend = AuthBackend::from_settings(preview)?;
     let url = service.url();
 
     // Extract credentials from URL if present
@@ -43,7 +41,7 @@ pub(crate) async fn token(
     };
 
     let credentials = match &backend {
-        AuthBackend::Keyring(provider) => provider
+        AuthBackend::System(provider) => provider
             .fetch(url, Some(&username))
             .await
             .ok_or_else(|| anyhow::anyhow!("Failed to fetch credentials for {display_url}"))?,

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -12,7 +12,6 @@ use uv_cache::Cache;
 use uv_client::{AuthIntegration, BaseClient, BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{KeyringProviderType, TrustedPublishing};
 use uv_distribution_types::{IndexCapabilities, IndexLocations, IndexUrl};
-use uv_preview::Preview;
 use uv_publish::{
     CheckUrlClient, TrustedPublishResult, check_trusted_publishing, files_for_publishing, upload,
 };
@@ -35,7 +34,6 @@ pub(crate) async fn publish(
     index_locations: IndexLocations,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     if client_builder.is_offline() {
         bail!("Unable to publish files in offline mode");
@@ -85,7 +83,6 @@ pub(crate) async fn publish(
         check_url.as_ref(),
         Prompt::Enabled,
         printer,
-        preview,
     )
     .await?;
 
@@ -200,7 +197,6 @@ async fn gather_credentials(
     check_url: Option<&IndexUrl>,
     prompt: Prompt,
     printer: Printer,
-    preview: Preview,
 ) -> Result<(DisplaySafeUrl, Credentials)> {
     // Support reading username and password from the URL, for symmetry with the index API.
     if let Some(url_password) = publish_url.password() {
@@ -284,7 +280,7 @@ async fn gather_credentials(
 
     // If applicable, fetch the password from the keyring eagerly to avoid user confusion about
     // missing keyring entries later.
-    if let Some(provider) = keyring_provider.to_provider(&preview) {
+    if let Some(provider) = keyring_provider.to_provider() {
         if password.is_none() {
             if let Some(username) = &username {
                 debug!("Fetching password from keyring");
@@ -354,7 +350,6 @@ mod tests {
             None,
             Prompt::Disabled,
             Printer::Quiet,
-            Preview::default(),
         )
         .await
     }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -451,7 +451,6 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.username,
                 args.password,
                 args.token,
-                args.keyring_provider,
                 printer,
                 globals.preview,
             )
@@ -464,14 +463,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             let args = settings::AuthLogoutSettings::resolve(args, filesystem);
             show_settings!(args);
 
-            commands::auth_logout(
-                args.service,
-                args.username,
-                args.keyring_provider,
-                printer,
-                globals.preview,
-            )
-            .await
+            commands::auth_logout(args.service, args.username, printer, globals.preview).await
         }
         Commands::Auth(AuthNamespace {
             command: AuthCommand::Token(args),
@@ -480,14 +472,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             let args = settings::AuthTokenSettings::resolve(args, filesystem);
             show_settings!(args);
 
-            commands::auth_token(
-                args.service,
-                args.username,
-                args.keyring_provider,
-                printer,
-                globals.preview,
-            )
-            .await
+            commands::auth_token(args.service, args.username, printer, globals.preview).await
         }
         Commands::Auth(AuthNamespace {
             command: AuthCommand::Dir,
@@ -1689,7 +1674,6 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 index_locations,
                 &cache,
                 printer,
-                globals.preview,
             )
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -3490,28 +3490,14 @@ impl PublishSettings {
 pub(crate) struct AuthLogoutSettings {
     pub(crate) service: Service,
     pub(crate) username: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) keyring_provider: Option<KeyringProviderType>,
 }
 
 impl AuthLogoutSettings {
     /// Resolve the [`AuthLogoutSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(args: AuthLogoutArgs, filesystem: Option<FilesystemOptions>) -> Self {
-        let Options { top_level, .. } = filesystem
-            .map(FilesystemOptions::into_options)
-            .unwrap_or_default();
-
-        let ResolverInstallerSchema {
-            keyring_provider, ..
-        } = top_level;
-
-        let keyring_provider = args.keyring_provider.combine(keyring_provider);
-
+    pub(crate) fn resolve(args: AuthLogoutArgs, _filesystem: Option<FilesystemOptions>) -> Self {
         Self {
             service: args.service,
             username: args.username,
-            keyring_provider,
         }
     }
 }
@@ -3521,28 +3507,14 @@ impl AuthLogoutSettings {
 pub(crate) struct AuthTokenSettings {
     pub(crate) service: Service,
     pub(crate) username: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) keyring_provider: Option<KeyringProviderType>,
 }
 
 impl AuthTokenSettings {
     /// Resolve the [`AuthTokenSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(args: AuthTokenArgs, filesystem: Option<FilesystemOptions>) -> Self {
-        let Options { top_level, .. } = filesystem
-            .map(FilesystemOptions::into_options)
-            .unwrap_or_default();
-
-        let ResolverInstallerSchema {
-            keyring_provider, ..
-        } = top_level;
-
-        let keyring_provider = args.keyring_provider.combine(keyring_provider);
-
+    pub(crate) fn resolve(args: AuthTokenArgs, _filesystem: Option<FilesystemOptions>) -> Self {
         Self {
             service: args.service,
             username: args.username,
-            keyring_provider,
         }
     }
 }
@@ -3554,30 +3526,16 @@ pub(crate) struct AuthLoginSettings {
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
     pub(crate) token: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) keyring_provider: Option<KeyringProviderType>,
 }
 
 impl AuthLoginSettings {
     /// Resolve the [`AuthLoginSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(args: AuthLoginArgs, filesystem: Option<FilesystemOptions>) -> Self {
-        let Options { top_level, .. } = filesystem
-            .map(FilesystemOptions::into_options)
-            .unwrap_or_default();
-
-        let ResolverInstallerSchema {
-            keyring_provider, ..
-        } = top_level;
-
-        let keyring_provider = args.keyring_provider.combine(keyring_provider);
-
+    pub(crate) fn resolve(args: AuthLoginArgs, _filesystem: Option<FilesystemOptions>) -> Self {
         Self {
             service: args.service,
             username: args.username,
             password: args.password,
             token: args.token,
-            keyring_provider,
         }
     }
 }

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -7684,7 +7684,7 @@ fn preview_features() {
         show_settings: true,
         preview: Preview {
             flags: PreviewFeatures(
-                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | PACKAGE_CONFLICTS | EXTRA_BUILD_DEPENDENCIES | DETECT_MODULE_CONFLICTS | FORMAT | NATIVE_KEYRING,
+                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | PACKAGE_CONFLICTS | EXTRA_BUILD_DEPENDENCIES | DETECT_MODULE_CONFLICTS | FORMAT | NATIVE_AUTH,
             ),
         },
         python_preference: Managed,
@@ -7908,7 +7908,7 @@ fn preview_features() {
         show_settings: true,
         preview: Preview {
             flags: PreviewFeatures(
-                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | PACKAGE_CONFLICTS | EXTRA_BUILD_DEPENDENCIES | DETECT_MODULE_CONFLICTS | FORMAT | NATIVE_KEYRING,
+                PYTHON_INSTALL_DEFAULT | PYTHON_UPGRADE | JSON_OUTPUT | PYLOCK | ADD_BOUNDS | PACKAGE_CONFLICTS | EXTRA_BUILD_DEPENDENCIES | DETECT_MODULE_CONFLICTS | FORMAT | NATIVE_AUTH,
             ),
         },
         python_preference: Managed,

--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -52,9 +52,7 @@ $ uv auth token --username foo example.com
 
 ## Configuring the storage backend
 
-By default, credentials are persisted in plain text to the uv
-[credentials file](./http.md#the-uv-credentials-file).
+Credentials are persisted to the uv [credentials store](./http.md#the-uv-credentials-store).
 
-If the [native keyring provider](./http.md#the-native-keyring-provider) is enabled, it will be used
-instead, and the credentials will be stored in a secure system store. The native keyring is
-currently experimental, but will become the default in the future.
+By default, credentials are written to a plaintext file. An encrypted system-native storage backend
+can be enabled with `UV_PREVIEW_FEATURES=native-auth`.

--- a/docs/concepts/authentication/http.md
+++ b/docs/concepts/authentication/http.md
@@ -6,7 +6,7 @@ Authentication can come from the following sources, in order of precedence:
 
 - The URL, e.g., `https://<user>:<password>@<hostname>/...`
 - A [netrc](#netrc-files) configuration file
-- The uv credentials file
+- The uv credentials store
 - A [keyring provider](#keyring-providers) (off by default)
 
 Authentication may be used for hosts specified in the following contexts:
@@ -25,45 +25,39 @@ for storing credentials on a system.
 Reading credentials from `.netrc` files is always enabled. The target file path will be loaded from
 the `NETRC` environment variable if defined, falling back to `~/.netrc` if not.
 
-## The uv credentials file
+## The uv credentials store
 
-uv will read credentials from `~/.local/share/uv/credentials/credentials.toml`. This file is
-currently not intended to be edited manually.
+uv can read and write credentials from a store using the [`uv auth` commands](./cli.md).
 
-To add or remove credentials, use the [`uv auth` commands](./cli.md).
-
-## Keyring providers
-
-A keyring provider typically fetches credentials from an operating system store.
-
-The keyring providers are not used by default.
-
-### The 'subprocess' keyring provider
-
-The 'subprocess' keyring provider invokes the `keyring` command to fetch credentials.
-
-The expected interface for this is based on the popular [keyring](https://github.com/jaraco/keyring)
-Python package. Similar support is built-in to pip.
-
-Set `--keyring-provider subprocess`, `UV_KEYRING_PROVIDER=subprocess`, or
-`tool.uv.keyring-provider = "subprocess"` to use the provider.
-
-### The 'native' keyring provider
+Credentials are stored in a plaintext file in uv's state directory, e.g.,
+`~/.local/share/uv/credentials/credentials.toml` on Unix. This file is currently not intended to be
+edited manually.
 
 !!! note
 
-    The native keyring provider is in [preview](../preview.md) — it is still experimental and being
-    actively developed.
+    A secure, system native storage mechanism is in [preview](../preview.md) — it is still
+    experimental and being actively developed. In the future, this will become the default storage
+    mechanism.
 
-The native keyring provider uses the secret storage mechanism native to your operating system. On
-macOS, it uses the Keychain Services. On Windows, it uses the Windows Credential Manager. On Linux,
-it uses the DBus-based Secret Service API.
+    When enabled, uv will use the secret storage mechanism native to your operating system. On
+    macOS, it uses the Keychain Services. On Windows, it uses the Windows Credential Manager. On
+    Linux, it uses the DBus-based Secret Service API.
 
-Currently, uv only searches the native keyring provider for credentials it has added to the secret
-store. To add or remove credentials, use the [`uv auth` commands](./cli.md).
+    Currently, uv only searches the native store for credentials it has added to the secret store —
+    it will not retrieve credentials persisted by other applications.
 
-Set `--keyring-provider native`, `UV_KEYRING_PROVIDER=native`, or
-`tool.uv.keyring-provider = "native"` to use the provider.
+    Set `UV_PREVIEW_FEATURES=native-auth` to use this storage mechanism.
+
+## Keyring providers
+
+A keyring provider is a concept from `pip` allowing retrieval of credentials from an interface
+matching the popular [keyring](https://github.com/jaraco/keyring) Python package.
+
+The "subprocess" keyring provider invokes the `keyring` command to fetch credentials. uv does not
+support additional keyring provider types at this time.
+
+Set `--keyring-provider subprocess`, `UV_KEYRING_PROVIDER=subprocess`, or
+`tool.uv.keyring-provider = "subprocess"` to use the provider.
 
 ## Persistence of credentials
 

--- a/docs/concepts/preview.md
+++ b/docs/concepts/preview.md
@@ -70,6 +70,8 @@ The following preview features are available:
 - `python-upgrade`: Allows
   [transparent Python version upgrades](./python-versions.md#upgrading-python-versions).
 - `format`: Allows using `uv format`.
+- `native-auth`: Enables storage of credentials in a
+  [system-native location](../concepts/authentication/http.md#the-uv-credentials-store).
 
 ## Disabling preview features
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -94,7 +94,6 @@ uv auth login [OPTIONS] <SERVICE>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-auth-login--managed-python"><a href="#uv-auth-login--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -168,7 +167,6 @@ uv auth logout [OPTIONS] <SERVICE>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-auth-logout--managed-python"><a href="#uv-auth-logout--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -238,7 +236,6 @@ uv auth token [OPTIONS] <SERVICE>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-auth-token--managed-python"><a href="#uv-auth-token--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -447,7 +444,6 @@ uv run [OPTIONS] [COMMAND]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-run--link-mode"><a href="#uv-run--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -852,7 +848,6 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-add--link-mode"><a href="#uv-add--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -1053,7 +1048,6 @@ uv remove [OPTIONS] <PACKAGES>...
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-remove--link-mode"><a href="#uv-remove--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -1236,7 +1230,6 @@ uv version [OPTIONS] [VALUE]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-version--link-mode"><a href="#uv-version--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -1435,7 +1428,6 @@ uv sync [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-sync--link-mode"><a href="#uv-sync--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -1680,7 +1672,6 @@ uv lock [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-lock--link-mode"><a href="#uv-lock--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used when building source distributions.</p>
@@ -1860,7 +1851,6 @@ uv export [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-export--link-mode"><a href="#uv-export--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used when building source distributions.</p>
@@ -2055,7 +2045,6 @@ uv tree [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-tree--link-mode"><a href="#uv-tree--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used when building source distributions.</p>
@@ -2398,7 +2387,6 @@ uv tool run [OPTIONS] [COMMAND]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-tool-run--link-mode"><a href="#uv-tool-run--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -2619,7 +2607,6 @@ uv tool install [OPTIONS] <PACKAGE>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-tool-install--link-mode"><a href="#uv-tool-install--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -2832,7 +2819,6 @@ uv tool upgrade [OPTIONS] <NAME>...
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-tool-upgrade--link-mode"><a href="#uv-tool-upgrade--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -4052,7 +4038,6 @@ uv pip compile [OPTIONS] <SRC_FILE|--group <GROUP>>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-compile--link-mode"><a href="#uv-pip-compile--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used when building source distributions.</p>
@@ -4347,7 +4332,6 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-sync--link-mode"><a href="#uv-pip-sync--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -4620,7 +4604,6 @@ uv pip install [OPTIONS] <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDIT
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-install--link-mode"><a href="#uv-pip-install--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
@@ -4866,7 +4849,6 @@ uv pip uninstall [OPTIONS] <PACKAGE|--requirements <REQUIREMENTS>>
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-uninstall--managed-python"><a href="#uv-pip-uninstall--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -5045,7 +5027,6 @@ uv pip list [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-list--managed-python"><a href="#uv-pip-list--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -5221,7 +5202,6 @@ uv pip tree [OPTIONS]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-pip-tree--managed-python"><a href="#uv-pip-tree--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>
@@ -5462,7 +5442,6 @@ uv venv [OPTIONS] [PATH]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-venv--link-mode"><a href="#uv-venv--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used for installing seed packages.</p>
@@ -5619,7 +5598,6 @@ uv build [OPTIONS] [SRC]
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-build--link-mode"><a href="#uv-build--link-mode"><code>--link-mode</code></a> <i>link-mode</i></dt><dd><p>The method to use when installing packages from the global cache.</p>
 <p>This option is only used when building source distributions.</p>
@@ -5772,7 +5750,6 @@ uv publish --publish-url https://upload.pypi.org/legacy/ --check-url https://pyp
 <p>May also be set with the <code>UV_KEYRING_PROVIDER</code> environment variable.</p><p>Possible values:</p>
 <ul>
 <li><code>disabled</code>:  Do not use keyring for credential lookup</li>
-<li><code>native</code>:  Use a native integration with the system keychain for credential lookup</li>
 <li><code>subprocess</code>:  Use the <code>keyring</code> command for credential lookup</li>
 </ul></dd><dt id="uv-publish--managed-python"><a href="#uv-publish--managed-python"><code>--managed-python</code></a></dt><dd><p>Require use of uv-managed Python versions.</p>
 <p>By default, uv prefers using Python versions it manages. However, it will use system Python versions if a uv-managed Python is not installed. This option disables use of system Python versions.</p>

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1145,11 +1145,6 @@
           "const": "disabled"
         },
         {
-          "description": "Use a native integration with the system keychain for credential lookup.",
-          "type": "string",
-          "const": "native"
-        },
-        {
           "description": "Use the `keyring` command for credential lookup.",
           "type": "string",
           "const": "subprocess"


### PR DESCRIPTION
We're not sure what the best way to expose the native store to users is yet and it's a bit weird that you can use this in the `uv auth` commands but can't use any of the other keyring provider options. The simplest path forward is to just not expose it to users as a keyring provider, and instead frame it as a preview alternative to the plaintext uv credentials store. We can revisit the best way to expose configuration before stabilization.

Note this pull request retains the _internal_ keyring provider implementation — we can refactor it out later but I wanted to avoid a bunch of churn here.