### PR TITLE
Remove temporary with_added_extension in favour of stablised standard method

### DIFF
--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
-use uv_fs::{LockedFile, with_added_extension};
+use uv_fs::LockedFile;
 use uv_preview::{Preview, PreviewFeatures};
 use uv_redacted::DisplaySafeUrl;
 
@@ -238,7 +238,7 @@ impl TextCredentialStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let lock = with_added_extension(path, ".lock");
+        let lock = path.with_added_extension(".lock");
         Ok(LockedFile::acquire_blocking(lock, "credentials store")?)
     }
 

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
@@ -10,24 +9,6 @@ pub use crate::path::*;
 pub mod cachedir;
 mod path;
 pub mod which;
-
-/// Append an extension to a [`PathBuf`].
-///
-/// Unlike [`Path::with_extension`], this function does not replace an existing extension.
-///
-/// If there is no file name, the path is returned unchanged.
-///
-/// This mimics the behavior of the unstable [`Path::with_added_extension`] method.
-pub fn with_added_extension<'a>(path: &'a Path, extension: &str) -> Cow<'a, Path> {
-    let Some(name) = path.file_name() else {
-        // If there is no file name, we cannot add an extension.
-        return Cow::Borrowed(path);
-    };
-    let mut name = name.to_os_string();
-    name.push(".");
-    name.push(extension.trim_start_matches('.'));
-    Cow::Owned(path.with_file_name(name))
-}
 
 /// Attempt to check if the two paths refer to the same file.
 ///
@@ -925,46 +906,4 @@ pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Re
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_with_added_extension() {
-        // Test with simple package name (no dots)
-        let path = PathBuf::from("python");
-        let result = with_added_extension(&path, "exe");
-        assert_eq!(result, PathBuf::from("python.exe"));
-
-        // Test with package name containing single dot
-        let path = PathBuf::from("awslabs.cdk-mcp-server");
-        let result = with_added_extension(&path, "exe");
-        assert_eq!(result, PathBuf::from("awslabs.cdk-mcp-server.exe"));
-
-        // Test with package name containing multiple dots
-        let path = PathBuf::from("org.example.tool");
-        let result = with_added_extension(&path, "exe");
-        assert_eq!(result, PathBuf::from("org.example.tool.exe"));
-
-        // Test with different extensions
-        let path = PathBuf::from("script");
-        let result = with_added_extension(&path, "ps1");
-        assert_eq!(result, PathBuf::from("script.ps1"));
-
-        // Test with path that has directory components
-        let path = PathBuf::from("some/path/to/awslabs.cdk-mcp-server");
-        let result = with_added_extension(&path, "exe");
-        assert_eq!(
-            result,
-            PathBuf::from("some/path/to/awslabs.cdk-mcp-server.exe")
-        );
-
-        // Test with empty path (edge case)
-        let path = PathBuf::new();
-        let result = with_added_extension(&path, "exe");
-        assert_eq!(result, path); // Should return unchanged
-    }
 }

--- a/crates/uv-shell/src/runnable.rs
+++ b/crates/uv-shell/src/runnable.rs
@@ -5,8 +5,6 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 
-use uv_fs::with_added_extension;
-
 #[derive(Debug)]
 pub enum WindowsRunnable {
     /// Windows PE (.exe)
@@ -92,7 +90,7 @@ impl WindowsRunnable {
             .map(|script_type| {
                 (
                     script_type,
-                    with_added_extension(&script_path, script_type.to_extension()),
+                    script_path.with_added_extension(script_type.to_extension()),
                 )
             })
             .find(|(_, script_path)| script_path.is_file())


### PR DESCRIPTION
## Summary

Replace the with_added_extension function created in #15300 (and moved in #15610) with the now-stabilised version PathBuf::with_added_extension. 
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Uses existing tests (which were added in the original PR specifically to enable this change)
