### PR TITLE
 Log Python choice in `uv init`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -693,7 +693,7 @@ async fn determine_requires_python(
             None
         };
 
-        debug!("Using Python version `{requires_python}` from system interpreter");
+        debug!("Using Python version `{requires_python}` from default interpreter");
 
         Ok((requires_python, python_pin))
     }


### PR DESCRIPTION
Example output:

```
$ uv-debug init foo -v
  DEBUG uv 0.9.0+6 (https://github.com/astral-sh/uv/commit/d3324baf68823262f14d8e518b4292ed8f343c61 2025-10-08)
  DEBUG Acquired shared lock for `/home/konsti/.cache/uv`
  DEBUG No Python version file found in ancestors of working directory: /home/konsti/projects/foo
  DEBUG Checking for Python environment at: `foo/.venv`
  DEBUG Searching for default Python interpreter in managed installations or search path
  DEBUG Searching for managed installations at `/home/konsti/.local/share/uv/python`
  DEBUG Found managed installation `cpython-3.14.0-linux-x86_64-gnu`
  DEBUG Found `cpython-3.14.0-linux-x86_64-gnu` at `/home/konsti/.local/share/uv/python/cpython-3.14.0-linux-x86_64-gnu/bin/python3.14` (managed installations)
  DEBUG Using Python version `>=3.14` from default interpreter
  DEBUG `git rev-parse --is-inside-work-tree` failed but didn't contain `not a git repository` in stderr for `/home/konsti/projects/foo`
  DEBUG No Python version file found in ancestors of working directory: /home/konsti/projects/foo
  DEBUG Writing Python versions to `/home/konsti/projects/foo/.python-version`
  Initialized project `foo` at `/home/konsti/projects/foo`
  DEBUG Released lock at `/home/konsti/.cache/uv/.lock`
```

First commit is refactoring, second commit is the actual change.