### PR TITLE
Improve hint on `pip install --system` when externally managed

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -236,27 +236,34 @@ pub(crate) async fn pip_install(
         if break_system_packages {
             debug!("Ignoring externally managed environment due to `--break-system-packages`");
         } else {
-            let base_message = match externally_managed.into_error() {
+            let managed_message = match externally_managed.into_error() {
                 Some(error) => format!(
-                    "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`.",
+                    "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n",
                     environment.root().user_display().cyan(),
                     textwrap::indent(&error, "  ").green(),
                 ),
                 None => format!(
-                    "The interpreter at {} is externally managed. Instead, create a virtual environment with `uv venv`.",
+                    "The interpreter at {} is externally managed and cannot be modified.",
                     environment.root().user_display().cyan()
                 ),
             };
 
             let error_message = if system {
+                // Add a hint about the `--system` flag
                 format!(
-                    "{}\n{}{} This happens because the `--system` flag was used, which selected the system Python interpreter.",
-                    base_message,
+                    "{}\n{}{} Virtual environments were not considered due to the `--system` flag",
+                    managed_message,
                     "hint".bold().cyan(),
                     ":".bold()
                 )
             } else {
-                base_message
+                // Add a hint to create a virtual environment
+                format!(
+                    "{}\n{}{} Consider creating a virtual environment, e.g., with `uv venv`",
+                    managed_message,
+                    "hint".bold().cyan(),
+                    ":".bold()
+                )
             };
 
             return Err(anyhow::Error::msg(error_message));


### PR DESCRIPTION
I had some qualms with https://github.com/astral-sh/uv/pull/16318

1. The snapshot was specific to uv's managed interpreter due to inclusion of the externally-managed output. This will break downstream distros. We either need to filter the message, or, as done here, install a managed interpreter.
2. It had a custom filter for the interpreter path, which we shouldn't need. If needed, we should fix that in the test context.
3. We already had an implicit hint to create a virtual environment. The change in styling of the new hint hint following it is confusing. It's also confusing to hint creating a virtual environment when `--system` was used.
4. There were unresolved requested changes to the language for the message / it didn't fit stylistic with our existing ones.
5. The message was also very confusing for a uv-managed interpreter, which is both a "system" Python interpreter (in that it's global) and the opposite of a "system" interpreter per UV_PYTHON_PREFERENCE.

Also problematic, but not addressed here, is that there are other commands that display an externally-managed message, e.g., `uv pip sync`, but #16318 was just limited to `pip install`. We should not just implement this in one place — I'll open a tracking issue to consolidate and reuse the logic.