### PR TITLE
Switch default indentation to 2 spaces in `pyproject.toml`

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -1580,7 +1580,7 @@ fn reformat_array_multiline(deps: &mut Array) {
         indentation_prefix = (!decor_prefix.is_empty()).then_some(decor_prefix.to_string());
     }
 
-    let indentation_prefix_str = format!("\n{}", indentation_prefix.as_deref().unwrap_or("    "));
+    let indentation_prefix_str = format!("\n{}", indentation_prefix.as_deref().unwrap_or("  "));
 
     for item in deps.iter_mut() {
         let decor = item.decor_mut();
@@ -1610,7 +1610,7 @@ fn reformat_array_multiline(deps: &mut Array) {
                 match comment.comment_type {
                     CommentType::OwnLine => {
                         let indentation_prefix_str =
-                            format!("\n{}", indentation_prefix.as_deref().unwrap_or("    "));
+                            format!("\n{}", indentation_prefix.as_deref().unwrap_or("  "));
                         rv.push_str(&indentation_prefix_str);
                     }
                     CommentType::EndOfLine => {

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -62,7 +62,7 @@ fn add_registry() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -212,8 +212,8 @@ fn add_git() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
-            "uv-public-pypackage",
+          "anyio==3.7.0",
+          "uv-public-pypackage",
         ]
 
         [tool.uv.sources]
@@ -344,7 +344,7 @@ fn add_git_private_source() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-private-pypackage",
+          "uv-private-pypackage",
         ]
 
         [tool.uv.sources]
@@ -442,7 +442,7 @@ fn add_git_private_raw() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-private-pypackage @ git+https://***@github.com/astral-test/uv-private-pypackage",
+          "uv-private-pypackage @ git+https://***@github.com/astral-test/uv-private-pypackage",
         ]
         "#
         );
@@ -724,8 +724,8 @@ fn add_git_raw() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
-            "uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@0.0.1",
+          "anyio==3.7.0",
+          "uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@0.0.1",
         ]
         "###
         );
@@ -1016,7 +1016,7 @@ fn add_unnamed() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-public-pypackage",
+          "uv-public-pypackage",
         ]
 
         [tool.uv.sources]
@@ -1114,7 +1114,7 @@ fn add_remove_dev() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -1321,7 +1321,7 @@ fn add_remove_optional() -> Result<()> {
 
         [project.optional-dependencies]
         io = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -1526,7 +1526,7 @@ fn add_remove_inline_optional() -> Result<()> {
         optional-dependencies = { io = [
             "anyio==3.7.0",
         ], types = [
-            "typing-extensions>=4.10.0",
+          "typing-extensions>=4.10.0",
         ] }
         "###
         );
@@ -1667,7 +1667,7 @@ fn add_remove_workspace() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child2",
+          "child2",
         ]
 
         [build-system]
@@ -1862,7 +1862,7 @@ fn update_existing_dev() -> Result<()> {
 
         [tool.uv]
         dev-dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
 
         [dependency-groups]
@@ -1922,7 +1922,7 @@ fn add_existing_dev() -> Result<()> {
 
         [tool.uv]
         dev-dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -1979,7 +1979,7 @@ fn update_existing_dev_group() -> Result<()> {
 
         [tool.uv]
         dev-dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -2038,7 +2038,7 @@ fn add_existing_dev_group() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -2286,7 +2286,7 @@ fn add_workspace_editable() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child2",
+          "child2",
         ]
 
         [build-system]
@@ -2329,7 +2329,7 @@ fn add_workspace_editable() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child2",
+          "child2",
         ]
 
         [build-system]
@@ -2462,7 +2462,7 @@ fn add_workspace_path() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child",
+          "child",
         ]
 
         [tool.uv.workspace]
@@ -2588,12 +2588,12 @@ fn add_path_implicit_workspace() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child",
+          "child",
         ]
 
         [tool.uv.workspace]
         members = [
-            "packages/child",
+          "packages/child",
         ]
 
         [tool.uv.sources]
