### PR TITLE
Build backend error message style consistency

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -35,14 +35,14 @@ pub enum Error {
     Validation(#[from] ValidationError),
     #[error("Invalid module name: {0}")]
     InvalidModuleName(String, #[source] IdentifierParseError),
-    #[error("Unsupported glob expression in: `{field}`")]
+    #[error("Unsupported glob expression in: {field}")]
     PortableGlob {
         field: String,
         #[source]
         source: PortableGlobError,
     },
     /// <https://github.com/BurntSushi/ripgrep/discussions/2927>
-    #[error("Glob expressions caused to large regex in: `{field}`")]
+    #[error("Glob expressions caused to large regex in: {field}")]
     GlobSetTooLarge {
         field: String,
         #[source]
@@ -50,7 +50,7 @@ pub enum Error {
     },
     #[error("`pyproject.toml` must not be excluded from source distribution build")]
     PyprojectTomlExcluded,
-    #[error("Failed to walk source tree: `{}`", root.user_display())]
+    #[error("Failed to walk source tree: {}", root.user_display())]
     WalkDir {
         root: PathBuf,
         #[source]
@@ -60,19 +60,19 @@ pub enum Error {
     Zip(#[from] zip::result::ZipError),
     #[error("Failed to write RECORD file")]
     Csv(#[from] csv::Error),
-    #[error("Expected a Python module at: `{}`", _0.user_display())]
+    #[error("Expected a Python module at: {}", _0.user_display())]
     MissingInitPy(PathBuf),
-    #[error("For namespace packages, `__init__.py[i]` is not allowed in parent directory: `{}`", _0.user_display())]
+    #[error("For namespace packages, `__init__.py[i]` is not allowed in parent directory: {}", _0.user_display())]
     NotANamespace(PathBuf),
     /// Either an absolute path or a parent path through `..`.
-    #[error("Module root must be inside the project: `{}`", _0.user_display())]
+    #[error("Module root must be inside the project: {}", _0.user_display())]
     InvalidModuleRoot(PathBuf),
     /// Either an absolute path or a parent path through `..`.
-    #[error("The path for the data directory {} must be inside the project: `{}`", name, path.user_display())]
+    #[error("The path for the data directory {} must be inside the project: {}", name, path.user_display())]
     InvalidDataRoot { name: String, path: PathBuf },
     #[error("Virtual environments must not be added to source distributions or wheels, remove the directory or exclude it from the build: {}", _0.user_display())]
     VenvInSourceTree(PathBuf),
-    #[error("Inconsistent metadata between prepare and build step: `{0}`")]
+    #[error("Inconsistent metadata between prepare and build step: {0}")]
     InconsistentSteps(&'static str),
     #[error("Failed to write to {}", _0.user_display())]
     TarWrite(PathBuf, #[source] io::Error),
@@ -969,7 +969,7 @@ mod tests {
             .replace('\\', "/");
         assert_snapshot!(
             err_message,
-            @"Expected a Python module at: `[TEMP_PATH]/src/camel_case/__init__.py`"
+            @"Expected a Python module at: [TEMP_PATH]/src/camel_case/__init__.py"
         );
     }
 
@@ -1034,7 +1034,7 @@ mod tests {
             .replace('\\', "/");
         assert_snapshot!(
             err_message,
-            @"Expected a Python module at: `[TEMP_PATH]/src/stuffed_bird-stubs/__init__.pyi`"
+            @"Expected a Python module at: [TEMP_PATH]/src/stuffed_bird-stubs/__init__.pyi"
         );
 
         // Create the correct file
@@ -1100,7 +1100,7 @@ mod tests {
 
         assert_snapshot!(
             build_err(src.path()),
-            @"Expected a Python module at: `[TEMP_PATH]/src/simple_namespace/part/__init__.py`"
+            @"Expected a Python module at: [TEMP_PATH]/src/simple_namespace/part/__init__.py"
         );
 
         // Create the correct file
@@ -1122,7 +1122,7 @@ mod tests {
         File::create(&bogus_init_py).unwrap();
         assert_snapshot!(
             build_err(src.path()),
-            @"For namespace packages, `__init__.py[i]` is not allowed in parent directory: `[TEMP_PATH]/src/simple_namespace`"
+            @"For namespace packages, `__init__.py[i]` is not allowed in parent directory: [TEMP_PATH]/src/simple_namespace"
         );
         fs_err::remove_file(bogus_init_py).unwrap();
 
@@ -1342,7 +1342,7 @@ mod tests {
         // The first module is missing an `__init__.py`.
         assert_snapshot!(
             build_err(src.path()),
-            @"Expected a Python module at: `[TEMP_PATH]/src/foo/__init__.py`"
+            @"Expected a Python module at: [TEMP_PATH]/src/foo/__init__.py"
         );
 
         // Create the first correct `__init__.py` file
@@ -1351,7 +1351,7 @@ mod tests {
         // The second module, a namespace, is missing an `__init__.py`.
         assert_snapshot!(
             build_err(src.path()),
-            @"Expected a Python module at: `[TEMP_PATH]/src/simple_namespace/part_a/__init__.py`"
+            @"Expected a Python module at: [TEMP_PATH]/src/simple_namespace/part_a/__init__.py"
         );
 
         // Create the other two correct `__init__.py` files
@@ -1381,7 +1381,7 @@ mod tests {
         File::create(&bogus_init_py).unwrap();
         assert_snapshot!(
             build_err(src.path()),
-            @"For namespace packages, `__init__.py[i]` is not allowed in parent directory: `[TEMP_PATH]/src/simple_namespace`"
+            @"For namespace packages, `__init__.py[i]` is not allowed in parent directory: [TEMP_PATH]/src/simple_namespace"
         );
         fs_err::remove_file(bogus_init_py).unwrap();
 

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -40,7 +40,7 @@ pub enum ValidationError {
     UnknownExtension(String),
     #[error("Can't infer content type because `{}` does not have an extension. Please use a support extension (`.md`, `.rst`, `.txt`) or set the content type manually.", _0.user_display())]
     MissingExtension(PathBuf),
-    #[error("Unsupported content type: `{0}`")]
+    #[error("Unsupported content type: {0}")]
     UnsupportedContentType(String),
     #[error("`project.description` must be a single line")]
     DescriptionNewlines,
@@ -51,14 +51,14 @@ pub enum ValidationError {
     )]
     MixedLicenseGenerations,
     #[error(
-        "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: `{0}`"
+        "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: {0}"
     )]
     InvalidGroup(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]
     ReservedScripts,
     #[error("Use `project.gui-scripts` instead of `project.entry-points.gui_scripts`")]
     ReservedGuiScripts,
-    #[error("`project.license` is not a valid SPDX expression: `{0}`")]
+    #[error("`project.license` is not a valid SPDX expression: {0}")]
     InvalidSpdx(String, #[source] spdx::error::ParseError),
 }
 
@@ -437,12 +437,12 @@ impl PyProjectToml {
                         .strip_prefix(root)
                         .expect("walkdir starts with root");
                     if !license_globs.match_path(relative) {
-                        trace!("Not a license files match: `{}`", relative.user_display());
+                        trace!("Not a license files match: {}", relative.user_display());
                         continue;
                     }
                     if !entry.file_type().is_file() {
                         trace!(
-                            "Not a file in license files match: `{}`",
+                            "Not a file in license files match: {}",
                             relative.user_display()
                         );
                         continue;
@@ -450,7 +450,7 @@ impl PyProjectToml {
 
                     error_on_venv(entry.file_name(), entry.path())?;
 
-                    debug!("License files match: `{}`", relative.user_display());
+                    debug!("License files match: {}", relative.user_display());
                     license_files.push(relative.portable_display().to_string());
                 }
 
@@ -624,7 +624,7 @@ impl PyProjectToml {
             {
                 warn!(
                     "Entrypoint names should consist of letters, numbers, dots, underscores and \
-                    dashes; non-compliant name: `{name}`"
+                    dashes; non-compliant name: {name}"
                 );
             }
 
@@ -1360,12 +1360,12 @@ mod tests {
             .to_metadata(Path::new("/do/not/read"))
             .unwrap_err();
         // TODO(konsti): We mess up the indentation in the error.
-        assert_snapshot!(format_err(err), @r###"
+        assert_snapshot!(format_err(err), @r"
         Invalid pyproject.toml
-          Caused by: `project.license` is not a valid SPDX expression: `MIT XOR Apache-2`
+          Caused by: `project.license` is not a valid SPDX expression: MIT XOR Apache-2
           Caused by: MIT XOR Apache-2
             ^^^ unknown term
-        "###);
+        ");
     }
 
     #[test]
@@ -1400,7 +1400,7 @@ mod tests {
             foo = "bar"
         "#
         });
-        assert_snapshot!(script_error(&contents), @"Entrypoint groups must consist of letters and numbers separated by dots, invalid group: `a@b`");
+        assert_snapshot!(script_error(&contents), @"Entrypoint groups must consist of letters and numbers separated by dots, invalid group: a@b");
     }
 
     #[test]

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -104,7 +104,7 @@ fn source_dist_matcher(
         .and_then(|readme| readme.path())
     {
         let readme = uv_fs::normalize_path(readme);
-        trace!("Including readme at: `{}`", readme.user_display());
+        trace!("Including readme at: {}", readme.user_display());
         let readme = readme.portable_display().to_string();
         let glob = Glob::new(&globset::escape(&readme)).expect("escaped globset is parseable");
         include_globs.push(glob);
@@ -112,7 +112,7 @@ fn source_dist_matcher(
 
     // Include the license files
     for license_files in pyproject_toml.license_files_source_dist() {
-        trace!("Including license files at: `{license_files}`");
+        trace!("Including license files at: {license_files}`");
         let glob = PortableGlobParser::Pep639
             .parse(license_files)
             .map_err(|err| Error::PortableGlob {
@@ -125,11 +125,7 @@ fn source_dist_matcher(
     // Include the data files
     for (name, directory) in settings.data.iter() {
         let directory = uv_fs::normalize_path(directory);
-        trace!(
-            "Including data ({}) at: `{}`",
-            name,
-            directory.user_display()
-        );
+        trace!("Including data ({}) at: {}", name, directory.user_display());
         if directory
             .components()
             .next()
@@ -151,7 +147,7 @@ fn source_dist_matcher(
     }
 
     debug!(
-        "Source distribution includes: `{:?}`",
+        "Source distribution includes: {:?}",
         include_globs
             .iter()
             .map(ToString::to_string)
@@ -263,7 +259,7 @@ fn write_source_dist(
             .expect("walkdir starts with root");
 
         if !include_matcher.match_path(relative) || exclude_matcher.is_match(relative) {
-            trace!("Excluding from sdist: `{}`", relative.user_display());
+            trace!("Excluding from sdist: {}", relative.user_display());
             continue;
         }
 

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -177,7 +177,7 @@ fn write_wheel(
                 .strip_prefix(&src_root)
                 .expect("walkdir starts with root");
             if exclude_matcher.is_match(match_path) {
-                trace!("Excluding from module: `{}`", match_path.user_display());
+                trace!("Excluding from module: {}", match_path.user_display());
                 continue;
             }
 
@@ -211,7 +211,7 @@ fn write_wheel(
     // Add the data files
     for (name, directory) in settings.data.iter() {
         debug!(
-            "Adding {name} data files from: `{}`",
+            "Adding {name} data files from: {}",
             directory.user_display()
         );
         if directory
@@ -302,7 +302,7 @@ pub fn build_editable(
         src_root.as_os_str().as_encoded_bytes(),
     )?;
 
-    debug!("Adding metadata files to: `{}`", wheel_path.user_display());
+    debug!("Adding metadata files to: {}", wheel_path.user_display());
     let dist_info_dir = write_dist_info(
         &mut wheel_writer,
         &pyproject_toml,
@@ -528,7 +528,7 @@ fn wheel_subdir_from_globs(
             .expect("walkdir starts with root");
 
         if !matcher.match_path(relative) {
-            trace!("Excluding {}: `{}`", globs_field, relative.user_display());
+            trace!("Excluding {}: {}", globs_field, relative.user_display());
             continue;
         }
 
@@ -538,7 +538,7 @@ fn wheel_subdir_from_globs(
             .join(relative)
             .portable_display()
             .to_string();
-        debug!("Adding for {}: `{}`", globs_field, relative.user_display());
+        debug!("Adding for {}: {}", globs_field, relative.user_display());
         wheel_writer.write_dir_entry(&entry, &license_path)?;
     }
     Ok(())

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2006,7 +2006,7 @@ fn force_pep517() -> Result<()> {
     ----- stderr -----
     Building source distribution (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Expected a Python module at: `src/does_not_exist/__init__.py`
+      ╰─▶ Expected a Python module at: src/does_not_exist/__init__.py
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--force-pep517").env(EnvVars::RUST_BACKTRACE, "0"), @r"

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -453,7 +453,7 @@ fn build_module_name_normalization() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module at: `src/Django_plugin/__init__.py`
+    error: Expected a Python module at: src/Django_plugin/__init__.py
     ");
 
     fs_err::create_dir_all(context.temp_dir.join("src/Django_plugin"))?;
@@ -467,7 +467,7 @@ fn build_module_name_normalization() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module at: `src/Django_plugin/__init__.py`
+    error: Expected a Python module at: src/Django_plugin/__init__.py
     ");
 
     // Use `Django_plugin` instead of `django_plugin`
@@ -603,7 +603,7 @@ fn sdist_error_without_module() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module at: `src/foo/__init__.py`
+    error: Expected a Python module at: src/foo/__init__.py
     ");
 
     fs_err::create_dir(context.temp_dir.join("src"))?;
@@ -617,7 +617,7 @@ fn sdist_error_without_module() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Expected a Python module at: `src/foo/__init__.py`
+    error: Expected a Python module at: src/foo/__init__.py
     ");
 
     Ok(())
@@ -916,7 +916,7 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building source distribution (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Module root must be inside the project: `..`
+      ╰─▶ Module root must be inside the project: ..
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("--wheel"), @r"
@@ -927,7 +927,7 @@ fn error_on_relative_module_root_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
-      ╰─▶ Module root must be inside the project: `..`
+      ╰─▶ Module root must be inside the project: ..
     ");
 
     Ok(())
@@ -971,7 +971,7 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building source distribution (uv build backend)...
       × Failed to build `[TEMP_DIR]/project`
-      ╰─▶ The path for the data directory headers must be inside the project: `../header`
+      ╰─▶ The path for the data directory headers must be inside the project: ../header
     ");
 
     uv_snapshot!(context.filters(), context.build().arg("project").arg("--wheel"), @r"
@@ -982,7 +982,7 @@ fn error_on_relative_data_dir_outside_project_root() -> Result<()> {
     ----- stderr -----
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/project`
-      ╰─▶ The path for the data directory headers must be inside the project: `../header`
+      ╰─▶ The path for the data directory headers must be inside the project: ../header
     ");
 
     Ok(())


### PR DESCRIPTION
Consistently omit backticks after a colon in build backend messages, following https://github.com/astral-sh/uv/pull/15733#discussion_r2330156783.

There's still 74 matches for `: {}"` and 183 matches for `: {[^{]*}"`, but this PR clears all matches in the build backend.