### PR TITLE
Fix backtick escaping for PowerShell

### DIFF
--- a/crates/uv-shell/src/lib.rs
+++ b/crates/uv-shell/src/lib.rs
@@ -331,7 +331,7 @@ fn backtick_escape(s: &str) -> String {
         match c {
             // Need to also escape unicode double quotes that PowerShell treats
             // as the ASCII double quote.
-            '"' | '\u{201C}' | '\u{201D}' | '\u{201E}' | '$' => escaped.push('`'),
+            '"' | '`' | '\u{201C}' | '\u{201D}' | '\u{201E}' | '$' => escaped.push('`'),
             _ => {}
         }
         escaped.push(c);


### PR DESCRIPTION
## Summary
Fixes the logic for escaping a double quoted string in PowerShell by not escaping a backslash but escaping the Unicode double quote variants that PowerShell treats the same as the ASCII double quotes.

<img width="685" height="99" alt="image" src="https://github.com/user-attachments/assets/ac1368c2-d915-4e49-b67f-ac71ee0f7d46" />

## Test Plan
There does not seem to be any tests for this. I'm fairly new to rust but happy to add some if someone can point me in the right direction.