### PR TITLE
Support iOS platform tags

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1446,8 +1446,11 @@ pub struct PipCompileArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -1775,8 +1778,11 @@ pub struct PipSyncArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -2081,8 +2087,11 @@ pub struct PipInstallArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -2407,8 +2416,11 @@ pub struct PipCheckArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -3335,8 +3347,11 @@ pub struct RunArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -3615,8 +3630,11 @@ pub struct SyncArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -4641,8 +4659,11 @@ pub struct ToolRunArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -4766,8 +4787,11 @@ pub struct ToolInstallArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
@@ -4866,8 +4890,11 @@ pub struct ToolUpgradeArgs {
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
     ///
-    /// When targeting macOS (Darwin), the default minimum version is `12.0`. Use
-    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `13.0`.
+    /// When targeting macOS (Darwin), the default minimum version is `13.0`. Use
+    /// `MACOSX_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
+    ///
+    /// When targeting iOS, the default minimum version is `13.0`. Use
+    /// `IPHONEOS_DEPLOYMENT_TARGET` to specify a different minimum version, e.g., `14.0`.
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.

--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -42,18 +42,50 @@ impl Platform {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "name", rename_all = "lowercase")]
 pub enum Os {
-    Manylinux { major: u16, minor: u16 },
-    Musllinux { major: u16, minor: u16 },
+    Manylinux {
+        major: u16,
+        minor: u16,
+    },
+    Musllinux {
+        major: u16,
+        minor: u16,
+    },
     Windows,
-    Pyodide { major: u16, minor: u16 },
-    Macos { major: u16, minor: u16 },
-    FreeBsd { release: String },
-    NetBsd { release: String },
-    OpenBsd { release: String },
-    Dragonfly { release: String },
-    Illumos { release: String, arch: String },
-    Haiku { release: String },
-    Android { api_level: u16 },
+    Pyodide {
+        major: u16,
+        minor: u16,
+    },
+    Macos {
+        major: u16,
+        minor: u16,
+    },
+    FreeBsd {
+        release: String,
+    },
+    NetBsd {
+        release: String,
+    },
+    OpenBsd {
+        release: String,
+    },
+    Dragonfly {
+        release: String,
+    },
+    Illumos {
+        release: String,
+        arch: String,
+    },
+    Haiku {
+        release: String,
+    },
+    Android {
+        api_level: u16,
+    },
+    Ios {
+        major: u16,
+        minor: u16,
+        simulator: bool,
+    },
 }
 
 impl fmt::Display for Os {
@@ -71,6 +103,7 @@ impl fmt::Display for Os {
             Self::Haiku { .. } => write!(f, "haiku"),
             Self::Android { .. } => write!(f, "android"),
             Self::Pyodide { .. } => write!(f, "pyodide"),
+            Self::Ios { .. } => write!(f, "ios"),
         }
     }
 }

