### PR TITLE
Drop terminal coloring from `uv auth token` output

### DIFF
--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use anyhow::{Result, bail};
-use owo_colors::OwoColorize;
 use tracing::debug;
 
 use uv_auth::{AuthBackend, Service};


### PR DESCRIPTION
It's too common to set `FORCE_COLOR` in CI which then breaks consumption of the token.

This is actually specific to `pyx.dev`, as we print passwords without coloring.