### PR TITLE
docs: installation.md add info about installing via MacPorts

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,6 +96,14 @@ uv is available in the core Homebrew packages.
 $ brew install uv
 ```
 
+### MacPorts
+
+uv is available via [MacPorts](https://ports.macports.org/port/uv/).
+
+```console
+$ sudo port install uv
+```
+
 ### WinGet
 
 uv is available via [WinGet](https://winstall.app/apps/astral-sh.uv).


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Add info about uv being available in MacPorts.

## Test Plan

<!-- How was it tested? -->

`uvx --with-requirements .\docs\requirements.txt mkdocs serve --config-file mkdocs.public.yml` worked.