### PR TITLE
Only run debug assertion tests when debug assertions are active

### DIFF
--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -400,45 +400,45 @@ mod tests {
     use url::Url;
 
     #[tokio::test]
-    #[cfg(debug_assertions)]
     async fn fetch_url_no_host() {
         let url = Url::parse("file:/etc/bin/").unwrap();
         let keyring = KeyringProvider::empty();
         // Panics due to debug assertion; returns `None` in production
-        let result = std::panic::AssertUnwindSafe(
-            keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some("user")),
-        )
-        .catch_unwind()
-        .await;
-        assert!(result.is_err());
+        let fetch = keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some("user"));
+        if cfg!(debug_assertions) {
+            let result = std::panic::AssertUnwindSafe(fetch).catch_unwind().await;
+            assert!(result.is_err());
+        } else {
+            assert_eq!(fetch.await, None);
+        }
     }
 
     #[tokio::test]
-    #[cfg(debug_assertions)]
     async fn fetch_url_with_password() {
         let url = Url::parse("https://user:password@example.com").unwrap();
         let keyring = KeyringProvider::empty();
         // Panics due to debug assertion; returns `None` in production
-        let result = std::panic::AssertUnwindSafe(
-            keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some(url.username())),
-        )
-        .catch_unwind()
-        .await;
-        assert!(result.is_err());
+        let fetch = keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some(url.username()));
+        if cfg!(debug_assertions) {
+            let result = std::panic::AssertUnwindSafe(fetch).catch_unwind().await;
+            assert!(result.is_err());
+        } else {
+            assert_eq!(fetch.await, None);
+        }
     }
 
     #[tokio::test]
-    #[cfg(debug_assertions)]
     async fn fetch_url_with_empty_username() {
         let url = Url::parse("https://example.com").unwrap();
         let keyring = KeyringProvider::empty();
         // Panics due to debug assertion; returns `None` in production
-        let result = std::panic::AssertUnwindSafe(
-            keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some(url.username())),
-        )
-        .catch_unwind()
-        .await;
-        assert!(result.is_err());
+        let fetch = keyring.fetch(DisplaySafeUrl::ref_cast(&url), Some(url.username()));
+        if cfg!(debug_assertions) {
+            let result = std::panic::AssertUnwindSafe(fetch).catch_unwind().await;
+            assert!(result.is_err());
+        } else {
+            assert_eq!(fetch.await, None);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
These tests currently fail when running tests in release mode.