### PR TITLE
Update the spdx dependency to version 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4207,9 +4207,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
+checksum = "41cf87c0efffc158b9dde4d6e0567a43e4383adc4c949e687a2039732db2f23a"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ serde-untagged = { version = "0.1.6" }
 serde_json = { version = "1.0.128" }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
-spdx = { version = "0.10.6" }
+spdx = { version = "0.12.0" }
 syn = { version = "2.0.77" }
 sys-info = { version = "0.9.1" }
 tar = { version = "0.4.43" }


### PR DESCRIPTION
https://github.com/EmbarkStudios/spdx/blob/0.12.0/CHANGELOG.md

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Simply keeps up with the latest `spdx` crate release.

## Test Plan

<!-- How was it tested? -->
I don’t currently have access to my machine that has enough memory to compile uv without workarounds, so I tested this via [a patch to the downstream Fedora packages](https://copr.fedorainfracloud.org/coprs/music/spdx/packages/).