### PR TITLE
Make `uv cache clean` parallel process safe

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -9,9 +9,8 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 use tracing::debug;
 
-pub use archive::ArchiveId;
 use uv_cache_info::Timestamp;
-use uv_fs::{LockedFile, cachedir, directories};
+use uv_fs::{LockedFile, Simplified, cachedir, directories};
 use uv_normalize::PackageName;
 use uv_pypi_types::ResolutionMetadata;
 
@@ -22,6 +21,7 @@ use crate::removal::Remover;
 pub use crate::removal::{Removal, rm_rf};
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
+pub use archive::ArchiveId;
 
 mod archive;
 mod by_timestamp;
@@ -135,6 +135,8 @@ impl Deref for CacheShard {
 }
 
 /// The main cache abstraction.
+///
+/// While the cache is active, it holds a read (shared) lock that prevents cache cleaning
 #[derive(Debug, Clone)]
 pub struct Cache {
     /// The cache directory.
@@ -146,6 +148,9 @@ pub struct Cache {
     /// Included to ensure that the temporary directory exists for the length of the operation, but
     /// is dropped at the end as appropriate.
     temp_dir: Option<Arc<tempfile::TempDir>>,
+    /// Ensure that `uv cache` operations don't remove items from the cache that are used by another
+    /// uv process.
+    lock_file: Option<Arc<LockedFile>>,
 }
 
 impl Cache {
@@ -155,6 +160,7 @@ impl Cache {
             root: root.into(),
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: None,
+            lock_file: None,
         }
     }
 
@@ -165,6 +171,7 @@ impl Cache {
             root: temp_dir.path().to_path_buf(),
             refresh: Refresh::None(Timestamp::now()),
             temp_dir: Some(Arc::new(temp_dir)),
+            lock_file: None,
         })
     }
 
@@ -172,6 +179,34 @@ impl Cache {
     #[must_use]
     pub fn with_refresh(self, refresh: Refresh) -> Self {
         Self { refresh, ..self }
+    }
+
+    /// Acquire a lock that allows removing entries from the cache.
+    pub fn with_exclusive_lock(self) -> Result<Self, io::Error> {
+        let Self {
+            root,
+            refresh,
+            temp_dir,
+            lock_file,
+        } = self;
+
+        // Release the existing lock, avoid deadlocks from a cloned cache.
+        if let Some(lock_file) = lock_file {
+            drop(
+                Arc::try_unwrap(lock_file).expect(
+                    "cloning the cache before acquiring an exclusive lock causes a deadlock",
+                ),
+            );
+        }
+        let lock_file =
+            LockedFile::acquire_blocking(root.join(".lock"), root.simplified_display())?;
+
+        Ok(Self {
+            root,
+            refresh,
+            temp_dir,
+            lock_file: Some(Arc::new(lock_file)),
+        })
     }
 
     /// Return the root of the cache.
@@ -359,8 +394,13 @@ impl Cache {
                 .join(".git"),
         )?;
 
+        // Block cache removal operations from interfering.
+        let lock_file =
+            LockedFile::acquire_shared_blocking(root.join(".lock"), root.simplified_display())?;
+
         Ok(Self {
             root: std::path::absolute(root)?,
+            lock_file: Some(Arc::new(lock_file)),
             ..self
         })
     }
