### PR TITLE
Add C compiler instructions to Fedora-based distros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,12 @@ On Ubuntu and other Debian-based distributions, you can install a C compiler wit
 sudo apt install build-essential
 ```
 
+On Fedora-based distributions, you can install a C compiler with:
+
+```shell
+sudo dnf install gcc
+```
+
 ## Testing
 
 For running tests, we recommend [nextest](https://nexte.st/).


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR adds instructions to install a C compiler on Fedora-based Linux distributions.

## Test Plan

```
# Start Fedora container interactively (can probably be done on Docker as well)
podman run -it registry.fedoraproject.org/fedora

# From now on, run all commands inside the container.
# Install Rustup
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

# Add cargo bin folder to PATH
export PATH="${HOME}/.cargo/bin:${PATH}"

# Install git, clone uv project and get into its folder
dnf install git
git clone https://github.com/astral-sh/uv.git
cd uv

# Try to compile uv and fail (error: linker `cc` not found)
cargo build

# Install C compiler
dnf install gcc

# Try to compile uv again. This time, successfully.
cargo build
```
