### PR TITLE
Short overview of project creation options

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -6,6 +6,14 @@ When creating projects, uv supports two basic templates: [**applications**](#app
 [**libraries**](#libraries). By default, uv will create a project for an application. The `--lib`
 flag can be used to create a project for a library instead.
 
+| Option                | When to Use                                                                  | Project Layout                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `--bare`              | You only want a minimal `pyproject.toml` without README, pin file, or source | Just `pyproject.toml` (can combine with `--lib` or `--build-backend`)           |
+| *(default)* / `--app` | You’re building a simple application (script, CLI, web server)               | Flat layout with `main.py`, `README.md`, `.python-version`, `pyproject.toml`    |
+| `--package`           | You want an installable packaged app (e.g. CLI on PyPI, tests, entry points) | `src/` layout with package module, `pyproject.toml` including build system      |
+| `--lib`               | You’re creating a reusable library to distribute on PyPI                     | Like `--package`, but with `py.typed` and intended for import by other projects |
+
+
 ## Target directory
 
 uv will create a project in the working directory, or, in a target directory by providing a name,


### PR DESCRIPTION
Added a short overview for project creation options

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Whenever I use `uv init`, it have to scroll through the documentation to determine the correct option to use. This PR adds a short overview table at the top of the document to provide quick advice for users like me.

## Test Plan

*(Just a change in the documentation.)