### PR TITLE
Add `UV_NO_SOURCES` as an environment variable

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5174,7 +5174,7 @@ pub struct ToolUpgradeArgs {
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
     /// URL, or local path sources.
-    #[arg(long, help_heading = "Resolver options")]
+    #[arg(long, env = EnvVars::UV_NO_SOURCES, help_heading = "Resolver options")]
     pub no_sources: bool,
 
     #[command(flatten)]
@@ -6070,7 +6070,7 @@ pub struct InstallerArgs {
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
     /// URL, or local path sources.
-    #[arg(long, help_heading = "Resolver options")]
+    #[arg(long, env = EnvVars::UV_NO_SOURCES, help_heading = "Resolver options")]
     pub no_sources: bool,
 }
 
@@ -6258,7 +6258,7 @@ pub struct ResolverArgs {
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
     /// URL, or local path sources.
-    #[arg(long, help_heading = "Resolver options")]
+    #[arg(long, env = EnvVars::UV_NO_SOURCES, help_heading = "Resolver options")]
     pub no_sources: bool,
 }
 
@@ -6496,7 +6496,7 @@ pub struct ResolverInstallerArgs {
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any workspace, Git,
     /// URL, or local path sources.
-    #[arg(long, help_heading = "Resolver options")]
+    #[arg(long, env = EnvVars::UV_NO_SOURCES, help_heading = "Resolver options")]
     pub no_sources: bool,
 }
 

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -41,6 +41,10 @@ impl EnvVars {
     /// comma-separated list of additional locations to search for packages.
     pub const UV_FIND_LINKS: &'static str = "UV_FIND_LINKS";
 
+    /// Equivalent to the `--no-sources` command-line argument. If set, uv will
+    /// not use the sources for any operations.
+    pub const UV_NO_SOURCES: &'static str = "UV_NO_SOURCES";
+
     /// Equivalent to the `--cache-dir` command-line argument. If set, uv will use this
     /// directory for caching instead of the default cache directory.
     pub const UV_CACHE_DIR: &'static str = "UV_CACHE_DIR";

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -10484,10 +10484,12 @@ fn directory_and_group() -> Result<()> {
     Ok(())
 }
 
-/// Regression test that we don't discover workspaces with `--no-sources`.
+/// Regression test that we don't discover workspaces with `--no-sources` or the UV_NO_SOURCES
+/// environment variable.
 ///
 /// We have a workspace dependency shadowing a PyPI package and using this package's version to
-/// check that by default we respect workspace package, but with `--no-sources`, we ignore them.
+/// check that by default we respect workspace package, but with `--no-sources` or `UV_NO_SOURCES=true`,
+/// we ignore them.
 #[test]
 fn no_sources_workspace_discovery() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -10587,6 +10589,67 @@ fn no_sources_workspace_discovery() -> Result<()> {
      + anyio==2.0.0 (from file://[TEMP_DIR]/anyio)
      ~ foo==1.0.0 (from file://[TEMP_DIR]/)
     "###
+    );
+
+    // Test with UV_NO_SOURCES=true environment variable (should behave same as flag)
+    uv_snapshot!(context.filters(), context.pip_install()
+    .arg("--upgrade")
+    .arg(".")
+    .env("UV_NO_SOURCES", "true"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     - anyio==2.0.0 (from file://[TEMP_DIR]/anyio)
+     + anyio==4.3.0
+     ~ foo==1.0.0 (from file://[TEMP_DIR]/)
+    "###
+    );
+
+    // Test UV_NO_SOURCES=false doesn't activate no-sources
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--upgrade")
+        .arg(".")
+        .env("UV_NO_SOURCES", "false"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     - anyio==4.3.0
+     + anyio==2.0.0 (from file://[TEMP_DIR]/anyio)
+     ~ foo==1.0.0 (from file://[TEMP_DIR]/)
+    "###
+    );
+
+    // Test that CLI flag overrides env var
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--upgrade")
+        .arg("--no-sources")
+        .arg(".")
+        .env("UV_NO_SOURCES", "False"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 2 packages in [TIME]
+    Uninstalled 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     - anyio==2.0.0 (from file://[TEMP_DIR]/anyio)
+     + anyio==4.3.0
+     ~ foo==1.0.0 (from file://[TEMP_DIR]/)
+    "
     );
 
     Ok(())

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -261,6 +261,11 @@ skip isolation when building source distributions.
 Equivalent to the `--no-build-package` command line argument. If set, uv will
 not build source distributions for the given space-delimited list of packages.
 
+### `UV_NO_SOURCES`
+
+Equivalent to the `--no-sources` command-line argument. If set, uv will
+Ignore the `tool.uv.sources` table when resolving dependencies.
+
 ### `UV_NO_CACHE`
 
 Equivalent to the `--no-cache` command-line argument. If set, uv will not use the


### PR DESCRIPTION
## Summary

This is an enhancement that makes the cli flag `--no-sources` an environment variable - "UV_NO_SOURCES"

Why is this a relevant change? 

When working across different environments, in our case remote vs local, we often have our packages hosted in a artifact registry but when developing locally we build our packages from github.  This results in us using the uv.tool.sources table quite a bit however this then also forces us to use `--no-sources` for all our remote work. 

This change enables us to set an environment variable once and to never have to type --no-sources after every uv run command again.

## Test Plan

Expanded on the current --no-sources tests, to test when UV_NO_SOURCES=true/false the behaviour is the same as the flag. Additionally ensured that the cli overrides the env variable.
