### PR TITLE
Fix typo in MissingTopLevel warning

### DIFF
--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -688,7 +688,7 @@ async fn execute_plan(
                     uv_install_wheel::Error::MissingTopLevel(_),
                 )) => {
                     warn_user!(
-                        "Failed to uninstall package at {} due to missing `top-level.txt` file. Installation may result in an incomplete environment.",
+                        "Failed to uninstall package at {} due to missing `top_level.txt` file. Installation may result in an incomplete environment.",
                         dist_info.install_path().user_display().cyan(),
                     );
                 }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -9019,7 +9019,7 @@ fn missing_top_level() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: Failed to uninstall package at [SITE_PACKAGES]/suds_community.egg-info due to missing `top-level.txt` file. Installation may result in an incomplete environment.
+    warning: Failed to uninstall package at [SITE_PACKAGES]/suds_community.egg-info due to missing `top_level.txt` file. Installation may result in an incomplete environment.
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      ~ suds-community==0.8.5


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
The warning shown when `egg-info` lacks `top_level.txt` incorrectly warns about missing `top-level.txt`
https://github.com/astral-sh/uv/blob/ee2649feaa78b847ebcd44daebdce28c2e974842/crates/uv-install-wheel/src/uninstall.rs#L179-L188
https://github.com/astral-sh/uv/blob/ee2649feaa78b847ebcd44daebdce28c2e974842/crates/uv/src/commands/pip/operations.rs#L687-L693

The non fatal warning with incorrect filename was introduced in https://github.com/astral-sh/uv/pull/6881 which changed previous fatal error https://github.com/astral-sh/uv/issues/6872 with correct `top_level.txt` output.

## Test Plan

<!-- How was it tested? -->
Updated unit test to reflect change in warning
