### PR TITLE
Add instructions for publishing to Cloudsmith

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -1,16 +1,15 @@
 ---
 title: Using uv in GitLab CI/CD
-description:
-  A guide to using uv in GitLab CI/CD, including installation, setting up Python, installing
-  dependencies, and more.
+description: A guide to using uv in GitLab CI/CD, including installation, setting up Python,
+  installing dependencies, and more.
 ---
 
 # Using uv in GitLab CI/CD
 
 ## Using the uv image
 
-Astral provides [Docker images](docker.md#available-images) with uv preinstalled. Select a variant
-that is suitable for your workflow.
+Astral provides [Docker images](docker.md#available-images) with uv preinstalled.
+Select a variant that is suitable for your workflow.
 
 ```yaml title="gitlab-ci.yml"
 variables:
@@ -60,9 +59,8 @@ uv-install:
 See the [GitLab caching documentation](https://docs.gitlab.com/ee/ci/caching/) for more details on
 configuring caching.
 
-Using `uv cache prune --ci` at the end of the job is recommended to reduce cache size. See the
-[uv cache documentation](../../concepts/cache.md#caching-in-continuous-integration) for more
-details.
+Using `uv cache prune --ci` at the end of the job is recommended to reduce cache size. See the [uv
+cache documentation](../../concepts/cache.md#caching-in-continuous-integration) for more details.
 
 ## Using `uv pip`
 
@@ -70,18 +68,19 @@ If using the `uv pip` interface instead of the uv project interface, uv requires
 environment by default. To allow installing packages into the system environment, use the `--system`
 flag on all uv invocations or set the `UV_SYSTEM_PYTHON` variable.
 
-The `UV_SYSTEM_PYTHON` variable can be defined in at different scopes. You can read more about how
-[variables and their precedence works in GitLab here](https://docs.gitlab.com/ee/ci/variables/)
+The `UV_SYSTEM_PYTHON` variable can be defined in at different scopes. You can read more about
+how [variables and their precedence works in GitLab here](https://docs.gitlab.com/ee/ci/variables/)
 
 Opt-in for the entire workflow by defining it at the top level:
 
 ```yaml title="gitlab-ci.yml"
 variables:
   UV_SYSTEM_PYTHON: 1
+
 # [...]
 ```
 
 To opt-out again, the `--no-system` flag can be used in any uv invocation.
 
-When persisting the cache, you may want to use `requirements.txt` or `pyproject.toml` as your cache
-key files instead of `uv.lock`.
+When persisting the cache, you may want to use `requirements.txt` or `pyproject.toml` as
+your cache key files instead of `uv.lock`.


### PR DESCRIPTION
## Summary
Add instructions for publishing to Cloudsmith into [documentation](https://docs.astral.sh/uv/guides/integration/alternative-indexes/).

Example to push and pull artifacts into Cloudsmith using 'uv': https://docs.cloudsmith.com/formats/python-repository#uv-support

Related Issue: [#15948](https://github.com/astral-sh/uv/issues/15948)

## Test Plan
I ran the documentation locally to confirm it works