@@ -2715,7 +2715,7 @@ fn add_path_no_workspace() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "child",
+          "child",
         ]
 
         [tool.uv.sources]
@@ -2829,7 +2829,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "dependency",
+          "dependency",
         ]
 
         [tool.uv.sources]
@@ -2937,7 +2937,7 @@ fn update() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security]==2.31.0",
+          "requests[security]==2.31.0",
         ]
         "###
         );
@@ -2969,8 +2969,8 @@ fn update() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security]==2.31.0",
-            "requests[socks,use-chardet-on-py3]>=2.31.0 ; python_full_version >= '3.8'",
+          "requests[security]==2.31.0",
+          "requests[socks,use-chardet-on-py3]>=2.31.0 ; python_full_version >= '3.8'",
         ]
         "###
         );
@@ -3004,8 +3004,8 @@ fn update() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security]==2.31.0",
-            "requests[socks,use-chardet-on-py3]>=2.31.0 ; python_full_version >= '3.8'",
+          "requests[security]==2.31.0",
+          "requests[socks,use-chardet-on-py3]>=2.31.0 ; python_full_version >= '3.8'",
         ]
 
         [tool.uv.sources]
@@ -3207,8 +3207,8 @@ fn add_update_marker() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.8"
         dependencies = [
-            "requests>=2.0,<2.29 ; python_full_version < '3.11'",
-            "requests>=2.30; python_version >= '3.11'",
+          "requests>=2.0,<2.29 ; python_full_version < '3.11'",
+          "requests>=2.30; python_version >= '3.11'",
         ]
         "###
         );
@@ -3238,8 +3238,8 @@ fn add_update_marker() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.8"
         dependencies = [
-            "requests>=2.0,<2.20 ; python_full_version < '3.11'",
-            "requests>=2.30; python_version >= '3.11'",
+          "requests>=2.0,<2.20 ; python_full_version < '3.11'",
+          "requests>=2.30; python_version >= '3.11'",
         ]
         "###
         );
@@ -3269,9 +3269,9 @@ fn add_update_marker() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.8"
         dependencies = [
-            "requests>=2.0,<2.20 ; python_full_version < '3.11'",
-            "requests>=2.30; python_version >= '3.11'",
-            "requests>=2.31 ; python_full_version >= '3.12' and sys_platform == 'win32'",
+          "requests>=2.0,<2.20 ; python_full_version < '3.11'",
+          "requests>=2.30; python_version >= '3.11'",
+          "requests>=2.31 ; python_full_version >= '3.12' and sys_platform == 'win32'",
         ]
         "###
         );
@@ -3302,10 +3302,10 @@ fn add_update_marker() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.8"
         dependencies = [
-            "requests>=2.0,<2.20 ; python_full_version < '3.11'",
-            "requests>=2.10 ; sys_platform == 'win32'",
-            "requests>=2.30; python_version >= '3.11'",
-            "requests>=2.31 ; python_full_version >= '3.12' and sys_platform == 'win32'",
+          "requests>=2.0,<2.20 ; python_full_version < '3.11'",
+          "requests>=2.10 ; sys_platform == 'win32'",
+          "requests>=2.30; python_version >= '3.11'",
+          "requests>=2.31 ; python_full_version >= '3.12' and sys_platform == 'win32'",
         ]
         "###
         );
@@ -3359,7 +3359,7 @@ fn update_source_replace_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security] @ https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+          "requests[security] @ https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
         ]
     "#})?;
 
@@ -3392,7 +3392,7 @@ fn update_source_replace_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security]",
+          "requests[security]",
         ]
 
         [tool.uv.sources]
@@ -3428,7 +3428,7 @@ fn update_source_replace_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests[security]",
+          "requests[security]",
         ]
 
         [tool.uv.sources]
