### PR TITLE
Don't trace logs all architectures

### DIFF
--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -111,10 +111,6 @@ impl Platform {
         // See https://github.com/astral-sh/uv/pull/9788
         // For now, allow same architecture family as a fallback
         if self.arch.family() != other.arch.family() {
-            trace!(
-                "Architecture `{}` is not compatible with `{}`",
-                self.arch, other.arch
-            );
             return false;
         }
 


### PR DESCRIPTION
On my machine, this statement print over 500 lines for `uv python list -vv` of evident statements.
