### PR TITLE
Extract IO errors from h2 for streaming retries of Connection Reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5380,6 +5380,7 @@ dependencies = [
  "bytecheck",
  "fs-err",
  "futures",
+ "h2",
  "html-escape",
  "http",
  "http-body-util",

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -38,6 +38,7 @@ async_zip = { workspace = true }
 bytecheck = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+h2 = { workspace = true }
 html-escape = { workspace = true }
 http = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
Our streaming retries were missing connection reset errors as h2 was shadowing IO errors (https://github.com/hyperium/h2/issues/862).

**Test plan**

In one terminal:

```
cargo python uninstall 3.12 && cargo run python install 3.12 -vv
```

In another:

```
sudo tcpkill -i wlp2s0 port 443
```

Output:

```
error: Failed to install cpython-3.12.11-linux-x86_64-gnu
  Caused by: Request failed after 3 retries
  Caused by: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/20250902/cpython-3.12.11%2B20250902-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
  Caused by: error sending request for url (https://github.com/astral-sh/python-build-standalone/releases/download/20250902/cpython-3.12.11%2B20250902-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz)
  Caused by: client error (SendRequest)
  Caused by: connection error
  Caused by: connection reset
```

I don't know how to test that from inside Rust.

Fix #14171 (again, hopefully)