### PR TITLE
Clarify user-level and system-level configuration file locations

### DIFF
--- a/docs/concepts/configuration-files.md
+++ b/docs/concepts/configuration-files.md
@@ -54,8 +54,8 @@ uv will also discover user-level and system-level configuration files:
     - User-level: `%APPDATA%\uv\uv.toml`
     - System-level: `%SYSTEMDRIVE%\ProgramData\uv\uv.toml`
 
-User-level and system-level configuration must use the `uv.toml` format, rather than the `pyproject.toml`
-format, as a `pyproject.toml` is intended to define a Python _project_.
+User-level and system-level configuration must use the `uv.toml` format, rather than the
+`pyproject.toml` format, as a `pyproject.toml` is intended to define a Python _project_.
 
 If project-, user-, and system-level configuration files are found, the settings will be merged,
 with project-level configuration taking precedence over the user-level configuration, and user-level


### PR DESCRIPTION
## Summary

A small tweak to the layout of the configuration file documentation to help visually clarify that macOS/Linux and Windows have different file locations. I accidently misread this section at first and got confused why my Windows PC wasn't respecting `~/.config/uv/uv.toml`. The refactor uses a tabbed layout similar to [Getting Started->Installation ](https://docs.astral.sh/uv/getting-started/installation/).

## Test Plan

Built the docs locally and this is the old/new layout:

### Old

<img width="777" height="211" alt="image" src="https://github.com/user-attachments/assets/87e1a075-c450-45cb-bb28-a8a7446c1749" />

### New

<img width="774" height="288" alt="image" src="https://github.com/user-attachments/assets/ec59c2d5-692b-491b-84e6-0cd06a7fa2dc" />


