### PR TITLE
Respect `--no-color` on the CLI

### DIFF
--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -89,6 +89,9 @@ impl GlobalSettings {
             color: if let Some(color_choice) = args.color {
                 // If `--color` is passed explicitly, use its value.
                 color_choice
+            } else if args.no_color {
+                // If `--no-color` is passed explicitly, disable color output.
+                ColorChoice::Never
             } else if std::env::var_os(EnvVars::NO_COLOR)
                 .filter(|v| !v.is_empty())
                 .is_some()


### PR DESCRIPTION
## Summary

This argument has always existed for compatibility, but apparently we don't respect it. I assume it was unintentionally dropped during a refactor.

Closes https://github.com/astral-sh/uv/issues/15950.
