### PR TITLE
Add handling for unnamed conda environments in base environment detection

### DIFF
--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -98,6 +98,12 @@ impl CondaEnvironmentKind {
             return Self::Child;
         };
 
+        // If the `CONDA_PREFIX` equals the `CONDA_DEFAULT_ENV`, we're in an unnamed environment
+        // which is typical for environments created with `conda create -p /path/to/env`.
+        if path == Path::new(&current_env) {
+            return Self::Child;
+        }
+
         // These are the expected names for the base environment; we may want to remove this
         // restriction in the future as it's not strictly necessary.
         if current_env != "base" && current_env != "root" {


### PR DESCRIPTION
While investigating https://github.com/astral-sh/uv/pull/15679, I created an unnamed conda environment and noticed this quality which allows us to detect that it's not the base environment.