### PR TITLE
Add `MACOSX_DEPLOYMENT_TARGET` hint for macos platform wheels

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -937,7 +937,7 @@ impl TargetTriple {
 }
 
 /// Return the macOS deployment target as parsed from the environment.
-fn macos_deployment_target() -> Option<(u16, u16)> {
+pub fn macos_deployment_target() -> Option<(u16, u16)> {
     let version = std::env::var(EnvVars::MACOSX_DEPLOYMENT_TARGET).ok()?;
     let mut parts = version.split('.');
 

--- a/crates/uv-platform-tags/src/platform_tag.rs
+++ b/crates/uv-platform-tags/src/platform_tag.rs
@@ -148,6 +148,18 @@ impl PlatformTag {
         matches!(self, Self::Macos { .. })
     }
 
+    /// Return the major and minor version associated with the tag, if present.
+    pub fn major_minor(&self) -> Option<(u16, u16)> {
+        match self {
+            Self::Manylinux { major, minor, .. }
+            | Self::Musllinux { major, minor, .. }
+            | Self::Macos { major, minor, .. }
+            | Self::Pyodide { major, minor }
+            | Self::Ios { major, minor, .. } => Some((*major, *minor)),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if the platform is Android-only.
     pub fn is_android(&self) -> bool {
         matches!(self, Self::Android { .. })

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -17883,3 +17883,52 @@ fn post_release_less_than() -> Result<()> {
 
     Ok(())
 }
+
+/// See: <https://github.com/astral-sh/uv/issues/10699>
+#[test]
+fn invalid_platform_macos() -> Result<()> {
+    let context = TestContext::new("3.12");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("mlx")?;
+
+    uv_snapshot!(context
+        .pip_compile()
+        .env(EnvVars::MACOSX_DEPLOYMENT_TARGET, "12.5")
+        .arg("--python-platform")
+        .arg("macos")
+        .arg("requirements.in"), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only the following versions of mlx are available:
+              mlx==0.0.2
+              mlx==0.0.3
+              mlx==0.0.4
+              mlx==0.0.5
+              mlx==0.0.6
+              mlx==0.0.7
+              mlx==0.0.9
+              mlx==0.0.10
+              mlx==0.0.11
+              mlx==0.1.0
+              mlx==0.2.0
+              mlx==0.3.0
+              mlx==0.4.0
+              mlx==0.5.1
+              mlx==0.6.0
+              mlx==0.7.0
+          and mlx<=0.0.3 has no wheels with a matching Python ABI tag (e.g., `cp312`), we can conclude that mlx<=0.0.3 cannot be used.
+          And because mlx>=0.0.4 has no wheels with a matching platform tag (e.g., `macosx_12_0_arm64`) and you require mlx, we can conclude that your requirements are unsatisfiable.
+
+          hint: You require CPython 3.12 (`cp312`), but we only found wheels for `mlx` (v0.0.3) with the following Python ABI tags: `cp38`, `cp39`, `cp310`, `cp311`
+
+          hint: Wheels are available for `mlx` (v0.7.0) on the following platforms: `macosx_13_0_arm64`, `macosx_14_0_arm64`
+
+          hint: Wheels are built for macOS 13.0 or newer; set environment variable MACOSX_DEPLOYMENT_TARGET (e.g. MACOSX_DEPLOYMENT_TARGET=13.0) to target a compatible minimum deployment target (current minimum is 12.5)
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes  #10699

Since #11783 hadn’t been merged yet, I fixed the issues mentioned in the comments and opened this new pull request.

## Test Plan

<!-- How was it tested? -->

Added `invalid_platform_macos` to `pip_compile.rs`.