### PR TITLE
Remove `torch-model-archiver` and `torch-tb-profiler` from PyTorch backend

### DIFF
--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -306,8 +306,6 @@ impl TorchStrategy {
                 matches!(
                     package_name.as_str(),
                     "torch"
-                        | "torch-model-archiver"
-                        | "torch-tb-profiler"
                         | "torcharrow"
                         | "torchaudio"
                         | "torchcsprng"
@@ -337,8 +335,6 @@ impl TorchStrategy {
                         | "torch-spline-conv"
                         | "vllm"
                         | "torch"
-                        | "torch-model-archiver"
-                        | "torch-tb-profiler"
                         | "torcharrow"
                         | "torchaudio"
                         | "torchcsprng"


### PR DESCRIPTION
## Summary

These are present on the PyTorch index, but only at very old versions. The PyPI versions are newer, and seemingly these don't need to be built against CUDA, etc.

Closes https://github.com/astral-sh/uv/issues/16651.
