### PR TITLE
Add prerelease guidance for build-system resolution failures

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -1361,7 +1361,7 @@ impl std::fmt::Display for PubGrubHint {
                 let spec = format!("{package}>={version}");
                 write!(
                     f,
-                    "{}{} Only pre-releases of `{}` (e.g., {}) match these build requirements, and build environments can't enable pre-releases automatically.\n    Add {} to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.",
+                    "{}{} Only pre-releases of `{}` (e.g., {}) match these build requirements, and build environments can't enable pre-releases automatically. Add `{}` to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.",
                     "hint".bold().cyan(),
                     ":".bold(),
                     package.cyan(),
@@ -1383,7 +1383,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::BuildPrereleaseRequested { name, range } => {
                 write!(
                     f,
-                    "{}{} `{}` was requested with a pre-release marker (e.g., {}), but build environments can't opt into pre-releases automatically.\n    Add {} to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.",
+                    "{}{} `{}` was requested with a pre-release marker (e.g., {}), but build environments can't opt into pre-releases automatically.  Add `{}` to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.",
                     "hint".bold().cyan(),
                     ":".bold(),
                     name.cyan(),

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -3709,7 +3709,7 @@ fn build_prerelease_hint() -> Result<()> {
     uv_snapshot!(
         context.filters(),
         command,
-        @r###"
+        @r"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3722,9 +3722,8 @@ fn build_prerelease_hint() -> Result<()> {
       ╰─▶ Because only transitive-package-only-prereleases-in-range-b<0.1 is available and transitive-package-only-prereleases-in-range-a==0.1.0 depends on transitive-package-only-prereleases-in-range-b>0.1, we can conclude that transitive-package-only-prereleases-in-range-a==0.1.0 cannot be used.
           And because only transitive-package-only-prereleases-in-range-a==0.1.0 is available and you require transitive-package-only-prereleases-in-range-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Only pre-releases of `transitive-package-only-prereleases-in-range-b` (e.g., 1.0.0a1) match these build requirements, and build environments can't enable pre-releases automatically.
-              Add transitive-package-only-prereleases-in-range-b>=1.0.0a1 to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.
-    "###
+          hint: Only pre-releases of `transitive-package-only-prereleases-in-range-b` (e.g., 1.0.0a1) match these build requirements, and build environments can't enable pre-releases automatically. Add `transitive-package-only-prereleases-in-range-b>=1.0.0a1` to `build-system.requires`, `[tool.uv.extra-build-dependencies]`, or supply it via `uv build --build-constraint`.
+    "
     );
 
     Ok(())


### PR DESCRIPTION
Resolves https://github.com/astral-sh/uv/issues/16496

This PR updates the resolver so `build-system` dependency failures surface prerelease hints even when prerelease selection is fixed. When a build dependency only has prerelease candidates, or the requested version explicitly includes a prerelease marker, we now emit a tailored hint explaining that build environments can’t auto-enable prereleases and describing how to opt in. 