### PR TITLE
Emit a message on `cache clean` and `prune` when lock is held

### DIFF
--- a/crates/uv/src/commands/cache_prune.rs
+++ b/crates/uv/src/commands/cache_prune.rs
@@ -26,17 +26,19 @@ pub(crate) fn cache_prune(
         return Ok(ExitStatus::Success);
     }
 
-    let cache = if force {
-        // If `--force` is used, attempt to acquire the exclusive lock but do not block.
-        match cache.with_exclusive_lock_no_wait() {
-            Ok(cache) => cache,
-            Err(cache) => {
-                debug!("Cache is currently in use, proceeding due to `--force`");
-                cache
-            }
+    let cache = match cache.with_exclusive_lock_no_wait() {
+        Ok(cache) => cache,
+        Err(cache) if force => {
+            debug!("Cache is currently in use, proceeding due to `--force`");
+            cache
         }
-    } else {
-        cache.with_exclusive_lock()?
+        Err(cache) => {
+            writeln!(
+                printer.stderr(),
+                "Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)"
+            )?;
+            cache.with_exclusive_lock()?
+        }
     };
 
     writeln!(


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/16112

```
❯ cargo run -q cache clean
Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)
```

Otherwise, `-v` is required to see we're waiting on a lock.

I'd rather do this than elevate the exclusive lock log message to something more verbose because this allows us to use a more specific message as appropriate for the situation. We also previously reduced the verbosity of arbitrary locks, e.g., see https://github.com/astral-sh/uv/issues/7489