### PR TITLE
Don't retry connection on SSL certificate error

### DIFF
--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -64,6 +64,7 @@ reqwest-retry = { workspace = true }
 rkyv = { workspace = true }
 rmp-serde = { workspace = true }
 rustc-hash = { workspace = true }
+rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
@@ -86,7 +87,6 @@ hyper-util = { workspace = true }
 insta = { workspace = true }
 rcgen = { workspace = true }
 regex = { workspace = true }
-rustls = { workspace = true }
 temp-env = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -664,7 +664,7 @@ impl WrappedReqwestError {
 
     /// Check if the error chain contains a `reqwest` error that looks like this:
     /// * invalid peer certificate: `UnknownIssuer`
-    pub(crate) fn is_ssl(&self) -> bool {
+    fn is_ssl(&self) -> bool {
         if let Some(reqwest_err) = self.inner() {
             if !reqwest_err.is_connect() {
                 return false;

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -664,7 +664,7 @@ impl WrappedReqwestError {
 
     /// Check if the error chain contains a `reqwest` error that looks like this:
     /// * invalid peer certificate: `UnknownIssuer`
-    fn is_ssl(&self) -> bool {
+    pub(crate) fn is_ssl(&self) -> bool {
         if let Some(reqwest_err) = self.inner() {
             if !reqwest_err.is_connect() {
                 return false;

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -9,6 +9,7 @@ use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{
     RetryPolicy, Retryable, RetryableStrategy, default_on_request_error, default_on_request_success,
 };
+use rustls::{AlertDescription, Error as RustlsError};
 use tracing::{debug, trace};
 use url::Url;
 
@@ -174,8 +175,8 @@ pub fn retryable_on_request_failure(err: &(dyn Error + 'static)) -> Option<Retry
 
         if let Some(reqwest_err) = reqwest_err {
             has_known_error = true;
-            if is_tls_request_error(reqwest_err) {
-                trace!("Fatal nested reqwest TLS error");
+            if is_tls_certificate_error(reqwest_err) {
+                trace!("Fatal nested reqwest TLS certificate error");
                 return Some(Retryable::Fatal);
             }
             // Ignore the default retry strategy returning fatal.
@@ -259,8 +260,31 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
         || status == StatusCode::TOO_MANY_REQUESTS
 }
 
-fn is_tls_request_error(reqwest_err: &reqwest::Error) -> bool {
-    reqwest_err.is_connect() && find_source_with_io::<rustls::Error>(reqwest_err).is_some()
+fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
+    find_source_with_io::<RustlsError>(reqwest_err).is_some_and(is_certificate_error)
+}
+
+fn is_certificate_error(error: &RustlsError) -> bool {
+    match error {
+        RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
+        RustlsError::AlertReceived(alert) => matches!(
+            alert,
+            AlertDescription::AccessDenied
+                | AlertDescription::BadCertificate
+                | AlertDescription::BadCertificateHashValue
+                | AlertDescription::BadCertificateStatusResponse
+                | AlertDescription::CertificateExpired
+                | AlertDescription::CertificateRequired
+                | AlertDescription::CertificateRevoked
+                | AlertDescription::CertificateUnknown
+                | AlertDescription::CertificateUnobtainable
+                | AlertDescription::DecryptError
+                | AlertDescription::NoCertificate
+                | AlertDescription::UnknownCA
+                | AlertDescription::UnsupportedCertificate
+        ),
+        _ => false,
+    }
 }
 
 /// Find the first source error of a specific type.
@@ -313,6 +337,39 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use crate::{UvRetryableStrategy, retryable_on_request_failure};
+
+    #[test]
+    fn recognizes_tls_certificate_errors() {
+        let certificate_alerts = [
+            AlertDescription::AccessDenied,
+            AlertDescription::BadCertificate,
+            AlertDescription::BadCertificateHashValue,
+            AlertDescription::BadCertificateStatusResponse,
+            AlertDescription::CertificateExpired,
+            AlertDescription::CertificateRequired,
+            AlertDescription::CertificateRevoked,
+            AlertDescription::CertificateUnknown,
+            AlertDescription::CertificateUnobtainable,
+            AlertDescription::DecryptError,
+            AlertDescription::NoCertificate,
+            AlertDescription::UnknownCA,
+            AlertDescription::UnsupportedCertificate,
+        ];
+
+        assert!(is_certificate_error(&RustlsError::InvalidCertificate(
+            rustls::CertificateError::UnknownIssuer
+        )));
+        assert!(is_certificate_error(&RustlsError::NoCertificatesPresented));
+        for alert in certificate_alerts {
+            assert!(
+                is_certificate_error(&RustlsError::AlertReceived(alert)),
+                "expected {alert:?} to be classified as a certificate error"
+            );
+        }
+        assert!(!is_certificate_error(&RustlsError::AlertReceived(
+            AlertDescription::InternalError
+        )));
+    }
 
     /// Enumerate which status codes we are retrying.
     #[tokio::test]

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -174,6 +174,10 @@ pub fn retryable_on_request_failure(err: &(dyn Error + 'static)) -> Option<Retry
 
         if let Some(reqwest_err) = reqwest_err {
             has_known_error = true;
+            if is_tls_request_error(reqwest_err) {
+                trace!("Fatal nested reqwest TLS error");
+                return Some(Retryable::Fatal);
+            }
             // Ignore the default retry strategy returning fatal.
             if default_on_request_error(reqwest_err) == Some(Retryable::Transient) {
                 trace!("Transient nested reqwest error");
@@ -255,6 +259,10 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
         || status == StatusCode::TOO_MANY_REQUESTS
 }
 
+fn is_tls_request_error(reqwest_err: &reqwest::Error) -> bool {
+    reqwest_err.is_connect() && find_source_with_io::<rustls::Error>(reqwest_err).is_some()
+}
+
 /// Find the first source error of a specific type.
 ///
 /// See <https://github.com/seanmonstar/reqwest/issues/1602#issuecomment-1220996681>
@@ -263,6 +271,30 @@ fn find_source<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
     while let Some(err) = cause {
         if let Some(typed) = err.downcast_ref() {
             return Some(typed);
+        }
+        cause = err.source();
+    }
+    None
+}
+
+/// Find the first source error of a specific type, including errors wrapped by [`io::Error`].
+///
+/// Inspired by <https://github.com/seanmonstar/reqwest/issues/1602#issuecomment-1220996681>
+/// See <https://github.com/hyperium/h2/issues/862>
+fn find_source_with_io<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
+    let mut cause = orig.source();
+    while let Some(err) = cause {
+        if let Some(concrete_err) = err.downcast_ref() {
+            return Some(concrete_err);
+        }
+        if let Some(io_err) = err.downcast_ref::<io::Error>()
+            && let Some(inner_err) = io_err.get_ref()
+        {
+            if let Some(concrete_err) = inner_err.downcast_ref() {
+                return Some(concrete_err);
+            }
+            cause = Some(inner_err);
+            continue;
         }
         cause = err.source();
     }

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -261,12 +261,12 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
 }
 
 fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
-    find_source_with_io::<RustlsError>(reqwest_err).is_some_and(is_certificate_error)
-}
+    let Some(rustls_error) = find_source_with_io::<RustlsError>(reqwest_err) else {
+        return false;
+    };
 
-fn is_certificate_error(error: &RustlsError) -> bool {
     // TODO(konsti): https://github.com/seanmonstar/reqwest/issues/2819#issuecomment-5032072023
-    match error {
+    match rustls_error {
         RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
         RustlsError::AlertReceived(alert) => matches!(
             alert,

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -338,39 +338,6 @@ mod tests {
 
     use crate::{UvRetryableStrategy, retryable_on_request_failure};
 
-    #[test]
-    fn recognizes_tls_certificate_errors() {
-        let certificate_alerts = [
-            AlertDescription::AccessDenied,
-            AlertDescription::BadCertificate,
-            AlertDescription::BadCertificateHashValue,
-            AlertDescription::BadCertificateStatusResponse,
-            AlertDescription::CertificateExpired,
-            AlertDescription::CertificateRequired,
-            AlertDescription::CertificateRevoked,
-            AlertDescription::CertificateUnknown,
-            AlertDescription::CertificateUnobtainable,
-            AlertDescription::DecryptError,
-            AlertDescription::NoCertificate,
-            AlertDescription::UnknownCA,
-            AlertDescription::UnsupportedCertificate,
-        ];
-
-        assert!(is_certificate_error(&RustlsError::InvalidCertificate(
-            rustls::CertificateError::UnknownIssuer
-        )));
-        assert!(is_certificate_error(&RustlsError::NoCertificatesPresented));
-        for alert in certificate_alerts {
-            assert!(
-                is_certificate_error(&RustlsError::AlertReceived(alert)),
-                "expected {alert:?} to be classified as a certificate error"
-            );
-        }
-        assert!(!is_certificate_error(&RustlsError::AlertReceived(
-            AlertDescription::InternalError
-        )));
-    }
-
     /// Enumerate which status codes we are retrying.
     #[tokio::test]
     async fn retried_status_codes() -> Result<()> {

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -261,7 +261,7 @@ fn is_retryable_status_error(reqwest_err: &reqwest::Error) -> bool {
 }
 
 fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
-    let Some(rustls_error) = find_source_with_io::<RustlsError>(reqwest_err) else {
+    let Some(rustls_error) = find_source::<RustlsError>(reqwest_err) else {
         return false;
     };
 
@@ -288,25 +288,11 @@ fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
     }
 }
 
-/// Find the first source error of a specific type.
-///
-/// See <https://github.com/seanmonstar/reqwest/issues/1602#issuecomment-1220996681>
-fn find_source<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
-    let mut cause = orig.source();
-    while let Some(err) = cause {
-        if let Some(typed) = err.downcast_ref() {
-            return Some(typed);
-        }
-        cause = err.source();
-    }
-    None
-}
-
 /// Find the first source error of a specific type, including errors wrapped by [`io::Error`].
 ///
 /// Inspired by <https://github.com/seanmonstar/reqwest/issues/1602#issuecomment-1220996681>
 /// See <https://github.com/hyperium/h2/issues/862>
-fn find_source_with_io<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
+fn find_source<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
     let mut cause = orig.source();
     while let Some(err) = cause {
         if let Some(concrete_err) = err.downcast_ref() {

--- a/crates/uv-client/src/retry.rs
+++ b/crates/uv-client/src/retry.rs
@@ -265,6 +265,7 @@ fn is_tls_certificate_error(reqwest_err: &reqwest::Error) -> bool {
 }
 
 fn is_certificate_error(error: &RustlsError) -> bool {
+    // TODO(konsti): https://github.com/seanmonstar/reqwest/issues/2819#issuecomment-5032072023
     match error {
         RustlsError::InvalidCertificate(_) | RustlsError::NoCertificatesPresented => true,
         RustlsError::AlertReceived(alert) => matches!(

--- a/crates/uv-client/tests/it/http_util.rs
+++ b/crates/uv-client/tests/it/http_util.rs
@@ -55,10 +55,27 @@ pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSi
     generate_self_signed_certs_with_ca_custom_extensions(Vec::new())
 }
 
-/// Generates a self-signed root CA, server certificate, and client certificate,
-/// with additional custom extensions on the CA certificate.
+/// Like [`generate_self_signed_certs_with_ca`], but the server certificate is
+/// already expired (`not_after` is in the past).
+pub(crate) fn generate_expired_self_signed_certs_with_ca()
+-> Result<(SelfSigned, SelfSigned, SelfSigned)> {
+    generate_self_signed_certs_with_ca_impl(Vec::new(), (2020, 1, 1), (2021, 1, 1))
+}
+
+/// Like [`generate_self_signed_certs_with_ca`], but the CA certificate contains
+/// additional custom extensions.
 pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
     custom_extensions: Vec<CustomExtension>,
+) -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
+    generate_self_signed_certs_with_ca_impl(custom_extensions, (1975, 1, 1), (4096, 1, 1))
+}
+
+/// Generates a self-signed root CA, server certificate, and client certificate,
+/// with a configurable validity period for the server certificate.
+fn generate_self_signed_certs_with_ca_impl(
+    ca_custom_extensions: Vec<CustomExtension>,
+    server_not_before: (i32, u8, u8),
+    server_not_after: (i32, u8, u8),
 ) -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
     let mut ca_params = CertificateParams::default();
     ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained); // root cert
@@ -67,7 +84,7 @@ pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
     ca_params.key_usages.push(KeyUsagePurpose::DigitalSignature);
     ca_params.key_usages.push(KeyUsagePurpose::KeyCertSign);
     ca_params.key_usages.push(KeyUsagePurpose::CrlSign);
-    ca_params.custom_extensions = custom_extensions;
+    ca_params.custom_extensions = ca_custom_extensions;
     ca_params
         .distinguished_name
         .push(DnType::OrganizationName, "Astral Software Inc.");
@@ -84,8 +101,13 @@ pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
     // Generate server cert issued by this CA
     let mut server_params = CertificateParams::default();
     server_params.is_ca = IsCa::NoCa;
-    server_params.not_before = date_time_ymd(1975, 1, 1);
-    server_params.not_after = date_time_ymd(4096, 1, 1);
+    server_params.not_before = date_time_ymd(
+        server_not_before.0,
+        server_not_before.1,
+        server_not_before.2,
+    );
+    server_params.not_after =
+        date_time_ymd(server_not_after.0, server_not_after.1, server_not_after.2);
     server_params.use_authority_key_identifier_extension = true;
     server_params
         .key_usages

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -20,7 +20,7 @@ use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 
 use crate::http_util::{
-    SelfSigned, generate_self_signed_certs_with_ca,
+    SelfSigned, generate_expired_self_signed_certs_with_ca, generate_self_signed_certs_with_ca,
     generate_self_signed_certs_with_ca_custom_extensions, start_https_mtls_user_agent_server,
     start_https_user_agent_server, test_cert_dir,
 };
@@ -46,6 +46,12 @@ impl TestCertificate {
     /// relevant PEM files to a temporary directory.
     fn new() -> Result<Self> {
         let (ca, server, client) = generate_self_signed_certs_with_ca()?;
+        Self::persist(ca, server, &client)
+    }
+
+    /// Generate a fresh certificate set whose server certificate is expired.
+    fn new_expired() -> Result<Self> {
+        let (ca, server, client) = generate_expired_self_signed_certs_with_ca()?;
         Self::persist(ca, server, &client)
     }
 
@@ -461,6 +467,17 @@ async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
             assert_fatal_reqwest_error(&response);
             let _ = server_task.await;
         })
+        .await;
+    Ok(())
+}
+
+/// An expired server certificate is rejected without retries.
+#[tokio::test]
+async fn test_expired_cert_rejected() -> Result<()> {
+    let cert = TestCertificate::new_expired()?;
+    client()
+        .ssl_cert_file(&cert.trust_path)
+        .expect_https_connect_fails(&cert)
         .await;
     Ok(())
 }

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -1,4 +1,5 @@
-use std::io::Write;
+use std::error::Error;
+use std::io::{self, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -449,12 +450,62 @@ fn assert_connection_error(res: &Result<reqwest::Response, reqwest_middleware::E
     assert!(reqwest_error.is_connect());
 }
 
+/// Find the first source error of a specific type, including errors wrapped by [`io::Error`].
+fn find_source_with_io<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
+    let mut cause = orig.source();
+    while let Some(err) = cause {
+        if let Some(concrete_err) = err.downcast_ref() {
+            return Some(concrete_err);
+        }
+        if let Some(io_err) = err.downcast_ref::<io::Error>()
+            && let Some(inner_err) = io_err.get_ref()
+        {
+            if let Some(concrete_err) = inner_err.downcast_ref() {
+                return Some(concrete_err);
+            }
+            cause = Some(inner_err);
+            continue;
+        }
+        cause = err.source();
+    }
+    None
+}
+
 /// A self-signed server certificate is rejected when no custom certs are
 /// configured — the bundled webpki roots don't include our test CA.
 #[tokio::test]
 async fn test_no_custom_certs_rejects_self_signed() -> Result<()> {
     let cert = TestCertificate::new()?;
     client().expect_https_connect_fails(&cert).await;
+    Ok(())
+}
+
+/// TLS certificate failures are fatal and preserve the original TLS error
+/// instead of retrying against the single-use server.
+#[tokio::test]
+async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
+    let cert = TestCertificate::new()?;
+    client()
+        .run_https(&cert, |response, server_task| async move {
+            assert!(
+                matches!(response, Err(reqwest_middleware::Error::Middleware(_))),
+                "expected middleware error, got: {response:?}"
+            );
+            let Err(reqwest_middleware::Error::Middleware(middleware_error)) = response else {
+                return;
+            };
+            let tls_error = find_source_with_io::<rustls::Error>(middleware_error.as_ref());
+            assert!(tls_error.is_some(), "expected TLS error in chain");
+            let Some(tls_error) = tls_error else {
+                return;
+            };
+            assert!(matches!(
+                tls_error,
+                rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer)
+            ));
+            let _ = server_task.await;
+        })
+        .await;
     Ok(())
 }
 

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::io::{self, Write};
+use std::io::Write;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -274,18 +273,15 @@ impl TestClient {
 
     /// Assert that an mTLS connection to `cert`'s server fails and the server
     /// reports a specific TLS error.
-    async fn expect_mtls_connect_fails_with_tls_errors<F>(
+    async fn expect_mtls_connect_fails_with_server_tls_error<F>(
         &self,
         cert: &TestCertificate,
-        assert_tls_errors: F,
+        assert_tls_error: F,
     ) where
-        F: FnOnce(&rustls::Error, &rustls::Error),
+        F: FnOnce(&rustls::Error),
     {
         self.run_mtls(cert, |response, server_task| async move {
-            let reqwest_error = assert_fatal_reqwest_error(&response);
-            let Some(client_tls_error) = find_source_with_io::<rustls::Error>(reqwest_error) else {
-                panic!("expected client TLS error, got: {reqwest_error:?}");
-            };
+            assert_fatal_reqwest_error(&response);
 
             let server_res = server_task.await.expect("server task panicked");
             let Err(anyhow_err) = server_res else {
@@ -300,7 +296,7 @@ impl TestClient {
             let Some(tls_err) = wrapped_err.downcast_ref::<rustls::Error>() else {
                 panic!("expected rustls::Error, got: {wrapped_err}");
             };
-            assert_tls_errors(client_tls_error, tls_err);
+            assert_tls_error(tls_err);
         })
         .await;
     }
@@ -308,14 +304,7 @@ impl TestClient {
     /// Assert that an mTLS connection to `cert`'s server fails because no
     /// valid client certificate was presented.
     async fn expect_mtls_connect_fails(&self, cert: &TestCertificate) {
-        self.expect_mtls_connect_fails_with_tls_errors(cert, |client_tls_err, server_tls_err| {
-            assert!(
-                matches!(
-                    client_tls_err,
-                    rustls::Error::AlertReceived(rustls::AlertDescription::CertificateRequired)
-                ),
-                "expected CertificateRequired alert, got: {client_tls_err}"
-            );
+        self.expect_mtls_connect_fails_with_server_tls_error(cert, |server_tls_err| {
             assert!(
                 matches!(server_tls_err, rustls::Error::NoCertificatesPresented),
                 "expected NoCertificatesPresented, got: {server_tls_err}"
@@ -443,39 +432,15 @@ async fn send_request_to(
 }
 
 /// Assert that a request failed with a reqwest error without being retried.
-fn assert_fatal_reqwest_error(
-    res: &Result<reqwest::Response, reqwest_middleware::Error>,
-) -> &reqwest::Error {
+fn assert_fatal_reqwest_error(res: &Result<reqwest::Response, reqwest_middleware::Error>) {
     let Some(reqwest_middleware::Error::Middleware(middleware_error)) = res.as_ref().err() else {
         panic!("expected middleware error, got: {res:?}");
     };
-    let Some(reqwest_retry::RetryError::Error(reqwest_middleware::Error::Reqwest(reqwest_error))) =
+    let Some(reqwest_retry::RetryError::Error(reqwest_middleware::Error::Reqwest(_))) =
         middleware_error.downcast_ref::<reqwest_retry::RetryError>()
     else {
         panic!("expected fatal reqwest error without retries, got: {middleware_error:?}");
     };
-    reqwest_error
-}
-
-/// Find the first source error of a specific type, including errors wrapped by [`io::Error`].
-fn find_source_with_io<E: Error + 'static>(orig: &dyn Error) -> Option<&E> {
-    let mut cause = orig.source();
-    while let Some(err) = cause {
-        if let Some(concrete_err) = err.downcast_ref() {
-            return Some(concrete_err);
-        }
-        if let Some(io_err) = err.downcast_ref::<io::Error>()
-            && let Some(inner_err) = io_err.get_ref()
-        {
-            if let Some(concrete_err) = inner_err.downcast_ref() {
-                return Some(concrete_err);
-            }
-            cause = Some(inner_err);
-            continue;
-        }
-        cause = err.source();
-    }
-    None
 }
 
 /// A self-signed server certificate is rejected when no custom certs are
@@ -487,26 +452,13 @@ async fn test_no_custom_certs_rejects_self_signed() -> Result<()> {
     Ok(())
 }
 
-/// TLS certificate failures are fatal and preserve the original TLS error
-/// instead of retrying against the single-use server.
+/// TLS certificate failures are fatal instead of being retried against the single-use server.
 #[tokio::test]
 async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
     let cert = TestCertificate::new()?;
     client()
         .run_https(&cert, |response, server_task| async move {
             assert_fatal_reqwest_error(&response);
-            let Err(reqwest_middleware::Error::Middleware(middleware_error)) = response else {
-                panic!("expected middleware error");
-            };
-            let tls_error = find_source_with_io::<rustls::Error>(middleware_error.as_ref());
-            assert!(tls_error.is_some(), "expected TLS error in chain");
-            let Some(tls_error) = tls_error else {
-                return;
-            };
-            assert!(matches!(
-                tls_error,
-                rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer)
-            ));
             let _ = server_task.await;
         })
         .await;
@@ -796,17 +748,7 @@ async fn test_mtls_with_wrong_client_cert() -> Result<()> {
     client()
         .ssl_cert_file(&server_cert.trust_path)
         .ssl_client_cert(&other_cert.client_cert_path)
-        .expect_mtls_connect_fails_with_tls_errors(&server_cert, |client_tls_err, server_tls_err| {
-            assert!(
-                matches!(
-                    client_tls_err,
-                    rustls::Error::AlertReceived(
-                        rustls::AlertDescription::DecryptError
-                            | rustls::AlertDescription::UnknownCA
-                    )
-                ),
-                "expected DecryptError or UnknownCA alert, got: {client_tls_err}"
-            );
+        .expect_mtls_connect_fails_with_server_tls_error(&server_cert, |server_tls_err| {
             assert!(
                 matches!(
                     server_tls_err,

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -8,7 +8,7 @@ use rcgen::CustomExtension;
 use temp_env::async_with_vars;
 use tempfile::{NamedTempFile, TempDir};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use url::Url;
 
 use uv_cache::Cache;
@@ -287,7 +287,10 @@ impl TestClient {
         F: FnOnce(&rustls::Error),
     {
         self.run_mtls(cert, |response, server_task| async move {
-            assert_fatal_reqwest_error(&response);
+            assert!(
+                response.is_err(),
+                "expected request error, got: {response:?}"
+            );
 
             let server_res = server_task.await.expect("server task panicked");
             let Err(anyhow_err) = server_res else {
@@ -449,6 +452,22 @@ fn assert_fatal_reqwest_error(res: &Result<reqwest::Response, reqwest_middleware
     };
 }
 
+/// Read the client's complete TLS record before sending a fatal alert.
+async fn send_tls_alert(stream: &mut TcpStream, alert_description: u8) -> Result<()> {
+    let mut client_hello_header = [0; 5];
+    stream.read_exact(&mut client_hello_header).await?;
+    let client_hello_length = usize::from(u16::from_be_bytes([
+        client_hello_header[3],
+        client_hello_header[4],
+    ]));
+    let mut client_hello = vec![0; client_hello_length];
+    stream.read_exact(&mut client_hello).await?;
+    stream
+        .write_all(&[0x15, 0x03, 0x03, 0x00, 0x02, 0x02, alert_description])
+        .await?;
+    Ok(())
+}
+
 /// A self-signed server certificate is rejected when no custom certs are
 /// configured — the bundled webpki roots don't include our test CA.
 #[tokio::test]
@@ -471,6 +490,24 @@ async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
     Ok(())
 }
 
+/// Certificate TLS alerts are fatal instead of being retried.
+#[tokio::test]
+async fn test_certificate_tls_alerts_are_not_retried() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await?;
+        // A fatal TLS `unknown_ca` alert.
+        send_tls_alert(&mut stream, 0x30).await?;
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let response = send_request(addr, false).await;
+    assert_fatal_reqwest_error(&response);
+    server_task.await??;
+    Ok(())
+}
+
 /// An expired server certificate is rejected without retries.
 #[tokio::test]
 async fn test_expired_cert_rejected() -> Result<()> {
@@ -490,12 +527,8 @@ async fn test_non_certificate_tls_errors_are_retried() -> Result<()> {
     let server_task = tokio::spawn(async move {
         for _ in 0..4 {
             let (mut stream, _) = listener.accept().await?;
-            let mut client_hello = [0];
-            stream.read_exact(&mut client_hello).await?;
             // A fatal TLS `internal_error` alert.
-            stream
-                .write_all(&[0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x50])
-                .await?;
+            send_tls_alert(&mut stream, 0x50).await?;
         }
         Ok::<_, anyhow::Error>(())
     });

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -8,6 +8,8 @@ use anyhow::Result;
 use rcgen::CustomExtension;
 use temp_env::async_with_vars;
 use tempfile::{NamedTempFile, TempDir};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 use url::Url;
 
 use uv_cache::Cache;
@@ -203,7 +205,7 @@ impl TestClient {
     /// error on the client side.
     async fn expect_https_connect_fails(&self, cert: &TestCertificate) {
         self.run_https(cert, |response, server_task| async move {
-            assert_connection_error(&response);
+            assert_fatal_reqwest_error(&response);
             // Server may or may not have errored — just ensure no panic.
             let _ = server_task.await;
         })
@@ -272,15 +274,18 @@ impl TestClient {
 
     /// Assert that an mTLS connection to `cert`'s server fails and the server
     /// reports a specific TLS error.
-    async fn expect_mtls_connect_fails_with_server_tls_error<F>(
+    async fn expect_mtls_connect_fails_with_tls_errors<F>(
         &self,
         cert: &TestCertificate,
-        assert_tls_error: F,
+        assert_tls_errors: F,
     ) where
-        F: FnOnce(&rustls::Error),
+        F: FnOnce(&rustls::Error, &rustls::Error),
     {
         self.run_mtls(cert, |response, server_task| async move {
-            assert_connection_error(&response);
+            let reqwest_error = assert_fatal_reqwest_error(&response);
+            let Some(client_tls_error) = find_source_with_io::<rustls::Error>(reqwest_error) else {
+                panic!("expected client TLS error, got: {reqwest_error:?}");
+            };
 
             let server_res = server_task.await.expect("server task panicked");
             let Err(anyhow_err) = server_res else {
@@ -295,7 +300,7 @@ impl TestClient {
             let Some(tls_err) = wrapped_err.downcast_ref::<rustls::Error>() else {
                 panic!("expected rustls::Error, got: {wrapped_err}");
             };
-            assert_tls_error(tls_err);
+            assert_tls_errors(client_tls_error, tls_err);
         })
         .await;
     }
@@ -303,10 +308,17 @@ impl TestClient {
     /// Assert that an mTLS connection to `cert`'s server fails because no
     /// valid client certificate was presented.
     async fn expect_mtls_connect_fails(&self, cert: &TestCertificate) {
-        self.expect_mtls_connect_fails_with_server_tls_error(cert, |tls_err| {
+        self.expect_mtls_connect_fails_with_tls_errors(cert, |client_tls_err, server_tls_err| {
             assert!(
-                matches!(tls_err, rustls::Error::NoCertificatesPresented),
-                "expected NoCertificatesPresented, got: {tls_err}"
+                matches!(
+                    client_tls_err,
+                    rustls::Error::AlertReceived(rustls::AlertDescription::CertificateRequired)
+                ),
+                "expected CertificateRequired alert, got: {client_tls_err}"
+            );
+            assert!(
+                matches!(server_tls_err, rustls::Error::NoCertificatesPresented),
+                "expected NoCertificatesPresented, got: {server_tls_err}"
             );
         })
         .await;
@@ -352,7 +364,7 @@ impl TestClient {
         let system_certs = self.system_certs;
         async_with_vars(vars, async {
             let response = send_request_to(&url, system_certs).await;
-            assert_connection_error(&response);
+            assert_fatal_reqwest_error(&response);
         })
         .await;
     }
@@ -430,24 +442,19 @@ async fn send_request_to(
         .await
 }
 
-/// Assert that a request result is a TLS connection error.
-fn assert_connection_error(res: &Result<reqwest::Response, reqwest_middleware::Error>) {
+/// Assert that a request failed with a reqwest error without being retried.
+fn assert_fatal_reqwest_error(
+    res: &Result<reqwest::Response, reqwest_middleware::Error>,
+) -> &reqwest::Error {
     let Some(reqwest_middleware::Error::Middleware(middleware_error)) = res.as_ref().err() else {
         panic!("expected middleware error, got: {res:?}");
     };
-    let reqwest_error = middleware_error
-        .chain()
-        .find_map(|err| {
-            err.downcast_ref::<reqwest_middleware::Error>().map(|err| {
-                if let reqwest_middleware::Error::Reqwest(inner) = err {
-                    inner
-                } else {
-                    panic!("expected reqwest error, got: {err}")
-                }
-            })
-        })
-        .expect("expected reqwest error");
-    assert!(reqwest_error.is_connect());
+    let Some(reqwest_retry::RetryError::Error(reqwest_middleware::Error::Reqwest(reqwest_error))) =
+        middleware_error.downcast_ref::<reqwest_retry::RetryError>()
+    else {
+        panic!("expected fatal reqwest error without retries, got: {middleware_error:?}");
+    };
+    reqwest_error
 }
 
 /// Find the first source error of a specific type, including errors wrapped by [`io::Error`].
@@ -487,12 +494,9 @@ async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
     let cert = TestCertificate::new()?;
     client()
         .run_https(&cert, |response, server_task| async move {
-            assert!(
-                matches!(response, Err(reqwest_middleware::Error::Middleware(_))),
-                "expected middleware error, got: {response:?}"
-            );
+            assert_fatal_reqwest_error(&response);
             let Err(reqwest_middleware::Error::Middleware(middleware_error)) = response else {
-                return;
+                panic!("expected middleware error");
             };
             let tls_error = find_source_with_io::<rustls::Error>(middleware_error.as_ref());
             assert!(tls_error.is_some(), "expected TLS error in chain");
@@ -506,6 +510,38 @@ async fn test_tls_certificate_errors_are_not_retried() -> Result<()> {
             let _ = server_task.await;
         })
         .await;
+    Ok(())
+}
+
+/// TLS protocol failures that are not certificate errors remain retryable.
+#[tokio::test]
+async fn test_non_certificate_tls_errors_are_retried() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let server_task = tokio::spawn(async move {
+        for _ in 0..4 {
+            let (mut stream, _) = listener.accept().await?;
+            let mut client_hello = [0];
+            stream.read_exact(&mut client_hello).await?;
+            // A fatal TLS `internal_error` alert.
+            stream
+                .write_all(&[0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x50])
+                .await?;
+        }
+        Ok::<_, anyhow::Error>(())
+    });
+
+    let response = send_request(addr, false).await;
+    let Err(reqwest_middleware::Error::Middleware(middleware_error)) = response else {
+        panic!("expected middleware error, got: {response:?}");
+    };
+    let Some(reqwest_retry::RetryError::WithRetries { retries, .. }) =
+        middleware_error.downcast_ref::<reqwest_retry::RetryError>()
+    else {
+        panic!("expected retries after a non-certificate TLS error, got: {middleware_error:?}");
+    };
+    assert_eq!(*retries, 3);
+    server_task.await??;
     Ok(())
 }
 
@@ -760,16 +796,26 @@ async fn test_mtls_with_wrong_client_cert() -> Result<()> {
     client()
         .ssl_cert_file(&server_cert.trust_path)
         .ssl_client_cert(&other_cert.client_cert_path)
-        .expect_mtls_connect_fails_with_server_tls_error(&server_cert, |tls_err| {
+        .expect_mtls_connect_fails_with_tls_errors(&server_cert, |client_tls_err, server_tls_err| {
             assert!(
                 matches!(
-                    tls_err,
+                    client_tls_err,
+                    rustls::Error::AlertReceived(
+                        rustls::AlertDescription::DecryptError
+                            | rustls::AlertDescription::UnknownCA
+                    )
+                ),
+                "expected DecryptError or UnknownCA alert, got: {client_tls_err}"
+            );
+            assert!(
+                matches!(
+                    server_tls_err,
                     rustls::Error::InvalidCertificate(
                         rustls::CertificateError::BadSignature
                             | rustls::CertificateError::UnknownIssuer
                     )
                 ),
-                "expected InvalidCertificate(BadSignature | UnknownIssuer), got: {tls_err}"
+                "expected InvalidCertificate(BadSignature | UnknownIssuer), got: {server_tls_err}"
             );
         })
         .await;


### PR DESCRIPTION
## Summary
SSL errors should not be retryable from the cached on non cached client: https://github.com/astral-sh/uv/issues/16235

## Test Plan
Unsure on if its possible/how to simulate an SSL certificate failure with the mock server so we can get a test going. Open to ideas on how to test this. See comment below

