### PR TITLE
Skip python_install_emulated_macos except on ARM64 macos with rosetta

### DIFF
--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -2707,7 +2707,11 @@ fn python_install_emulated_macos() {
         .arg("true")
         .status();
     if !arch_status.is_ok_and(|x| x.success()) {
-        // skip this test if Rosetta is not available to run the x86_64 interpreter
+        // Rosetta is not available to run the x86_64 interpreter
+        // fail the test in CI, otherwise skip it
+        if env::var("CI").is_ok() {
+            panic!("x86_64 emulation is not available on this CI runner");
+        }
         debug!("Skipping test because x86_64 emulation is not available");
         return;
     }


### PR DESCRIPTION
## Summary

This test isn't useful on non-arm64 macs, and it outright fails if rosetta isn't installed.

## Test Plan

Run it on my rosetta-stripped macbook
