### PR TITLE
Add `--no-wait` argument for the `run` command to not wait for spawned process to finish

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3666,6 +3666,10 @@ pub struct RunArgs {
     /// `--python-platform` option is intended for advanced use cases.
     #[arg(long)]
     pub python_platform: Option<TargetTriple>,
+
+    /// Run the command and exit without waiting for the spawned process to finish.
+    #[arg(long, env = EnvVars::UV_NO_WAIT, value_parser = clap::builder::BoolishValueParser::new())]
+    pub no_wait: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1514,4 +1514,7 @@ impl EnvVars {
     /// Defaults to 300s (5 min).
     #[attr_added_in("0.9.4")]
     pub const UV_LOCK_TIMEOUT: &'static str = "UV_LOCK_TIMEOUT";
+
+    #[attr_added_in("0.10.0")]
+    pub const UV_NO_WAIT: &'static str = "UV_NO_WAIT";
 }

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -122,6 +122,7 @@ pub(crate) async fn run(
     max_recursion_depth: u32,
     malware_settings: MalwareCheckSettings,
     #[cfg(unix)] run_rlimit_nofile: Option<u32>,
+    no_wait: bool,
 ) -> anyhow::Result<ExitStatus> {
     // Check if max recursion depth was exceeded. This most commonly happens
     // for scripts with a shebang line like `#!/usr/bin/env -S uv run`, so try
@@ -1314,6 +1315,12 @@ pub(crate) async fn run(
         })?;
     }
 
+    #[cfg(windows)]
+    if no_wait {
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        process.creation_flags(CREATE_NEW_CONSOLE);
+    }
+
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found
@@ -1321,7 +1328,11 @@ pub(crate) async fn run(
         .spawn()
         .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()))?;
 
-    run_to_completion(handle).await
+    if no_wait {
+        Ok(ExitStatus::Success)
+    } else {
+        run_to_completion(handle).await
+    }
 }
 
 /// Returns `true` if we can skip creating an additional ephemeral environment in `uv run`.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2387,6 +2387,7 @@ async fn run_project(
                 args.malware_settings,
                 #[cfg(unix)]
                 args.run_rlimit_nofile,
+                args.no_wait,
             ))
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -683,6 +683,7 @@ pub(crate) struct RunSettings {
     pub(crate) malware_settings: MalwareCheckSettings,
     #[cfg(unix)]
     pub(crate) run_rlimit_nofile: Option<u32>,
+    pub(crate) no_wait: bool,
 }
 
 impl RunSettings {
@@ -744,6 +745,7 @@ impl RunSettings {
             env_file,
             no_env_file,
             max_recursion_depth,
+            no_wait,
         } = args;
 
         let filesystem_install_mirrors = filesystem
@@ -851,6 +853,7 @@ impl RunSettings {
             malware_settings,
             #[cfg(unix)]
             run_rlimit_nofile: environment.run_rlimit_nofile,
+            no_wait,
         })
     }
 }


### PR DESCRIPTION
Here is an unsolicited attempt to implement the feature to `uv run` a script and make `uv` exit immediately without waiting for the spawned `python` process to finish.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I usually need to wrap a bunch of `uv` invocations in other Python scripts. Since `uv` always waits for child process to finish, this ends up with a lot of recursive `uv` processes lingering. Sometimes this is useful, so that logic that must happen after the child process can run at right time. Other times this is unnecessary/wasteful because all I need is to let `uv` to spawn the virtual env. The child script will handle everything by themselves.

This is a very rough initial attempt to implement `uv run --no-wait`. The PR basically consists of adding and passing the argument, then if user needs `--no-wait`, skip the `run_to_completion(handle).await` call. Additionally, only in Windows, to avoid the child process console being detached to the terminal, the process is spawned with [CREATE_NEW_CONSOLE](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags). This way it has its own console.

## Test Plan

As this is rough initial attempt, I only tested manually. If the PR is OK to be moved to next phase, I'll add programmatic tests.

1. Create two Python scripts, `a.py` and `b.py`.
```python
a.py

import subprocess
subprocess.check_call(['uv.exe', 'run', 'b.py'])
```

```python
b.py

import time
time.sleep(9999)
```
2. `uv run a.py`.
3. Verify that there is no lingering `uv.exe` process in task manager.