### PR TITLE
Move parsing concurrency env variable to EnvironmentOptions

### DIFF
--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -117,15 +117,21 @@ impl GlobalSettings {
             },
             network_settings,
             concurrency: Concurrency {
-                downloads: env(env::CONCURRENT_DOWNLOADS)
+                downloads: environment
+                    .concurrency
+                    .downloads
                     .combine(workspace.and_then(|workspace| workspace.globals.concurrent_downloads))
                     .map(NonZeroUsize::get)
                     .unwrap_or(Concurrency::DEFAULT_DOWNLOADS),
-                builds: env(env::CONCURRENT_BUILDS)
+                builds: environment
+                    .concurrency
+                    .builds
                     .combine(workspace.and_then(|workspace| workspace.globals.concurrent_builds))
                     .map(NonZeroUsize::get)
                     .unwrap_or_else(Concurrency::threads),
-                installs: env(env::CONCURRENT_INSTALLS)
+                installs: environment
+                    .concurrency
+                    .installs
                     .combine(workspace.and_then(|workspace| workspace.globals.concurrent_installs))
                     .map(NonZeroUsize::get)
                     .unwrap_or_else(Concurrency::threads),
@@ -3744,16 +3750,6 @@ impl AuthLoginSettings {
 // Environment variables that are not exposed as CLI arguments.
 mod env {
     use uv_static::EnvVars;
-
-    pub(super) const CONCURRENT_DOWNLOADS: (&str, &str) =
-        (EnvVars::UV_CONCURRENT_DOWNLOADS, "a non-zero integer");
-
-    pub(super) const CONCURRENT_BUILDS: (&str, &str) =
-        (EnvVars::UV_CONCURRENT_BUILDS, "a non-zero integer");
-
-    pub(super) const CONCURRENT_INSTALLS: (&str, &str) =
-        (EnvVars::UV_CONCURRENT_INSTALLS, "a non-zero integer");
-
     pub(super) const UV_PYTHON_DOWNLOADS: (&str, &str) = (
         EnvVars::UV_PYTHON_DOWNLOADS,
         "one of 'auto', 'true', 'manual', 'never', or 'false'",

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -135,6 +135,15 @@ impl TestContext {
         self
     }
 
+    /// Set the "concurrent installs" for all commands in this context.
+    pub fn with_concurrent_installs(mut self, concurrent_installs: &str) -> Self {
+        self.extra_env.push((
+            EnvVars::UV_CONCURRENT_INSTALLS.into(),
+            concurrent_installs.into(),
+        ));
+        self
+    }
+
     /// Add extra standard filtering for messages like "Resolved 10 packages" which
     /// can differ between platforms.
     ///

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -901,6 +901,24 @@ fn create_venv_with_invalid_http_timeout() {
 }
 
 #[test]
+fn create_venv_with_invalid_concurrent_installs() {
+    let context = TestContext::new_with_versions(&["3.12"]).with_concurrent_installs("0");
+
+    // Create a virtual environment at `.venv`.
+    uv_snapshot!(context.filters(), context.venv()
+        .arg(context.venv.as_os_str())
+        .arg("--python")
+        .arg("3.12"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse environment variable `UV_CONCURRENT_INSTALLS` with invalid value `0`: expected a non-zero positive integer
+    "###);
+}
+
+#[test]
 fn create_venv_unknown_python_minor() {
     let context = TestContext::new_with_versions(&["3.12"]).with_filtered_python_sources();
 


### PR DESCRIPTION
## Summary
- Move  parsing `UV_CONCURRENT_INSTALLS`, `UV_CONCURRENT_BUILDS` and `UV_CONCURRENT_DOWNLOADS` to `EnvironmentOptions`

Relates https://github.com/astral-sh/uv/issues/14720

## Test Plan

- Tests with existing tests
- Add test with invalid parsing