### PR TITLE
Fix CMD path in FastAPI Dockerfile

### DIFF
--- a/docs/guides/integration/fastapi.md
+++ b/docs/guides/integration/fastapi.md
@@ -113,7 +113,7 @@ WORKDIR /app
 RUN uv sync --frozen --no-cache
 
 # Run the application.
-CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0"]
+CMD ["/app/.venv/bin/fastapi", "run", "main.py", "--port", "80", "--host", "0.0.0.0"]
 ```
 
 Build the Docker image with:


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix suggestion for uv when used with FastAPI and Docker.

## Test Plan

The Dockerfile sets `/app` as workdir, later the CMD command points again to `app/main.py` instead of only `main.py`, causing the following error:
```
Path does not exist app/main.py
```
