### PR TITLE
Don't panic in `uv export --frozen` when the lockfile is outdated

### DIFF
--- a/crates/uv-resolver/src/lock/export/pylock_toml.rs
+++ b/crates/uv-resolver/src/lock/export/pylock_toml.rs
@@ -631,7 +631,7 @@ impl<'lock> PylockToml {
             dev,
             annotate,
             install_options,
-        );
+        )?;
 
         // Sort the nodes.
         nodes.sort_unstable_by_key(|node| &node.package.id);

--- a/crates/uv-resolver/src/lock/export/requirements_txt.rs
+++ b/crates/uv-resolver/src/lock/export/requirements_txt.rs
@@ -46,7 +46,7 @@ impl<'lock> RequirementsTxtExport<'lock> {
             dev,
             annotate,
             install_options,
-        );
+        )?;
 
         // Sort the nodes, such that unnamed URLs (editables) appear at the top.
         nodes.sort_unstable_by(|a, b| {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1269,7 +1269,7 @@ impl Lock {
     /// Returns the package with the given name. If there are multiple
     /// matching packages, then an error is returned. If there are no
     /// matching packages, then `Ok(None)` is returned.
-    fn find_by_name(&self, name: &PackageName) -> Result<Option<&Package>, String> {
+    pub fn find_by_name(&self, name: &PackageName) -> Result<Option<&Package>, String> {
         let mut found_dist = None;
         for dist in &self.packages {
             if &dist.id.name == name {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -88,6 +88,11 @@ pub(crate) enum ProjectError {
     MissingLockfile,
 
     #[error(
+        "The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `{0}`. To update the lockfile, run `uv lock`."
+    )]
+    LockWorkspaceMismatch(PackageName),
+
+    #[error(
         "The lockfile at `uv.lock` uses an unsupported schema version (v{1}, but only v{0} is supported). Downgrade to a compatible uv version, or remove the `uv.lock` prior to running `uv lock` or `uv sync`."
     )]
     UnsupportedLockVersion(u32, u32),


### PR DESCRIPTION
Provide a good error message when the discovered workspace members mismatch with the locked workspace members in `uv export --frozen`, instead of panicking.

Fixes #16406