### PR TITLE
Ignore pre-release Python versions when a patch version is requested

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2690,6 +2690,9 @@ impl VersionRequest {
                     interpreter.python_minor(),
                     interpreter.python_patch(),
                 ) == (*major, *minor, *patch)
+                    // When a patch version is included, we treat it as a request for a stable
+                    // release
+                    && interpreter.python_version().pre().is_none()
                     && variant.matches_interpreter(interpreter)
             }
             Self::Range(specifiers, variant) => {
@@ -2814,6 +2817,9 @@ impl VersionRequest {
             }
             Self::MajorMinorPatch(self_major, self_minor, self_patch, _) => {
                 (*self_major, *self_minor, *self_patch) == (major, minor, patch)
+                    // When a patch version is included, we treat it as a request for a stable
+                    // release
+                    && prerelease.is_none()
             }
             Self::Range(specifiers, _) => specifiers.contains(
                 &Version::new([u64::from(major), u64::from(minor), u64::from(patch)])


### PR DESCRIPTION
I think this is ostensively breaking, though I think the impact would be small given this will go out in 0.9.1 and should only affect people using pre-release Python versions.

When `3.14.0` is requested (opposed to `3.14`), we treat this as a request for a final / stable version and ignore pre-releases.

I think this is a fairly clean way to allow users to explicitly request the stable version.

Closes https://github.com/astral-sh/uv/issues/16175
Follows #16208 