### PR TITLE
Use correct tag comment for Vampire/setup-wsl v6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1694,7 +1694,7 @@ jobs:
           name: uv-linux-musl-${{ github.sha }}
 
       - name: "Setup WSL"
-        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
           distribution: Ubuntu-22.04
 


### PR DESCRIPTION
Renovate complained that it was the wrong tag.

For the actual CI, it's a comment change only.
