### PR TITLE
Re-add `triton` as a torch backend package

### DIFF
--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -313,7 +313,10 @@ impl TorchStrategy {
                         | "torchserve"
                         | "torchtext"
                         | "torchvision"
+                        | "triton"
                         | "pytorch-triton"
+                        | "pytorch-triton-rocm"
+                        | "pytorch-triton-xpu"
                 )
             }
             TorchSource::Pyx => {
@@ -336,7 +339,10 @@ impl TorchStrategy {
                         | "torchserve"
                         | "torchtext"
                         | "torchvision"
+                        | "triton"
                         | "pytorch-triton"
+                        | "pytorch-triton-rocm"
+                        | "pytorch-triton-xpu"
                 )
             }
         }


### PR DESCRIPTION
## Summary

This accidentally regressed in https://github.com/astral-sh/uv/pull/15769/files#diff-fcd4a516243929cdb086b7b79af9865a6ed432a0386765b0436392edc17a5a4eL260.
