### PR TITLE
Show a dedicated error for venvs in source trees

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -7,9 +7,9 @@ mod wheel;
 pub use metadata::{PyProjectToml, check_direct_build};
 pub use settings::{BuildBackendSettings, WheelDataIncludes};
 pub use source_dist::{build_source_dist, list_source_dist};
-use std::ffi::OsStr;
 pub use wheel::{build_editable, build_wheel, list_wheel, metadata};
 
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -357,7 +357,6 @@ fn module_path_from_module_name(src_root: &Path, module_name: &str) -> Result<Pa
 
 /// Error if we're adding a venv to a distribution.
 pub(crate) fn error_on_venv(file_name: &OsStr, path: &Path) -> Result<(), Error> {
-    //dbg!(path);
     // On 64-bit Unix, `lib64` is a (compatibility) symlink to lib. If we traverse `lib64` before
     // `pyvenv.cfg`, we show a generic error for symlink directories instead.
     if !(file_name == "pyvenv.cfg" || file_name == "lib64") {

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -21,7 +21,7 @@ use uv_pep508::{
 use uv_pypi_types::{Metadata23, VerbatimParsedUrl};
 
 use crate::serde_verbatim::SerdeVerbatim;
-use crate::{BuildBackendSettings, Error};
+use crate::{BuildBackendSettings, Error, error_on_venv};
 
 /// By default, we ignore generated python files.
 pub(crate) const DEFAULT_EXCLUDES: &[&str] = &["__pycache__", "*.pyc", "*.pyo"];
@@ -447,6 +447,8 @@ impl PyProjectToml {
                         );
                         continue;
                     }
+
+                    error_on_venv(entry.file_name(), entry.path())?;
 
                     debug!("License files match: `{}`", relative.user_display());
                     license_files.push(relative.portable_display().to_string());

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -1,7 +1,8 @@
 use crate::metadata::DEFAULT_EXCLUDES;
 use crate::wheel::build_exclude_matcher;
 use crate::{
-    BuildBackendSettings, DirectoryWriter, Error, FileList, ListWriter, PyProjectToml, find_roots,
+    BuildBackendSettings, DirectoryWriter, Error, FileList, ListWriter, PyProjectToml,
+    error_on_venv, find_roots,
 };
 use flate2::Compression;
 use flate2::write::GzEncoder;
@@ -265,6 +266,8 @@ fn write_source_dist(
             trace!("Excluding from sdist: `{}`", relative.user_display());
             continue;
         }
+
+        error_on_venv(entry.file_name(), entry.path())?;
 
         let entry_path = Path::new(&top_level)
             .join(relative)

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -19,7 +19,8 @@ use uv_warnings::warn_user_once;
 
 use crate::metadata::DEFAULT_EXCLUDES;
 use crate::{
-    BuildBackendSettings, DirectoryWriter, Error, FileList, ListWriter, PyProjectToml, find_roots,
+    BuildBackendSettings, DirectoryWriter, Error, FileList, ListWriter, PyProjectToml,
+    error_on_venv, find_roots,
 };
 
 /// Build a wheel from the source tree and place it in the output directory.
@@ -179,6 +180,8 @@ fn write_wheel(
                 trace!("Excluding from module: `{}`", match_path.user_display());
                 continue;
             }
+
+            error_on_venv(entry.file_name(), entry.path())?;
 
             let entry_path = entry_path.portable_display().to_string();
             debug!("Adding to wheel: {entry_path}");
@@ -528,6 +531,8 @@ fn wheel_subdir_from_globs(
             trace!("Excluding {}: `{}`", globs_field, relative.user_display());
             continue;
         }
+
+        error_on_venv(entry.file_name(), entry.path())?;
 
         let license_path = Path::new(target)
             .join(relative)


### PR DESCRIPTION
A user in the support chat had an error message for `uv build` with the `uv_build` backend they didn't understand, which was caused by them having a venv in their build directory. This PR adds a dedicated error message when adding something to a distribution that looks like a venv.