### PR TITLE
Clarify that `uv auth` commands take a URL

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5538,7 +5538,7 @@ pub struct PythonPinArgs {
 
 #[derive(Args)]
 pub struct AuthLogoutArgs {
-    /// The service to logout of.
+    /// The domain or URL of the service to logout from.
     pub service: Service,
 
     /// The username to logout.
@@ -5559,7 +5559,7 @@ pub struct AuthLogoutArgs {
 
 #[derive(Args)]
 pub struct AuthLoginArgs {
-    /// The service to log into.
+    /// The domain or URL of the service to log into.
     pub service: Service,
 
     /// The username to use for the service.
@@ -5594,7 +5594,7 @@ pub struct AuthLoginArgs {
 
 #[derive(Args)]
 pub struct AuthTokenArgs {
-    /// The URL of the service to lookup.
+    /// The domain or URL of the service to lookup.
     pub service: Service,
 
     /// The username to lookup.
@@ -5612,7 +5612,7 @@ pub struct AuthTokenArgs {
 
 #[derive(Args)]
 pub struct AuthDirArgs {
-    /// The URL of the service to lookup.
+    /// The domain or URL of the service to lookup.
     pub service: Option<Service>,
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,7 +64,7 @@ uv auth login [OPTIONS] <SERVICE>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="uv-auth-login--service"><a href="#uv-auth-login--service"<code>SERVICE</code></a></dt><dd><p>The service to log into</p>
+<dl class="cli-reference"><dt id="uv-auth-login--service"><a href="#uv-auth-login--service"<code>SERVICE</code></a></dt><dd><p>The domain or URL of the service to log into</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -139,7 +139,7 @@ uv auth logout [OPTIONS] <SERVICE>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="uv-auth-logout--service"><a href="#uv-auth-logout--service"<code>SERVICE</code></a></dt><dd><p>The service to logout of</p>
+<dl class="cli-reference"><dt id="uv-auth-logout--service"><a href="#uv-auth-logout--service"<code>SERVICE</code></a></dt><dd><p>The domain or URL of the service to logout from</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -209,7 +209,7 @@ uv auth token [OPTIONS] <SERVICE>
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="uv-auth-token--service"><a href="#uv-auth-token--service"<code>SERVICE</code></a></dt><dd><p>The service to lookup</p>
+<dl class="cli-reference"><dt id="uv-auth-token--service"><a href="#uv-auth-token--service"<code>SERVICE</code></a></dt><dd><p>The domain or URL of the service to lookup</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>
@@ -284,7 +284,7 @@ uv auth dir [OPTIONS] [SERVICE]
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt id="uv-auth-dir--service"><a href="#uv-auth-dir--service"<code>SERVICE</code></a></dt><dd><p>The service to lookup</p>
+<dl class="cli-reference"><dt id="uv-auth-dir--service"><a href="#uv-auth-dir--service"<code>SERVICE</code></a></dt><dd><p>The domain or URL of the service to lookup</p>
 </dd></dl>
 
 <h3 class="cli-reference">Options</h3>


### PR DESCRIPTION
From the previous description I tried `uv auth token pyx`, which didn't work.