### PR TITLE
Fix the glob for filtering `uv_build` loongarch wheels

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -50,6 +50,6 @@ jobs:
           path: wheels_uv_build
           merge-multiple: true
       - name: Remove wheels unsupported by PyPI
-        run: rm wheels_uv/*loong*
+        run: rm wheels_uv_build/*loong*
       - name: Publish to PyPI
         run: uv publish -v wheels_uv_build/*


### PR DESCRIPTION
Introduced in https://github.com/astral-sh/uv/pull/15387 and broke the latest release.

cc @SkyBird233 