### PR TITLE
chore(ci): pin loong64 base image to a digest

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -851,7 +851,7 @@ jobs:
         platform:
           - target: loongarch64-unknown-linux-gnu
             arch: loong64
-            base_image: --platform=linux/loong64 ghcr.io/loong64/debian:trixie
+            base_image: --platform=linux/loong64 ghcr.io/loong64/debian:trixie@sha256:71a1f5a556f142729662ef4ccc7c86b47f3260ffa69ea40f890809442aced342
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

This is a third-party Docker image, so let's pin it conservatively.

## Test Plan

See what happens in CI.