### PR TITLE
Docker builds target rust toolchain with bundled musl v1.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,15 @@ RUN case "$TARGETPLATFORM" in \
   *) exit 1 ;; \
   esac
 
+# Temporarily using nightly-2025-11-02 for bundled musl v1.2.5
+# Ref: https://github.com/rust-lang/rust/pull/142682
+# TODO(samypr100): Remove when toolchain updates to 1.93
+COPY <<EOF rust-toolchain.toml
+[toolchain]
+channel = "nightly-2025-11-02"
+EOF
 # Update rustup whenever we bump the rust version
-COPY rust-toolchain.toml rust-toolchain.toml
+# COPY rust-toolchain.toml rust-toolchain.toml
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target $(cat rust_target.txt) --profile minimal --default-toolchain none
 ENV PATH="$HOME/.cargo/bin:$PATH"
 # Install the toolchain then the musl target

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
+# TODO(samypr100): When updating to 1.93, adjust Dockerfile to remove nightly-2025-11-02
 [toolchain]
 channel = "1.91"


### PR DESCRIPTION
## Summary

Addresses https://github.com/astral-sh/uv/issues/8450 for docker builds

## Test Plan

* Ubuntu Tests [CI Run](https://github.com/samypr100/uv/actions/runs/19054484993/job/54421786118) with `nightly-2025-11-02` set in root `rust-toolchain.toml`
* Manually test functionality using locally built binaries from cargo-zigbuild