@@ -407,6 +447,7 @@ impl Cache {
             if entry.file_name() == "CACHEDIR.TAG"
                 || entry.file_name() == ".gitignore"
                 || entry.file_name() == ".git"
+                || entry.file_name() == ".lock"
             {
                 continue;
             }

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -37,9 +37,10 @@ pub(crate) fn cache_clean(
         let num_paths = walkdir::WalkDir::new(cache.root()).into_iter().count();
         let reporter = CleaningDirectoryReporter::new(printer, num_paths);
 
+        let root = cache.root().to_path_buf();
         cache
             .clear(Box::new(reporter))
-            .with_context(|| format!("Failed to clear cache at: {}", cache.root().user_display()))?
+            .with_context(|| format!("Failed to clear cache at: {}", root.user_display()))?
     } else {
         let reporter = CleaningPackageReporter::new(printer, packages.len());
         let mut summary = Removal::default();

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -14,7 +14,7 @@ use crate::printer::Printer;
 /// Clear the cache, removing all entries or those linked to specific packages.
 pub(crate) fn cache_clean(
     packages: &[PackageName],
-    cache: &Cache,
+    cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     if !cache.root().exists() {
@@ -25,6 +25,7 @@ pub(crate) fn cache_clean(
         )?;
         return Ok(ExitStatus::Success);
     }
+    let cache = cache.with_exclusive_lock()?;
 
     let summary = if packages.is_empty() {
         writeln!(

--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -10,7 +10,7 @@ use crate::commands::{ExitStatus, human_readable_bytes};
 use crate::printer::Printer;
 
 /// Prune all unreachable objects from the cache.
-pub(crate) fn cache_prune(ci: bool, cache: &Cache, printer: Printer) -> Result<ExitStatus> {
+pub(crate) fn cache_prune(ci: bool, cache: Cache, printer: Printer) -> Result<ExitStatus> {
     if !cache.root().exists() {
         writeln!(
             printer.stderr(),
@@ -19,6 +19,7 @@ pub(crate) fn cache_prune(ci: bool, cache: &Cache, printer: Printer) -> Result<E
         )?;
         return Ok(ExitStatus::Success);
     }
+    let cache = cache.with_exclusive_lock()?;
 
     writeln!(
         printer.stderr(),
@@ -29,7 +30,7 @@ pub(crate) fn cache_prune(ci: bool, cache: &Cache, printer: Printer) -> Result<E
     let mut summary = Removal::default();
 
     // Prune the source distribution cache, which is tightly coupled to the builder crate.
-    summary += uv_distribution::prune(cache)
+    summary += uv_distribution::prune(&cache)
         .with_context(|| format!("Failed to prune cache at: {}", cache.root().user_display()))?;
 
     // Prune the remaining cache buckets.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -104,7 +104,7 @@ pub(crate) async fn run(
     python_downloads: PythonDownloads,
     installer_metadata: bool,
     concurrency: Concurrency,
-    cache: &Cache,
+    cache: Cache,
     printer: Printer,
     env_file: EnvFile,
     preview: Preview,
@@ -244,7 +244,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 no_sync,
                 no_config,
                 active.map_or(Some(false), Some),
-                cache,
+                &cache,
                 DryRun::Disabled,
                 printer,
                 preview,
@@ -281,7 +281,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     Box::new(SummaryResolveLogger)
                 },
                 concurrency,
-                cache,
+                &cache,
                 &workspace_cache,
                 printer,
                 preview,
@@ -328,7 +328,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 },
                 installer_metadata,
                 concurrency,
-                cache,
+                &cache,
                 workspace_cache.clone(),
                 DryRun::Disabled,
                 printer,
@@ -382,7 +382,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     no_sync,
                     no_config,
                     active.map_or(Some(false), Some),
-                    cache,
+                    &cache,
                     DryRun::Disabled,
                     printer,
                     preview,
@@ -437,7 +437,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     },
                     installer_metadata,
                     concurrency,
-                    cache,
+                    &cache,
                     workspace_cache.clone(),
                     DryRun::Disabled,
                     printer,
@@ -468,7 +468,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     no_sync,
                     no_config,
                     active.map_or(Some(false), Some),
-                    cache,
+                    &cache,
                     printer,
                     preview,
                 )
@@ -656,7 +656,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     python_preference,
                     python_downloads,
                     &client_builder,
-                    cache,
+                    &cache,
                     Some(&download_reporter),
                     install_mirrors.python_install_mirror.as_deref(),
                     install_mirrors.pypy_install_mirror.as_deref(),
@@ -705,7 +705,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     no_sync,
                     no_config,
                     active,
-                    cache,
+                    &cache,
                     DryRun::Disabled,
                     printer,
                     preview,
@@ -758,7 +758,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                         Box::new(SummaryResolveLogger)
                     },
                     concurrency,
-                    cache,
+                    &cache,
                     &workspace_cache,
                     printer,
                     preview,
@@ -846,7 +846,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     },
                     installer_metadata,
                     concurrency,
-                    cache,
+                    &cache,
                     workspace_cache.clone(),
                     DryRun::Disabled,
                     printer,
@@ -896,7 +896,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     python_preference,
                     python_downloads,
                     &client_builder,
-                    cache,
+                    &cache,
                     Some(&download_reporter),
                     install_mirrors.python_install_mirror.as_deref(),
                     install_mirrors.pypy_install_mirror.as_deref(),
@@ -1002,7 +1002,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 },
                 installer_metadata,
                 concurrency,
-                cache,
+                &cache,
                 printer,
                 preview,
             )
@@ -1308,6 +1308,9 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
     if interpreter.is_virtualenv() {
         process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
     }
+
+    // Unblock cache removal operations.
+    drop(cache);
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -386,6 +386,9 @@ pub(crate) async fn run(
         args.iter().map(|arg| arg.to_string_lossy()).join(" ")
     );
 
