### PR TITLE
Use PEP 639 license metadata for uv itself

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ requires-python = ">=3.8"
 keywords = [
   "uv", "requirements", "packaging"
 ]
+license="MIT OR Apache-2.0"
+license-files = ["LICENSE-APACHE", "LICENSE-MIT"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
-  "License :: OSI Approved :: MIT License",
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In [pep 639](https://peps.python.org/pep-0639/) the classifier for licenses gets deprecated in favor of the license field.
The benefits for UV:
- Clear that you can pick a license, not have to have both
- Clear it is version 2 for the Apache license

https://peps.python.org/pep-0639/

## Test Plan

Builds, works.
If the license shows up in pypi.org with the SPDX operator, it works
