### PR TITLE
Add expectation for externally managed marker in x86-64 macOS system test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2496,7 +2496,7 @@ jobs:
         run: echo $(which python3)
 
       - name: "Validate global Python install"
-        run: python3 scripts/check_system_python.py --uv ./uv
+        run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-windows-python-310:
     timeout-minutes: 10


### PR DESCRIPTION
This is failing with

```
Run python3 scripts/check_system_python.py --uv ./uv
INFO: Checking that `pylint` isn't installed.
WARNING: Package(s) not found: pylint
INFO: Installing the package `pylint`.
DEBUG uv 0.9.7 (2cd1400fb 2025-11-06)
DEBUG Acquired shared lock for `/Users/runner/.cache/uv`
DEBUG Searching for default Python interpreter in search path or managed installations
DEBUG Found `cpython-3.14.0-macos-x86_64-none` at `/usr/local/bin/python3` (first executable in the search path)
Using Python 3.14.0 environment at: /usr/local/opt/python@3.14/Frameworks/Python.framework/Versions/3.14
DEBUG Released lock at `/Users/runner/.cache/uv/.lock`
error: The interpreter at /usr/local/opt/python@3.14/Frameworks/Python.framework/Versions/3.14 is externally managed, and indicates the following:

  To install Python packages system-wide, try brew install
  xyz, where xyz is the package you are trying to
  install.

  If you wish to install a Python library that isn't in Homebrew,
  use a virtual environment:

  python3 -m venv path/to/venv
  source path/to/venv/bin/activate
  python3 -m pip install xyz

  If you wish to install a Python application that isn't in Homebrew,
  it may be easiest to use 'pipx install xyz', which will manage a
  virtual environment for you. You can install pipx with

  brew install pipx

  You may restore the old behavior of pip by passing
  the '--break-system-packages' flag to pip, or by adding
  'break-system-packages = true' to your pip.conf file. The latter
  will permanently disable this error.

  If you disable this error, we STRONGLY recommend that you additionally
  pass the '--user' flag to pip, or set 'user = true' in your pip.conf
  file. Failure to do this can result in a broken Homebrew installation.

  Read more about this behavior here: <https://peps.python.org/pep-0668/>
```