### PR TITLE
Drop annotations from DockerHub uv images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -385,7 +385,7 @@ jobs:
       # minimized to just touch the GHCR manifest.
       - name: Add annotations to images
         env:
-          IMAGES: "${{ env.UV_GHCR_IMAGE }} ${{ env.UV_DOCKERHUB_IMAGE }}"
+          IMAGES: "${{ env.UV_GHCR_IMAGE }}"
           DIGEST: ${{ needs.docker-publish-base.outputs.image-digest }}
           TAGS: ${{ needs.docker-publish-base.outputs.image-tags }}
           ANNOTATIONS: ${{ needs.docker-publish-base.outputs.image-annotations }}


### PR DESCRIPTION
Also needed to achieve the goal of #16355 and workaround https://github.com/astral-sh/uv/issues/16350