### PR TITLE
Remove fs2 dependency and update Rust to 1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,16 +1417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,7 +5688,6 @@ dependencies = [
  "either",
  "encoding_rs_io",
  "fs-err",
- "fs2",
  "junction",
  "path-slash",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.87"
+rust-version = "1.89"
 homepage = "https://pypi.org/project/uv/"
 documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
@@ -110,7 +110,6 @@ encoding_rs_io = { version = "0.1.7" }
 etcetera = { version = "0.10.0" }
 flate2 = { version = "1.0.33", default-features = false, features = ["zlib-rs"] }
 fs-err = { version = "3.0.0", features = ["tokio"] }
-fs2 = { version = "0.4.3" }
 futures = { version = "0.3.30" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.15" }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -20,14 +20,13 @@ dunce = { workspace = true }
 either = { workspace = true }
 encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }
-fs2 = { workspace = true }
 path-slash = { workspace = true }
 percent-encoding = { workspace = true }
 same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, optional = true}
+tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 
 [target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? --> 

This PR removes the crate fs2 and updates Rust version to 1.89.

*Why?*

Crate fs2 is unmaintained for a long time now and has unfixed issues. Especially it doesn't build on AIX, which is the reason I started fixing it.

*How?*

I removed fs2 and replaced it by std:fs:File methods.

## Test Plan

<!-- How was it tested? -->
- I built it on Windows and AIX only.
- I did not test the artifacts.
