### PR TITLE
Error when built wheel is for the wrong platform

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -131,7 +131,7 @@ mod resolver {
     );
 
     static TAGS: LazyLock<Tags> = LazyLock::new(|| {
-        Tags::from_env(&PLATFORM, (3, 11), "cpython", (3, 11), false, false).unwrap()
+        Tags::from_env(&PLATFORM, (3, 11), "cpython", (3, 11), false, false, false).unwrap()
     });
 
     pub(crate) async fn resolve(

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -6,11 +6,12 @@ use zip::result::ZipError;
 
 use crate::metadata::MetadataError;
 use uv_client::WrappedReqwestError;
-use uv_distribution_filename::WheelFilenameError;
+use uv_distribution_filename::{WheelFilename, WheelFilenameError};
 use uv_distribution_types::{InstalledDist, InstalledDistError, IsBuildBackendError};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifiers};
+use uv_platform_tags::Platform;
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 use uv_redacted::DisplaySafeUrl;
 use uv_types::AnyErrorBuild;
@@ -73,6 +74,35 @@ pub enum Error {
     WheelFilenameVersionMismatch {
         filename: Version,
         metadata: Version,
+    },
+    /// This shouldn't happen, it's a bug in the build backend.
+    #[error(
+        "The wheel `{}` built from source distribution is not compatible with the current Python {}.{} on {} {}",
+        filename,
+        python_version.0,
+        python_version.1,
+        python_platform.os(),
+        python_platform.arch(),
+    )]
+    BuiltWheelIncompatibleHostPlatform {
+        filename: WheelFilename,
+        python_platform: Platform,
+        python_version: (u8, u8),
+    },
+    /// This may happen when trying to cross-install native dependencies without their build backend
+    /// being aware that the target is a cross-install.
+    #[error(
+        "The wheel `{}` built from source distribution is not compatible with the target Python {}.{} on {} {}. Consider using `--no-build` to disable building wheels.",
+        filename,
+        python_version.0,
+        python_version.1,
+        python_platform.os(),
+        python_platform.arch(),
+    )]
+    BuiltWheelIncompatibleTargetPlatform {
+        filename: WheelFilename,
+        python_platform: Platform,
+        python_version: (u8, u8),
     },
     #[error("Failed to parse metadata from built wheel")]
     Metadata(#[from] uv_pypi_types::MetadataError),

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -252,6 +252,7 @@ impl Interpreter {
                 self.implementation_tuple(),
                 self.manylinux_compatible,
                 self.gil_disabled,
+                false,
             )?;
             self.tags.set(tags).expect("tags should not be set");
         }

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -52,7 +52,7 @@ use uv_workspace::WorkspaceCache;
 use uv_workspace::pyproject::ExtraBuildDependencies;
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
-use crate::commands::pip::{operations, resolution_environment};
+use crate::commands::pip::{operations, resolution_markers, resolution_tags};
 use crate::commands::{ExitStatus, OutputWriter, diagnostics};
 use crate::printer::Printer;
 
@@ -370,8 +370,16 @@ pub(crate) async fn pip_compile(
             ResolverEnvironment::universal(environments.into_markers()),
         )
     } else {
-        let (tags, marker_env) =
-            resolution_environment(python_version, python_platform, &interpreter)?;
+        let tags = resolution_tags(
+            python_version.as_ref(),
+            python_platform.as_ref(),
+            &interpreter,
+        )?;
+        let marker_env = resolution_markers(
+            python_version.as_ref(),
+            python_platform.as_ref(),
+            &interpreter,
+        );
         (Some(tags), ResolverEnvironment::specific(marker_env))
     };
 

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -42,82 +42,33 @@ pub(crate) fn resolution_tags<'env>(
     python_platform: Option<&TargetTriple>,
     interpreter: &'env Interpreter,
 ) -> Result<Cow<'env, Tags>, TagsError> {
