### PR TITLE
Use `git ls-remote` to resolve Git SHAs

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -601,6 +601,9 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         source: &BuildableSource<'_>,
         hashes: HashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
+        // Resolve the source distribution to a precise revision (i.e., a specific Git commit).
+        self.builder.resolve_revision(source, &self.client).await?;
+
         // If the metadata was provided by the user directly, prefer it.
         if let Some(dist) = source.as_dist() {
             if let Some(metadata) = self
@@ -608,10 +611,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 .dependency_metadata()
                 .get(dist.name(), dist.version())
             {
-                // If we skipped the build, we should still resolve any Git dependencies to precise
-                // commits.
-                self.builder.resolve_revision(source, &self.client).await?;
-
                 return Ok(ArchiveMetadata::from_metadata23(metadata.clone()));
             }
         }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1733,68 +1733,49 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .as_ref()
             .is_some_and(|cache_shard| cache_shard.is_dir())
         {
-            debug!("Skipping GitHub fast path for: {source} (shard exists)");
+            debug!("Skipping GitHub `pyproject.toml` fast path for: {source} (shard exists)");
         } else {
-            debug!("Attempting GitHub fast path for: {source}");
+            debug!("Attempting GitHub `pyproject.toml` fast path: {source}");
 
-            // If this is GitHub URL, attempt to resolve to a precise commit using the GitHub API.
-            match self
-                .build_context
-                .git()
-                .github_fast_path(
-                    resource.git,
-                    client
-                        .unmanaged
-                        .uncached_client(resource.git.url())
-                        .raw_client(),
-                )
-                .await
-            {
-                Ok(Some(precise)) => {
-                    // There's no need to check the cache, since we can't use cached metadata if there are
-                    // sources, and we can't know if there are sources without fetching the
-                    // `pyproject.toml`.
-                    //
-                    // For the same reason, there's no need to write to the cache, since we won't be able to
-                    // use it on subsequent runs.
-                    match self
-                        .github_metadata(precise, source, resource, client)
-                        .await
-                    {
-                        Ok(Some(metadata)) => {
-                            // Validate the metadata, but ignore it if the metadata doesn't match.
-                            match validate_metadata(source, &metadata) {
-                                Ok(()) => {
-                                    debug!(
-                                        "Found static metadata via GitHub fast path for: {source}"
-                                    );
-                                    return Ok(ArchiveMetadata {
-                                        metadata: Metadata::from_metadata23(metadata),
-                                        hashes: HashDigests::empty(),
-                                    });
-                                }
-                                Err(err) => {
-                                    debug!(
-                                        "Ignoring `pyproject.toml` from GitHub for {source}: {err}"
-                                    );
-                                }
+            if let Some(precise) = self.build_context.git().get_precise(resource.git) {
+                // If this is GitHub URL, attempt to fetch the `pyproject.toml` directly.
+                //
+                // There's no need to check the cache, since we can't use cached metadata if there
+                // are sources, and we can't know if there are sources without fetching the
+                // `pyproject.toml`.
+                //
+                // For the same reason, there's no need to write to the cache, since we won't be
+                // able to use it on subsequent runs.
+                //
+                // TODO(charlie): Skip this fetch if the GitHub commit resolution fast path failed
+                // with a 404 or similar.
+                match self
+                    .github_metadata(precise, source, resource, client)
+                    .await
+                {
+                    Ok(Some(metadata)) => {
+                        // Validate the metadata, but ignore it if the metadata doesn't match.
+                        match validate_metadata(source, &metadata) {
+                            Ok(()) => {
+                                debug!("Found static metadata via GitHub fast path for: {source}");
+                                return Ok(ArchiveMetadata {
+                                    metadata: Metadata::from_metadata23(metadata),
+                                    hashes: HashDigests::empty(),
+                                });
+                            }
+                            Err(err) => {
+                                debug!("Ignoring `pyproject.toml` from GitHub for {source}: {err}");
                             }
                         }
-                        Ok(None) => {
-                            // Nothing to do.
-                        }
-                        Err(err) => {
-                            debug!(
-                                "Failed to fetch `pyproject.toml` via GitHub fast path for: {source} ({err})"
-                            );
-                        }
                     }
-                }
-                Ok(None) => {
-                    // Nothing to do.
-                }
-                Err(err) => {
-                    debug!("Failed to resolve commit via GitHub fast path for: {source} ({err})");
+                    Ok(None) => {
+                        // Nothing to do.
+                    }
+                    Err(err) => {
+                        debug!(
+                            "Failed to fetch `pyproject.toml` via GitHub fast path for: {source} ({err})"
+                        );
+                    }
                 }
             }
         }
@@ -2068,7 +2049,23 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             )
             .await?
         {
-            debug!("Resolved to precise commit via GitHub fast path: {source}");
+            debug!("Resolved to a precise commit via GitHub fast path: {source}");
+            return Ok(Some(precise));
+        }
+
+        // Otherwise, attempt to resolve using `git ls-remote`.
+        if let Some(precise) = self
+            .build_context
+            .git()
+            .ls_remote(
+                git,
+                client.unmanaged.disable_ssl(git.url()),
+                client.unmanaged.connectivity() == Connectivity::Offline,
+                self.build_context.cache().bucket(CacheBucket::Git),
+            )
+            .await?
+        {
+            debug!("Resolved to a precise commit via `git ls-remote`: {source}");
             return Ok(Some(precise));
         }
 

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -361,6 +361,21 @@ impl GitRemote {
             lfs_ready: None,
         })
     }
+
+    /// Resolve the OID of a reference or a revision from this remote.
+    pub(crate) fn ls(
+        &self,
+        reference: &GitReference,
+        locked_rev: Option<GitOid>,
+        disable_ssl: bool,
+        offline: bool,
+    ) -> Result<Option<GitOid>> {
+        let reference = locked_rev
+            .map(ReferenceOrOid::Oid)
+            .unwrap_or(ReferenceOrOid::Reference(reference));
+
+        ls_remote(&self.url, reference, disable_ssl, offline)
+    }
 }
 
 impl GitDatabase {
@@ -557,6 +572,61 @@ impl GitCheckout {
 
         Ok(lfs_validation)
     }
+}
+
+/// Perform a `git ls-remote` operation to resolve a reference or revision to an OID.
+fn ls_remote(
+    remote_url: &DisplaySafeUrl,
+    reference: ReferenceOrOid<'_>,
+    disable_ssl: bool,
+    offline: bool,
+) -> Result<Option<GitOid>> {
+    debug!("Performing a Git ls-remote for: {remote_url}");
+    let mut cmd = GIT.as_ref().cloned()?;
+    cmd.arg("ls-remote");
+    if disable_ssl {
+        debug!("Disabling SSL verification for Git ls-remote via `GIT_SSL_NO_VERIFY`");
+        cmd.env(EnvVars::GIT_SSL_NO_VERIFY, "true");
+    }
+    if offline {
+        debug!("Disabling remote protocols for Git ls-remote via `GIT_ALLOW_PROTOCOL=file`");
+        cmd.env(EnvVars::GIT_ALLOW_PROTOCOL, "file");
+    }
+    cmd.arg(remote_url.as_str());
+
+    match reference {
+        ReferenceOrOid::Reference(r) => match r {
+            GitReference::Branch(_) => {
+                cmd.arg("--heads");
+                cmd.arg(reference.as_rev());
+            }
+            GitReference::Tag(_) => {
+                cmd.arg("--tags");
+                cmd.arg(reference.as_rev());
+            }
+            _ => {
+                cmd.arg(reference.as_rev());
+            }
+        },
+        ReferenceOrOid::Oid(_) => {
+            cmd.arg(reference.as_rev());
+        }
+    }
+
+    let output = cmd.exec_with_output()?;
+    let stdout = str::from_utf8(&output.stdout)?;
+
+    for line in stdout.lines() {
+        let mut parts = line.split_whitespace();
+        if let (Some(oid_str), Some(ref_str)) = (parts.next(), parts.next()) {
+            if ref_str == reference.as_rev() {
+                let oid: GitOid = oid_str.parse()?;
+                return Ok(Some(oid));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Attempts to fetch the given git `reference` for a Git repository.

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -2,7 +2,6 @@
 //! Cargo is dual-licensed under either Apache 2.0 or MIT, at the user's choice.
 //! Source: <https://github.com/rust-lang/cargo/blob/23eb492cf920ce051abfc56bbaf838514dc8365c/src/cargo/sources/git/source.rs>
 
-use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -60,6 +59,25 @@ impl GitSource {
         }
     }
 
+    /// Resolve the OID of a reference or a revision from the Git repository.
+    #[instrument(skip(self), fields(repository = %self.git.repository(), rev = ?self.git.precise()))]
+    pub fn ls_remote(&self) -> Result<Option<GitOid>> {
+        // Authenticate the URL, if necessary.
+        let remote = if let Some(credentials) = GIT_STORE.get(self.git.repository()) {
+            credentials.apply(self.git.url().clone())
+        } else {
+            self.git.url().clone()
+        };
+
+        let git_remote = GitRemote::new(&remote);
+        git_remote.ls(
+            self.git.reference(),
+            self.git.precise(),
+            self.disable_ssl,
+            self.offline,
+        )
+    }
+
     /// Fetch the underlying Git repository at the given revision.
     #[instrument(skip(self), fields(repository = %self.git.url(), rev = ?self.git.precise()))]
     pub fn fetch(self) -> Result<Fetch> {
@@ -71,9 +89,9 @@ impl GitSource {
 
         // Authenticate the URL, if necessary.
         let remote = if let Some(credentials) = GIT_STORE.get(self.git.repository()) {
-            Cow::Owned(credentials.apply(self.git.url().clone()))
+            credentials.apply(self.git.url().clone())
         } else {
-            Cow::Borrowed(self.git.url())
+            self.git.url().clone()
         };
 
         // Fetch the commit, if we don't already have it. Wrapping this section in a closure makes
@@ -170,7 +188,7 @@ impl GitSource {
         // Report the checkout operation to the reporter.
         if let Some(task) = maybe_task {
             if let Some(reporter) = self.reporter.as_ref() {
-                reporter.on_checkout_complete(remote.as_ref(), actual_rev.as_str(), task);
+                reporter.on_checkout_complete(&remote, actual_rev.as_str(), task);
             }
         }
 


### PR DESCRIPTION
## Summary

This enables us to take a fast-path for commit resolution even for private repositories. This can be beneficial for cases in which we have a tag or branch name, but it's not clear that it's a tag or branch name, since we can skip the expensive path where we fetch all tags and branches.

Closes #16604.
