### PR TITLE
Add source files of python extension to tool.uv cache-keys when initializing projects with build backend maturin or scikit

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -989,6 +989,9 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 python-packages = ["{module_name}"]
                 python-source = "src"
 
+                [tool.uv]
+                cache-keys = [{ file = "pyproject.toml" }, { file = "requirements.txt" }, { file = "src/lib.rs" }, { file = "Cargo.toml" }]
+
                 [build-system]
                 requires = ["maturin>=1.0,<2.0"]
                 build-backend = "maturin"
@@ -997,6 +1000,9 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 [tool.scikit-build]
                 minimum-version = "build-system.requires"
                 build-dir = "build/{wheel_tag}"
+
+                [tool.uv]
+                cache-keys = [{ file = "pyproject.toml" }, { file = "requirements.txt" }, { file = "src/main.cpp" }, { file = "CMakeLists.txt" }]
 
                 [build-system]
                 requires = ["scikit-build-core>=0.10", "pybind11"]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -990,7 +990,7 @@ fn pyproject_build_system(package: &PackageName, build_backend: ProjectBuildBack
                 python-source = "src"
 
                 [tool.uv]
-                cache-keys = [{ file = "pyproject.toml" }, { file = "requirements.txt" }, { file = "src/lib.rs" }, { file = "Cargo.toml" }]
+                cache-keys = [{{ file = "pyproject.toml" }}, {{ file = "requirements.txt" }}, {{ file = "src/lib.rs" }}, {{ file = "Cargo.toml" }}]
 
                 [build-system]
                 requires = ["maturin>=1.0,<2.0"]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change extends the default initialized projects with scikit and maturin build backends to ensure that the rust or C++ build gets invoked when a source file changes.

## Test Plan

`cargo run init cppextension-test --build-backend=scikit` followed by manual testing of the behaviour of the resulting project under `uv run --with jupyter jupyter lab` and changes to the source file of the extension.
Analogous for `cargo run init maturin-test --build-backend=maturin `.

## Relevant Issues

The question of why the python extension is not rebuilt on source changes has been discussed in https://github.com/astral-sh/uv/issues/15701#issuecomment-3258714942.
