### PR TITLE
Avoid erroring when `match-runtime` target is optional

### DIFF
--- a/crates/uv-distribution-types/src/build_requires.rs
+++ b/crates/uv-distribution-types/src/build_requires.rs
@@ -83,6 +83,8 @@ impl ExtraBuildRequires {
     /// Apply runtime constraints from a resolution to the extra build requirements.
     pub fn match_runtime(self, resolution: &Resolution) -> Result<Self, ExtraBuildRequiresError> {
         self.into_iter()
+            .filter(|(_, requirements)| !requirements.is_empty())
+            .filter(|(name, _)| resolution.distributions().any(|dist| dist.name() == name))
             .map(|(name, requirements)| {
                 let requirements = requirements
                     .into_iter()


### PR DESCRIPTION

## Summary

If the package that has the `match-runtime` dependency itself isn't being installed, we should avoid erroring if the package it _depends on_ isn't in the resolution.

Closes https://github.com/astral-sh/uv/issues/15661.
