### PR TITLE
Set opt-level 1 for fast build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,6 +314,7 @@ lto = false
 
 [profile.fast-build]
 inherits = "dev"
+opt-level = 1
 debug = 0
 strip = "debuginfo"
 


### PR DESCRIPTION
Test cases:

```
touch crates/uv-resolver/src/resolver/mod.rs && time cargo nextest run --cargo-profile dev --no-fail-fast -- --skip python_install
touch crates/uv-resolver/src/resolver/mod.rs && time cargo nextest run --cargo-profile fast-build --no-fail-fast -- --skip python_install
```

On my machine, we go from 7.x s (dev) to 8.x s (dev + opt-level 1) for compilation, and 6.x s for the combined `fast-build` profile. With opt-level 1, we go from 84s for the first line to 64s for the second line.
