### PR TITLE
Move 'Scripts' section down

### DIFF
--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -17,16 +17,6 @@ Installing and managing Python itself.
 
 See the [guide on installing Python](../guides/install-python.md) to get started.
 
-## Scripts
-
-Executing standalone Python scripts, e.g., `example.py`.
-
-- `uv run`: Run a script.
-- `uv add --script`: Add a dependency to a script.
-- `uv remove --script`: Remove a dependency from a script.
-
-See the [guide on running scripts](../guides/scripts.md) to get started.
-
 ## Projects
 
 Creating and working on Python projects, i.e., with a `pyproject.toml`.
@@ -42,6 +32,16 @@ Creating and working on Python projects, i.e., with a `pyproject.toml`.
 - `uv publish`: Publish the project to a package index.
 
 See the [guide on projects](../guides/projects.md) to get started.
+
+## Scripts
+
+Executing standalone Python scripts, e.g., `example.py`.
+
+- `uv run`: Run a script.
+- `uv add --script`: Add a dependency to a script.
+- `uv remove --script`: Remove a dependency from a script.
+
+See the [guide on running scripts](../guides/scripts.md) to get started.
 
 ## Tools
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Opening this as more of a discussion. A friend of mine (who is not super familiar with programming) started using `uv` and for his project he is using inline metadata in every script, presumably because this feature is mentioned in the documentation first.

Personally I do not think you should use this, except in niche use cases (like downloading a single script from the internet). Mainly because VSCode does not support it, whereas a regular project's `.venv` is automatically recognized. I would propose moving the discussion about projects earlier in the documentation, to indicate that this is the recommended path in most use cases.

## Test Plan

Not relevant.
