### PR TITLE
Add example to docs for a release job within GitLab CI

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -87,9 +87,15 @@ your cache key files instead of `uv.lock`.
 
 ## Publishing to the GitLab PyPI index
 
-`uv publish` can be used to publish to the GitLab PyPI registry, but it will not update your release with corresponding assets links to the uploaded wheel files. It also does not provide assets links as they would be required by `glab release create --assets-links` to connect the wheel files with their corresponding release item.
+`uv publish` can be used to publish to the GitLab PyPI registry, but it will
+not update your release with corresponding assets links to the uploaded wheel
+files. It also does not provide assets links as they would be required by
+`glab release create --assets-links` to connect the wheel files with their
+corresponding release item.
 
-The following example of a release job, triggered by a pushed tag, will publish all wheel files in the GitLab PyPI registry of the project and create assets links for the corresponding release item.
+The following example of a release job, triggered by a pushed tag, will publish
+all wheel files in the GitLab PyPI registry of the project and create assets
+links for the corresponding release item.
 
 ```yaml title="gitlab-ci.yml"
 release-job:
@@ -118,6 +124,9 @@ release-job:
       done
 ```
 
-The items in the PyPI registry of the GitLab project will also be available via the PyPI registry of the corresponding GitLab group.
+The items in the PyPI registry of the GitLab project will also be available via
+the PyPI registry of the corresponding GitLab group.
 
-Note also the [package request forwarding behaviour](https://docs.gitlab.com/user/packages/pypi_repository/#package-request-forwarding-security-notice) of GitLab, which might forward your request automatically to `pypi.org`, even when using the `--default-index` flag.
+Note also the [package request forwarding behaviour](https://docs.gitlab.com/user/packages/pypi_repository/#package-request-forwarding-security-notice)
+of GitLab, which might forward your request automatically to `pypi.org`, even
+when using the `--default-index` flag.


### PR DESCRIPTION
## Summary

This pull request adds an example of a GitLab release job to the integration docs.

How to publish to the GitLab registry with `uv publish` was discussed in issue [#9195](https://github.com/astral-sh/uv/issues/9195#issuecomment-2483840918), including a suggestion to show an example in the docs, which has not happened yet.

Furthermore, it took a bit of effort to combine the following for a uv workspace:

- Publish all packages to GitLab PyPI registry (as explained in the issue linked above)
- Create one release item (using the GitLab CI release block)
- Link wheel files in PyPI registry to the release using assets-links (`uv publish` knows, but does not provide those links)

An example in the docs might be very helpful for others who want to publish and use code from their GitLab registry.