### PR TITLE
Fix renovate typo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,7 +89,7 @@
     {
       groupName: "pubgrub",
       matchManagers: ["cargo"],
-      matchDepName: ["pubgrub", "version-ranges"],
+      matchDepNames: ["pubgrub", "version-ranges"],
       description: "version-ranges and pubgrub are in the same Git repository",
     },
     {


### PR DESCRIPTION
Ref https://github.com/astral-sh/uv/issues/16097

In my test fork, both the version with and without the typo worked in grouping pubgrub and version-ranges.