-    Ok(match (python_platform, python_version.as_ref()) {
-        (Some(python_platform), Some(python_version)) => Cow::Owned(Tags::from_env(
-            &python_platform.platform(),
-            (python_version.major(), python_version.minor()),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
-            python_platform.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (Some(python_platform), None) => Cow::Owned(Tags::from_env(
-            &python_platform.platform(),
-            interpreter.python_tuple(),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
-            python_platform.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (None, Some(python_version)) => Cow::Owned(Tags::from_env(
-            interpreter.platform(),
-            (python_version.major(), python_version.minor()),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
-            interpreter.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (None, None) => Cow::Borrowed(interpreter.tags()?),
-    })
-}
+    if python_platform.is_none() && python_version.is_none() {
+        return Ok(Cow::Borrowed(interpreter.tags()?));
+    }
 
-/// Determine the tags, markers, and interpreter to use for resolution.
-pub(crate) fn resolution_environment(
-    python_version: Option<PythonVersion>,
-    python_platform: Option<TargetTriple>,
-    interpreter: &Interpreter,
-) -> Result<(Cow<'_, Tags>, ResolverMarkerEnvironment), TagsError> {
-    let tags = match (python_platform, python_version.as_ref()) {
-        (Some(python_platform), Some(python_version)) => Cow::Owned(Tags::from_env(
+    let (platform, manylinux_compatible) = if let Some(python_platform) = python_platform {
+        (
             &python_platform.platform(),
-            (python_version.major(), python_version.minor()),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
             python_platform.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (Some(python_platform), None) => Cow::Owned(Tags::from_env(
-            &python_platform.platform(),
-            interpreter.python_tuple(),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
-            python_platform.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (None, Some(python_version)) => Cow::Owned(Tags::from_env(
-            interpreter.platform(),
-            (python_version.major(), python_version.minor()),
-            interpreter.implementation_name(),
-            interpreter.implementation_tuple(),
-            interpreter.manylinux_compatible(),
-            interpreter.gil_disabled(),
-        )?),
-        (None, None) => Cow::Borrowed(interpreter.tags()?),
+        )
+    } else {
+        (interpreter.platform(), interpreter.manylinux_compatible())
     };
 
-    // Apply the platform tags to the markers.
-    let markers = match (python_platform, python_version) {
-        (Some(python_platform), Some(python_version)) => ResolverMarkerEnvironment::from(
-            python_version.markers(&python_platform.markers(interpreter.markers())),
-        ),
-        (Some(python_platform), None) => {
-            ResolverMarkerEnvironment::from(python_platform.markers(interpreter.markers()))
-        }
-        (None, Some(python_version)) => {
-            ResolverMarkerEnvironment::from(python_version.markers(interpreter.markers()))
-        }
-        (None, None) => interpreter.resolver_marker_environment(),
+    let version_tuple = if let Some(python_version) = python_version {
+        (python_version.major(), python_version.minor())
+    } else {
+        interpreter.python_tuple()
     };
 
-    Ok((tags, markers))
+    let tags = Tags::from_env(
+        platform,
+        version_tuple,
+        interpreter.implementation_name(),
+        interpreter.implementation_tuple(),
+        manylinux_compatible,
+        interpreter.gil_disabled(),
+        true,
+    )?;
+    Ok(Cow::Owned(tags))
 }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -7,7 +7,7 @@ use assert_fs::prelude::*;
 use flate2::write::GzEncoder;
 use fs_err as fs;
 use fs_err::File;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use predicates::prelude::predicate;
 use url::Url;
 use wiremock::{
@@ -12906,6 +12906,170 @@ fn pip_install_no_sources_editable_to_registry_switch() -> Result<()> {
     Audited 1 package in [TIME]
     "
     );
+
+    Ok(())
+}
+
+/// Use a wheel that is only compatible with Python 3.13 with Python 3.12 or Python 3.13 to simulate
+/// a wheel build for the wrong platform in a cross-install scenario. Ensure that we catch this case
+/// and error accordingly. Additionally, we ensure that for a build dependency, which builds and
+/// runs on the host, not the target, we accept wheel platforms for the host.
+#[test]
+fn build_backend_wrong_wheel_platform() -> Result<()> {
+    let context = TestContext::new_with_versions(&["3.12", "3.13"]);
+
+    let mut filters = context.filters();
+    filters.push((r" on [^ ]+ [^ ]+\.", " on [ARCH] [OS]."));
+    filters.push((r" on [^ ]+ [^ ]+$", " on [ARCH] [OS]"));
+
+    let py313 = context.temp_dir.child("child");
+    py313.create_dir_all()?;
+    let py313_pyproject_toml = py313.child("pyproject.toml");
+    py313_pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "py313"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling"]
+        backend-path = ["."]
+        build-backend = "build_backend"
+    "#})?;
+
+    let build_backend = py313.child("build_backend.py");
+    build_backend.write_str(indoc! {r#"
+        import os
+
+        from hatchling.build import *
+        from hatchling.build import build_wheel as build_wheel_original
+
+
+        def build_wheel(
+            wheel_directory: str,
+            config_settings: "Mapping[Any, Any] | None" = None,
+            metadata_directory: "str | None" = None,
+        ) -> str:
+            filename = build_wheel_original(
+                wheel_directory, config_settings, metadata_directory
+            )
+            py313_wheel = "py313-0.1.0-py313-none-any.whl"
+            os.rename(
+                os.path.join(wheel_directory, filename),
+                os.path.join(wheel_directory, py313_wheel),
+            )
+            return py313_wheel
+    "#})?;
+    py313.child("src/py313/__init__.py").touch()?;
+
+    // Test the matrix of
+    // (compatible host, incompatible host) x (compatible target, incompatible target)
+
+    // A Python 3.13 host with a 3.13 implicit target works.
+    context.venv().arg("-p").arg("3.13").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("./child"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + py313==0.1.0 (from file://[TEMP_DIR]/child)
+    ");
+
+    // A Python 3.13 host with a 3.12 explicit target fails.
+    context.venv().arg("-p").arg("3.13").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("--python-version").arg("3.12").arg("./child"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to build `py313 @ file://[TEMP_DIR]/child`
+      ╰─▶ The wheel `py313-0.1.0-py313-none-any.whl` built from source distribution is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
+    ");
+
+    // A python 3.12 host with a 3.13 explicit target works.
+    context.venv().arg("-p").arg("3.13").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("--python-version").arg("3.13").arg("./child"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ py313==0.1.0 (from file://[TEMP_DIR]/child)
+    ");
+
+    // A Python 3.13 host with a 3.12 explicit target fails.
+    context.venv().arg("-p").arg("3.13").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("--python-version").arg("3.12").arg("./child"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to build `py313 @ file://[TEMP_DIR]/child`
+      ╰─▶ The wheel `py313-0.1.0-py313-none-any.whl` built from source distribution is not compatible with the target Python 3.12 on [ARCH] [OS]. Consider using `--no-build` to disable building wheels.
+    ");
+
+    // Create a project that will resolve to a non-latest version of `anyio`
+    let parent = &context.temp_dir;
+    let pyproject_toml = parent.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling", "py313 @ {py313}"]
+        build-backend = "hatchling.build"
+        "#,
+        py313 = py313.path().display()
+    })?;
+    context
+        .temp_dir
+        .child("src")
+        .child("parent")
+        .child("__init__.py")
+        .touch()?;
+
+    // A build host of 3.13 works.
+    context.venv().arg("-p").arg("3.13").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("--python-version").arg("3.12").arg("."), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + parent==0.1.0 (from file://[TEMP_DIR]/)
+    ");
+
+    // A build host of 3.12 fails.
+    context.venv().arg("-p").arg("3.12").assert().success();
+    uv_snapshot!(filters, context.pip_install().arg("--python-version").arg("3.12").arg("."), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to build `parent @ file://[TEMP_DIR]/`
+      ├─▶ Failed to install requirements from `build-system.requires`
+      ├─▶ Failed to build `py313 @ file://[TEMP_DIR]/child`
+      ╰─▶ The wheel `py313-0.1.0-py313-none-any.whl` built from source distribution is not compatible with the current Python 3.12 on [ARCH] [OS]
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
Error when a built wheel is for the wrong platform. This can happen especially when using `--python-platform` or `--python-version` with `uv pip install`.

Fixes #16019

Ready for review but I want to make some more testing before merging.
