### PR TITLE
Use std `home_dir` instead of `home` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6555,7 +6555,6 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "fs-err",
- "home",
  "nix",
  "same-file",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ goblin = { version = "0.10.0", default-features = false, features = ["std", "elf
 h2 = { version = "0.4.7" }
 hashbrown = { version = "0.16.0" }
 hex = { version = "0.4.3" }
-home = { version = "0.5.9" }
 html-escape = { version = "0.2.13" }
 http = { version = "1.1.0" }
 indexmap = { version = "2.5.0" }

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -22,7 +22,6 @@ uv-static = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }
-home = { workspace = true }
 same-file = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/uv-shell/src/lib.rs
+++ b/crates/uv-shell/src/lib.rs
@@ -4,7 +4,9 @@ pub mod windows;
 
 pub use shlex::{escape_posix_for_single_quotes, shlex_posix, shlex_windows};
 
+use std::env::home_dir;
 use std::path::{Path, PathBuf};
+
 use uv_fs::Simplified;
 use uv_static::EnvVars;
 
@@ -145,7 +147,7 @@ impl Shell {
     ///
     /// See: <https://github.com/rust-lang/rustup/blob/fede22fea7b160868cece632bd213e6d72f8912f/src/cli/self_update/shell.rs#L197>
     pub fn configuration_files(self) -> Vec<PathBuf> {
-        let Some(home_dir) = home::home_dir() else {
+        let Some(home_dir) = home_dir() else {
             return vec![];
         };
         match self {
@@ -232,7 +234,7 @@ impl Shell {
 
     /// Returns `true` if the given path is on the `PATH` in this shell.
     pub fn contains_path(path: &Path) -> bool {
-        let home_dir = home::home_dir();
+        let home_dir = home_dir();
         std::env::var_os(EnvVars::PATH)
             .as_ref()
             .iter()


### PR DESCRIPTION
The `home_dir` function in std was deprecated for some years for reading `HOME` on Windows. It has recently been fixed and undeprecated: https://github.com/rust-lang/rust/pull/132515

Conversely, the Cargo maintainers want us to move away from the home crate (https://github.com/rust-lang/cargo/tree/master/crates/home):

> Note: This has been fixed in Rust 1.85 to no longer use the HOME environment variable on Windows. If you are still using this crate for the purpose of getting a home directory, you are strongly encouraged to switch to using the standard library's home_dir instead. It is planned to have the deprecation notice removed in 1.87.
>
> This crate further provides two functions, cargo_home and rustup_home, which are the canonical way to determine the location that Cargo and rustup store their data.
>
> See rust-lang/rust#43321.
>
> > This crate is maintained by the Cargo team, primarily for use by Cargo and Rustup and not intended for external use. This crate may make major changes to its APIs or be deprecated without warning.

When https://github.com/lunacookies/etcetera/pull/36 merges, we can remove the home crate from our dependency tree.


