### PR TITLE
Update maturin build backend init template

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1075,7 +1075,7 @@ fn pyproject_build_backend_prerequisites(
                     [package]
                     name = "{module_name}"
                     version = "0.1.0"
-                    edition = "2021"
+                    edition = "2024"
 
                     [lib]
                     name = "_core"
@@ -1085,7 +1085,7 @@ fn pyproject_build_backend_prerequisites(
                     [dependencies]
                     # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
                     # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.9
-                    pyo3 = {{ version = "0.22.4", features = ["extension-module", "abi3-py39"] }}
+                    pyo3 = {{ version = "0.27.1", features = ["extension-module", "abi3-py39"] }}
                 "#},
                 )?;
             }
@@ -1174,18 +1174,17 @@ fn generate_package_scripts(
                     indoc::formatdoc! {r#"
                     use pyo3::prelude::*;
 
-                    #[pyfunction]
-                    fn hello_from_bin() -> String {{
-                        "Hello from {package}!".to_string()
-                    }}
-
-                    /// A Python module implemented in Rust. The name of this function must match
+                    /// A Python module implemented in Rust. The name of this module must match
                     /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
                     /// import the module.
                     #[pymodule]
-                    fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {{
-                        m.add_function(wrap_pyfunction!(hello_from_bin, m)?)?;
-                        Ok(())
+                    mod _core {{
+                        use pyo3::prelude::*;
+
+                        #[pyfunction]
+                        fn hello_from_bin() -> String {{
+                            "Hello from {package}!".to_string()
+                        }}
                     }}
                 "#},
                 )?;

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -3366,18 +3366,17 @@ fn init_app_build_backend_maturin() -> Result<()> {
             lib_core_contents, @r###"
         use pyo3::prelude::*;
 
-        #[pyfunction]
-        fn hello_from_bin() -> String {
-            "Hello from foo!".to_string()
-        }
-
-        /// A Python module implemented in Rust. The name of this function must match
+        /// A Python module implemented in Rust. The name of this module must match
         /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
         /// import the module.
         #[pymodule]
-        fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-            m.add_function(wrap_pyfunction!(hello_from_bin, m)?)?;
-            Ok(())
+        mod _core {
+            use pyo3::prelude::*;
+
+            #[pyfunction]
+            fn hello_from_bin() -> String {
+                "Hello from foo!".to_string()
+            }
         }
         "###
         );
@@ -3392,7 +3391,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
         [package]
         name = "foo"
         version = "0.1.0"
-        edition = "2021"
+        edition = "2024"
 
         [lib]
         name = "_core"
@@ -3402,7 +3401,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
         [dependencies]
         # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
         # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.9
-        pyo3 = { version = "0.22.4", features = ["extension-module", "abi3-py39"] }
+        pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py39"] }
         "###
         );
     });
@@ -3623,18 +3622,17 @@ fn init_lib_build_backend_maturin() -> Result<()> {
             lib_core_contents, @r###"
         use pyo3::prelude::*;
 
-        #[pyfunction]
-        fn hello_from_bin() -> String {
-            "Hello from foo!".to_string()
-        }
-
-        /// A Python module implemented in Rust. The name of this function must match
+        /// A Python module implemented in Rust. The name of this module must match
         /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
         /// import the module.
         #[pymodule]
-        fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-            m.add_function(wrap_pyfunction!(hello_from_bin, m)?)?;
-            Ok(())
+        mod _core {
+            use pyo3::prelude::*;
+
+            #[pyfunction]
+            fn hello_from_bin() -> String {
+                "Hello from foo!".to_string()
+            }
         }
         "###
         );
@@ -3649,7 +3647,7 @@ fn init_lib_build_backend_maturin() -> Result<()> {
         [package]
         name = "foo"
         version = "0.1.0"
-        edition = "2021"
+        edition = "2024"
 
         [lib]
         name = "_core"
@@ -3659,7 +3657,7 @@ fn init_lib_build_backend_maturin() -> Result<()> {
         [dependencies]
         # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
         # "abi3-py39" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.9
-        pyo3 = { version = "0.22.4", features = ["extension-module", "abi3-py39"] }
+        pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py39"] }
         "###
         );
     });


### PR DESCRIPTION
## Summary

Upgrades to the latest Rust edition and pyo3 version. 
Change initialized module to "Inline Declaration" format.
https://pyo3.rs/v0.27.1/module.html#inline-declaration

The output of `maturin new` is also updating to the new declarative format
https://github.com/PyO3/maturin/commit/342239a95a0f3274ad3224e835dddfdb08737e15

## Test Plan

Updated the relevant snapshot tests and to confirm ran
`cargo nextest run --all-features --no-fail-fast maturin`

Also used the updated template to generate a library in a different project with
```
cargo run -- init --lib --build-backend maturin --name try-template ../_OTHER_PROJECT_/backend/try-template
```
and the generated workspace member functioned as expected.