### PR TITLE
Remove outdated aarch64 musl note

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -444,7 +444,7 @@ As Python does not publish official distributable CPython binaries, uv instead u
 distributions from the Astral
 [`python-build-standalone`](https://github.com/astral-sh/python-build-standalone) project.
 `python-build-standalone` is also is used in many other Python projects, like
-[Rye](https://github.com/astral-sh/rye), [Mise](https://mise.jdx.dev/lang/python.html), and
+[Mise](https://mise.jdx.dev/lang/python.html) and
 [bazelbuild/rules_python](https://github.com/bazelbuild/rules_python).
 
 The uv Python distributions are self-contained, highly-portable, and performant. While Python can be


### PR DESCRIPTION
We now build aarch64 musl Python distributions. I've also removed the rye mention since it's now officially deprecated.