### PR TITLE
refactor: update deprecated renovate schedule syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
     "customManagers:githubActionsVersions",
   ],
   labels: ["internal"],
-  schedule: ["before 4am on Monday"],
+  schedule: ["* 0-3 * * 1"],
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Related issue: none
This is a minor change; no issue is associated. Please let me know if one is required.

## Summary
Update deprecated renovate schedule syntax
```diff
- schedule: ["before 4am on Monday"],
+ schedule: ["* 0-3 * * 1"],
```

<!-- What's the purpose of the change? What does it do, and why? -->
## Rationale
- Deprecated: Renovate plans to remove the @breejs/later library, so cron syntax is recommended.
- Time range: at least 3-4 hours recommended for any schedule.

References:
- [Deprecated later syntax](https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax)
- [Schedule options](https://docs.renovatebot.com/configuration-options/#schedule)


## Test Plan
<!-- How was it tested? -->
- Cron syntax verified on [crontab.guru](https://crontab.guru/#*_0-3_*_*_1)
- Behavior in Renovate not testable directly
