### PR TITLE
Only add actual schema in schemastore PRs

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -74,11 +74,11 @@ def update_schemastore(schemastore: Path, *, root: Path) -> None:
         commit_url = f"{UV_REPOSITORY}/commit/{current_sha}"
         commit_body = f"This updates uv's JSON schema to [{current_sha}]({commit_url})"
         # https://stackoverflow.com/a/22909204/3549270
+        check_call(["git", "add", UV_JSON_PATH.as_posix()], cwd=src)
         check_call(
             [
                 "git",
                 "commit",
-                "-a",
                 "-m",
                 "Update uv's JSON schema",
                 "-m",


### PR DESCRIPTION
## Summary

Last time I ran the `update_schemastore.py` script in ty, due to what I assume was a `npm` version mismatch, the `package-lock.json` file was updated while running `npm install` in the `schemastore`. Due to the use of `git commit -a`, it was accidentally included in the commit for the semi-automated schemastore PR. The solution here is to only add the actual file that we want to commit.

Same as https://github.com/astral-sh/ty/pull/1391

## Test Plan

I did a dry-run of this script (by commenting out the final `push`) and verified that the commit did include the schema, but not the updated `package-lock.json` file.