### PR TITLE
add more desc for externally_managed error

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -238,7 +238,7 @@ pub(crate) async fn pip_install(
         } else {
             return if let Some(error) = externally_managed.into_error() {
                 Err(anyhow::anyhow!(
-                    "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`.",
+                    "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`, or use `--break-system-packages`.",
                     environment.root().user_display().cyan(),
                     textwrap::indent(&error, "  ").green(),
                 ))


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I Googled for hours trying to solve this error message

> This Python installation is managed by uv and should not be modified.
> Consider creating a virtual environment with `uv venv`.

I propose change the second sentence as:

> Consider creating a virtual environment with `uv venv`, or use `--break-system-packages`.


## Test Plan

No need really, just adding some description text