### PR TITLE
Fix typo in `_CONDA_ROOT` docs

### DIFF
--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -92,7 +92,11 @@ pub fn attribute_env_vars_metadata(_attr: TokenStream, input: TokenStream) -> To
         .filter_map(|item| match item {
             ImplItem::Const(item) if !is_hidden(&item.attrs) => {
                 let doc = get_doc_comment(&item.attrs);
-                let syn::Expr::Lit(syn::ExprLit { lit:syn::Lit::Str(lit), .. }) = &item.expr else {
+                let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit),
+                    ..
+                }) = &item.expr
+                else {
                     return None;
                 };
                 let name = lit.value();

--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -91,8 +91,11 @@ pub fn attribute_env_vars_metadata(_attr: TokenStream, input: TokenStream) -> To
         .iter()
         .filter_map(|item| match item {
             ImplItem::Const(item) if !is_hidden(&item.attrs) => {
-                let name = item.ident.to_string();
                 let doc = get_doc_comment(&item.attrs);
+                let syn::Expr::Lit(syn::ExprLit { lit:syn::Lit::Str(lit), .. }) = &item.expr else {
+                    return None;
+                };
+                let name = lit.value();
                 Some((name, doc))
             }
             ImplItem::Fn(item) if !is_hidden(&item.attrs) => {

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -635,10 +635,6 @@ Used to determine the name of the active Conda environment.
 
 Used to detect the path of an active Conda environment.
 
-### `CONDA_ROOT`
-
-Used to determine the root install path of Conda.
-
 ### `FISH_VERSION`
 
 Used to detect Fish shell usage.
@@ -888,4 +884,8 @@ Used to determine which `.zshenv` to use when Zsh is being used.
 ### `ZSH_VERSION`
 
 Used to detect Zsh shell usage.
+
+### `_CONDA_ROOT`
+
+Used to determine the root install path of Conda.
 


### PR DESCRIPTION
All other references are correct, just slipped through in the actual docs.