### PR TITLE
Improve 403 Forbidden error message to indicate package may not exist

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -1549,7 +1549,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::ForbiddenIndex { index } => {
                 write!(
                     f,
-                    "{}{} An index URL ({}) returned a {} error. This could indicate missing authentication credentials, or the package may not exist on this index.",
+                    "{}{} An index URL ({}) returned a {} error. This could indicate lack of valid authentication credentials, or the package may not exist on this index.",
                     "hint".bold().cyan(),
                     ":".bold(),
                     index.without_credentials().cyan(),

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -12491,7 +12491,7 @@ fn add_empty_ignore_error_codes() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because flask was not found in the package registry and your project depends on flask, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: An index URL (https://download.pytorch.org/whl/cpu) returned a 403 Forbidden error. This could indicate missing authentication credentials, or the package may not exist on this index.
+          hint: An index URL (https://download.pytorch.org/whl/cpu) returned a 403 Forbidden error. This could indicate lack of valid authentication credentials, or the package may not exist on this index.
       help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
     "
     );


### PR DESCRIPTION
Fixes #16340

## Summary

Some package registries (PyTorch, corporate PyPI mirrors) return `403 Forbidden` when a package is not found, instead of `404 Not Found`. The previous error message incorrectly suggested this was always an authentication issue, causing confusion for users.

This PR updates the error hint to clarify that a 403 error could indicate either missing authentication credentials OR that the package doesn't exist on the index.

## Test Plan

- Updated existing snapshot test in `crates/uv/tests/it/edit.rs` to reflect the new error message
- The change is purely a message improvement with no behavioral changes

## Changes

### Before

hint: An index URL (https://example.com/simple) could not be queried due to a lack of valid authentication credentials (403 Forbidden).

### After

hint: An index URL (https://example.com/simple) returned a 403 Forbidden error. This could indicate missing authentication credentials, or the package may not exist on this index.


## Files Changed

- `crates/uv-resolver/src/pubgrub/report.rs` - Updated error message
- `crates/uv/tests/it/edit.rs` - Updated snapshot test expectation