### PR TITLE
Deny stdout/stderr printing in `uv` crate via clippy

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fmt::Write;


### PR DESCRIPTION
Follow-up from https://github.com/astral-sh/uv/pull/16690, in `uv` every command should be using `write!(...)/writeln!(...)` with the `Printer` abstraction instead of bypassing control with the standard printing functions. This lint ensures that.