### PR TITLE
Remove fast path from `uv-git` fetch

### DIFF
--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -49,6 +49,7 @@ impl GitResolver {
         self.0.get(reference)
     }
 
+    /// Return the [`GitOid`] for the given [`GitUrl`], if it is already known.
     pub fn get_precise(&self, url: &GitUrl) -> Option<GitOid> {
         // If the URL is already precise, return it.
         if let Some(precise) = url.precise() {
@@ -143,7 +144,6 @@ impl GitResolver {
     pub async fn fetch(
         &self,
         url: &GitUrl,
-        client: impl Into<ClientWithMiddleware>,
         disable_ssl: bool,
         offline: bool,
         cache: PathBuf,
@@ -175,9 +175,9 @@ impl GitResolver {
 
         // Fetch the Git repository.
         let source = if let Some(reporter) = reporter {
-            GitSource::new(url.as_ref().clone(), client, cache, offline).with_reporter(reporter)
+            GitSource::new(url.as_ref().clone(), cache, offline).with_reporter(reporter)
         } else {
-            GitSource::new(url.as_ref().clone(), client, cache, offline)
+            GitSource::new(url.as_ref().clone(), cache, offline)
         };
 
         // If necessary, disable SSL.

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use reqwest_middleware::ClientWithMiddleware;
 use tracing::{debug, instrument};
 
 use uv_cache_key::{RepositoryUrl, cache_digest};
@@ -21,8 +20,6 @@ use crate::git::{GitDatabase, GitRemote};
 pub struct GitSource {
     /// The Git reference from the manifest file.
     git: GitUrl,
-    /// The HTTP client to use for fetching.
-    client: ClientWithMiddleware,
     /// Whether to disable SSL verification.
     disable_ssl: bool,
     /// Whether to operate without network connectivity.
@@ -35,17 +32,11 @@ pub struct GitSource {
 
 impl GitSource {
     /// Initialize a [`GitSource`] with the given Git URL, HTTP client, and cache path.
-    pub fn new(
-        git: GitUrl,
-        client: impl Into<ClientWithMiddleware>,
-        cache: impl Into<PathBuf>,
-        offline: bool,
-    ) -> Self {
+    pub fn new(git: GitUrl, cache: impl Into<PathBuf>, offline: bool) -> Self {
         Self {
             git,
             disable_ssl: false,
             offline,
-            client: client.into(),
             cache: cache.into(),
             reporter: None,
         }
@@ -132,7 +123,6 @@ impl GitSource {
                 maybe_db,
                 self.git.reference(),
                 self.git.precise(),
-                &self.client,
                 self.disable_ssl,
                 self.offline,
             )?;


### PR DESCRIPTION
## Summary

Now that we perform this fast-path in `crates/uv-distribution/src/source/mod.rs`, I _think_ the fast-path here is no longer used? In my testing, we only actually took this path when the fast-path _already_ failed (and thus it would fail again, wasting time).