@@ -3454,7 +3454,7 @@ fn add_non_normalized_source() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-public-pypackage"
+          "uv-public-pypackage"
         ]
 
         [tool.uv.sources]
@@ -3485,7 +3485,7 @@ fn add_non_normalized_source() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-public-pypackage",
+          "uv-public-pypackage",
         ]
 
         [tool.uv.sources]
@@ -3671,7 +3671,7 @@ fn remove_non_normalized_source() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "uv-public-pypackage"
+          "uv-public-pypackage"
         ]
 
         [tool.uv.sources]
@@ -3776,7 +3776,7 @@ fn add_inexact() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
         "###
         );
@@ -3955,7 +3955,9 @@ fn add_preserves_indentation_in_pyproject_toml() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = ["anyio==3.7.0"]
+        dependencies = [
+            "anyio==3.7.0",
+        ]
     "#})?;
 
     uv_snapshot!(context.filters(), context.add().arg("requests==2.31.0"), @r"
@@ -4040,8 +4042,8 @@ fn add_puts_default_indentation_in_pyproject_toml_if_not_observed() -> Result<()
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
-            "requests==2.31.0",
+          "anyio==3.7.0",
+          "requests==2.31.0",
         ]
         "###
         );
@@ -4087,7 +4089,7 @@ fn add_frozen() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -4138,7 +4140,7 @@ fn add_no_sync() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
         );
@@ -4333,7 +4335,7 @@ fn add_lower_bound() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
         "###
         );
@@ -4384,7 +4386,7 @@ fn add_lower_bound_existing() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio",
+          "anyio",
         ]
         "###
         );
@@ -4434,7 +4436,7 @@ fn add_lower_bound_raw() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio",
+          "anyio",
         ]
         "###
         );
@@ -4487,7 +4489,7 @@ fn add_lower_bound_dev() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
         "###
         );
@@ -4540,7 +4542,7 @@ fn add_lower_bound_optional() -> Result<()> {
 
         [project.optional-dependencies]
         io = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
         "###
         );
@@ -4650,7 +4652,7 @@ fn add_lower_bound_local() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "local-simple-a>=1.2.3",
+          "local-simple-a>=1.2.3",
         ]
 
         [[tool.uv.index]]
@@ -4755,7 +4757,7 @@ fn add_non_project() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
         "###
         );
@@ -4858,7 +4860,7 @@ fn add_virtual_empty() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "sortedcontainers>=2.4.0",
+          "sortedcontainers>=2.4.0",
         ]
         "#
         );
@@ -4909,8 +4911,8 @@ fn add_virtual_dependency_group() -> Result<()> {
         foo = ["sortedcontainers"]
         bar = ["iniconfig"]
         dev = [
-            "sniffio",
-            "sortedcontainers>=2.4.0",
+          "sniffio",
+          "sortedcontainers>=2.4.0",
         ]
         "#
         );
@@ -4941,11 +4943,11 @@ fn add_virtual_dependency_group() -> Result<()> {
         foo = ["sortedcontainers"]
         bar = ["iniconfig"]
         dev = [
-            "sniffio",
-            "sortedcontainers>=2.4.0",
+          "sniffio",
+          "sortedcontainers>=2.4.0",
         ]
         baz = [
-            "sortedcontainers>=2.4.0",
+          "sortedcontainers>=2.4.0",
         ]
         "#
         );
@@ -5135,7 +5137,7 @@ fn add_repeat() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
         "###
         );
@@ -5163,7 +5165,7 @@ fn add_repeat() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
         "###
         );
@@ -5224,8 +5226,8 @@ fn add_requirements_file() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio",
-            "flask==2.3.2",
+          "anyio",
+          "flask==2.3.2",
         ]
 
         [tool.uv.sources]
