### PR TITLE
Deactivate zizmor due to GitHub ratelimiting

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,4 +21,5 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
+        if: false # TODO(konsti): Reactivate once we figured out how to not get rate-limited
         uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2


### PR DESCRIPTION
A lot of CI workflows are currently failing because we're hitting GitHub Actions limits. Temporarily disable zizmor, which makes a lot of GitHub API requests.
