### PR TITLE
Retain the cache lock and temporary caches during `uv run` and `uvx`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1309,9 +1309,6 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
         process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
     }
 
-    // Unblock cache removal operations.
-    drop(cache);
-
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -386,9 +386,6 @@ pub(crate) async fn run(
         args.iter().map(|arg| arg.to_string_lossy()).join(" ")
     );
 
-    // Unblock cache removal operations.
-    drop(cache);
-
     let handle = match process.spawn() {
         Ok(handle) => Ok(handle),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
We're seeing reports of a regression from https://github.com/astral-sh/uv/pull/15888 where `--no-cache` causes `uv run` and `uvx` to fail to spawn a command.

The intent of this code was to allow destructive cache operations _after_ we'd finished setting up the environment. However, it's unclear to me that it's safe to run `uv cache clean` during a `uv run` operation (e.g., `uv run --script` uses an environment in the cache) and, more importantly, we cannot drop non-persistent caches (e.g., from `--no-cache`) as they include the environment we're spawning the command in.

Alternative to #15977 which retains release of the lock — we may want to consider that approach still but this regression needs to be resolved quickly. 

Closes https://github.com/astral-sh/uv/issues/15989
Closes https://github.com/astral-sh/uv/issues/15987
Closes https://github.com/astral-sh/uv/issues/15967