### PR TITLE
Use walltime for codspeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2859,7 +2859,7 @@ jobs:
         uses: CodSpeedHQ/action@6b43a0cd438f6ca5ad26f9ed03ed159ed2df7da9 # v4.1.1
         with:
           run: cargo codspeed run
-          mode: instrumentation
+          mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   benchmarks-instrumented:
@@ -2899,5 +2899,5 @@ jobs:
         uses: CodSpeedHQ/action@6b43a0cd438f6ca5ad26f9ed03ed159ed2df7da9 # v4.1.1
         with:
           run: cargo codspeed run
-          mode: instrumentation
+          mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
The docs imply that this works with Rust now?
