### PR TITLE
Respect hashes from dist-info/core-metadata in simple package index

### DIFF
--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -3318,17 +3318,35 @@ fn requirements_txt_complex_conflict_markers() -> Result<()> {
         --hash=sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f \
         --hash=sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8
         # via torch
-    torch==2.6.0 ; sys_platform == 'darwin'
+    torch==2.6.0 ; sys_platform == 'darwin' \
+        --hash=sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068 \
+        --hash=sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068
         # via
         #   project
         #   torchvision
-    torch==2.6.0+cpu ; sys_platform != 'darwin'
+    torch==2.6.0+cpu ; sys_platform != 'darwin' \
+        --hash=sha256:00132587f15194dfce61988d5ac88c755d1e2a501feef2c3f511831c76b2104f \
+        --hash=sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80 \
+        --hash=sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80 \
+        --hash=sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80 \
+        --hash=sha256:0fc88ff13b016b20f1fe3d23d03315b6e14ef5a89ba5ee23f155586c89bb6706 \
+        --hash=sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a \
+        --hash=sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a \
+        --hash=sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a
         # via
         #   project
         #   torchvision
-    torchvision==0.21.0 ; (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'
+    torchvision==0.21.0 ; (python_full_version < '3.14' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin' \
+        --hash=sha256:cac83b7239876e796d6ca40b7f6f2daf69b80373852555429607e1d3f6cd784d \
+        --hash=sha256:cac83b7239876e796d6ca40b7f6f2daf69b80373852555429607e1d3f6cd784d \
+        --hash=sha256:cac83b7239876e796d6ca40b7f6f2daf69b80373852555429607e1d3f6cd784d \
+        --hash=sha256:cac83b7239876e796d6ca40b7f6f2daf69b80373852555429607e1d3f6cd784d
         # via project
-    torchvision==0.21.0+cpu ; (python_full_version >= '3.14' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')
+    torchvision==0.21.0+cpu ; (python_full_version >= '3.14' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux') \
+        --hash=sha256:1bf60f6e955eabcf85d9f8facceea1faec25b5e92507be1af978d2951d3b9bca \
+        --hash=sha256:1bf60f6e955eabcf85d9f8facceea1faec25b5e92507be1af978d2951d3b9bca \
+        --hash=sha256:3fcf807786d83cbae4e9e07ddc52677bef9e47e6aff3b0d5502310377dc1feb3 \
+        --hash=sha256:3fcf807786d83cbae4e9e07ddc52677bef9e47e6aff3b0d5502310377dc1feb3
         # via project
     typing-extensions==4.12.2 \
         --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -29339,8 +29339,8 @@ fn lock_pytorch_local_preference() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]
@@ -29360,14 +29360,14 @@ fn lock_pytorch_local_preference() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:0fc88ff13b016b20f1fe3d23d03315b6e14ef5a89ba5ee23f155586c89bb6706", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:00132587f15194dfce61988d5ac88c755d1e2a501feef2c3f511831c76b2104f", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -14639,8 +14639,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]
@@ -14660,14 +14660,14 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:0fc88ff13b016b20f1fe3d23d03315b6e14ef5a89ba5ee23f155586c89bb6706", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:00132587f15194dfce61988d5ac88c755d1e2a501feef2c3f511831c76b2104f", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]
@@ -14698,11 +14698,11 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:d28ac83095d1df286693d57b81219b8a23c2487a8f945964a8fe175b0e28a78d", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:a70d80ee8a79337e331249b9659a4e2a4a7056501d950f59bee7a3a833833983", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
         ]
 
         [[package]]
@@ -15054,8 +15054,8 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:09942b3e6552f6c3a8400e323ae1a177bdc07c27b65c634ef0a52b3c2d137068", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]
@@ -15075,14 +15075,14 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
-            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:0fc88ff13b016b20f1fe3d23d03315b6e14ef5a89ba5ee23f155586c89bb6706", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:00132587f15194dfce61988d5ac88c755d1e2a501feef2c3f511831c76b2104f", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-linux_x86_64.whl", hash = "sha256:05d5e2f9aec5224a4e8e6d661125da8159b11e4a301cd5c0658ff8c5b7842b80", upload-time = "2025-01-29T22:50:59.085Z" },
+            { url = "https://download.pytorch.org/whl/cpu/torch-2.6.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:6846bf9fd7e4901f115814c965084a3c88575d747ae1ab098fdd300b6c58720a", upload-time = "2025-01-29T22:50:59.085Z" },
         ]
 
         [[package]]
@@ -15113,11 +15113,11 @@ fn avoids_exponential_lock_file_growth() -> Result<()> {
             { name = "typing-extensions" },
         ]
         wheels = [
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
-            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp312-cp312-win_amd64.whl", hash = "sha256:d28ac83095d1df286693d57b81219b8a23c2487a8f945964a8fe175b0e28a78d", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:a70d80ee8a79337e331249b9659a4e2a4a7056501d950f59bee7a3a833833983", upload-time = "2025-01-29T22:51:41.169Z" },
+            { url = "https://download.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:76581c0d424f2d45de443327dfe1d5e115fd5e090b553deca3c3e23fc31c8da0", upload-time = "2025-01-29T22:51:41.169Z" },
         ]
 
         [[package]]


### PR DESCRIPTION
## Summary

When a package defines a hash as a file URL fragment the hash is honoured:
```html
<a href="/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl#sha256=ac59d7d8f73f4f515c949c9583ead0cce1f230a649f6c63fea0e949f93f02ae6">torch-2.8.0+cpu-cp313-cp313-manylinux_2_28_x86_64.whl</a><br/>
```
and is recorded in `uv.lock`:
```toml
[[package]]
name = "torch"
version = "2.8.0+cpu"
source = { registry = "local" }
dependencies = [
    { name = "filelock" },
    { name = "fsspec" },
    { name = "jinja2" },
    { name = "networkx" },
    { name = "setuptools" },
    { name = "sympy" },
    { name = "typing-extensions" },
]
wheels = [
    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ac59d7d8f73f4f515c949c9583ead0cce1f230a649f6c63fea0e949f93f02ae6" },
]
```

But when defined as dist-info metadata or core metadata their hashes are ignored:
```html
<a href="/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" data-dist-info-metadata="sha256=ac59d7d8f73f4f515c949c9583ead0cce1f230a649f6c63fea0e949f93f02ae6" data-core-metadata="sha256=ac59d7d8f73f4f515c949c9583ead0cce1f230a649f6c63fea0e949f93f02ae6">torch-2.8.0+cpu-cp313-cp313-manylinux_2_28_x86_64.whl</a><br/>
```
and uv.lock is rendered without wheel hashes:
```toml
[[package]]
name = "torch"
version = "2.8.0+cpu"
source = { registry = "local" }
dependencies = [
    { name = "filelock" },
    { name = "fsspec" },
    { name = "jinja2" },
    { name = "networkx" },
    { name = "setuptools" },
    { name = "sympy" },
    { name = "typing-extensions" },
]
wheels = [
    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" },
]
```
despite hash metadata being available.

This makes uv respect hashes from `data-dist-info` & `data-core-metadata` HTML attributes.

## Test Plan

Automated test included.

Closes #16009
