### PR TITLE
Error when there is an authentication failure in check URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6861,6 +6861,7 @@ dependencies = [
  "glob",
  "insta",
  "itertools 0.14.0",
+ "owo-colors",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -405,8 +405,12 @@ pub enum ErrorKind {
     ///
     /// Make sure the package name is spelled correctly and that you've
     /// configured the right registry to fetch it from.
-    #[error("Package `{0}` was not found in the registry")]
-    RemotePackageNotFound(PackageName),
+    #[error("Package `{package_name}` was not found in the registry")]
+    RemotePackageNotFound {
+        package_name: PackageName,
+        /// Not mentioned in the message, there's a separate hint with the details.
+        status_code_error: bool,
+    },
 
     /// The package was not found in the local (file-based) index.
     #[error("Package `{0}` was not found in the local index")]

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 
 use async_http_range_reader::AsyncHttpRangeReaderError;
 use async_zip::error::ZipError;
+use http::StatusCode;
 use reqwest::Response;
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use tracing::warn;
 
@@ -413,7 +415,7 @@ pub enum ErrorKind {
     /// Make sure the package name is spelled correctly and that you've
     /// configured the right registry to fetch it from.
     #[error("Package `{0}` was not found in the registry")]
-    RemotePackageStatusCodeError(PackageName),
+    RemotePackageStatusCodeError(PackageName, FxHashSet<StatusCode>),
 
     /// The package was not found in the local (file-based) index.
     #[error("Package `{0}` was not found in the local index")]

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -401,16 +401,19 @@ pub enum ErrorKind {
     #[error("{0} isn't available locally, but making network requests to registries was banned")]
     NoIndex(String),
 
-    /// The package was not found in the registry.
+    /// The package was not found in the registry (HTTP Error 404).
     ///
     /// Make sure the package name is spelled correctly and that you've
     /// configured the right registry to fetch it from.
-    #[error("Package `{package_name}` was not found in the registry")]
-    RemotePackageNotFound {
-        package_name: PackageName,
-        /// Not mentioned in the message, there's a separate hint with the details.
-        status_code_error: bool,
-    },
+    #[error("Package `{0}` was not found in the registry")]
+    RemotePackageNotFound(PackageName),
+
+    /// The package was not found in the registry (HTTP Error 401 or 403).
+    ///
+    /// Make sure the package name is spelled correctly and that you've
+    /// configured the right registry to fetch it from.
+    #[error("Package `{0}` was not found in the registry")]
+    RemotePackageStatusCodeError(PackageName),
 
     /// The package was not found in the local (file-based) index.
     #[error("Package `{0}` was not found in the local index")]

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_http_range_reader::AsyncHttpRangeReader;
@@ -11,7 +10,7 @@ use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::{HeaderMap, StatusCode};
 use itertools::Either;
 use reqwest::{Proxy, Response};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
@@ -345,7 +344,7 @@ impl RegistryClient {
         };
 
         let mut results = Vec::new();
-        let any_status_code_error = AtomicBool::new(false);
+        let status_code_errors = Arc::new(Mutex::new(FxHashSet::default()));
 
         match self.index_strategy_for(package_name) {
             // If we're searching for the first index that contains the package, fetch serially.
@@ -377,7 +376,7 @@ impl RegistryClient {
                                     debug!(
                                         "Indexes search failed because of status code failure: {status_code}"
                                     );
-                                    any_status_code_error.store(true, Ordering::Relaxed);
+                                    status_code_errors.lock().await.insert(status_code);
                                     break;
                                 }
                             }
@@ -414,8 +413,8 @@ impl RegistryClient {
                                 {
                                     SimpleMetadataSearchOutcome::Found(metadata) => Some(metadata),
                                     SimpleMetadataSearchOutcome::NotFound => None,
-                                    SimpleMetadataSearchOutcome::StatusCodeFailure(_) => {
-                                        any_status_code_error.store(true, Ordering::Relaxed);
+                                    SimpleMetadataSearchOutcome::StatusCodeFailure(status_code) => {
+                                        status_code_errors.lock().await.insert(status_code);
                                         None
                                     }
                                 };
@@ -442,8 +441,13 @@ impl RegistryClient {
         if results.is_empty() {
             return match self.connectivity {
                 Connectivity::Online => {
-                    if any_status_code_error.load(Ordering::Relaxed) {
-                        Err(ErrorKind::RemotePackageStatusCodeError(package_name.clone()).into())
+                    let status_code_errors = status_code_errors.lock().await;
+                    if !status_code_errors.is_empty() {
+                        Err(ErrorKind::RemotePackageStatusCodeError(
+                            package_name.clone(),
+                            status_code_errors.clone(),
+                        )
+                        .into())
                     } else {
                         Err(ErrorKind::RemotePackageNotFound(package_name.clone()).into())
                     }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_http_range_reader::AsyncHttpRangeReader;
@@ -344,6 +345,7 @@ impl RegistryClient {
         };
 
         let mut results = Vec::new();
+        let any_status_code_error = AtomicBool::new(false);
 
         match self.index_strategy_for(package_name) {
             // If we're searching for the first index that contains the package, fetch serially.
@@ -375,6 +377,7 @@ impl RegistryClient {
                                     debug!(
                                         "Indexes search failed because of status code failure: {status_code}"
                                     );
+                                    any_status_code_error.store(true, Ordering::Relaxed);
                                     break;
                                 }
                             }
@@ -410,7 +413,11 @@ impl RegistryClient {
                                     .await?
                                 {
                                     SimpleMetadataSearchOutcome::Found(metadata) => Some(metadata),
-                                    _ => None,
+                                    SimpleMetadataSearchOutcome::NotFound => None,
+                                    SimpleMetadataSearchOutcome::StatusCodeFailure(_) => {
+                                        any_status_code_error.store(true, Ordering::Relaxed);
+                                        None
+                                    }
                                 };
                                 Ok((index.url, metadata.map(MetadataFormat::Simple)))
                             }
@@ -434,9 +441,11 @@ impl RegistryClient {
 
         if results.is_empty() {
             return match self.connectivity {
-                Connectivity::Online => {
-                    Err(ErrorKind::RemotePackageNotFound(package_name.clone()).into())
+                Connectivity::Online => Err(ErrorKind::RemotePackageNotFound {
+                    package_name: package_name.clone(),
+                    status_code_error: any_status_code_error.load(Ordering::Relaxed),
                 }
+                .into()),
                 Connectivity::Offline => Err(ErrorKind::Offline(package_name.to_string()).into()),
             };
         }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -441,11 +441,13 @@ impl RegistryClient {
 
         if results.is_empty() {
             return match self.connectivity {
-                Connectivity::Online => Err(ErrorKind::RemotePackageNotFound {
-                    package_name: package_name.clone(),
-                    status_code_error: any_status_code_error.load(Ordering::Relaxed),
+                Connectivity::Online => {
+                    if any_status_code_error.load(Ordering::Relaxed) {
+                        Err(ErrorKind::RemotePackageStatusCodeError(package_name.clone()).into())
+                    } else {
+                        Err(ErrorKind::RemotePackageNotFound(package_name.clone()).into())
+                    }
                 }
-                .into()),
                 Connectivity::Offline => Err(ErrorKind::Offline(package_name.to_string()).into()),
             };
         }

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -36,6 +36,7 @@ fs-err = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }
 itertools = { workspace = true }
+owo-colors = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true, features = ["json"] }
 reqwest-retry = { workspace = true }

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -997,16 +997,18 @@ pub async fn check_url(
                     );
                     Ok(false)
                 }
-                uv_client::ErrorKind::RemotePackageStatusCodeError(_) => {
+                uv_client::ErrorKind::RemotePackageStatusCodeError(_, status_code_error) => {
+                    // TODO(konsti): We currently can't track that this must be exactly one status
+                    // error with check URL.
+                    debug_assert!(
+                        status_code_error.len() == 1,
+                        "Check URL must only check a single URL"
+                    );
+                    let status_code = status_code_error.iter().next();
                     // The package may or may not exist, there was an authentication failure.
-                    // TODO(konsti): We should show the real index error instead.
-                    let status_code_detail = if index_capabilities.unauthorized(index_url) {
-                        "401 Unauthorized"
-                    } else if index_capabilities.forbidden(index_url) {
-                        "403 Forbidden"
-                    } else {
-                        "Status code error"
-                    };
+                    let status_code_detail = status_code
+                        .map(ToString::to_string)
+                        .unwrap_or("Status code error".to_string());
                     warn!(
                         "Package not found in the registry; skipping upload check for {filename}"
                     );

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1014,7 +1014,7 @@ pub async fn check_url(
                     );
                     return Err(PublishError::CheckUrlAuthentication {
                         url: index_url.url().clone(),
-                        status_code_detail: status_code_detail.to_string(),
+                        status_code_detail: status_code_detail.clone(),
                     });
                 }
                 _ => Err(PublishError::CheckUrlIndex(err)),

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -990,20 +990,14 @@ pub async fn check_url(
         Ok(response) => response,
         Err(err) => {
             return match err.kind() {
-                uv_client::ErrorKind::RemotePackageNotFound {
-                    status_code_error: false,
-                    ..
-                } => {
+                uv_client::ErrorKind::RemotePackageNotFound(_) => {
                     // The package doesn't exist, it's the first upload of the package.
                     warn!(
                         "Package not found in the registry; skipping upload check for {filename}"
                     );
                     Ok(false)
                 }
-                uv_client::ErrorKind::RemotePackageNotFound {
-                    status_code_error: true,
-                    ..
-                } => {
+                uv_client::ErrorKind::RemotePackageStatusCodeError(_) => {
                     // The package may or may not exist, there was an authentication failure.
                     // TODO(konsti): We should show the real index error instead.
                     let status_code_detail = if index_capabilities.unauthorized(index_url) {

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -9,6 +9,7 @@ use fs_err::tokio::File;
 use futures::TryStreamExt;
 use glob::{GlobError, PatternError, glob};
 use itertools::Itertools;
+use owo_colors::OwoColorize;
 use reqwest::header::{AUTHORIZATION, LOCATION, ToStrError};
 use reqwest::multipart::Part;
 use reqwest::{Body, Response, StatusCode};
@@ -76,6 +77,18 @@ pub enum PublishError {
     TrustedPublishing(#[from] Box<TrustedPublishingError>),
     #[error("{0} are not allowed when using trusted publishing")]
     MixedCredentials(String),
+    #[error(
+        "Failed to query check URL due to a lack of valid authentication credentials ({}): {}.\n\n\
+        {}{} Check URL credentials must be configured separately from publish URL credentials",
+        status_code_detail.red(),
+        url.to_string().cyan(),
+        "hint".bold().cyan(),
+        ":".bold(),
+    )]
+    CheckUrlAuthentication {
+        url: DisplaySafeUrl,
+        status_code_detail: String,
+    },
     #[error("Failed to query check URL")]
     CheckUrlIndex(#[source] uv_client::Error),
     #[error(
@@ -977,12 +990,36 @@ pub async fn check_url(
         Ok(response) => response,
         Err(err) => {
             return match err.kind() {
-                uv_client::ErrorKind::RemotePackageNotFound(_) => {
-                    // The package doesn't exist, so we can't have uploaded it.
+                uv_client::ErrorKind::RemotePackageNotFound {
+                    status_code_error: false,
+                    ..
+                } => {
+                    // The package doesn't exist, it's the first upload of the package.
                     warn!(
                         "Package not found in the registry; skipping upload check for {filename}"
                     );
                     Ok(false)
+                }
+                uv_client::ErrorKind::RemotePackageNotFound {
+                    status_code_error: true,
+                    ..
+                } => {
+                    // The package may or may not exist, there was an authentication failure.
+                    // TODO(konsti): We should show the real index error instead.
+                    let status_code_detail = if index_capabilities.unauthorized(index_url) {
+                        "401 Unauthorized"
+                    } else if index_capabilities.forbidden(index_url) {
+                        "403 Forbidden"
+                    } else {
+                        "Status code error"
+                    };
+                    warn!(
+                        "Package not found in the registry; skipping upload check for {filename}"
+                    );
+                    return Err(PublishError::CheckUrlAuthentication {
+                        url: index_url.url().clone(),
+                        status_code_detail: status_code_detail.to_string(),
+                    });
                 }
                 _ => Err(PublishError::CheckUrlIndex(err)),
             };

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -229,7 +229,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                     .collect(),
             )),
             Err(err) => match err.kind() {
-                uv_client::ErrorKind::RemotePackageNotFound(_) => {
+                uv_client::ErrorKind::RemotePackageNotFound { .. } => {
                     if let Some(flat_index) = flat_index
                         .and_then(|flat_index| flat_index.get(package_name))
                         .cloned()

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -230,7 +230,7 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
             )),
             Err(err) => match err.kind() {
                 uv_client::ErrorKind::RemotePackageNotFound(_)
-                | uv_client::ErrorKind::RemotePackageStatusCodeError(_) => {
+                | uv_client::ErrorKind::RemotePackageStatusCodeError(..) => {
                     if let Some(flat_index) = flat_index
                         .and_then(|flat_index| flat_index.get(package_name))
                         .cloned()

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -229,7 +229,8 @@ impl<Context: BuildContext> ResolverProvider for DefaultResolverProvider<'_, Con
                     .collect(),
             )),
             Err(err) => match err.kind() {
-                uv_client::ErrorKind::RemotePackageNotFound { .. } => {
+                uv_client::ErrorKind::RemotePackageNotFound(_)
+                | uv_client::ErrorKind::RemotePackageStatusCodeError(_) => {
                     if let Some(flat_index) = flat_index
                         .and_then(|flat_index| flat_index.get(package_name))
                         .cloned()

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -135,7 +135,7 @@ impl LatestClient<'_> {
                 if matches!(
                     err.kind(),
                     uv_client::ErrorKind::RemotePackageNotFound(_)
-                        | uv_client::ErrorKind::RemotePackageStatusCodeError(_)
+                        | uv_client::ErrorKind::RemotePackageStatusCodeError(..)
                         | uv_client::ErrorKind::NoIndex(_)
                         | uv_client::ErrorKind::Offline(_)
                 ) =>

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -134,7 +134,7 @@ impl LatestClient<'_> {
             Err(err)
                 if matches!(
                     err.kind(),
-                    uv_client::ErrorKind::RemotePackageNotFound(_)
+                    uv_client::ErrorKind::RemotePackageNotFound { .. }
                         | uv_client::ErrorKind::NoIndex(_)
                         | uv_client::ErrorKind::Offline(_)
                 ) =>

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -134,7 +134,8 @@ impl LatestClient<'_> {
             Err(err)
                 if matches!(
                     err.kind(),
-                    uv_client::ErrorKind::RemotePackageNotFound { .. }
+                    uv_client::ErrorKind::RemotePackageNotFound(_)
+                        | uv_client::ErrorKind::RemotePackageStatusCodeError(_)
                         | uv_client::ErrorKind::NoIndex(_)
                         | uv_client::ErrorKind::Offline(_)
                 ) =>

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -9,7 +9,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use uv_static::EnvVars;
 use uv_test::{uv_snapshot, venv_bin_path};
-use wiremock::matchers::{basic_auth, method, path};
+use wiremock::matchers::{basic_auth, method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn dummy_wheel() -> PathBuf {
@@ -955,6 +955,115 @@ fn non_normalized_filename_skip() {
     ----- stderr -----
     Publishing 1 file to https://test.pypi.org/legacy/
     warning: `ok-1.01.0-py3-none-any.whl` has a non-normalized filename (expected `ok-1.1.0-py3-none-any.whl`), skipping
+    "
+    );
+}
+
+/// Capture the behavior for a simple index page for check URL that returns a status code error
+/// that is not specifically handled as 401 and 403 are.
+#[tokio::test]
+async fn check_url_400() {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex("^/simple/.*"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_string("Access to this page is forbidden"),
+        )
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--check-url")
+        .arg(format!("{}/simple", server.uri()))
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("--username")
+        .arg("ferris")
+        .arg("--password")
+        .arg("password")
+        .arg(dummy_wheel()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    error: Failed to query check URL
+      Caused by: Failed to fetch: `http://[LOCALHOST]/simple/ok/`
+      Caused by: HTTP status client error (400 Bad Request) for url (http://[LOCALHOST]/simple/ok/)
+    "
+    );
+}
+
+#[tokio::test]
+async fn check_url_401() {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex("^/simple/.*"))
+        .respond_with(
+            ResponseTemplate::new(401).set_body_string("Access to this page is unauthorized"),
+        )
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--check-url")
+        .arg(format!("{}/simple", server.uri()))
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("--username")
+        .arg("ferris")
+        .arg("--password")
+        .arg("password")
+        .arg(dummy_wheel()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    error: Failed to query check URL due to a lack of valid authentication credentials (401 Unauthorized): http://[LOCALHOST]/simple.
+
+    hint: Check URL credentials must be configured separately from publish URL credentials
+    "
+    );
+}
+#[tokio::test]
+async fn check_url_403() {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex("^/simple/.*"))
+        .respond_with(
+            ResponseTemplate::new(403).set_body_string("Access to this page is forbidden"),
+        )
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--check-url")
+        .arg(format!("{}/simple", server.uri()))
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg("--username")
+        .arg("ferris")
+        .arg("--password")
+        .arg("password")
+        .arg(dummy_wheel()), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    error: Failed to query check URL due to a lack of valid authentication credentials (403 Forbidden): http://[LOCALHOST]/simple.
+
+    hint: Check URL credentials must be configured separately from publish URL credentials
     "
     );
 }


### PR DESCRIPTION
Currently, when `--check-url` or the index URL from `--index` returns a 401 or 403, we continue with the update, not actually performing the check. Instead, we now error and hint at missing check URL credentials.

There are two ways this change could go wrong:

* Someone publishes a new package to an index that sends 401 or 403 for missing packages (torch is known to do this, but is also not a regular upload target)
* Someone publishes to an index with invalid credentials, but didn't realize that they were invalid due to this bug

Fixes #16073