@@ -5317,9 +5319,9 @@ fn add_requirements_file_with_marker_flag() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio>=2.31.0 ; python_full_version == '3.11.*'",
-        "iniconfig>=2 ; python_full_version == '3.11.*' and sys_platform != 'fantasy_os'",
-        "numpy>1.9 ; python_full_version == '3.11.*' and sys_platform == 'fantasy_os'",
+      "anyio>=2.31.0 ; python_full_version == '3.11.*'",
+      "iniconfig>=2 ; python_full_version == '3.11.*' and sys_platform != 'fantasy_os'",
+      "numpy>1.9 ; python_full_version == '3.11.*' and sys_platform == 'fantasy_os'",
     ]
     "#
     );
@@ -5352,9 +5354,9 @@ fn add_requirements_file_with_marker_flag() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio>=2.31.0 ; python_full_version == '3.12.*'",
-        "iniconfig>=2 ; python_full_version == '3.12.*' and sys_platform != 'fantasy_os'",
-        "numpy>1.9 ; python_full_version == '3.12.*' and sys_platform == 'fantasy_os'",
+      "anyio>=2.31.0 ; python_full_version == '3.12.*'",
+      "iniconfig>=2 ; python_full_version == '3.12.*' and sys_platform != 'fantasy_os'",
+      "numpy>1.9 ; python_full_version == '3.12.*' and sys_platform == 'fantasy_os'",
     ]
     "#
     );
@@ -5452,8 +5454,8 @@ fn add_requirements_file_constraints() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio>=3.7.1",
-            "flask>=1.1.4",
+          "anyio>=3.7.1",
+          "flask>=1.1.4",
         ]
         "#
         );
@@ -5646,7 +5648,7 @@ fn add_group() -> Result<()> {
 
         [dependency-groups]
         test = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
     );
@@ -5677,8 +5679,8 @@ fn add_group() -> Result<()> {
 
         [dependency-groups]
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         "###
     );
@@ -5704,11 +5706,11 @@ fn add_group() -> Result<()> {
 
         [dependency-groups]
         second = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         "#
     );
@@ -5734,14 +5736,14 @@ fn add_group() -> Result<()> {
 
         [dependency-groups]
         alpha = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         second = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         "#
     );
