### PR TITLE
add Renovate CustomManager to manage maturin version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,6 +141,16 @@
       packageNameTemplate: "rust-lang/rust",
       datasourceTemplate: "github-releases",
     },
+    {
+      customType: "regex",
+      managerFilePatterns: ["^\\.github/workflow/build-binaries\\.yml$"],
+      matchStrings: [
+        "maturin-version:\\s*['\"]?(?<currentValue>[\\w\\.\\-]+)['\"]?",
+      ],
+      depNameTemplate: "maturin",
+      packageNameTemplate: "PyO3/maturin",
+      datasourceTemplate: "github-releases",
+    },
   ],
   vulnerabilityAlerts: {
     commitMessageSuffix: "",


### PR DESCRIPTION
added a custom regex manager in renovate.json5 to update the maturin version in build-binaries.yml

closes #16440 