--- a/crates/uv-platform/src/os.rs
+++ b/crates/uv-platform/src/os.rs
@@ -107,6 +107,9 @@ impl From<&uv_platform_tags::Os> for Os {
             uv_platform_tags::Os::Pyodide { .. } => {
                 Self::new(target_lexicon::OperatingSystem::Emscripten)
             }
+            uv_platform_tags::Os::Ios { .. } => {
+                Self::new(target_lexicon::OperatingSystem::IOS(None))
+            }
         }
     }
 }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -531,6 +531,12 @@ impl EnvVars {
     /// Defaults to `13.0`, the least-recent non-EOL macOS version at time of writing.
     pub const MACOSX_DEPLOYMENT_TARGET: &'static str = "MACOSX_DEPLOYMENT_TARGET";
 
+    /// Used with `--python-platform arm64-apple-ios` and related variants to set the
+    /// deployment target (i.e., the minimum supported iOS version).
+    ///
+    /// Defaults to `13.0`.
+    pub const IPHONEOS_DEPLOYMENT_TARGET: &'static str = "IPHONEOS_DEPLOYMENT_TARGET";
+
     /// Used with `--python-platform aarch64-linux-android` and related variants to set the
     /// Android API level. (i.e., the minimum supported Android API level).
     ///

--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -339,7 +339,8 @@ impl TorchStrategy {
                     | Os::Illumos { .. }
                     | Os::Haiku { .. }
                     | Os::Android { .. }
-                    | Os::Pyodide { .. } => {
+                    | Os::Pyodide { .. }
+                    | Os::Ios { .. } => {
                         Either::Right(Either::Left(std::iter::once(TorchBackend::Cpu.index_url())))
                     }
                 }
@@ -369,7 +370,8 @@ impl TorchStrategy {
                 | Os::Illumos { .. }
                 | Os::Haiku { .. }
                 | Os::Android { .. }
-                | Os::Pyodide { .. } => {
+                | Os::Pyodide { .. }
+                | Os::Ios { .. } => {
                     Either::Right(Either::Left(std::iter::once(TorchBackend::Cpu.index_url())))
                 }
             },
@@ -387,7 +389,8 @@ impl TorchStrategy {
                 | Os::Illumos { .. }
                 | Os::Haiku { .. }
                 | Os::Android { .. }
-                | Os::Pyodide { .. } => {
+                | Os::Pyodide { .. }
+                | Os::Ios { .. } => {
                     Either::Right(Either::Left(std::iter::once(TorchBackend::Cpu.index_url())))
                 }
             },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -537,7 +537,8 @@ used.</p>
 <p>See <a href="#uv-python">uv python</a> to view supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-run--python-platform"><a href="#uv-run--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -584,6 +585,9 @@ used.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-run--quiet"><a href="#uv-run--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 </dd><dt id="uv-run--refresh"><a href="#uv-run--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
@@ -1533,7 +1537,8 @@ environment in the project.</p>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-sync--python-platform"><a href="#uv-sync--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -1580,6 +1585,9 @@ environment in the project.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-sync--quiet"><a href="#uv-sync--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 </dd><dt id="uv-sync--refresh"><a href="#uv-sync--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
@@ -2183,6 +2191,9 @@ interpreter. Use <code>--universal</code> to display the tree for all platforms,
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-tree--python-version"><a href="#uv-tree--python-version"><code>--python-version</code></a> <i>python-version</i></dt><dd><p>The Python version to use when filtering the tree.</p>
 <p>For example, pass <code>--python-version 3.10</code> to display the dependencies that would be included when installing on Python 3.10.</p>
 <p>Defaults to the version of the discovered Python interpreter.</p>
@@ -2464,7 +2475,8 @@ uv tool run [OPTIONS] [COMMAND]
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-tool-run--python-platform"><a href="#uv-tool-run--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -2511,6 +2523,9 @@ uv tool run [OPTIONS] [COMMAND]
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-tool-run--quiet"><a href="#uv-tool-run--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 </dd><dt id="uv-tool-run--refresh"><a href="#uv-tool-run--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
@@ -2687,7 +2702,8 @@ uv tool install [OPTIONS] <PACKAGE>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-tool-install--python-platform"><a href="#uv-tool-install--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -2734,6 +2750,9 @@ uv tool install [OPTIONS] <PACKAGE>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-tool-install--quiet"><a href="#uv-tool-install--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 </dd><dt id="uv-tool-install--refresh"><a href="#uv-tool-install--refresh"><code>--refresh</code></a></dt><dd><p>Refresh all cached data</p>
@@ -2901,7 +2920,8 @@ Use with <code>--all</code> to apply to all tools.</p>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-tool-upgrade--python-platform"><a href="#uv-tool-upgrade--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -2948,6 +2968,9 @@ Use with <code>--all</code> to apply to all tools.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-tool-upgrade--quiet"><a href="#uv-tool-upgrade--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
 <p>Repeating this option, e.g., <code>-qq</code>, will enable a silent mode in which uv will write no output to stdout.</p>
 </dd><dt id="uv-tool-upgrade--reinstall"><a href="#uv-tool-upgrade--reinstall"><code>--reinstall</code></a>, <code>--force-reinstall</code></dt><dd><p>Reinstall all packages, regardless of whether they're already installed. Implies <code>--refresh</code></p>
@@ -4144,7 +4167,8 @@ by <code>--python-version</code>.</p>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 </dd><dt id="uv-pip-compile--python-platform"><a href="#uv-pip-compile--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be resolved.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>Possible values:</p>
 <ul>
@@ -4190,6 +4214,9 @@ by <code>--python-version</code>.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-pip-compile--python-version"><a href="#uv-pip-compile--python-version"><code>--python-version</code></a> <i>python-version</i></dt><dd><p>The Python version to use for resolution.</p>
 <p>For example, <code>3.8</code> or <code>3.8.17</code>.</p>
 <p>Defaults to the version of the Python interpreter used for resolution.</p>
@@ -4418,7 +4445,8 @@ be used with caution, as it can modify the system Python installation.</p>
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-pip-sync--python-platform"><a href="#uv-pip-sync--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -4465,6 +4493,9 @@ be used with caution, as it can modify the system Python installation.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-pip-sync--python-version"><a href="#uv-pip-sync--python-version"><code>--python-version</code></a> <i>python-version</i></dt><dd><p>The minimum Python version that should be supported by the requirements (e.g., <code>3.7</code> or <code>3.7.9</code>).</p>
 <p>If a patch version is omitted, the minimum patch version is assumed. For example, <code>3.7</code> is mapped to <code>3.7.0</code>.</p>
 </dd><dt id="uv-pip-sync--quiet"><a href="#uv-pip-sync--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
@@ -4711,7 +4742,8 @@ should be used with caution, as it can modify the system Python installation.</p
 <p>See <a href="#uv-python">uv python</a> for details on Python discovery and supported request formats.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-pip-install--python-platform"><a href="#uv-pip-install--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 <p>Possible values:</p>
@@ -4758,6 +4790,9 @@ should be used with caution, as it can modify the system Python installation.</p
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-pip-install--python-version"><a href="#uv-pip-install--python-version"><code>--python-version</code></a> <i>python-version</i></dt><dd><p>The minimum Python version that should be supported by the requirements (e.g., <code>3.7</code> or <code>3.7.9</code>).</p>
 <p>If a patch version is omitted, the minimum patch version is assumed. For example, <code>3.7</code> is mapped to <code>3.7.0</code>.</p>
 </dd><dt id="uv-pip-install--quiet"><a href="#uv-pip-install--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>
@@ -5345,7 +5380,8 @@ Python environment if no virtual environment is found.</p>
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p></dd><dt id="uv-pip-check--python-platform"><a href="#uv-pip-check--python-platform"><code>--python-platform</code></a> <i>python-platform</i></dt><dd><p>The platform for which packages should be checked.</p>
 <p>By default, the installed packages are checked against the platform of the current interpreter.</p>
 <p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
-<p>When targeting macOS (Darwin), the default minimum version is <code>12.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>13.0</code>.</p>
+<p>When targeting macOS (Darwin), the default minimum version is <code>13.0</code>. Use <code>MACOSX_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
+<p>When targeting iOS, the default minimum version is <code>13.0</code>. Use <code>IPHONEOS_DEPLOYMENT_TARGET</code> to specify a different minimum version, e.g., <code>14.0</code>.</p>
 <p>When targeting Android, the default minimum Android API level is <code>24</code>. Use <code>ANDROID_API_LEVEL</code> to specify a different minimum version, e.g., <code>26</code>.</p>
 <p>Possible values:</p>
 <ul>
@@ -5391,6 +5427,9 @@ Python environment if no virtual environment is found.</p>
 <li><code>aarch64-linux-android</code>:  An ARM64 Android target</li>
 <li><code>x86_64-linux-android</code>:  An <code>x86_64</code> Android target</li>
 <li><code>wasm32-pyodide2024</code>:  A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12</li>
+<li><code>arm64-apple-ios</code>:  An ARM64 target for iOS device</li>
+<li><code>arm64-apple-ios-simulator</code>:  An ARM64 target for iOS simulator</li>
+<li><code>x86_64-apple-ios-simulator</code>:  An <code>x86_64</code> target for iOS simulator</li>
 </ul></dd><dt id="uv-pip-check--python-version"><a href="#uv-pip-check--python-version"><code>--python-version</code></a> <i>python-version</i></dt><dd><p>The Python version against which packages should be checked.</p>
 <p>By default, the installed packages are checked against the version of the current interpreter.</p>
 </dd><dt id="uv-pip-check--quiet"><a href="#uv-pip-check--quiet"><code>--quiet</code></a>, <code>-q</code></dt><dd><p>Use quiet output.</p>

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -633,6 +633,13 @@ Proxy for HTTP requests.
 
 Timeout (in seconds) for HTTP requests. Equivalent to `UV_HTTP_TIMEOUT`.
 
+### `IPHONEOS_DEPLOYMENT_TARGET`
+
+Used with `--python-platform arm64-apple-ios` and related variants to set the
+deployment target (i.e., the minimum supported iOS version).
+
+Defaults to `13.0`.
+
 ### `JPY_SESSION_NAME`
 
 Used to detect when running inside a Jupyter notebook.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -2440,6 +2440,21 @@
           "description": "A wasm32 target using the Pyodide 2024 platform. Meant for use with Python 3.12.",
           "type": "string",
           "const": "wasm32-pyodide2024"
+        },
+        {
+          "description": "An ARM64 target for iOS device\n\nBy default, iOS 13.0 is used, but respects the `IPHONEOS_DEPLOYMENT_TARGET`\nenvironment variable if set.",
+          "type": "string",
+          "const": "arm64-apple-ios"
+        },
+        {
+          "description": "An ARM64 target for iOS simulator\n\nBy default, iOS 13.0 is used, but respects the `IPHONEOS_DEPLOYMENT_TARGET`\nenvironment variable if set.",
+          "type": "string",
+          "const": "arm64-apple-ios-simulator"
+        },
+        {
+          "description": "An `x86_64` target for iOS simulator\n\nBy default, iOS 13.0 is used, but respects the `IPHONEOS_DEPLOYMENT_TARGET`\nenvironment variable if set.",
+          "type": "string",
+          "const": "x86_64-apple-ios-simulator"
         }
       ]
     },


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
This implements the iOS part of https://github.com/astral-sh/uv/issues/8029

FYI: @freakboy3742

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Create a venv with uv and run `cargo run pip install --python-platform arm64-apple-ios pillow`. Then the iOS binary of pillow should be installed inside the venv.