### PR TITLE
Propagate preview flag to client for `native-auth` feature

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -152,8 +152,10 @@ impl BaseClientBuilder<'_> {
         connectivity: Connectivity,
         native_tls: bool,
         allow_insecure_host: Vec<TrustedHost>,
+        preview: Preview,
     ) -> Self {
         Self {
+            preview,
             allow_insecure_host,
             native_tls,
             connectivity,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -174,6 +174,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 settings.network_settings.connectivity,
                 settings.network_settings.native_tls,
                 settings.network_settings.allow_insecure_host,
+                settings.preview,
             )
             .retries_from_env()?;
             Some(
@@ -435,6 +436,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         globals.network_settings.connectivity,
         globals.network_settings.native_tls,
         globals.network_settings.allow_insecure_host.clone(),
+        globals.preview,
     )
     .retries_from_env()?;
 


### PR DESCRIPTION
Somehow propagation of this got dropped during a rebase, so we never actually used the native store during resolution.

Part of https://github.com/astral-sh/uv/issues/15818