### PR TITLE
feat(uv-auth): increase access token tolerance to 30 minutes

### DIFF
--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -90,7 +90,7 @@ impl From<AccessToken> for Credentials {
 }
 
 /// The default tolerance for the access token expiration.
-pub const DEFAULT_TOLERANCE_SECS: u64 = 60 * 5;
+pub const DEFAULT_TOLERANCE_SECS: u64 = 60 * 30;
 
 #[derive(Debug, Clone)]
 struct PyxDirectories {


### PR DESCRIPTION
## Summary

pyx access tokens are valid for an hour at a time, so our current default tolerance of 5m means that we pessimistically refresh the access token up to 12 times per hour. 

This increases to tolerance to 30m, meaning that we'll now pessimistically refresh only twice an hour. This has two main benefits:

1. End users should see slightly faster average requests, since they'll do implicit token refreshes less often;
2. The pyx backend sees less chaff volume from token refreshes (these aren't a load issue at the moment, but in the distant future they could be at current tolerances).

## Test Plan

Backend testing in pyx only, most likely? I'm not sure there's a great way to test this (ATM) in uv itself.