### PR TITLE
Avoid initiating login flow for invalid API keys

### DIFF
--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -261,11 +261,24 @@ impl PyxTokenStore {
         Ok(())
     }
 
+    /// Returns `true` if the user appears to have an authentication token set.
+    pub fn has_auth_token(&self) -> bool {
+        read_pyx_auth_token().is_some()
+    }
+
+    /// Returns `true` if the user appears to have an API key set.
+    pub fn has_api_key(&self) -> bool {
+        read_pyx_api_key().is_some()
+    }
+
+    /// Returns `true` if the user appears to have OAuth tokens stored on disk.
+    pub fn has_oauth_tokens(&self) -> bool {
+        self.subdirectory.join("tokens.json").is_file()
+    }
+
     /// Returns `true` if the user appears to have credentials (which may be invalid).
     pub fn has_credentials(&self) -> bool {
-        read_pyx_auth_token().is_some()
-            || read_pyx_api_key().is_some()
-            || self.subdirectory.join("tokens.json").is_file()
+        self.has_auth_token() || self.has_api_key() || self.has_oauth_tokens()
     }
 
     /// Read the tokens from the store.

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -110,6 +110,13 @@ async fn pyx_refresh(store: &PyxTokenStore, client: &BaseClient, printer: Printe
 
         // Similarly, if the refresh token expired, prompt for login.
         Err(err) if err.is_unauthorized() => {
+            if store.has_auth_token() {
+                return Err(
+                    anyhow::Error::from(err).context("Failed to authenticate with access token")
+                );
+            } else if store.has_api_key() {
+                return Err(anyhow::Error::from(err).context("Failed to authenticate with API key"));
+            }
             debug!(
                 "Received 401 (Unauthorized) response from refresh endpoint; prompting for login..."
             );


### PR DESCRIPTION
## Summary

If the login flow fails, and the user provided an API key, it's unintuitive to initiate the login flow.