### PR TITLE
Add missing fields to the Cargo package manifests

### DIFF
--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -2,6 +2,12 @@
 name = "uv-auth"
 version = "0.0.1"
 edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -2,6 +2,12 @@
 name = "uv-client"
 version = "0.0.1"
 edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -2,6 +2,12 @@
 name = "uv-keyring"
 version = "0.0.1"
 edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -3,6 +3,13 @@ name = "uv-scripts"
 version = "0.0.1"
 edition = { workspace = true }
 description = "Parse PEP 723-style Python scripts."
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
 
 [lib]
 doctest = false

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -3,6 +3,12 @@ name = "uv-shell"
 version = "0.0.1"
 edition = { workspace = true }
 description = "Utilities for detecting and manipulating shell environments"
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Hey devs, great tool as always, you're doing amazing work. 

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds the following fields to the `[package]` table of `Cargo.toml` files where they were missing:
```toml
rust-version = { workspace = true }
homepage = { workspace = true }
documentation = { workspace = true }
repository = { workspace = true }
authors = { workspace = true }
license = { workspace = true }
```

Most crates already had these fields, this just aligns the rest for consistency.

This also resolves the warnings from `cargo-deny` when using `uv` crates as dependencies in Pixi.
## Test Plan
No tests needed, this only updates metadata.