+    // Unblock cache removal operations.
+    drop(cache);
+
     let handle = match process.spawn() {
         Ok(handle) => Ok(handle),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1010,13 +1010,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         })
         | Commands::Clean(args) => {
             show_settings!(args);
-            commands::cache_clean(&args.package, &cache, printer)
+            commands::cache_clean(&args.package, cache, printer)
         }
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Prune(args),
         }) => {
             show_settings!(args);
-            commands::cache_prune(args.ci, &cache, printer)
+            commands::cache_prune(args.ci, cache, printer)
         }
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Dir,
@@ -1836,7 +1836,7 @@ async fn run_project(
                 globals.python_downloads,
                 globals.installer_metadata,
                 globals.concurrency,
-                &cache,
+                cache,
                 printer,
                 args.env_file,
                 globals.preview,

--- a/crates/uv/tests/it/cache_clean.rs
+++ b/crates/uv/tests/it/cache_clean.rs
@@ -19,16 +19,18 @@ fn clean_all() -> Result<()> {
         .assert()
         .success();
 
-    uv_snapshot!(context.with_filtered_counts().filters(), context.clean().arg("--verbose"), @r###"
+    uv_snapshot!(context.with_filtered_counts().filters(), context.clean().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     Ok(())
 }
@@ -73,16 +75,18 @@ fn clean_package_pypi() -> Result<()> {
         ])
         .collect();
 
-    uv_snapshot!(&filters, context.clean().arg("--verbose").arg("iniconfig"), @r###"
+    uv_snapshot!(&filters, context.clean().arg("--verbose").arg("iniconfig"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     // Assert that the `.rkyv` file is removed for `iniconfig`.
     assert!(
@@ -91,16 +95,18 @@ fn clean_package_pypi() -> Result<()> {
     );
 
     // Running `uv cache prune` should have no effect.
-    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     Ok(())
 }
@@ -148,16 +154,18 @@ fn clean_package_index() -> Result<()> {
         ])
         .collect();
 
-    uv_snapshot!(&filters, context.clean().arg("--verbose").arg("iniconfig"), @r###"
+    uv_snapshot!(&filters, context.clean().arg("--verbose").arg("iniconfig"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     // Assert that the `.rkyv` file is removed for `iniconfig`.
     assert!(

--- a/crates/uv/tests/it/cache_clean.rs
+++ b/crates/uv/tests/it/cache_clean.rs
@@ -28,8 +28,8 @@ fn clean_all() -> Result<()> {
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Acquired lock for `[CACHE_DIR]/`
     Clearing cache at: [CACHE_DIR]/
-    Removed [N] files ([SIZE])
     DEBUG Released lock at `[CACHE_DIR]/.lock`
+    Removed [N] files ([SIZE])
     ");
 
     Ok(())

--- a/crates/uv/tests/it/cache_prune.rs
+++ b/crates/uv/tests/it/cache_prune.rs
@@ -29,16 +29,18 @@ fn prune_no_op() -> Result<()> {
         .chain(std::iter::once((r"Removed \d+ files", "Removed [N] files")))
         .collect();
 
-    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     Ok(())
 }
@@ -68,17 +70,19 @@ fn prune_stale_directory() -> Result<()> {
         .chain(std::iter::once((r"Removed \d+ files", "Removed [N] files")))
         .collect();
 
-    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache bucket: [CACHE_DIR]/simple-v4
     Removed 1 directory
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     Ok(())
 }
@@ -128,18 +132,20 @@ fn prune_cached_env() {
         ])
         .collect();
 
-    uv_snapshot!(filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache environment: [CACHE_DIR]/environments-v2/[ENTRY]
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 }
 
 /// `cache prune` should remove any stale symlink from the cache.
@@ -173,17 +179,19 @@ fn prune_stale_symlink() -> Result<()> {
         ])
         .collect();
 
-    uv_snapshot!(filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed 44 files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     Ok(())
 }
@@ -340,18 +348,20 @@ fn prune_stale_revision() -> Result<()> {
         .collect();
 
     // Pruning should remove the unused revision.
-    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r###"
+    uv_snapshot!(&filters, context.prune().arg("--verbose"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired lock for `[CACHE_DIR]/`
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling source revision: [CACHE_DIR]/sdists-v9/[ENTRY]
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
-    "###);
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
+    ");
 
     // Uninstall and reinstall the package. We should use the cached version.
     uv_snapshot!(&filters, context

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -17704,6 +17704,7 @@ fn lock_explicit_default_index() -> Result<()> {
 
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Acquired shared lock for `[CACHE_DIR]/`
     DEBUG Found workspace root: `[TEMP_DIR]/`
     DEBUG Adding root workspace member: `[TEMP_DIR]/`
     DEBUG No Python version file found in workspace: [TEMP_DIR]/
@@ -17728,6 +17729,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG No compatible version found for: project
       × No solution found when resolving dependencies:
       ╰─▶ Because anyio was not found in the package registry and your project depends on anyio, we can conclude that your project's requirements are unsatisfiable.
+    DEBUG Released lock at `[CACHE_DIR]/.lock`
     "#);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();


### PR DESCRIPTION
Currently, `uv cache clean` and `uv cache prune` can cause crashes in other uv processes running in parallel by removing their in-use files.

We can solve this by using a shared (read) lock on the cache directory, while the `uv cache` operations use an exclusive (write) lock. The drawback is that this is always one extra lock, and that we assume that all platforms support shared locks.

Once Rust 1.89 fulfills our N-2 policy, we can add support for these methods in fs_err and switch to https://doc.rust-lang.org/std/fs/struct.File.html#platform-specific-behavior-2.

**Test Plan**

Open one terminal, run:

```
uv venv -c -p 3.13
UV_CACHE_DIR=cache uv cache clean
UV_CACHE_DIR=cache uv pip install numpy==2.0.0
```

Open another terminal, run:

```
UV_CACHE_DIR=cache uv cache clean
```

Fixes #15704
Part of #13883