### PR TITLE
Don't allow local versions when a non-local version is pinned

### DIFF
--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -562,7 +562,7 @@ impl Display for VersionSpecifiersOrExact {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::VersionSpecifiers(specifiers) => Display::fmt(specifiers, f),
-            Self::Exact(version) => write!(f, "=={}", version),
+            Self::Exact(version) => write!(f, "=={version}"),
         }
     }
 }

--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -9,7 +9,7 @@ use uv_distribution_filename::DistExtension;
 use uv_fs::{CWD, PortablePath, PortablePathBuf, normalize_path, try_relative_to_if};
 use uv_git_types::{GitLfs, GitOid, GitReference, GitUrl, GitUrlParseError, OidParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
-use uv_pep440::VersionSpecifiers;
+use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{
     MarkerEnvironment, MarkerTree, RequirementOrigin, VerbatimUrl, VersionOrUrl, marker,
 };
@@ -196,9 +196,9 @@ impl From<Requirement> for uv_pep508::Requirement<VerbatimUrl> {
             marker: requirement.marker,
             origin: requirement.origin,
             version_or_url: match requirement.source {
-                RequirementSource::Registry { specifier, .. } => {
-                    Some(VersionOrUrl::VersionSpecifier(specifier))
-                }
+                RequirementSource::Registry { specifier, .. } => Some(
+                    VersionOrUrl::VersionSpecifier(specifier.to_version_specifiers()),
+                ),
                 RequirementSource::Url { url, .. }
                 | RequirementSource::GitPath { url, .. }
                 | RequirementSource::GitDirectory { url, .. }
@@ -218,9 +218,9 @@ impl From<Requirement> for uv_pep508::Requirement<VerbatimParsedUrl> {
             marker: requirement.marker,
             origin: requirement.origin,
             version_or_url: match requirement.source {
-                RequirementSource::Registry { specifier, .. } => {
-                    Some(VersionOrUrl::VersionSpecifier(specifier))
-                }
+                RequirementSource::Registry { specifier, .. } => Some(
+                    VersionOrUrl::VersionSpecifier(specifier.to_version_specifiers()),
+                ),
                 RequirementSource::Url {
                     location,
                     subdirectory,
@@ -294,13 +294,13 @@ impl From<uv_pep508::Requirement<VerbatimParsedUrl>> for Requirement {
     fn from(requirement: uv_pep508::Requirement<VerbatimParsedUrl>) -> Self {
         let source = match requirement.version_or_url {
             None => RequirementSource::Registry {
-                specifier: VersionSpecifiers::empty(),
+                specifier: VersionSpecifiersOrExact::VersionSpecifiers(VersionSpecifiers::empty()),
                 index: None,
                 conflict: None,
             },
             // The most popular case: just a name, a version range and maybe extras.
             Some(VersionOrUrl::VersionSpecifier(specifier)) => RequirementSource::Registry {
-                specifier,
+                specifier: VersionSpecifiersOrExact::VersionSpecifiers(specifier),
                 index: None,
                 conflict: None,
             },
@@ -425,6 +425,9 @@ impl CacheKey for Requirement {
                 conflict: _,
             } => {
                 0u8.cache_key(state);
+                // TODO(konsti): We should use the information whether this is an exact specifier
+                // or not here, but this changes the cache.
+                let specifier = specifier.to_version_specifiers();
                 specifier.len().cache_key(state);
                 for spec in specifier.iter() {
                     spec.operator().as_str().cache_key(state);
@@ -516,6 +519,54 @@ impl CacheKey for Requirement {
     }
 }
 
+/// A local version aware version specifier.
+///
+/// For checking installed requirements against a lockfile, we want to check that the local version
+/// matches, too. When checking whether the specifier `=={version}` contains `{version}+{local}`,
+/// the check will pass, which we avoid by doing an exact version comparison instead. An example
+/// is torch `2.9.0` in the lockfile vs. `2.9.0+cu128` installed.
+#[derive(Hash, Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum VersionSpecifiersOrExact {
+    VersionSpecifiers(VersionSpecifiers),
+    Exact(Version),
+}
+
+impl VersionSpecifiersOrExact {
+    /// Note that this conversion is lossy wrt to local version matching.
+    pub fn to_version_specifiers(&self) -> VersionSpecifiers {
+        match self {
+            Self::VersionSpecifiers(specifier) => specifier.clone(),
+            Self::Exact(version) => {
+                VersionSpecifiers::from(VersionSpecifier::equals_version(version.clone()))
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::VersionSpecifiers(specifier) => specifier.is_empty(),
+            Self::Exact(_) => false,
+        }
+    }
+
+    pub fn contains(&self, other: &Version) -> bool {
+        match self {
+            Self::VersionSpecifiers(specifiers) => specifiers.contains(other),
+            // Compare including the version specifier
+            Self::Exact(version) => version == other,
+        }
+    }
+}
+
+impl Display for VersionSpecifiersOrExact {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VersionSpecifiers(specifiers) => Display::fmt(specifiers, f),
+            Self::Exact(version) => write!(f, "=={}", version),
+        }
+    }
+}
+
 /// The different locations with can install a distribution from: Version specifier (from an index),
 /// HTTP(S) URL, git repository, and path.
 ///
@@ -529,7 +580,7 @@ impl CacheKey for Requirement {
 pub enum RequirementSource {
     /// The requirement has a version specifier, such as `foo >1,<2`.
     Registry {
-        specifier: VersionSpecifiers,
+        specifier: VersionSpecifiersOrExact,
         /// Choose a version from the index at the given URL.
         index: Option<IndexMetadata>,
         /// The conflict item associated with the source, if any.
@@ -720,9 +771,9 @@ impl RequirementSource {
     }
 
     /// If the source is the registry, return the version specifiers
-    pub fn version_specifiers(&self) -> Option<&VersionSpecifiers> {
+    pub fn version_specifiers(&self) -> Option<VersionSpecifiers> {
         match self {
-            Self::Registry { specifier, .. } => Some(specifier),
+            Self::Registry { specifier, .. } => Some(specifier.to_version_specifiers()),
             Self::Url { .. }
             | Self::GitPath { .. }
             | Self::GitDirectory { .. }
@@ -904,7 +955,7 @@ impl From<RequirementSource> for RequirementSourceWire {
                     index
                 });
                 Self::Registry {
-                    specifier,
+                    specifier: specifier.to_version_specifiers(),
                     index,
                     conflict,
                 }
@@ -1064,7 +1115,7 @@ impl TryFrom<RequirementSourceWire> for RequirementSource {
                 index,
                 conflict,
             } => Ok(Self::Registry {
-                specifier,
+                specifier: VersionSpecifiersOrExact::VersionSpecifiers(specifier),
                 index: index
                     .map(|index| IndexMetadata::from(IndexUrl::from(VerbatimUrl::from_url(index)))),
                 conflict,
@@ -1213,7 +1264,7 @@ mod tests {
 
     use uv_pep508::{MarkerTree, VerbatimUrl};
 
-    use crate::{Requirement, RequirementSource};
+    use crate::{Requirement, RequirementSource, VersionSpecifiersOrExact};
 
     #[test]
     fn roundtrip() {
@@ -1223,7 +1274,7 @@ mod tests {
             groups: Box::new([]),
             marker: MarkerTree::TRUE,
             source: RequirementSource::Registry {
-                specifier: ">1,<2".parse().unwrap(),
+                specifier: VersionSpecifiersOrExact::VersionSpecifiers(">1,<2".parse().unwrap()),
                 index: None,
                 conflict: None,
             },

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -4,6 +4,7 @@ use uv_pypi_types::{HashDigest, HashDigests};
 
 use crate::{
     BuiltDist, Diagnostic, Dist, IndexMetadata, Name, RequirementSource, ResolvedDist, SourceDist,
+    VersionSpecifiersOrExact,
 };
 
 /// A set of packages pinned at specific versions.
@@ -206,11 +207,7 @@ impl From<&ResolvedDist> for RequirementSource {
                 Dist::Built(BuiltDist::Registry(wheels)) => {
                     let wheel = wheels.best_wheel();
                     Self::Registry {
-                        specifier: uv_pep440::VersionSpecifiers::from(
-                            uv_pep440::VersionSpecifier::equals_version(
-                                wheel.filename.version.clone(),
-                            ),
-                        ),
+                        specifier: VersionSpecifiersOrExact::Exact(wheel.filename.version.clone()),
                         index: Some(IndexMetadata::from(wheel.index.clone())),
                         conflict: None,
                     }
@@ -237,9 +234,7 @@ impl From<&ResolvedDist> for RequirementSource {
                     ext: DistExtension::Wheel,
                 },
                 Dist::Source(SourceDist::Registry(sdist)) => Self::Registry {
-                    specifier: uv_pep440::VersionSpecifiers::from(
-                        uv_pep440::VersionSpecifier::equals_version(sdist.version.clone()),
-                    ),
+                    specifier: VersionSpecifiersOrExact::Exact(sdist.version.clone()),
                     index: Some(IndexMetadata::from(sdist.index.clone())),
                     conflict: None,
                 },
@@ -277,9 +272,7 @@ impl From<&ResolvedDist> for RequirementSource {
                 },
             },
             ResolvedDist::Installed { dist } => Self::Registry {
-                specifier: uv_pep440::VersionSpecifiers::from(
-                    uv_pep440::VersionSpecifier::equals_version(dist.version().clone()),
-                ),
+                specifier: VersionSpecifiersOrExact::Exact(dist.version().clone()),
                 index: None,
                 conflict: None,
             },

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -9,6 +9,7 @@ use uv_auth::CredentialsCache;
 use uv_distribution_filename::DistExtension;
 use uv_distribution_types::{
     Index, IndexLocations, IndexMetadata, IndexName, Origin, Requirement, RequirementSource,
+    VersionSpecifiersOrExact,
 };
 use uv_fs::{Simplified, normalize_absolute_path, normalize_path};
 use uv_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
@@ -796,17 +797,17 @@ fn registry_source(
 ) -> RequirementSource {
     match &requirement.version_or_url {
         None => RequirementSource::Registry {
-            specifier: VersionSpecifiers::empty(),
+            specifier: VersionSpecifiersOrExact::VersionSpecifiers(VersionSpecifiers::empty()),
             index: Some(index),
             conflict,
         },
         Some(VersionOrUrl::VersionSpecifier(version)) => RequirementSource::Registry {
-            specifier: version.clone(),
+            specifier: VersionSpecifiersOrExact::VersionSpecifiers(version.clone()),
             index: Some(index),
             conflict,
         },
         Some(VersionOrUrl::Url(_)) => RequirementSource::Registry {
-            specifier: VersionSpecifiers::empty(),
+            specifier: VersionSpecifiersOrExact::VersionSpecifiers(VersionSpecifiers::empty()),
             index: Some(index),
             conflict,
         },

--- a/crates/uv-resolver/src/prerelease.rs
+++ b/crates/uv-resolver/src/prerelease.rs
@@ -83,6 +83,7 @@ impl PrereleaseStrategy {
                     };
 
                     if specifier
+                        .to_version_specifiers()
                         .iter()
                         .filter(|spec| {
                             !matches!(spec.operator(), Operator::NotEqual | Operator::NotEqualStar)

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -267,7 +267,12 @@ impl PubGrubRequirement {
     ) -> Self {
         let (verbatim_url, parsed_url) = match &requirement.source {
             RequirementSource::Registry { specifier, .. } => {
-                return Self::from_registry_requirement(specifier, extra, group, requirement);
+                return Self::from_registry_requirement(
+                    specifier.to_version_specifiers(),
+                    extra,
+                    group,
+                    requirement,
+                );
             }
             RequirementSource::Url {
                 subdirectory,
@@ -345,7 +350,7 @@ impl PubGrubRequirement {
     }
 
     fn from_registry_requirement(
-        specifier: &VersionSpecifiers,
+        specifier: VersionSpecifiers,
         extra: Option<ExtraName>,
         group: Option<GroupName>,
         requirement: &Requirement,
@@ -353,7 +358,7 @@ impl PubGrubRequirement {
         Self {
             package: Self::package_for_requirement(requirement, extra, group),
             source: DependencySource::from_requirement(requirement),
-            version: Ranges::from(specifier.clone()),
+            version: Ranges::from(specifier),
         }
     }
 }

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -26,6 +26,7 @@ impl AllowedYanks {
             let RequirementSource::Registry { specifier, .. } = &requirement.source else {
                 continue;
             };
+            let specifier = specifier.to_version_specifiers();
             let [specifier] = specifier.as_ref() else {
                 continue;
             };

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use uv_configuration::HashCheckingMode;
 use uv_distribution_types::{
     DistributionMetadata, HashGeneration, HashPolicy, Name, Requirement, RequirementSource,
-    Resolution, UnresolvedRequirement, VersionId,
+    Resolution, UnresolvedRequirement, VersionId, VersionSpecifiersOrExact,
 };
 use uv_normalize::PackageName;
 use uv_pep440::Version;
@@ -360,19 +360,27 @@ impl HashStrategy {
         match &requirement.source {
             RequirementSource::Registry { specifier, .. } => {
                 // Must be a single specifier.
-                let [specifier] = specifier.as_ref() else {
-                    return None;
-                };
+                match specifier {
+                    VersionSpecifiersOrExact::VersionSpecifiers(specifier) => {
+                        let [specifier] = specifier.as_ref() else {
+                            return None;
+                        };
 
-                // Must be pinned to a specific version.
-                if *specifier.operator() != uv_pep440::Operator::Equal {
-                    return None;
+                        // Must be pinned to a specific version.
+                        if *specifier.operator() != uv_pep440::Operator::Equal {
+                            return None;
+                        }
+
+                        Some(VersionId::from_registry(
+                            requirement.name.clone(),
+                            specifier.version().clone(),
+                        ))
+                    }
+                    VersionSpecifiersOrExact::Exact(version) => Some(VersionId::from_registry(
+                        requirement.name.clone(),
+                        version.clone(),
+                    )),
                 }
-
-                Some(VersionId::from_registry(
-                    requirement.name.clone(),
-                    specifier.version().clone(),
-                ))
             }
             RequirementSource::Url {
                 location,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -14,7 +14,7 @@ use uv_configuration::{
 use uv_distribution::LoweredExtraBuildDependencies;
 use uv_distribution_types::{
     ExtraBuildRequires, IndexCapabilities, NameRequirementSpecification, Requirement,
-    RequirementSource, UnresolvedRequirementSpecification,
+    RequirementSource, UnresolvedRequirementSpecification, VersionSpecifiersOrExact,
 };
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
@@ -224,9 +224,7 @@ pub(crate) async fn install(
                 groups: Box::new([]),
                 marker: MarkerTree::default(),
                 source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(
-                        version.clone(),
-                    )),
+                    specifier: VersionSpecifiersOrExact::Exact(version.clone()),
                     index: None,
                     conflict: None,
                 },
@@ -248,7 +246,9 @@ pub(crate) async fn install(
                 groups: Box::new([]),
                 marker: MarkerTree::default(),
                 source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::empty(),
+                    specifier: VersionSpecifiersOrExact::VersionSpecifiers(
+                        VersionSpecifiers::empty(),
+                    ),
                     index: None,
                     conflict: None,
                 },
@@ -314,7 +314,9 @@ pub(crate) async fn install(
                 groups: Box::new([]),
                 marker: MarkerTree::default(),
                 source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(version)),
+                    specifier: VersionSpecifiersOrExact::VersionSpecifiers(
+                        VersionSpecifiers::from(VersionSpecifier::equals_version(version)),
+                    ),
                     index: None,
                     conflict: None,
                 },

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -18,10 +18,10 @@ use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{Concurrency, Constraints, GitLfsSetting, TargetTriple};
 use uv_distribution::LoweredExtraBuildDependencies;
-use uv_distribution_types::InstalledDist;
 use uv_distribution_types::{
-    IndexCapabilities, IndexUrl, Name, NameRequirementSpecification, Requirement,
+    IndexCapabilities, IndexUrl, InstalledDist, Name, NameRequirementSpecification, Requirement,
     RequirementSource, UnresolvedRequirement, UnresolvedRequirementSpecification,
+    VersionSpecifiersOrExact,
 };
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
@@ -839,9 +839,7 @@ async fn get_or_create_environment(
                         groups: Box::new([]),
                         marker: MarkerTree::default(),
                         source: RequirementSource::Registry {
-                            specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(
-                                version.clone(),
-                            )),
+                            specifier: VersionSpecifiersOrExact::Exact(version.clone()),
                             index: None,
                             conflict: None,
                         },
@@ -861,7 +859,9 @@ async fn get_or_create_environment(
                         groups: Box::new([]),
                         marker: MarkerTree::default(),
                         source: RequirementSource::Registry {
-                            specifier: VersionSpecifiers::empty(),
+                            specifier: VersionSpecifiersOrExact::VersionSpecifiers(
+                                VersionSpecifiers::empty(),
+                            ),
                             index: None,
                             conflict: None,
                         },
@@ -928,7 +928,9 @@ async fn get_or_create_environment(
                 groups: Box::new([]),
                 marker: MarkerTree::default(),
                 source: RequirementSource::Registry {
-                    specifier: VersionSpecifiers::from(VersionSpecifier::equals_version(version)),
+                    specifier: VersionSpecifiersOrExact::VersionSpecifiers(
+                        VersionSpecifiers::from(VersionSpecifier::equals_version(version)),
+                    ),
                     index: None,
                     conflict: None,
                 },

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -479,14 +479,13 @@ fn pinned_version_from(requirements: &[Requirement], name: &PackageName) -> Opti
         .iter()
         .filter(|requirement| requirement.name == *name)
         .find_map(|requirement| match &requirement.source {
-            RequirementSource::Registry { specifier, .. } => {
-                specifier
-                    .iter()
-                    .find_map(|specifier| match specifier.operator() {
-                        Operator::Equal | Operator::ExactEqual => Some(specifier.version().clone()),
-                        _ => None,
-                    })
-            }
+            RequirementSource::Registry { specifier, .. } => specifier
+                .to_version_specifiers()
+                .iter()
+                .find_map(|specifier| match specifier.operator() {
+                    Operator::Equal | Operator::ExactEqual => Some(specifier.version().clone()),
+                    _ => None,
+                }),
             _ => None,
         })
 }

--- a/crates/uv/tests/lock/lock.rs
+++ b/crates/uv/tests/lock/lock.rs
@@ -20387,8 +20387,8 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG Using request connect timeout of [TIME] and read timeout of [TIME]
     DEBUG Found static `requires-dist` for: [TEMP_DIR]/
     DEBUG Resolving despite existing lockfile due to mismatched requirements for: `project==0.1.0`
-      Requested: {Requirement { name: PackageName("anyio"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([]), index: None, conflict: None }, origin: None }}
-      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }]), index: Some(IndexMetadata { url: Url(VerbatimUrl { url: DisplaySafeUrl { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }, given: None, expanded: false }), format: Simple }), conflict: None }, origin: None }}
+      Requested: {Requirement { name: PackageName("anyio"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers(VersionSpecifiers([])), index: None, conflict: None }, origin: None }}
+      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers(VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }])), index: Some(IndexMetadata { url: Url(VerbatimUrl { url: DisplaySafeUrl { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }, given: None, expanded: false }), format: Simple }), conflict: None }, origin: None }}
     DEBUG Found static `pyproject.toml` for: project @ file://[TEMP_DIR]/
     DEBUG Solving with installed Python version: 3.12.[X]
     DEBUG Solving with target Python version: >=3.12

--- a/crates/uv/tests/sync/sync.rs
+++ b/crates/uv/tests/sync/sync.rs
@@ -17541,3 +17541,147 @@ fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
 
     Ok(())
 }
+
+/// Test that switching between indexes with local and non-local versions of the same package,
+/// the package is always reinstalled, not only when switching from a non-local to a local version.
+///
+/// <https://github.com/astral-sh/uv/issues/16368>
+#[test]
+fn install_non_local_version_when_local_version_is_installed() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "main"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [project.optional-dependencies]
+        non-local = ["project"]
+        local = ["project"]
+
+        [tool.uv]
+        conflicts = [
+          [
+            { extra = "non-local" },
+            { extra = "local" },
+          ],
+        ]
+
+        [tool.uv.sources]
+        project = [
+          { index = "non-local", extra = "non-local" },
+          { index = "local", extra = "local" },
+        ]
+
+        [[tool.uv.index]]
+        name = "non-local"
+        url = "./non-local/dist"
+        format = "flat"
+        explicit = true
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "./local/dist"
+        format = "flat"
+        explicit = true
+        "#,
+    )?;
+
+    context
+        .init()
+        .arg("--lib")
+        .arg("--no-workspace")
+        .arg("--name")
+        .arg("project")
+        .arg("local")
+        .assert()
+        .success();
+    context
+        .version()
+        .arg("1.0.0+local")
+        .current_dir(context.temp_dir.child("local").as_ref())
+        .assert()
+        .success();
+    context
+        .build()
+        .arg("--wheel")
+        .current_dir(context.temp_dir.child("local").as_ref())
+        .assert()
+        .success();
+    context
+        .init()
+        .arg("--lib")
+        .arg("--no-workspace")
+        .arg("--name")
+        .arg("project")
+        .arg("non-local")
+        .assert()
+        .success();
+    context
+        .version()
+        .arg("1.0.0")
+        .current_dir(context.temp_dir.child("non-local").as_ref())
+        .assert()
+        .success();
+    context
+        .build()
+        .arg("--wheel")
+        .current_dir(context.temp_dir.child("non-local").as_ref())
+        .assert()
+        .success();
+
+    // Install the non-local version.
+    uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("non-local"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + project==1.0.0
+    ");
+    // Check that switching to the local version
+    uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("local"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - project==1.0.0
+     + project==1.0.0+local
+    ");
+    // Keeping the local version is a noop.
+    uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("local"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Checked 1 package in [TIME]
+    ");
+    // Check that switching to the non-local version invalidates the installed local version.
+    uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("non-local"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - project==1.0.0+local
+     + project==1.0.0
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/16368

Current behavior of `uv sync`:
* Requested: `1.0.0+cpu`, Installed: `1.0.0`: Install new package
* Requested: `1.0.0+cpu`, Installed: `1.0.0+cu128`: Install new package
* Requested: `1.0.0`, Installed: `1.0.0+cpu`: Keep installed package

The new behavior is to always reinstall when the local version part is different, for consistency and to fix torch.

This behavior happens because internally, we translate the version from the lockfile to an `=={version}` request, and version matching says local versions are allowed if the specifier has no local version.

This is a (minor) behavior change: When running `uv sync` in a venv with a package after installing the same package with the same version except the local version, uv will now remove the installed package and use the one from the lockfile instead. This seems more correct, as the other version was not matching the lockfile. There is still a gap as what we actually want to track is the index URL (or even better, the package hash), but as that information is not tracked in the venv, checking the local version is the next bests thing we can do. The main motivation is fixing torch, our main user of packages with both local and non-local versions (https://github.com/astral-sh/uv/issues/16368).

Fix #16368