@@ -5913,12 +5915,12 @@ fn add_group_before_commented_groups() -> Result<()> {
         [dependency-groups]
         # This is our dev group
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         # This is our test group
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
     "#})?;
 
@@ -5949,16 +5951,16 @@ fn add_group_before_commented_groups() -> Result<()> {
 
         [dependency-groups]
         alpha = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         # This is our dev group
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         # This is our test group
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         "#
     );
@@ -5982,12 +5984,12 @@ fn add_group_between_commented_groups() -> Result<()> {
         [dependency-groups]
         # This is our dev group
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         # This is our test group
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
     "#})?;
 
@@ -6019,15 +6021,15 @@ fn add_group_between_commented_groups() -> Result<()> {
         [dependency-groups]
         # This is our dev group
         dev = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         eta = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         # This is our test group
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         "#
     );
@@ -6051,11 +6053,11 @@ fn add_group_to_unsorted() -> Result<()> {
 
         [dependency-groups]
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         second = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
     "#})?;
 
@@ -6084,14 +6086,14 @@ fn add_group_to_unsorted() -> Result<()> {
 
         [dependency-groups]
         test = [
-            "anyio==3.7.0",
-            "requests>=2.31.0",
+          "anyio==3.7.0",
+          "requests>=2.31.0",
         ]
         second = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         alpha = [
-            "anyio==3.7.0",
+          "anyio==3.7.0",
         ]
         "###
     );
@@ -6309,7 +6311,7 @@ fn add_script_relative_path() -> Result<()> {
         # /// script
         # requires-python = ">=3.12"
         # dependencies = [
-        #     "project",
+        #   "project",
         # ]
         #
         # [tool.uv.sources]
@@ -6597,8 +6599,8 @@ fn add_script_without_metadata_table() -> Result<()> {
         # /// script
         # requires-python = ">=3.12"
         # dependencies = [
-        #     "requests<3",
-        #     "rich",
+        #   "requests<3",
+        #   "rich",
         # ]
         # ///
         import requests
@@ -6649,8 +6651,8 @@ fn add_script_without_metadata_table_with_shebang() -> Result<()> {
         # /// script
         # requires-python = ">=3.12"
         # dependencies = [
-        #     "requests<3",
-        #     "rich",
+        #   "requests<3",
+        #   "rich",
         # ]
         # ///
         import requests
@@ -6705,8 +6707,8 @@ fn add_script_with_metadata_table_and_shebang() -> Result<()> {
         # /// script
         # requires-python = ">=3.12"
         # dependencies = [
-        #     "requests<3",
-        #     "rich",
+        #   "requests<3",
+        #   "rich",
         # ]
         # ///
         import requests
@@ -6756,8 +6758,8 @@ fn add_script_without_metadata_table_with_docstring() -> Result<()> {
         # /// script
         # requires-python = ">=3.12"
         # dependencies = [
-        #     "requests<3",
-        #     "rich",
+        #   "requests<3",
+        #   "rich",
         # ]
         # ///
         """This is a script."""
@@ -7708,7 +7710,7 @@ fn add_include_default_groups() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "typing-extensions>=4.10.0",
+          "typing-extensions>=4.10.0",
         ]
 
         [dependency-groups]
@@ -7962,7 +7964,7 @@ fn fail_to_edit_revert_project() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
         "###
         );
@@ -8954,7 +8956,7 @@ fn add_warn_index_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "idna>=3.6",
+          "idna>=3.6",
         ]
         "###
         );
@@ -9054,7 +9056,7 @@ fn add_no_warn_index_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
         [tool.uv]
         index-url = "https://test.pypi.org/simple"
@@ -9143,7 +9145,7 @@ fn add_index() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         [tool.uv]
@@ -9221,8 +9223,8 @@ fn add_index() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
-            "jinja2>=3.1.4",
+          "iniconfig==2.0.0",
+          "jinja2>=3.1.4",
         ]
 
         [tool.uv]
@@ -9333,8 +9335,8 @@ fn add_index() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
-            "jinja2>=3.1.4",
+          "iniconfig==2.0.0",
+          "jinja2>=3.1.4",
         ]
 
         [tool.uv]
@@ -9452,9 +9454,9 @@ fn add_index() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
-            "jinja2>=3.1.4",
-            "typing-extensions>=4.12.2",
+          "iniconfig==2.0.0",
+          "jinja2>=3.1.4",
+          "typing-extensions>=4.12.2",
         ]
 
         [tool.uv]
@@ -9581,9 +9583,9 @@ fn add_index() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
-            "jinja2>=3.1.4",
-            "typing-extensions>=4.12.2",
+          "iniconfig==2.0.0",
+          "jinja2>=3.1.4",
+          "typing-extensions>=4.12.2",
         ]
 
         [tool.uv]
@@ -9728,7 +9730,7 @@ fn add_default_index_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -9800,8 +9802,8 @@ fn add_default_index_url() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
-            "typing-extensions>=4.10.0",
+          "iniconfig>=2.0.0",
+          "typing-extensions>=4.10.0",
         ]
 
         [[tool.uv.index]]
@@ -9902,7 +9904,7 @@ fn add_index_credentials() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -9996,7 +9998,7 @@ fn existing_index_credentials() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         # Set an internal index as the default, without credentials.
@@ -10089,7 +10091,7 @@ fn add_index_with_trailing_slash() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         [tool.uv]
@@ -10185,7 +10187,7 @@ fn add_index_without_trailing_slash() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         [tool.uv]
@@ -10596,7 +10598,7 @@ fn add_index_comments() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig==2.0.0",
+          "iniconfig==2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -10711,7 +10713,7 @@ fn add_self() -> Result<()> {
         [project.optional-dependencies]
         types = ["typing-extensions>=4"]
         all = [
-            "anyio[types]",
+          "anyio[types]",
         ]
 
         [tool.uv.sources]
