### PR TITLE
Make `uv auth dir` service-aware

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4418,7 +4418,7 @@ pub enum AuthCommand {
     ///
     /// Credentials are only stored in this directory when the plaintext backend is used, as
     /// opposed to the native backend, which uses the system keyring.
-    Dir,
+    Dir(AuthDirArgs),
 }
 
 #[derive(Args)]
@@ -5604,6 +5604,12 @@ pub struct AuthTokenArgs {
         env = EnvVars::UV_KEYRING_PROVIDER,
     )]
     pub keyring_provider: Option<KeyringProviderType>,
+}
+
+#[derive(Args)]
+pub struct AuthDirArgs {
+    /// The service to lookup.
+    pub service: Option<Service>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/auth/dir.rs
+++ b/crates/uv/src/commands/auth/dir.rs
@@ -1,13 +1,20 @@
 use anstream::println;
 use owo_colors::OwoColorize;
 
-use uv_auth::TextCredentialStore;
+use uv_auth::{PyxTokenStore, Service, TextCredentialStore};
 use uv_fs::Simplified;
 
 /// Show the credentials directory.
-pub(crate) fn dir() -> anyhow::Result<()> {
+pub(crate) fn dir(service: Option<&Service>) -> anyhow::Result<()> {
+    if let Some(service) = service {
+        let pyx_store = PyxTokenStore::from_settings()?;
+        if pyx_store.is_known_domain(service.url()) {
+            println!("{}", pyx_store.root().simplified_display().cyan());
+            return Ok(());
+        }
+    }
+
     let root = TextCredentialStore::directory_path()?;
     println!("{}", root.simplified_display().cyan());
-
     Ok(())
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -502,9 +502,9 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             .await
         }
         Commands::Auth(AuthNamespace {
-            command: AuthCommand::Dir,
+            command: AuthCommand::Dir(args),
         }) => {
-            commands::auth_dir()?;
+            commands::auth_dir(args.service.as_ref())?;
             Ok(ExitStatus::Success)
         }
         Commands::Help(args) => commands::help(

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -277,8 +277,13 @@ Credentials are only stored in this directory when the plaintext backend is used
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv auth dir [OPTIONS]
+uv auth dir [OPTIONS] [SERVICE]
 ```
+
+<h3 class="cli-reference">Arguments</h3>
+
+<dl class="cli-reference"><dt id="uv-auth-dir--service"><a href="#uv-auth-dir--service"<code>SERVICE</code></a></dt><dd><p>The service to lookup</p>
+</dd></dl>
 
 <h3 class="cli-reference">Options</h3>
 


### PR DESCRIPTION
## Summary

We store pyx credentials in a different location vs. other indexes, so you can now pass a service to `uv auth dir` to ensure that we show the appropriate location based on the service.
