### PR TITLE
Pin a uv version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.9.0"
 
       - name: "rustfmt"
         run: cargo fmt --all --check
@@ -229,6 +231,9 @@ jobs:
         run: rustup show
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.9.0"
+
       - name: "Install required Python versions"
         run: uv python install
 
@@ -278,6 +283,9 @@ jobs:
         run: rustup show
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.9.0"
+
       - name: "Install required Python versions"
         run: uv python install
 
@@ -317,6 +325,9 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "$Env:UV_WORKSPACE" -Recurse
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.9.0"
+
       - name: "Install required Python versions"
         run: uv python install
 
@@ -479,6 +490,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          version: "0.9.0"
+
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - name: "Add SSH key"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}


### PR DESCRIPTION
To reduce rate-limiting by avoiding a latest version fetch