@@ -10747,7 +10749,7 @@ fn add_self() -> Result<()> {
         [project.optional-dependencies]
         types = ["typing-extensions>=4"]
         all = [
-            "anyio[types]",
+          "anyio[types]",
         ]
 
         [tool.uv.sources]
@@ -10755,7 +10757,7 @@ fn add_self() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "anyio[types]",
+          "anyio[types]",
         ]
         "#
         );
@@ -10918,7 +10920,7 @@ fn add_direct_url_subdirectory() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "root",
+          "root",
         ]
 
         [tool.uv.sources]
@@ -11051,7 +11053,7 @@ fn add_direct_url_subdirectory_raw() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "root @ https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz#subdirectory=packages/root",
+          "root @ https://github.com/user-attachments/files/18216295/subdirectory-test.tar.gz#subdirectory=packages/root",
         ]
         "###
         );
@@ -11543,8 +11545,8 @@ fn add_no_indent() -> Result<()> {
                 version = "0.1.0"
                 requires-python = ">=3.12"
                 dependencies = [
-            "charset-normalizer>=3.3.2",
-            "sniffio==1.3.1",
+          "charset-normalizer>=3.3.2",
+          "sniffio==1.3.1",
         ]
         "###
         );
@@ -11636,8 +11638,8 @@ fn remove_all_with_comments() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            # foo
-            # bar
+          # foo
+          # bar
         ]
         "###
         );
@@ -11693,7 +11695,7 @@ fn multiple_index_cli() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "requests>=2.5.4.1",
+          "requests>=2.5.4.1",
         ]
 
         [[tool.uv.index]]
@@ -11806,7 +11808,7 @@ fn repeated_index_cli_environment_variable() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -11913,7 +11915,7 @@ fn repeated_index_cli_environment_variable_newline() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -12023,7 +12025,7 @@ fn repeated_index_cli() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -12133,7 +12135,7 @@ fn repeated_index_cli_reversed() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [[tool.uv.index]]
@@ -13375,7 +13377,7 @@ fn add_bounds() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "idna==3.6",
+      "idna==3.6",
     ]
     "#
     );
@@ -13416,7 +13418,7 @@ fn add_bounds() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio>=4.3.0,<5.0.0",
+      "anyio>=4.3.0,<5.0.0",
     ]
 
     [tool.uv]
@@ -13443,7 +13445,7 @@ fn add_bounds() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio>=4.3.0,<5.0.0",
+      "anyio>=4.3.0,<5.0.0",
     ]
 
     [tool.uv]
@@ -13474,8 +13476,8 @@ fn add_bounds() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio==4.2",
-        "idna>=3.6,<3.7",
+      "anyio==4.2",
+      "idna>=3.6,<3.7",
     ]
 
     [tool.uv]
@@ -13502,9 +13504,9 @@ fn add_bounds() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio==4.2",
-        "idna>=3.6,<3.7",
-        "sniffio>=1.3.1,<1.4.0",
+      "anyio==4.2",
+      "idna>=3.6,<3.7",
+      "sniffio>=1.3.1,<1.4.0",
     ]
 
     [tool.uv]
@@ -13556,8 +13558,8 @@ fn add_bounds_requirement_over_bounds_kind() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "anyio==4.2",
-        "idna>=3.6,<3.7",
+      "anyio==4.2",
+      "idna>=3.6,<3.7",
     ]
     "#
     );
@@ -13636,8 +13638,8 @@ fn add_path_with_existing_workspace() -> Result<()> {
 
     [tool.uv.workspace]
     members = [
-        "project",
-        "dep",
+      "project",
+      "dep",
     ]
     "#
     );
@@ -13650,7 +13652,7 @@ fn add_path_with_existing_workspace() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.sources]
@@ -13713,12 +13715,12 @@ fn add_path_with_workspace() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.workspace]
     members = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.sources]
