### PR TITLE
Restore DockerHub images and annotations

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -387,7 +387,7 @@ jobs:
       # minimized to just touch the GHCR manifest.
       - name: Add annotations to images
         env:
-          IMAGES: "${{ env.UV_GHCR_IMAGE }}"
+          IMAGES: "${{ env.UV_GHCR_IMAGE }} ${{ env.UV_DOCKERHUB_IMAGE }}"
           DIGEST: ${{ needs.docker-publish-base.outputs.image-digest }}
           TAGS: ${{ needs.docker-publish-base.outputs.image-tags }}
           ANNOTATIONS: ${{ needs.docker-publish-base.outputs.image-annotations }}


### PR DESCRIPTION
- **Revert "Drop publish of extended images to DockerHub temporarily (#16355)"**
- **Revert "Drop annotations from DockerHub uv images (#16356)"**
