### PR TITLE
Use `uv_build` in `make_project` tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -1832,19 +1832,18 @@ pub fn make_project(dir: &Path, name: &str, body: &str) -> anyhow::Result<()> {
         [project]
         name = "{name}"
         version = "0.1.0"
-        description = "Test package for direct URLs in branches"
         requires-python = ">=3.11,<3.13"
         {body}
 
         [build-system]
-        requires = ["setuptools>=42"]
-        build-backend = "setuptools.build_meta"
+        requires = ["uv_build>=0.9.0,<10000"]
+        build-backend = "uv_build"
         "#
     };
     fs_err::create_dir_all(dir)?;
     fs_err::write(dir.join("pyproject.toml"), pyproject_toml)?;
-    fs_err::create_dir(dir.join(name))?;
-    fs_err::write(dir.join(name).join("__init__.py"), "")?;
+    fs_err::create_dir_all(dir.join("src").join(name))?;
+    fs_err::write(dir.join("src").join(name).join("__init__.py"), "")?;
     Ok(())
 }
 

--- a/crates/uv/tests/it/workspace.rs
+++ b/crates/uv/tests/it/workspace.rs
@@ -1983,7 +1983,7 @@ fn workspace_members_with_leading_dot_slash() -> Result<()> {
     "###);
 
     // Test syncing from within foo works correctly
-    uv_snapshot!(context.filters(), context.sync().current_dir(workspace.join("packages/foo")), @r###"
+    uv_snapshot!(context.filters(), context.sync().current_dir(workspace.join("packages").join("foo")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
Skip downloading and running setuptools.