### PR TITLE
Error when `pyproject.toml` target does not exist for dependency groups

### DIFF
--- a/crates/uv-distribution/src/metadata/dependency_groups.rs
+++ b/crates/uv-distribution/src/metadata/dependency_groups.rs
@@ -58,6 +58,13 @@ impl SourcedDependencyGroups {
         source_strategy: SourceStrategy,
         cache: &WorkspaceCache,
     ) -> Result<Self, MetadataError> {
+        // If the `pyproject.toml` doesn't exist, fail early.
+        if !pyproject_path.is_file() {
+            return Err(MetadataError::MissingPyprojectToml(
+                pyproject_path.to_path_buf(),
+            ));
+        }
+
         let discovery = DiscoveryOptions {
             stop_discovery_at: git_member.map(|git_member| {
                 git_member

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -28,6 +28,8 @@ pub enum MetadataError {
     Workspace(#[from] WorkspaceError),
     #[error(transparent)]
     DependencyGroup(#[from] DependencyGroupError),
+    #[error("No pyproject.toml found at: {0}")]
+    MissingPyprojectToml(PathBuf),
     #[error("Failed to parse entry: `{0}`")]
     LoweringError(PackageName, #[source] Box<LoweringError>),
     #[error("Failed to parse entry in group `{0}`: `{1}`")]

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -16179,6 +16179,34 @@ fn directory_and_group() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn group_target_does_not_exist() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "uv%%%"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_compile()
+        .arg("--group").arg("does/not/exist/pyproject.toml:foo"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to read dependency groups from: does/not/exist/pyproject.toml
+      Caused by: No pyproject.toml found at: does/not/exist/pyproject.toml
+    ");
+
+    Ok(())
+}
+
 /// See: <https://github.com/astral-sh/uv/issues/10957>
 #[cfg(feature = "python-eol")]
 #[test]


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/15789.
