### PR TITLE
auth: allow insecure http only on localhost

### DIFF
--- a/crates/uv-auth/src/service.rs
+++ b/crates/uv-auth/src/service.rs
@@ -8,7 +8,7 @@ use uv_redacted::DisplaySafeUrl;
 pub enum ServiceParseError {
     #[error(transparent)]
     InvalidUrl(#[from] url::ParseError),
-    #[error("only HTTPS is supported")]
+    #[error("only HTTPS (or HTTP on localhost) is supported")]
     UnsupportedScheme,
 }
 
@@ -35,6 +35,7 @@ impl Service {
     fn check_scheme(url: &Url) -> Result<(), ServiceParseError> {
         match url.scheme() {
             "https" => Ok(()),
+            "http" if matches!(url.host_str(), Some("localhost" | "127.0.0.1")) => Ok(()),
             #[cfg(test)]
             "http" => Ok(()),
             _ => Err(ServiceParseError::UnsupportedScheme),

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -616,9 +616,25 @@ fn login_native_auth_url() {
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value 'http://example.com' for '<SERVICE>': only HTTPS is supported
+    error: invalid value 'http://example.com' for '<SERVICE>': only HTTPS (or HTTP on localhost) is supported
 
     For more information, try '--help'.
+    ");
+
+    // HTTP URLs are fine for localhost
+    uv_snapshot!(context.auth_login()
+        .arg("http://localhost:1324")
+        .arg("--username")
+        .arg("test")
+        .arg("--password")
+        .arg("test")
+        .env(EnvVars::UV_PREVIEW_FEATURES, "native-auth"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Stored credentials for test@http://localhost:1324/
     ");
 
     uv_snapshot!(context.auth_login()


### PR DESCRIPTION
## Summary

This is useful for testing purposes.

## Test Plan

I tested using testing purposes.