### PR TITLE
Publish Python 3.14 Docker Images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -184,33 +184,33 @@ jobs:
           - buildpack-deps:trixie,trixie,debian
           - debian:bookworm-slim,bookworm-slim
           - buildpack-deps:bookworm,bookworm
-          - python:3.14-rc-alpine,python3.14-rc-alpine
+          - python:3.14-alpine,python3.14-alpine
           - python:3.13-alpine,python3.13-alpine
           - python:3.12-alpine,python3.12-alpine
           - python:3.11-alpine,python3.11-alpine
           - python:3.10-alpine,python3.10-alpine
           - python:3.9-alpine,python3.9-alpine
           - python:3.8-alpine,python3.8-alpine
-          - python:3.14-rc-trixie,python3.14-rc-trixie
+          - python:3.14-trixie,python3.14-trixie
           - python:3.13-trixie,python3.13-trixie
           - python:3.12-trixie,python3.12-trixie
           - python:3.11-trixie,python3.11-trixie
           - python:3.10-trixie,python3.10-trixie
           - python:3.9-trixie,python3.9-trixie
-          - python:3.14-rc-slim-trixie,python3.14-rc-trixie-slim
+          - python:3.14-slim-trixie,python3.14-trixie-slim
           - python:3.13-slim-trixie,python3.13-trixie-slim
           - python:3.12-slim-trixie,python3.12-trixie-slim
           - python:3.11-slim-trixie,python3.11-trixie-slim
           - python:3.10-slim-trixie,python3.10-trixie-slim
           - python:3.9-slim-trixie,python3.9-trixie-slim
-          - python:3.14-rc-bookworm,python3.14-rc-bookworm
+          - python:3.14-bookworm,python3.14-bookworm
           - python:3.13-bookworm,python3.13-bookworm
           - python:3.12-bookworm,python3.12-bookworm
           - python:3.11-bookworm,python3.11-bookworm
           - python:3.10-bookworm,python3.10-bookworm
           - python:3.9-bookworm,python3.9-bookworm
           - python:3.8-bookworm,python3.8-bookworm
-          - python:3.14-rc-slim-bookworm,python3.14-rc-bookworm-slim
+          - python:3.14-slim-bookworm,python3.14-bookworm-slim
           - python:3.13-slim-bookworm,python3.13-bookworm-slim
           - python:3.12-slim-bookworm,python3.12-bookworm-slim
           - python:3.11-slim-bookworm,python3.11-bookworm-slim

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -54,7 +54,7 @@ And the following derived images are available:
 - Based on `buildpack-deps:bookworm`:
     - `ghcr.io/astral-sh/uv:bookworm`
 - Based on `python3.x-alpine`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-alpine`
+    - `ghcr.io/astral-sh/uv:python3.14-alpine`
     - `ghcr.io/astral-sh/uv:python3.13-alpine`
     - `ghcr.io/astral-sh/uv:python3.12-alpine`
     - `ghcr.io/astral-sh/uv:python3.11-alpine`
@@ -62,21 +62,21 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.9-alpine`
     - `ghcr.io/astral-sh/uv:python3.8-alpine`
 - Based on `python3.x-trixie`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie`
+    - `ghcr.io/astral-sh/uv:python3.14-trixie`
     - `ghcr.io/astral-sh/uv:python3.13-trixie`
     - `ghcr.io/astral-sh/uv:python3.12-trixie`
     - `ghcr.io/astral-sh/uv:python3.11-trixie`
     - `ghcr.io/astral-sh/uv:python3.10-trixie`
     - `ghcr.io/astral-sh/uv:python3.9-trixie`
 - Based on `python3.x-slim-trixie`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-trixie-slim`
+    - `ghcr.io/astral-sh/uv:python3.14-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.13-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.12-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.11-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.10-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.9-trixie-slim`
 - Based on `python3.x-bookworm`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.14-bookworm`
     - `ghcr.io/astral-sh/uv:python3.13-bookworm`
     - `ghcr.io/astral-sh/uv:python3.12-bookworm`
     - `ghcr.io/astral-sh/uv:python3.11-bookworm`
@@ -84,7 +84,7 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.9-bookworm`
     - `ghcr.io/astral-sh/uv:python3.8-bookworm`
 - Based on `python3.x-slim-bookworm`:
-    - `ghcr.io/astral-sh/uv:python3.14-rc-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.14-bookworm-slim`
     - `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`
     - `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`
     - `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`


### PR DESCRIPTION
## Summary

Tentative PR to drop the `-rc` suffix from the published images.

Do not merge this yet until the formal release [upstream](https://hub.docker.com/_/python) :) 
