### PR TITLE
Avoid rejecting already-installed URL distributions with `--no-sources`

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{Level, debug, info, instrument, trace, warn};
 
-use uv_configuration::{Constraints, Overrides, SourceStrategy};
+use uv_configuration::{Constraints, Overrides};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, DistributionMetadata,
@@ -201,7 +201,6 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             build_context.git(),
             build_context.capabilities(),
             build_context.locations(),
-            build_context.sources(),
             provider,
             installed_packages,
         )
@@ -225,7 +224,6 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
         git: &GitResolver,
         capabilities: &IndexCapabilities,
         locations: &IndexLocations,
-        source_strategy: SourceStrategy,
         provider: Provider,
         installed_packages: InstalledPackages,
     ) -> Result<Self, ResolveError> {
@@ -233,7 +231,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             index: index.clone(),
             git: git.clone(),
             capabilities: capabilities.clone(),
-            selector: CandidateSelector::for_resolution(&options, &manifest, &env, source_strategy),
+            selector: CandidateSelector::for_resolution(&options, &manifest, &env),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, &env, git, options.dependency_mode),
             indexes: Indexes::from_manifest(&manifest, &env, options.dependency_mode),


### PR DESCRIPTION
## Summary

This PR removes a guard that was accidentally included in https://github.com/astral-sh/uv/pull/15234/files#diff-6be6d80fe4821c47b70a372260f55e73b8da8182b8dcad7525d5cd3eb584532b. I meant to remove that logic before merging.

Closes https://github.com/astral-sh/uv/issues/16068.
