### PR TITLE
Restrict the URLs considered compatible with pyx requests

### DIFF
--- a/crates/uv-auth/src/realm.rs
+++ b/crates/uv-auth/src/realm.rs
@@ -29,6 +29,20 @@ pub struct Realm {
     port: Option<u16>,
 }
 
+impl Realm {
+    #[must_use]
+    pub(crate) fn with_host(mut self, host: &str) -> Self {
+        self.host = Some(SmallString::from(host));
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_port(mut self, port: Option<u16>) -> Self {
+        self.port = port;
+        self
+    }
+}
+
 impl From<&Url> for Realm {
     fn from(url: &Url) -> Self {
         Self {


### PR DESCRIPTION
The implementation is more awkward than before here because I'm trying to keep using the `Realm` type for comparisons. We may want to consider not doing that, but I figured I'd share the draft.

In short, this no longer accepts:

- A URL on a different scheme than the API (e.g., http vs https)
- A URL with a superdomain matching the API superdomain
- A URL with a port that differs from the API

We require the CDN scheme and port to match the API URL.

However, we allow some special cases:

- A URL with a domain matching the API with `api.` stripped.  
- A URL with an arbitrary subdomain of the CDN domain
- A CDN URL with the default port for the scheme (when the API is on a different port)

I've chosen to restrict the subdomains we'll treat as matching for the API because we _generally_ should not allow credentials to be propagated across subdomains. This becomes relevant if, e.g., a user is customizing the API URL to a subdomain like `pyx.my-services.foo`, where we should not bleed credentials to arbitrary other services.
