### PR TITLE
Remove docs for custom GitHub caching

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -217,63 +217,8 @@ persisting the cache:
     enable-cache: true
 ```
 
-Alternatively, you can manage the cache manually with the `actions/cache` action:
-
-```yaml title="example.yml"
-jobs:
-  install_job:
-    env:
-      # Configure a constant location for the uv cache
-      UV_CACHE_DIR: /tmp/.uv-cache
-
-    steps:
-      # ... setup up Python and uv ...
-
-      - name: Restore uv cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.uv-cache
-          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-            uv-${{ runner.os }}
-
-      # ... install packages, run tests, etc ...
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci
-```
-
-The `uv cache prune --ci` command is used to reduce the size of the cache and is optimized for CI.
-Its effect on performance is dependent on the packages being installed.
-
-!!! tip
-
-    If using `uv pip`, use `requirements.txt` instead of `uv.lock` in the cache key.
-
-!!! note
-
-    [post-job-hook]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
-
-    When using non-ephemeral, self-hosted runners the default cache directory can grow unbounded.
-    In this case, it may not be optimal to share the cache between jobs. Instead, move the cache
-    inside the GitHub Workspace and remove it once the job finishes using a
-    [Post Job Hook][post-job-hook].
-
-    ```yaml
-    install_job:
-      env:
-        # Configure a relative location for the uv cache
-        UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
-    ```
-
-    Using a post job hook requires setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment
-    variable on the self-hosted runner to the path of a cleanup script such as the one shown below.
-
-    ```sh title="clean-uv-cache.sh"
-    #!/usr/bin/env sh
-    uv cache clean
-    ```
+The [documentation](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#enable-caching) also
+explains how you can control the caching e.g. what to cache and when to cache.
 
 ## Using `uv pip`
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Remove docs for custom GitHub caching

The alternative instructions confused users ([example](https://github.com/astral-sh/setup-uv/issues/589)) and did not explictily state that they only apply if `setup-uv` is not used. `setup-uv` allows full control over the cache, comes with good defaults and bugs/missing features should be discussed there.

This only applies to GitHub.

## Test Plan

N/A
