### PR TITLE
Update docs to reflect new signal forwarding semantics

### DIFF
--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -91,10 +91,10 @@ uv does not cede control of the process to the spawned command in order to provi
 messages on failure. Consequently, uv is responsible for forwarding some signals to the child
 process the requested command runs in.
 
-On Unix systems, uv will forward most signals (with the exception of SIGKILL, SIGCHLD, SIGIO, and 
-SIGPOLL) to the child process. Since terminals send SIGINT to the foreground process group on Ctrl-C, 
-uv will only forward a SIGINT to the child process if it is sent more than once or the child process 
-group differs from uv's.
+On Unix systems, uv will forward most signals (with the exception of SIGKILL, SIGCHLD, SIGIO, and
+SIGPOLL) to the child process. Since terminals send SIGINT to the foreground process group on
+Ctrl-C, uv will only forward a SIGINT to the child process if it is sent more than once or the child
+process group differs from uv's.
 
 On Windows, these concepts do not apply and uv ignores Ctrl-C events, deferring handling to the
 child process so it can exit cleanly.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
I am a new uv user and I was reading the docs to better understand the project scope & best practices. The section on [signal forwarding](https://docs.astral.sh/uv/concepts/projects/run/#signal-handling) with `uv run` caught my eye because I've used tools that use SIGHUP to trigger config reloads or SIGUSR1/2 to enable debugging/profiling/etc so I was a little concerned about using a runner that might block those signals. After some searching in issues/PRs, I found that this behavior was actually [changed earlier this year](https://github.com/astral-sh/uv/pull/13017) to forward additional signals (awesome!) and thought I would update the docs and save the next person/llm from thinking their tool won't work as expected if it uses custom signal handling. 

Thanks for all your great work!

P.S. If you think it makes more sense to explicitly list all forwarded signals as opposed to just the exclusions, I'm happy to edit.

