### PR TITLE
Prevent `uv export` from overwriting `pyproject.toml`

### DIFF
--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -298,7 +298,7 @@ pub(crate) async fn export(
         .is_some_and(|name| name.eq_ignore_ascii_case("pyproject.toml"))
     {
         return Err(anyhow!(
-            "`pyproject.toml` is not a supported output format for `{}`. Supported formats: {}",
+            "`pyproject.toml` is not a supported output format for `{}` (supported formats: {})",
             "uv export".green(),
             ExportFormat::value_variants()
                 .iter()

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -4489,7 +4489,7 @@ fn pep_751_infer_output_format() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    error: `pyproject.toml` is not a supported output format for `uv export`. Supported formats: requirements.txt, pylock.toml
+    error: `pyproject.toml` is not a supported output format for `uv export` (supported formats: requirements.txt, pylock.toml, cyclonedx1.5)
     ");
 
     Ok(())


### PR DESCRIPTION
Currently, it's possible for `uv export` to overwrite someones `pyproject.toml`. This diff simply rejects project files passed in with `-o`, so we avoid doing that.