### PR TITLE
Allow storage of multiple usernames per service in the plaintext store

### DIFF
--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, LazyLock};
 use tracing::trace;
 
 use cache::CredentialsCache;
-pub use credentials::Credentials;
+pub use credentials::{Credentials, Username};
 pub use index::{AuthPolicy, Index, Indexes};
 pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -3,9 +3,8 @@ use std::fmt::Write;
 use anyhow::{Context, Result, bail};
 use owo_colors::OwoColorize;
 
-use uv_auth::Service;
 use uv_auth::store::AuthBackend;
-use uv_auth::{Credentials, TextCredentialStore};
+use uv_auth::{Credentials, Service, TextCredentialStore, Username};
 use uv_distribution_types::IndexUrl;
 use uv_pep508::VerbatimUrl;
 use uv_preview::Preview;
@@ -60,7 +59,10 @@ pub(crate) async fn logout(
                 .with_context(|| format!("Unable to remove credentials for {display_url}"))?;
         }
         AuthBackend::TextStore(mut store, _lock) => {
-            if store.remove(&service).is_none() {
+            if store
+                .remove(&service, Username::from(Some(username.clone())))
+                .is_none()
+            {
                 bail!("No matching entry found for {display_url}");
             }
             store


### PR DESCRIPTION
We weren't keying our hash map with the username, which meant that only one user could be used per service. 