### PR TITLE
Fix simple typo for python that ends in -m

### DIFF
--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -240,7 +240,7 @@ module root alongside the source code.
 !!! tip
 
     When using the uv build backend through a frontend that is not uv, such as pip or
-    `pythom -m build`, debug logging can be enabled through environment variables with
+    `python -m build`, debug logging can be enabled through environment variables with
     `RUST_LOG=uv=debug` or `RUST_LOG=uv=verbose`. When used through uv, the uv build backend shares
     the verbosity level of uv.
 


### PR DESCRIPTION
## Summary

Fix simple doc typo `s/pythom/python`

## Test Plan

Doc string update, proposing accept as-is.
