### PR TITLE
Include SHA when listing lockfile changes

### DIFF
--- a/crates/uv-git-types/src/oid.rs
+++ b/crates/uv-git-types/src/oid.rs
@@ -25,6 +25,11 @@ impl GitOid {
     pub fn as_short_str(&self) -> &str {
         &self.as_str()[..16]
     }
+
+    /// Return a (very) truncated representation, i.e., the first 8 characters of the SHA.
+    pub fn as_tiny_str(&self) -> &str {
+        &self.as_str()[..8]
+    }
 }
 
 #[derive(Debug, Error, PartialEq)]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3058,6 +3058,14 @@ impl Package {
         self.id.version.as_ref()
     }
 
+    /// Returns the Git SHA of the package, if it is a Git source.
+    pub fn git_sha(&self) -> Option<&GitOid> {
+        match &self.id.source {
+            Source::Git(_, git) => Some(&git.precise),
+            _ => None,
+        }
+    }
+
     /// Return the fork markers for this package, if any.
     pub fn fork_markers(&self) -> &[UniversalMarker] {
         self.fork_markers.as_slice()


### PR DESCRIPTION
## Summary

Right now, we only list changes if the _version_ differs. This PR takes the SHA into account. We may want to list changes to _any_ sources, but that gets more complicated (e.g., if the user swaps the index URL, we'd have to show _all_ changes to the index URL).

Closes #15810.
