### PR TITLE
Improve readability of progress bars

### DIFF
--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -230,7 +230,7 @@ impl ProgressReporter {
             // Ignore spinners, such as for builds.
             if let ProgressBarKind::Numeric { progress, .. } = progress {
                 let template = format!(
-                    "{{msg:{max_len}.dim}} {{bar:30.green/dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}"
+                    "{{msg:{max_len}.dim}} {{bar:30.green/black.dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}"
                 );
                 progress.set_style(
                     ProgressStyle::with_template(&template)
@@ -252,7 +252,7 @@ impl ProgressReporter {
             progress.set_style(
                 ProgressStyle::with_template(
                     &format!(
-                        "{{msg:{}.dim}} {{bar:30.green/dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}", state.max_len
+                        "{{msg:{}.dim}} {{bar:30.green/black.dim}} {{binary_bytes:>7}}/{{binary_total_bytes:7}}", state.max_len
                     ),
                 )
                     .unwrap()


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Improve readability of progress bars by drawing the right portions in dimmed black instead of dimmed green. This makes it much easier to distinguish from the left (finished) part, which is drawn in green.

Fixes #6908.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Tested locally, looks as follows:

<img width="1100" height="731" alt="white" src="https://github.com/user-attachments/assets/2a396e96-27ef-41ed-8b03-a0de2061af12" />
<img width="1100" height="731" alt="black" src="https://github.com/user-attachments/assets/85d03a3a-a1dc-4389-9e51-fd486e60e067" />