### PR TITLE
Remove cmake from our Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt update \
   build-essential \
   curl \
   python3-venv \
-  cmake \
   && apt clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We no longer depend on CMake