@@ -13781,12 +13783,12 @@ fn add_path_within_workspace_defaults_to_workspace() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.workspace]
     members = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.sources]
@@ -13848,7 +13850,7 @@ fn add_path_with_no_workspace() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.workspace]
@@ -13921,7 +13923,7 @@ fn add_path_outside_workspace_no_default() -> Result<()> {
     version = "0.1.0"
     requires-python = ">=3.12"
     dependencies = [
-        "dep",
+      "dep",
     ]
 
     [tool.uv.workspace]
@@ -13979,9 +13981,9 @@ fn add_multiline_indentation() -> Result<()> {
 
         [dependency-groups]
         dev = [
-            "iniconfig>=2.0.0",
-            "ruff",
-            "typing-extensions",
+          "iniconfig>=2.0.0",
+          "ruff",
+          "typing-extensions",
         ]
         "#
         );
@@ -14039,7 +14041,7 @@ fn add_no_install_project() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "iniconfig>=2.0.0",
+          "iniconfig>=2.0.0",
         ]
 
         [build-system]

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -1358,7 +1358,7 @@ fn init_workspace() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );
@@ -1402,8 +1402,8 @@ fn init_workspace() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
-            "bar",
+          "foo",
+          "bar",
         ]
         "#
         );
@@ -1421,8 +1421,8 @@ fn init_workspace() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
-            "bar",
+          "foo",
+          "bar",
         ]
         "#,
     })?;
@@ -1455,9 +1455,9 @@ fn init_workspace() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
-            "bar",
-            "baz",
+          "foo",
+          "bar",
+          "baz",
         ]
         "#
         );
@@ -1543,7 +1543,7 @@ fn init_workspace_relative_sub_package() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );
@@ -1640,7 +1640,7 @@ fn init_workspace_outside() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );
@@ -1800,7 +1800,7 @@ fn init_isolated() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );
@@ -1966,8 +1966,8 @@ fn init_project_inside_project() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
-            "foo/bar",
+          "foo",
+          "foo/bar",
         ]
         "#
         );
@@ -2035,7 +2035,7 @@ fn init_explicit_workspace() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );
@@ -2106,7 +2106,7 @@ fn init_virtual_project() -> Result<()> {
 
         [tool.uv.workspace]
         members = [
-            "bar",
+          "bar",
         ]
         "#
         );
@@ -2150,7 +2150,7 @@ fn init_virtual_workspace() -> Result<()> {
             pyproject, @r#"
         [tool.uv.workspace]
         members = [
-            "bar",
+          "bar",
         ]
         "#
         );
@@ -2207,7 +2207,7 @@ fn init_nested_virtual_workspace() -> Result<()> {
             workspace, @r#"
         [tool.uv.workspace]
         members = [
-            "foo",
+          "foo",
         ]
         "#
         );

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -30322,7 +30322,7 @@ fn lock_trailing_slash_index_url_in_pyproject_not_index_argument() -> Result<()>
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = [
-            "anyio>=4.3.0",
+          "anyio>=4.3.0",
         ]
 
         [[tool.uv.index]]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix #5852 

Switch default `pyproject.toml` indendation from 4 spaces to 2. I've hit this problem because [pyproject-fmt](https://pyproject-fmt.readthedocs.io/en/latest/index.html) uses 2 spaces. As per the linked issue (#5009), the example in [the PyPA guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-and-requirements) also implies that. 

As far as I can tell, it would stick to 4 spaces if that's the existing indentation (as implemented in https://github.com/astral-sh/uv/issues/5009). I've change the associated test case to use a non-default indentation of 4.

I tried to go with the simplest solution, but I appreciate that it might be considered too disruptive by the maintainers. If the project prefers to go with a more configurable solution, then it's probably best to close this and start over.

## Test Plan

Update existing tests
