### PR TITLE
Replace `fs_err` alias

### DIFF
--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -4,7 +4,6 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use fs_err as fs;
 use fs_err::File;
 use tracing::{instrument, trace};
 
@@ -65,7 +64,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
     let wheel_file_path = wheel
         .as_ref()
         .join(format!("{dist_info_prefix}.dist-info/WHEEL"));
-    let wheel_text = fs::read_to_string(wheel_file_path)?;
+    let wheel_text = fs_err::read_to_string(wheel_file_path)?;
     let lib_kind = WheelFile::parse(&wheel_text)?.lib_kind();
 
     // > 1.c If Root-Is-Purelib == ‘true’, unpack archive into purelib (site-packages).

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
 
-use fs_err as fs;
 use std::sync::{LazyLock, Mutex};
 use tracing::trace;
 use uv_fs::write_atomic_sync;
@@ -20,7 +19,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
     // Read the RECORD file.
     let record = {
         let record_path = dist_info.join("RECORD");
-        let mut record_file = match fs::File::open(&record_path) {
+        let mut record_file = match fs_err::File::open(&record_path) {
             Ok(record_file) => record_file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 return Err(Error::MissingRecord(record_path));
@@ -66,7 +65,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
             }
         }
 
-        match fs::remove_file(&path) {
+        match fs_err::remove_file(&path) {
             Ok(()) => {
                 trace!("Removed file: {}", path.display());
                 file_count += 1;
@@ -119,7 +118,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
 
             // Try to read from the directory. If it doesn't exist, assume we deleted it in a
             // previous iteration.
-            let mut read_dir = match fs::read_dir(path) {
+            let mut read_dir = match fs_err::read_dir(path) {
                 Ok(read_dir) => read_dir,
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => break,
                 Err(err) => return Err(err.into()),
@@ -130,7 +129,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
                 break;
             }
 
-            fs::remove_dir(path)?;
+            fs_err::remove_dir(path)?;
 
             trace!("Removed directory: {}", path.display());
             dir_count += 1;
@@ -256,7 +255,7 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
     let mut file_count = 0usize;
 
     // Find the target line in the `.egg-link` file.
-    let contents = fs::read_to_string(egg_link)?;
+    let contents = fs_err::read_to_string(egg_link)?;
     let target_line = contents
         .lines()
         .find_map(|line| {
@@ -268,7 +267,7 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
     // This comes from `pkg_resources.normalize_path`
     let target_line = normcase(target_line);
 
-    match fs::remove_file(egg_link) {
+    match fs_err::remove_file(egg_link) {
         Ok(()) => {
             trace!("Removed file: {}", egg_link.display());
             file_count += 1;
@@ -287,7 +286,7 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
     // is modified).
     let _guard = EASY_INSTALL_PTH.lock().unwrap();
 
-    let content = fs::read_to_string(&easy_install)?;
+    let content = fs_err::read_to_string(&easy_install)?;
     let mut new_content = String::with_capacity(content.len());
     let mut removed = false;
 

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -6,7 +6,6 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use console::Term;
-use fs_err as fs;
 use fs_err::File;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
@@ -145,7 +144,7 @@ pub(crate) fn create(
                         .canonicalize()
                         .unwrap_or_else(|_| location.to_path_buf());
                     remove_virtualenv(&location)?;
-                    fs::create_dir_all(&location)?;
+                    fs_err::create_dir_all(&location)?;
                 }
                 OnExisting::Fail => return err,
                 // If not a virtual environment, fail without prompting.
@@ -161,7 +160,7 @@ pub(crate) fn create(
                                 .canonicalize()
                                 .unwrap_or_else(|_| location.to_path_buf());
                             remove_virtualenv(&location)?;
-                            fs::create_dir_all(&location)?;
+                            fs_err::create_dir_all(&location)?;
                         }
                         Some(false) => return err,
                         // When we don't have a TTY, warn that the behavior will change in the future
@@ -184,7 +183,7 @@ pub(crate) fn create(
             )));
         }
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            fs::create_dir_all(location)?;
+            fs_err::create_dir_all(location)?;
         }
         Err(err) => return Err(Error::Io(err)),
     }
@@ -205,7 +204,7 @@ pub(crate) fn create(
     cachedir::ensure_tag(&location)?;
 
     // Create a `.gitignore` file to ignore all files in the venv.
-    fs::write(location.join(".gitignore"), "*")?;
+    fs_err::write(location.join(".gitignore"), "*")?;
 
     let mut using_minor_version_link = false;
     let executable_target = if upgradeable && interpreter.is_standalone() {
@@ -254,7 +253,7 @@ pub(crate) fn create(
     let python_home = python_home.as_path();
 
     // Different names for the python interpreter
-    fs::create_dir_all(&scripts)?;
+    fs_err::create_dir_all(&scripts)?;
     let executable = scripts.join(format!("python{EXE_SUFFIX}"));
 
     #[cfg(unix)]
@@ -479,7 +478,7 @@ pub(crate) fn create(
             )
             .replace("{{ PATH_SEP }}", path_sep)
             .replace("{{ RELATIVE_SITE_PACKAGES }}", &relative_site_packages);
-        fs::write(scripts.join(name), activator)?;
+        fs_err::write(scripts.join(name), activator)?;
     }
 
     let mut pyvenv_cfg_data: Vec<(String, String)> = vec![
@@ -537,7 +536,7 @@ pub(crate) fn create(
 
     // Construct the path to the `site-packages` directory.
     let site_packages = location.join(&interpreter.virtualenv().purelib);
-    fs::create_dir_all(&site_packages)?;
+    fs_err::create_dir_all(&site_packages)?;
 
     // If necessary, create a symlink from `lib64` to `lib`.
     // See: https://github.com/python/cpython/blob/b228655c227b2ca298a8ffac44d14ce3d22f6faa/Lib/venv/__init__.py#L135C11-L135C16
@@ -556,8 +555,8 @@ pub(crate) fn create(
     }
 
     // Populate `site-packages` with a `_virtualenv.py` file.
-    fs::write(site_packages.join("_virtualenv.py"), VIRTUALENV_PATCH)?;
-    fs::write(site_packages.join("_virtualenv.pth"), "import _virtualenv")?;
+    fs_err::write(site_packages.join("_virtualenv.py"), VIRTUALENV_PATCH)?;
+    fs_err::write(site_packages.join("_virtualenv.pth"), "import _virtualenv")?;
 
     Ok(VirtualEnvironment {
         scheme: Scheme {
@@ -611,7 +610,7 @@ pub fn remove_virtualenv(location: &Path) -> Result<(), Error> {
 
     // We defer removal of the `pyvenv.cfg` until the end, so if we fail to remove the environment,
     // uv can still identify it as a Python virtual environment that can be deleted.
-    for entry in fs::read_dir(location)? {
+    for entry in fs_err::read_dir(location)? {
         let entry = entry?;
         let path = entry.path();
         if path == location.join("pyvenv.cfg") {
@@ -620,11 +619,11 @@ pub fn remove_virtualenv(location: &Path) -> Result<(), Error> {
         if path.is_dir() {
             fs_err::remove_dir_all(&path)?;
         } else {
-            fs::remove_file(&path)?;
+            fs_err::remove_file(&path)?;
         }
     }
 
-    match fs::remove_file(location.join("pyvenv.cfg")) {
+    match fs_err::remove_file(location.join("pyvenv.cfg")) {
         Ok(()) => {}
         Err(err) if err.kind() == io::ErrorKind::NotFound => {}
         Err(err) => return Err(err.into()),


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
This pr started with me trying to replace `fs` with `fs_err` in a couple places (#14985). As @konstin pointed out, `fs` was actually just an alias for `fs_err`. This pr removes that alias so the code is easier to reason about when only looking at the isolated pieces of code.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Green pipeline should suffice
<!-- How was it tested? -->
