### PR TITLE
Allow `editable = false` for workspace sources

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -307,12 +307,14 @@ impl LoweredRequirement {
                                     url,
                                 }
                             } else {
-                                let status = workspace.required_members().get(&requirement.name);
-                                if member.pyproject_toml().is_package(status.is_none()) {
+                                let value = workspace.required_members().get(&requirement.name);
+                                let is_required_member = value.is_some();
+                                let editability = value.copied().flatten();
+                                if member.pyproject_toml().is_package(!is_required_member) {
                                     RequirementSource::Directory {
                                         install_path: install_path.into_boxed_path(),
                                         url,
-                                        editable: Some(status.copied().flatten().unwrap_or(true)),
+                                        editable: Some(editability.unwrap_or(true)),
                                         r#virtual: Some(false),
                                     }
                                 } else {

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -306,22 +306,22 @@ impl LoweredRequirement {
                                     },
                                     url,
                                 }
-                            } else if member
-                                .pyproject_toml()
-                                .is_package(!workspace.is_required_member(&requirement.name))
-                            {
-                                RequirementSource::Directory {
-                                    install_path: install_path.into_boxed_path(),
-                                    url,
-                                    editable: Some(true),
-                                    r#virtual: Some(false),
-                                }
                             } else {
-                                RequirementSource::Directory {
-                                    install_path: install_path.into_boxed_path(),
-                                    url,
-                                    editable: Some(false),
-                                    r#virtual: Some(true),
+                                let status = workspace.required_members().get(&requirement.name);
+                                if member.pyproject_toml().is_package(status.is_none()) {
+                                    RequirementSource::Directory {
+                                        install_path: install_path.into_boxed_path(),
+                                        url,
+                                        editable: Some(status.copied().flatten().unwrap_or(true)),
+                                        r#virtual: Some(false),
+                                    }
+                                } else {
+                                    RequirementSource::Directory {
+                                        install_path: install_path.into_boxed_path(),
+                                        url,
+                                        editable: Some(false),
+                                        r#virtual: Some(true),
+                                    }
                                 }
                             };
                             (source, marker)

--- a/crates/uv-workspace/src/lib.rs
+++ b/crates/uv-workspace/src/lib.rs
@@ -1,6 +1,6 @@
 pub use workspace::{
-    DiscoveryOptions, MemberDiscovery, ProjectWorkspace, RequiresPythonSources, VirtualProject,
-    Workspace, WorkspaceCache, WorkspaceError, WorkspaceMember,
+    DiscoveryOptions, Editability, MemberDiscovery, ProjectWorkspace, RequiresPythonSources,
+    VirtualProject, Workspace, WorkspaceCache, WorkspaceError, WorkspaceMember,
 };
 
 pub mod dependency_groups;

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -1,5 +1,6 @@
 //! Resolve the current [`ProjectWorkspace`] or [`Workspace`].
 
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -56,7 +57,7 @@ pub enum WorkspaceError {
     NonWorkspace(PathBuf),
     #[error("Nested workspaces are not supported, but workspace member (`{}`) has a `uv.workspace` table", _0.simplified_display())]
     NestedWorkspace(PathBuf),
-    #[error("Two workspace members are both named: `{name}`: `{}` and `{}`", first.simplified_display(), second.simplified_display())]
+    #[error("Two workspace members are both named `{name}`: `{}` and `{}`", first.simplified_display(), second.simplified_display())]
     DuplicatePackage {
         name: PackageName,
         first: PathBuf,
@@ -64,6 +65,11 @@ pub enum WorkspaceError {
     },
     #[error("pyproject.toml section is declared as dynamic, but must be static: `{0}`")]
     DynamicNotAllowed(&'static str),
+    #[error(
+        "Workspace member `{}` was requested as both `editable = true` and `editable = false`",
+        _0
+    )]
+    EditableConflict(PackageName),
     #[error("Failed to find directories for glob: `{0}`")]
     Pattern(String, #[source] PatternError),
     // Syntax and other errors.
@@ -109,8 +115,9 @@ pub struct Workspace {
     install_path: PathBuf,
     /// The members of the workspace.
     packages: WorkspaceMembers,
-    /// The workspace members that are required by other members.
-    required_members: BTreeSet<PackageName>,
+    /// The workspace members that are required by other members, and whether they were requested
+    /// as editable.
+    required_members: BTreeMap<PackageName, Option<bool>>,
     /// The sources table from the workspace `pyproject.toml`.
     ///
     /// This table is overridden by the project sources.
@@ -255,15 +262,16 @@ impl Workspace {
     /// Set the [`ProjectWorkspace`] for a given workspace member.
     ///
     /// Assumes that the project name is unchanged in the updated [`PyProjectToml`].
-    #[must_use]
     pub fn with_pyproject_toml(
         self,
         package_name: &PackageName,
         pyproject_toml: PyProjectToml,
-    ) -> Option<Self> {
+    ) -> Result<Option<Self>, WorkspaceError> {
         let mut packages = self.packages;
 
-        let member = Arc::make_mut(&mut packages).get_mut(package_name)?;
+        let Some(member) = Arc::make_mut(&mut packages).get_mut(package_name) else {
+            return Ok(None);
+        };
 
         if member.root == self.install_path {
             // If the member is also the workspace root, update _both_ the member entry and the
@@ -287,28 +295,28 @@ impl Workspace {
                 &packages,
                 &workspace_sources,
                 &workspace_pyproject_toml,
-            );
+            )?;
 
-            Some(Self {
+            Ok(Some(Self {
                 pyproject_toml: workspace_pyproject_toml,
                 sources: workspace_sources,
                 packages,
                 required_members,
                 ..self
-            })
+            }))
         } else {
             // Set the `pyproject.toml` for the member.
             member.pyproject_toml = pyproject_toml;
 
             // Recompute required_members with the updated member data
             let required_members =
-                Self::collect_required_members(&packages, &self.sources, &self.pyproject_toml);
+                Self::collect_required_members(&packages, &self.sources, &self.pyproject_toml)?;
 
-            Some(Self {
+            Ok(Some(Self {
                 packages,
                 required_members,
                 ..self
-            })
+            }))
         }
     }
 
@@ -337,7 +345,13 @@ impl Workspace {
                 {
                     RequirementSource::Directory {
                         install_path: member.root.clone().into_boxed_path(),
-                        editable: Some(true),
+                        editable: Some(
+                            self.required_members
+                                .get(name)
+                                .copied()
+                                .flatten()
+                                .unwrap_or(true),
+                        ),
                         r#virtual: Some(false),
                         url,
                     }
@@ -355,11 +369,12 @@ impl Workspace {
     }
 
     /// The workspace members that are required my another member of the workspace.
-    pub fn required_members(&self) -> &BTreeSet<PackageName> {
+    pub fn required_members(&self) -> &BTreeMap<PackageName, Option<bool>> {
         &self.required_members
     }
 
-    /// Compute the workspace members that are required by another member of the workspace.
+    /// Compute the workspace members that are required by another member of the workspace, and
+    /// determine whether they should be installed as editable or non-editable.
     ///
     /// N.B. this checks if a workspace member is required by inspecting `tool.uv.source` entries,
     /// but does not actually check if the source is _used_, which could result in false positives
@@ -368,8 +383,10 @@ impl Workspace {
         packages: &BTreeMap<PackageName, WorkspaceMember>,
         sources: &BTreeMap<PackageName, Sources>,
         pyproject_toml: &PyProjectToml,
-    ) -> BTreeSet<PackageName> {
-        sources
+    ) -> Result<BTreeMap<PackageName, Option<bool>>, WorkspaceError> {
+        let mut required_members = BTreeMap::new();
+
+        for (package, sources) in sources
             .iter()
             .filter(|(name, _)| {
                 pyproject_toml
@@ -396,18 +413,37 @@ impl Workspace {
                     })
                     .flatten(),
             )
-            .filter_map(|(package, sources)| {
-                sources
-                    .iter()
-                    .any(|source| matches!(source, Source::Workspace { .. }))
-                    .then_some(package.clone())
-            })
-            .collect()
+        {
+            for source in sources.iter() {
+                let Source::Workspace { editable, .. } = &source else {
+                    continue;
+                };
+                match required_members.entry(package.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(*editable);
+                    }
+                    Entry::Occupied(mut entry) => {
+                        if let Some(existing) = entry.get() {
+                            if let Some(editable) = editable {
+                                // If there are conflicting `editable` values, raise an error.
+                                if existing != editable {
+                                    return Err(WorkspaceError::EditableConflict(package.clone()));
+                                }
+                            }
+                        } else {
+                            entry.insert(*editable);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(required_members)
     }
 
     /// Whether a given workspace member is required by another member.
     pub fn is_required_member(&self, name: &PackageName) -> bool {
-        self.required_members().contains(name)
+        self.required_members().contains_key(name)
     }
 
     /// Returns the set of all workspace member dependency groups.
@@ -441,18 +477,16 @@ impl Workspace {
                 return None;
             }
 
+            let status = self.required_members.get(name);
             Some(Requirement {
                 name: member.pyproject_toml.project.as_ref()?.name.clone(),
                 extras: Box::new([]),
                 groups: groups.into_boxed_slice(),
                 marker: MarkerTree::TRUE,
-                source: if member
-                    .pyproject_toml()
-                    .is_package(!self.is_required_member(name))
-                {
+                source: if member.pyproject_toml().is_package(status.is_none()) {
                     RequirementSource::Directory {
                         install_path: member.root.clone().into_boxed_path(),
-                        editable: Some(true),
+                        editable: Some(status.copied().flatten().unwrap_or(true)),
                         r#virtual: Some(false),
                         url,
                     }
@@ -831,7 +865,7 @@ impl Workspace {
             &workspace_members,
             &workspace_sources,
             &workspace_pyproject_toml,
-        );
+        )?;
 
         Ok(Self {
             install_path: workspace_root,
@@ -1250,14 +1284,17 @@ impl ProjectWorkspace {
     /// Set the `pyproject.toml` for the current project.
     ///
     /// Assumes that the project name is unchanged in the updated [`PyProjectToml`].
-    #[must_use]
-    pub fn with_pyproject_toml(self, pyproject_toml: PyProjectToml) -> Option<Self> {
-        Some(Self {
-            workspace: self
-                .workspace
-                .with_pyproject_toml(&self.project_name, pyproject_toml)?,
-            ..self
-        })
+    pub fn with_pyproject_toml(
+        self,
+        pyproject_toml: PyProjectToml,
+    ) -> Result<Option<Self>, WorkspaceError> {
+        let Some(workspace) = self
+            .workspace
+            .with_pyproject_toml(&self.project_name, pyproject_toml)?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Self { workspace, ..self }))
     }
 
     /// Find the workspace for a project.
@@ -1325,7 +1362,7 @@ impl ProjectWorkspace {
                 &current_project_as_members,
                 &workspace_sources,
                 project_pyproject_toml,
-            );
+            )?;
 
             return Ok(Self {
                 project_root: project_path.clone(),
@@ -1647,11 +1684,16 @@ impl VirtualProject {
     /// Set the `pyproject.toml` for the current project.
     ///
     /// Assumes that the project name is unchanged in the updated [`PyProjectToml`].
-    #[must_use]
-    pub fn with_pyproject_toml(self, pyproject_toml: PyProjectToml) -> Option<Self> {
-        match self {
+    pub fn with_pyproject_toml(
+        self,
+        pyproject_toml: PyProjectToml,
+    ) -> Result<Option<Self>, WorkspaceError> {
+        Ok(match self {
             Self::Project(project) => {
-                Some(Self::Project(project.with_pyproject_toml(pyproject_toml)?))
+                let Some(project) = project.with_pyproject_toml(pyproject_toml)? else {
+                    return Ok(None);
+                };
+                Some(Self::Project(project))
             }
             Self::NonProject(workspace) => {
                 // If this is a non-project workspace root, then by definition the root isn't a
@@ -1661,7 +1703,7 @@ impl VirtualProject {
                     ..workspace.clone()
                 }))
             }
-        }
+        })
     }
 
     /// Return the root of the project.
@@ -1788,7 +1830,7 @@ mod tests {
                 "pyproject_toml": "[PYPROJECT_TOML]"
               }
             },
-            "required_members": [],
+            "required_members": {},
             "sources": {},
             "indexes": [],
             "pyproject_toml": {
@@ -1842,7 +1884,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -1923,14 +1965,15 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [
-                  "bird-feeder",
-                  "seeds"
-                ],
+                "required_members": {
+                  "bird-feeder": null,
+                  "seeds": null
+                },
                 "sources": {
                   "bird-feeder": [
                     {
                       "workspace": true,
+                      "editable": null,
                       "extra": null,
                       "group": null
                     }
@@ -1954,6 +1997,7 @@ mod tests {
                         "bird-feeder": [
                           {
                             "workspace": true,
+                            "editable": null,
                             "extra": null,
                             "group": null
                           }
@@ -2048,10 +2092,10 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [
-                  "bird-feeder",
-                  "seeds"
-                ],
+                "required_members": {
+                  "bird-feeder": null,
+                  "seeds": null
+                },
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2119,7 +2163,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2254,7 +2298,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2362,7 +2406,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2484,7 +2528,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2580,7 +2624,7 @@ mod tests {
                     "pyproject_toml": "[PYPROJECT_TOML]"
                   }
                 },
-                "required_members": [],
+                "required_members": {},
                 "sources": {},
                 "indexes": [],
                 "pyproject_toml": {
@@ -2771,7 +2815,7 @@ bar = ["b"]
         insta::with_settings!({filters => filters}, {
             assert_snapshot!(
                 error,
-            @"Two workspace members are both named: `seeds`: `[ROOT]/packages/seeds` and `[ROOT]/packages/seeds2`");
+            @"Two workspace members are both named `seeds`: `[ROOT]/packages/seeds` and `[ROOT]/packages/seeds2`");
         });
 
         Ok(())

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -1391,7 +1391,7 @@ impl AddTarget {
                 let project = project
                     .with_pyproject_toml(
                         toml::from_str(content).map_err(ProjectError::PyprojectTomlParse)?,
-                    )
+                    )?
                     .ok_or(ProjectError::PyprojectTomlUpdate)?;
                 Ok(Self::Project(project, venv))
             }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -943,7 +943,7 @@ impl ValidatedLock {
         install_path: &Path,
         packages: &BTreeMap<PackageName, WorkspaceMember>,
         members: &[PackageName],
-        required_members: &BTreeSet<PackageName>,
+        required_members: &BTreeMap<PackageName, Option<bool>>,
         requirements: &[Requirement],
         dependency_groups: &BTreeMap<GroupName, Vec<Requirement>>,
         constraints: &[Requirement],
@@ -1187,6 +1187,18 @@ impl ValidatedLock {
                 );
                 Ok(Self::Preferable(lock))
             }
+            SatisfiesResult::MismatchedEditable(name, expected) => {
+                if expected {
+                    debug!(
+                        "Resolving despite existing lockfile due to mismatched source: `{name}` (expected: `editable`)"
+                    );
+                } else {
+                    debug!(
+                        "Resolving despite existing lockfile due to mismatched source: `{name}` (unexpected: `editable`)"
+                    );
+                }
+                Ok(Self::Preferable(lock))
+            }
             SatisfiesResult::MismatchedVirtual(name, expected) => {
                 if expected {
                     debug!(
@@ -1194,7 +1206,7 @@ impl ValidatedLock {
                     );
                 } else {
                     debug!(
-                        "Resolving despite existing lockfile due to mismatched source: `{name}` (expected: `editable`)"
+                        "Resolving despite existing lockfile due to mismatched source: `{name}` (unexpected: `virtual`)"
                     );
                 }
                 Ok(Self::Preferable(lock))

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -37,7 +37,7 @@ use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildContext, BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
-use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache, WorkspaceMember};
+use uv_workspace::{DiscoveryOptions, Editability, Workspace, WorkspaceCache, WorkspaceMember};
 
 use crate::commands::pip::loggers::{DefaultResolveLogger, ResolveLogger, SummaryResolveLogger};
 use crate::commands::project::lock_target::LockTarget;
@@ -943,7 +943,7 @@ impl ValidatedLock {
         install_path: &Path,
         packages: &BTreeMap<PackageName, WorkspaceMember>,
         members: &[PackageName],
-        required_members: &BTreeMap<PackageName, Option<bool>>,
+        required_members: &BTreeMap<PackageName, Editability>,
         requirements: &[Requirement],
         dependency_groups: &BTreeMap<GroupName, Vec<Requirement>>,
         constraints: &[Requirement],

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -12,7 +12,7 @@ use uv_pypi_types::{Conflicts, SupportedEnvironments, VerbatimParsedUrl};
 use uv_resolver::{Lock, LockVersion, VERSION};
 use uv_scripts::Pep723Script;
 use uv_workspace::dependency_groups::{DependencyGroupError, FlatDependencyGroup};
-use uv_workspace::{Workspace, WorkspaceMember};
+use uv_workspace::{Editability, Workspace, WorkspaceMember};
 
 use crate::commands::project::{ProjectError, find_requires_python};
 
@@ -156,11 +156,11 @@ impl<'lock> LockTarget<'lock> {
 
     /// Return the set of required workspace members, i.e., those that are required by other
     /// members.
-    pub(crate) fn required_members(self) -> &'lock BTreeMap<PackageName, Option<bool>> {
+    pub(crate) fn required_members(self) -> &'lock BTreeMap<PackageName, Editability> {
         match self {
             Self::Workspace(workspace) => workspace.required_members(),
             Self::Script(_) => {
-                static EMPTY: BTreeMap<PackageName, Option<bool>> = BTreeMap::new();
+                static EMPTY: BTreeMap<PackageName, Editability> = BTreeMap::new();
                 &EMPTY
             }
         }

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use itertools::Either;
@@ -156,11 +156,11 @@ impl<'lock> LockTarget<'lock> {
 
     /// Return the set of required workspace members, i.e., those that are required by other
     /// members.
-    pub(crate) fn required_members(self) -> &'lock BTreeSet<PackageName> {
+    pub(crate) fn required_members(self) -> &'lock BTreeMap<PackageName, Option<bool>> {
         match self {
             Self::Workspace(workspace) => workspace.required_members(),
             Self::Script(_) => {
-                static EMPTY: BTreeSet<PackageName> = BTreeSet::new();
+                static EMPTY: BTreeMap<PackageName, Option<bool>> = BTreeMap::new();
                 &EMPTY
             }
         }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -252,6 +252,9 @@ pub(crate) enum ProjectError {
     Lowering(#[from] uv_distribution::LoweringError),
 
     #[error(transparent)]
+    Workspace(#[from] uv_workspace::WorkspaceError),
+
+    #[error(transparent)]
     PyprojectMut(#[from] uv_workspace::pyproject_mut::Error),
 
     #[error(transparent)]

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -436,7 +436,7 @@ impl RemoveTarget {
                 let project = project
                     .with_pyproject_toml(
                         toml::from_str(content).map_err(ProjectError::PyprojectTomlParse)?,
-                    )
+                    )?
                     .ok_or(ProjectError::PyprojectTomlUpdate)?;
                 Ok(Self::Project(project))
             }

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -392,7 +392,7 @@ fn update_project(
 
     // Update the `pyproject.toml` in-memory.
     let project = project
-        .with_pyproject_toml(toml::from_str(&content).map_err(ProjectError::PyprojectTomlParse)?)
+        .with_pyproject_toml(toml::from_str(&content).map_err(ProjectError::PyprojectTomlParse)?)?
         .ok_or(ProjectError::PyprojectTomlUpdate)?;
 
     Ok(project)

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -13599,3 +13599,478 @@ fn sync_extra_build_dependencies_cache() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(not(windows))]
+fn toggle_workspace_editable() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let child = context.temp_dir.child("child");
+    let pyproject_toml = child.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig>=1"]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    child
+        .child("src")
+        .child("child")
+        .child("__init__.py")
+        .touch()?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child"]
+
+        [tool.uv.workspace]
+        members = ["child"]
+
+        [tool.uv.sources]
+        child = { workspace = true }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + child==0.1.0 (from file://[TEMP_DIR]/child)
+     + iniconfig==2.0.0
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // The child should be editable by default.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child",
+            "project",
+        ]
+
+        [[package]]
+        name = "child"
+        version = "0.1.0"
+        source = { editable = "child" }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", specifier = ">=1" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child", editable = "child" }]
+        "#
+        );
+    });
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child"]
+
+        [tool.uv.workspace]
+        members = ["child"]
+
+        [tool.uv.sources]
+        child = { workspace = true, editable = false }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ child==0.1.0 (from file://[TEMP_DIR]/child)
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // The child should be editable by default.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child",
+            "project",
+        ]
+
+        [[package]]
+        name = "child"
+        version = "0.1.0"
+        source = { directory = "child" }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", specifier = ">=1" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child", directory = "child" }]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
+#[cfg(not(windows))]
+fn workspace_editable_conflict() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let child1 = context.temp_dir.child("child1");
+    let pyproject_toml = child1.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "child1"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig>=1"]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    child1
+        .child("src")
+        .child("child1")
+        .child("__init__.py")
+        .touch()?;
+
+    let child2 = context.temp_dir.child("child2");
+    let pyproject_toml = child2.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "child2"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child1"]
+
+        [tool.uv.sources]
+        child1 = { workspace = true }
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    child2
+        .child("src")
+        .child("child2")
+        .child("__init__.py")
+        .touch()?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child1"]
+
+        [tool.uv.workspace]
+        members = ["child1", "child2"]
+
+        [tool.uv.sources]
+        child1 = { workspace = true, editable = true }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + child1==0.1.0 (from file://[TEMP_DIR]/child1)
+     + iniconfig==2.0.0
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // If one member declares `editable = true`, and the other omits `editable`, use editable.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child1",
+            "child2",
+            "project",
+        ]
+
+        [[package]]
+        name = "child1"
+        version = "0.1.0"
+        source = { editable = "child1" }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", specifier = ">=1" }]
+
+        [[package]]
+        name = "child2"
+        version = "0.1.0"
+        source = { editable = "child2" }
+        dependencies = [
+            { name = "child1" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child1", editable = "child1" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child1" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child1", editable = "child1" }]
+        "#
+        );
+    });
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child1"]
+
+        [tool.uv.workspace]
+        members = ["child1", "child2"]
+
+        [tool.uv.sources]
+        child1 = { workspace = true, editable = false }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ child1==0.1.0 (from file://[TEMP_DIR]/child1)
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // If one member declares `editable = false`, and the other omits `editable`, use non-editable.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        members = [
+            "child1",
+            "child2",
+            "project",
+        ]
+
+        [[package]]
+        name = "child1"
+        version = "0.1.0"
+        source = { directory = "child1" }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", specifier = ">=1" }]
+
+        [[package]]
+        name = "child2"
+        version = "0.1.0"
+        source = { editable = "child2" }
+        dependencies = [
+            { name = "child1" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child1", directory = "child1" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "child1" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "child1", directory = "child1" }]
+        "#
+        );
+    });
+
+    let child2 = context.temp_dir.child("child2");
+    let pyproject_toml = child2.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "child2"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child1"]
+
+        [tool.uv.sources]
+        child1 = { workspace = true, editable = true }
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+
+    // If the `editable` declarations are conflicting, raise an error.
+    uv_snapshot!(context.filters(), context.sync(), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Workspace member `child1` was requested as both `editable = true` and `editable = false`
+    ");
+
+    Ok(())
+}

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -2133,6 +2133,13 @@
           "description": "A dependency on another package in the workspace.",
           "type": "object",
           "properties": {
+            "editable": {
+              "description": "Whether the package should be installed as editable. Defaults to `true`.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "extra": {
               "anyOf": [
                 {


### PR DESCRIPTION
## Summary

This ended up being a bit more complex, similar to `package = false`, because we need to understand the editable status _globally_ across the workspace based on the packages that depend on it.

Closes https://github.com/astral-sh/uv/issues/15686.
