### PR TITLE
Use caching for `--python-downloads-json-url`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -11,7 +11,7 @@ use std::{path::Path, path::PathBuf, str::FromStr};
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use uv_cache::Cache;
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, CachedClient};
 use uv_distribution_types::RequiresPython;
 use uv_fs::Simplified;
 use uv_fs::which::is_executable;
@@ -1496,9 +1496,10 @@ pub(crate) async fn find_best_python_installation(
                 if let Some(download_state) = &mut download_state {
                     download_state
                 } else {
-                    let download_list_client = client_builder.build()?;
+                    let download_list_client = CachedClient::new(client_builder.build()?);
                     let download_list = ManagedPythonDownloadList::new(
                         &download_list_client,
+                        cache,
                         python_downloads_json_url,
                     )
                     .await?;

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -11,7 +11,7 @@ use std::{path::Path, path::PathBuf, str::FromStr};
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, CachedClient};
+use uv_client::BaseClientBuilder;
 use uv_distribution_types::RequiresPython;
 use uv_fs::Simplified;
 use uv_fs::which::is_executable;
@@ -1496,9 +1496,8 @@ pub(crate) async fn find_best_python_installation(
                 if let Some(download_state) = &mut download_state {
                     download_state
                 } else {
-                    let download_list_client = CachedClient::new(client_builder.build()?);
                     let download_list = ManagedPythonDownloadList::new(
-                        &download_list_client,
+                        client_builder,
                         cache,
                         python_downloads_json_url,
                     )

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1025,10 +1025,10 @@ impl ManagedPythonDownloadList {
         cache: &Cache,
         python_downloads_json_url: Option<&str>,
     ) -> Result<Self, Error> {
-        // Although read_url() handles file:// URLs and converts them to local file reads, here we
-        // want to also support parsing bare filenames like "/tmp/py.json", not just
-        // "file:///tmp/py.json". Note that "C:\Temp\py.json" should be considered a filename, even
-        // though Url::parse would successfully misparse it as a URL with scheme "C".
+        // file:// URLs are converted to local file reads, and we also support parsing bare
+        // filenames like "/tmp/py.json", not just "file:///tmp/py.json". Note that
+        // "C:\Temp\py.json" should be considered a filename, even though Url::parse would
+        // successfully misparse it as a URL with scheme "C".
         enum Source<'a> {
             BuiltIn,
             Path(Cow<'a, Path>),
@@ -1135,19 +1135,18 @@ async fn fetch_downloads_from_url(
         Connectivity::Offline => CacheControl::AllowStale,
     };
 
-    let start = Instant::now();
     let request = client
         .uncached()
         .for_host(url)
         .get(Url::from(url.clone()))
         .build()
-        .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))?;
+        .map_err(|err| Error::NetworkError(url.clone(), WrappedReqwestError::from(err)))?;
 
     let response_callback = async |response: Response| {
         let bytes = response
             .bytes()
             .await
-            .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))?;
+            .map_err(|err| Error::NetworkError(url.clone(), WrappedReqwestError::from(err)))?;
         parse_downloads_json(&bytes, url.to_string())
     };
 
@@ -1160,13 +1159,13 @@ async fn fetch_downloads_from_url(
                 err,
                 retries,
                 duration,
-            } => {
-                if retries > 0 {
-                    err.into_retried(retries, duration)
-                } else {
-                    err
-                }
-            }
+            } => match err {
+                // Avoid double-wrapping errors.
+                err @ (Error::InvalidPythonDownloadsJSON(..)
+                | Error::UnsupportedPythonDownloadsJSON(..)) => err,
+                err if retries > 0 => err.into_retried(retries, duration),
+                err => err,
+            },
         })
 }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1113,19 +1113,20 @@ async fn fetch_bytes_from_url(
         Connectivity::Offline => CacheControl::AllowStale,
     };
 
+    let start = Instant::now();
     let request = client
         .uncached()
         .for_host(url)
         .get(Url::from(url.clone()))
         .build()
-        .map_err(|err| Error::from_reqwest(url.clone(), err, None, Instant::now()))?;
+        .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))?;
 
     let response_callback = async |response: Response| {
         response
             .bytes()
             .await
             .map(|bytes| bytes.to_vec())
-            .map_err(|err| Error::from_reqwest(url.clone(), err, None, Instant::now()))
+            .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))
     };
 
     client
@@ -1133,7 +1134,17 @@ async fn fetch_bytes_from_url(
         .await
         .map_err(|err| match err {
             CachedClientError::Client(err) => Error::RemotePythonDownloadsJSONClient(Box::new(err)),
-            CachedClientError::Callback { err, .. } => err,
+            CachedClientError::Callback {
+                err,
+                retries,
+                duration,
+            } => {
+                if retries > 0 {
+                    err.into_retried(retries, duration)
+                } else {
+                    err
+                }
+            }
         })
 }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1015,10 +1015,6 @@ impl ManagedPythonDownloadList {
 
     /// Load available Python distributions from a provided source or the compiled-in list.
     ///
-    /// `http`/`https` URLs are fetched through the [`CachedClient`], so the response is cached and,
-    /// on subsequent calls, reused or revalidated according to the server's HTTP cache policy;
-    /// `--no-cache` bypasses the cache.
-    ///
     /// Returns an error if the provided list could not be opened, if the JSON is invalid, or if it
     /// does not parse into the expected data structure.
     pub async fn new(

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -25,8 +25,8 @@ use url::Url;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::cache_digest;
 use uv_client::{
-    BaseClient, CacheControl, CachedClient, CachedClientError, RetriableError, WrappedReqwestError,
-    fetch_with_url_fallback, retryable_on_request_failure,
+    BaseClient, CacheControl, CachedClient, CachedClientError, Connectivity, RetriableError,
+    WrappedReqwestError, fetch_with_url_fallback, retryable_on_request_failure,
 };
 use uv_distribution_filename::{ExtensionError, SourceDistExtension};
 use uv_extract::hash::Hasher;
@@ -1112,7 +1112,10 @@ async fn fetch_bytes_from_url(
         "downloads-json",
         format!("{}.msgpack", cache_digest(&url.as_str())),
     );
-    let cache_control = CacheControl::from(cache.freshness(&cache_entry, None, None)?);
+    let cache_control = match client.uncached().connectivity() {
+        Connectivity::Online => CacheControl::from(cache.freshness(&cache_entry, None, None)?),
+        Connectivity::Offline => CacheControl::AllowStale,
+    };
 
     let request = client
         .uncached()

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -25,8 +25,9 @@ use url::Url;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::cache_digest;
 use uv_client::{
-    BaseClient, CacheControl, CachedClient, CachedClientError, Connectivity, RetriableError,
-    WrappedReqwestError, fetch_with_url_fallback, retryable_on_request_failure,
+    BaseClient, BaseClientBuilder, CacheControl, CachedClient, CachedClientError, ClientBuildError,
+    Connectivity, RetriableError, WrappedReqwestError, fetch_with_url_fallback,
+    retryable_on_request_failure,
 };
 use uv_distribution_filename::{ExtensionError, SourceDistExtension};
 use uv_extract::hash::Hasher;
@@ -122,6 +123,8 @@ pub enum Error {
     FetchingPythonDownloadsJSONError(String, #[source] Box<Self>),
     #[error(transparent)]
     RemotePythonDownloadsJSONClient(Box<uv_client::Error>),
+    #[error(transparent)]
+    ClientBuild(Box<ClientBuildError>),
     #[error("An offline Python installation was requested, but {file} (from {url}) is missing in {}", python_builds_dir.user_display())]
     OfflinePythonMissing {
         file: Box<PythonInstallationKey>,
@@ -1018,7 +1021,7 @@ impl ManagedPythonDownloadList {
     /// Returns an error if the provided list could not be opened, if the JSON is invalid, or if it
     /// does not parse into the expected data structure.
     pub async fn new(
-        client: &CachedClient,
+        client_builder: &BaseClientBuilder<'_>,
         cache: &Cache,
         python_downloads_json_url: Option<&str>,
     ) -> Result<Self, Error> {
@@ -1048,24 +1051,30 @@ impl ManagedPythonDownloadList {
             Source::BuiltIn
         };
 
-        let json_downloads =
-            match json_source {
-                Source::BuiltIn => parse_downloads_json(
-                    BUILTIN_PYTHON_DOWNLOADS_JSON,
-                    "EMBEDDED IN THE BINARY".to_owned(),
-                )?,
-                Source::Path(ref path) => parse_downloads_json(
-                    &fs_err::read(path.as_ref())?,
-                    path.to_string_lossy().to_string(),
-                )?,
-                Source::Http(ref url) => fetch_downloads_from_url(client, cache, url)
+        let json_downloads = match json_source {
+            Source::BuiltIn => parse_downloads_json(
+                BUILTIN_PYTHON_DOWNLOADS_JSON,
+                "EMBEDDED IN THE BINARY".to_owned(),
+            )?,
+            Source::Path(ref path) => parse_downloads_json(
+                &fs_err::read(path.as_ref())?,
+                path.to_string_lossy().to_string(),
+            )?,
+            Source::Http(ref url) => {
+                let client = CachedClient::new(
+                    client_builder
+                        .build()
+                        .map_err(|err| Error::ClientBuild(Box::new(err)))?,
+                );
+                fetch_downloads_from_url(&client, cache, url)
                     .await
                     .map_err(|e| match e {
                         e @ (Error::InvalidPythonDownloadsJSON(..)
                         | Error::UnsupportedPythonDownloadsJSON(..)) => e,
                         e => Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(e)),
-                    })?,
-            };
+                    })?
+            }
+        };
 
         let downloads = parse_json_downloads(json_downloads);
         Ok(Self { downloads })
@@ -2075,13 +2084,9 @@ mod tests {
             .with_implementation(ImplementationName::CPython);
         request.build = Some("20240814".to_string());
 
-        let client = uv_client::CachedClient::new(
-            uv_client::BaseClientBuilder::default()
-                .build()
-                .expect("failed to build base client"),
-        );
+        let client_builder = uv_client::BaseClientBuilder::default();
         let cache = uv_cache::Cache::temp().expect("failed to create temp cache");
-        let download_list = ManagedPythonDownloadList::new(&client, &cache, None)
+        let download_list = ManagedPythonDownloadList::new(&client_builder, &cache, None)
             .await
             .unwrap();
 
@@ -2108,13 +2113,9 @@ mod tests {
             .with_implementation(ImplementationName::CPython);
         request.build = Some("99999999".to_string());
 
-        let client = uv_client::CachedClient::new(
-            uv_client::BaseClientBuilder::default()
-                .build()
-                .expect("failed to build base client"),
-        );
+        let client_builder = uv_client::BaseClientBuilder::default();
         let cache = uv_cache::Cache::temp().expect("failed to create temp cache");
-        let download_list = ManagedPythonDownloadList::new(&client, &cache, None)
+        let download_list = ManagedPythonDownloadList::new(&client_builder, &cache, None)
             .await
             .unwrap();
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -11,19 +11,22 @@ use std::{env, io};
 use futures::TryStreamExt;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use reqwest::Response;
 use reqwest_retry::RetryError;
 use reqwest_retry::policies::ExponentialBackoff;
 use serde::Deserialize;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufWriter, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWriteExt, BufWriter, ReadBuf};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::either::Either;
 use tracing::{debug, instrument};
 use url::Url;
 
+use uv_cache::{Cache, CacheBucket};
+use uv_cache_key::cache_digest;
 use uv_client::{
-    BaseClient, RetriableError, WrappedReqwestError, fetch_with_url_fallback,
-    retryable_on_request_failure,
+    BaseClient, CacheControl, CachedClient, CachedClientError, RetriableError, WrappedReqwestError,
+    fetch_with_url_fallback, retryable_on_request_failure,
 };
 use uv_distribution_filename::{ExtensionError, SourceDistExtension};
 use uv_extract::hash::Hasher;
@@ -117,6 +120,8 @@ pub enum Error {
     UnsupportedPythonDownloadsJSON(String),
     #[error("Error while fetching remote python downloads json from '{0}'")]
     FetchingPythonDownloadsJSONError(String, #[source] Box<Self>),
+    #[error(transparent)]
+    RemotePythonDownloadsJSONClient(Box<uv_client::Error>),
     #[error("An offline Python installation was requested, but {file} (from {url}) is missing in {}", python_builds_dir.user_display())]
     OfflinePythonMissing {
         file: Box<PythonInstallationKey>,
@@ -1010,14 +1015,15 @@ impl ManagedPythonDownloadList {
 
     /// Load available Python distributions from a provided source or the compiled-in list.
     ///
-    /// `python_downloads_json_url` can be either `None`, to use the default list (taken from
-    /// `crates/uv-python/download-metadata.json`), or `Some` local path
-    /// or file://, http://, or https:// URL.
+    /// `http`/`https` URLs are fetched through the [`CachedClient`], so the response is cached and,
+    /// on subsequent calls, reused or revalidated according to the server's HTTP cache policy;
+    /// `--no-cache` bypasses the cache.
     ///
     /// Returns an error if the provided list could not be opened, if the JSON is invalid, or if it
     /// does not parse into the expected data structure.
     pub async fn new(
-        client: &BaseClient,
+        client: &CachedClient,
+        cache: &Cache,
         python_downloads_json_url: Option<&str>,
     ) -> Result<Self, Error> {
         // Although read_url() handles file:// URLs and converts them to local file reads, here we
@@ -1049,7 +1055,7 @@ impl ManagedPythonDownloadList {
         let buf: Cow<'_, [u8]> = match json_source {
             Source::BuiltIn => BUILTIN_PYTHON_DOWNLOADS_JSON.into(),
             Source::Path(ref path) => fs_err::read(path.as_ref())?.into(),
-            Source::Http(ref url) => fetch_bytes_from_url(client, url)
+            Source::Http(ref url) => fetch_bytes_from_url(client, cache, url)
                 .await
                 .map_err(|e| Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(e)))?
                 .into(),
@@ -1096,12 +1102,40 @@ impl ManagedPythonDownloadList {
     }
 }
 
-async fn fetch_bytes_from_url(client: &BaseClient, url: &DisplaySafeUrl) -> Result<Vec<u8>, Error> {
-    let (mut reader, size) = read_url(url, client).await?;
-    let capacity = size.and_then(|s| s.try_into().ok()).unwrap_or(1_048_576);
-    let mut buf = Vec::with_capacity(capacity);
-    reader.read_to_end(&mut buf).await?;
-    Ok(buf)
+async fn fetch_bytes_from_url(
+    client: &CachedClient,
+    cache: &Cache,
+    url: &DisplaySafeUrl,
+) -> Result<Vec<u8>, Error> {
+    let cache_entry = cache.entry(
+        CacheBucket::Python,
+        "downloads-json",
+        format!("{}.msgpack", cache_digest(&url.as_str())),
+    );
+    let cache_control = CacheControl::from(cache.freshness(&cache_entry, None, None)?);
+
+    let request = client
+        .uncached()
+        .for_host(url)
+        .get(Url::from(url.clone()))
+        .build()
+        .map_err(|err| Error::from_reqwest(url.clone(), err, None, Instant::now()))?;
+
+    let response_callback = async |response: Response| {
+        response
+            .bytes()
+            .await
+            .map(|bytes| bytes.to_vec())
+            .map_err(|err| Error::from_reqwest(url.clone(), err, None, Instant::now()))
+    };
+
+    client
+        .get_serde_with_retry(request, &cache_entry, cache_control, response_callback)
+        .await
+        .map_err(|err| match err {
+            CachedClientError::Client(err) => Error::RemotePythonDownloadsJSONClient(Box::new(err)),
+            CachedClientError::Callback { err, .. } => err,
+        })
 }
 
 impl ManagedPythonDownload {
@@ -2019,10 +2053,15 @@ mod tests {
             .with_implementation(ImplementationName::CPython);
         request.build = Some("20240814".to_string());
 
-        let client = uv_client::BaseClientBuilder::default()
-            .build()
-            .expect("failed to build base client");
-        let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
+        let client = uv_client::CachedClient::new(
+            uv_client::BaseClientBuilder::default()
+                .build()
+                .expect("failed to build base client"),
+        );
+        let cache = uv_cache::Cache::temp().expect("failed to create temp cache");
+        let download_list = ManagedPythonDownloadList::new(&client, &cache, None)
+            .await
+            .unwrap();
 
         let downloads: Vec<_> = download_list
             .iter_all()
@@ -2047,10 +2086,15 @@ mod tests {
             .with_implementation(ImplementationName::CPython);
         request.build = Some("99999999".to_string());
 
-        let client = uv_client::BaseClientBuilder::default()
-            .build()
-            .expect("failed to build base client");
-        let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
+        let client = uv_client::CachedClient::new(
+            uv_client::BaseClientBuilder::default()
+                .build()
+                .expect("failed to build base client"),
+        );
+        let cache = uv_cache::Cache::temp().expect("failed to create temp cache");
+        let download_list = ManagedPythonDownloadList::new(&client, &cache, None)
+            .await
+            .unwrap();
 
         // Should find no matching downloads
         let downloads: Vec<_> = download_list

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1099,24 +1099,25 @@ fn parse_downloads_json(
     buf: &[u8],
     source: String,
 ) -> Result<HashMap<String, JsonPythonDownload>, Error> {
-    serde_json::from_slice(buf).map_err(
-        // As an explicit compatibility mechanism, if there's a top-level "version" key, it
-        // means it's a newer format than we know how to deal with.  Before reporting a
-        // parse error about the format of JsonPythonDownload, check for that key. We can do
-        // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
-        // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
-        // have the same parsing effect.)
-        #[expect(clippy::zero_sized_map_values)]
-        |e| {
+    match serde_json::from_slice(buf) {
+        Ok(data) => Ok(data),
+        Err(e) => {
+            // As an explicit compatibility mechanism, if there's a top-level "version" key, it
+            // means it's a newer format than we know how to deal with. Before reporting a
+            // parse error about the format of JsonPythonDownload, check for that key. We can do
+            // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
+            // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
+            // have the same parsing effect.)
+            #[expect(clippy::zero_sized_map_values)]
             if let Ok(keys) = serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(buf)
                 && keys.contains_key("version")
             {
-                Error::UnsupportedPythonDownloadsJSON(source)
+                Err(Error::UnsupportedPythonDownloadsJSON(source))
             } else {
-                Error::InvalidPythonDownloadsJSON(source, e)
+                Err(Error::InvalidPythonDownloadsJSON(source, e))
             }
-        },
-    )
+        }
+    }
 }
 
 async fn fetch_downloads_from_url(

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -14,7 +14,7 @@ use owo_colors::OwoColorize;
 use reqwest::Response;
 use reqwest_retry::RetryError;
 use reqwest_retry::policies::ExponentialBackoff;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWriteExt, BufWriter, ReadBuf};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -950,7 +950,7 @@ pub struct ManagedPythonDownloadList {
     downloads: Vec<ManagedPythonDownload>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 struct JsonPythonDownload {
     name: String,
     arch: JsonArch,
@@ -966,7 +966,7 @@ struct JsonPythonDownload {
     build: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 struct JsonArch {
     family: String,
     variant: Option<String>,
@@ -1048,42 +1048,27 @@ impl ManagedPythonDownloadList {
             Source::BuiltIn
         };
 
-        let buf: Cow<'_, [u8]> = match json_source {
-            Source::BuiltIn => BUILTIN_PYTHON_DOWNLOADS_JSON.into(),
-            Source::Path(ref path) => fs_err::read(path.as_ref())?.into(),
-            Source::Http(ref url) => fetch_bytes_from_url(client, cache, url)
-                .await
-                .map_err(|e| Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(e)))?
-                .into(),
-        };
-        let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(&buf)
-            .map_err(
-                // As an explicit compatibility mechanism, if there's a top-level "version" key, it
-                // means it's a newer format than we know how to deal with.  Before reporting a
-                // parse error about the format of JsonPythonDownload, check for that key. We can do
-                // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
-                // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
-                // have the same parsing effect.)
-                #[expect(clippy::zero_sized_map_values)]
-                |e| {
-                    let source = match json_source {
-                        Source::BuiltIn => "EMBEDDED IN THE BINARY".to_owned(),
-                        Source::Path(path) => path.to_string_lossy().to_string(),
-                        Source::Http(url) => url.to_string(),
-                    };
-                    if let Ok(keys) =
-                        serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(&buf)
-                        && keys.contains_key("version")
-                    {
-                        Error::UnsupportedPythonDownloadsJSON(source)
-                    } else {
-                        Error::InvalidPythonDownloadsJSON(source, e)
-                    }
-                },
-            )?;
+        let json_downloads =
+            match json_source {
+                Source::BuiltIn => parse_downloads_json(
+                    BUILTIN_PYTHON_DOWNLOADS_JSON,
+                    "EMBEDDED IN THE BINARY".to_owned(),
+                )?,
+                Source::Path(ref path) => parse_downloads_json(
+                    &fs_err::read(path.as_ref())?,
+                    path.to_string_lossy().to_string(),
+                )?,
+                Source::Http(ref url) => fetch_downloads_from_url(client, cache, url)
+                    .await
+                    .map_err(|e| match e {
+                        e @ (Error::InvalidPythonDownloadsJSON(..)
+                        | Error::UnsupportedPythonDownloadsJSON(..)) => e,
+                        e => Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(e)),
+                    })?,
+            };
 
-        let result = parse_json_downloads(json_downloads);
-        Ok(Self { downloads: result })
+        let downloads = parse_json_downloads(json_downloads);
+        Ok(Self { downloads })
     }
 
     /// Load available Python distributions from the compiled-in list only.
@@ -1098,11 +1083,38 @@ impl ManagedPythonDownloadList {
     }
 }
 
-async fn fetch_bytes_from_url(
+/// Parse the downloads JSON.
+///
+/// `source` is where the JSON came from for error reporting.
+fn parse_downloads_json(
+    buf: &[u8],
+    source: String,
+) -> Result<HashMap<String, JsonPythonDownload>, Error> {
+    serde_json::from_slice(buf).map_err(
+        // As an explicit compatibility mechanism, if there's a top-level "version" key, it
+        // means it's a newer format than we know how to deal with.  Before reporting a
+        // parse error about the format of JsonPythonDownload, check for that key. We can do
+        // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
+        // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
+        // have the same parsing effect.)
+        #[expect(clippy::zero_sized_map_values)]
+        |e| {
+            if let Ok(keys) = serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(buf)
+                && keys.contains_key("version")
+            {
+                Error::UnsupportedPythonDownloadsJSON(source)
+            } else {
+                Error::InvalidPythonDownloadsJSON(source, e)
+            }
+        },
+    )
+}
+
+async fn fetch_downloads_from_url(
     client: &CachedClient,
     cache: &Cache,
     url: &DisplaySafeUrl,
-) -> Result<Vec<u8>, Error> {
+) -> Result<HashMap<String, JsonPythonDownload>, Error> {
     let cache_entry = cache.entry(
         CacheBucket::Python,
         "downloads-json",
@@ -1122,11 +1134,11 @@ async fn fetch_bytes_from_url(
         .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))?;
 
     let response_callback = async |response: Response| {
-        response
+        let bytes = response
             .bytes()
             .await
-            .map(|bytes| bytes.to_vec())
-            .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))
+            .map_err(|err| Error::from_reqwest(url.clone(), err, None, start))?;
+        parse_downloads_json(&bytes, url.to_string())
     };
 
     client

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -12,7 +12,7 @@ use uv_warnings::warn_user;
 
 use uv_cache::Cache;
 use uv_cache_key::{CacheKey, CacheKeyHasher};
-use uv_client::{BaseClient, BaseClientBuilder};
+use uv_client::{BaseClient, BaseClientBuilder, CachedClient};
 use uv_pep440::{Prerelease, Version};
 use uv_platform::{Arch, Libc, Os, Platform};
 
@@ -165,6 +165,7 @@ impl PythonInstallation {
             .download_and_warn_if_outdated_prerelease(
                 request,
                 client_builder,
+                cache,
                 python_downloads_json_url,
             )
             .await?;
@@ -194,6 +195,7 @@ impl PythonInstallation {
                     .download_and_warn_if_outdated_prerelease(
                         request,
                         client_builder,
+                        cache,
                         python_downloads_json_url,
                     )
                     .await?;
@@ -216,9 +218,9 @@ impl PythonInstallation {
             return Err(err);
         };
 
-        let download_list_client = client_builder.build()?;
+        let download_list_client = CachedClient::new(client_builder.build()?);
         let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
+            ManagedPythonDownloadList::new(&download_list_client, cache, python_downloads_json_url)
                 .await?;
 
         let downloads_enabled = preference.allows_managed()
@@ -530,15 +532,16 @@ impl PythonInstallation {
         &self,
         request: &PythonRequest,
         client_builder: &BaseClientBuilder<'_>,
+        cache: &Cache,
         python_downloads_json_url: Option<&str>,
     ) -> Result<(), Error> {
         if !self.should_check_outdated_prerelease_warning(request) {
             return Ok(());
         }
 
-        let download_list_client = client_builder.build()?;
+        let download_list_client = CachedClient::new(client_builder.build()?);
         let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
+            ManagedPythonDownloadList::new(&download_list_client, cache, python_downloads_json_url)
                 .await?;
         self.warn_if_outdated_prerelease(request, &download_list);
 

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -12,7 +12,7 @@ use uv_warnings::warn_user;
 
 use uv_cache::Cache;
 use uv_cache_key::{CacheKey, CacheKeyHasher};
-use uv_client::{BaseClient, BaseClientBuilder, CachedClient};
+use uv_client::{BaseClient, BaseClientBuilder};
 use uv_pep440::{Prerelease, Version};
 use uv_platform::{Arch, Libc, Os, Platform};
 
@@ -218,9 +218,8 @@ impl PythonInstallation {
             return Err(err);
         };
 
-        let download_list_client = CachedClient::new(client_builder.build()?);
         let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, cache, python_downloads_json_url)
+            ManagedPythonDownloadList::new(client_builder, cache, python_downloads_json_url)
                 .await?;
 
         let downloads_enabled = preference.allows_managed()
@@ -539,9 +538,8 @@ impl PythonInstallation {
             return Ok(());
         }
 
-        let download_list_client = CachedClient::new(client_builder.build()?);
         let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, cache, python_downloads_json_url)
+            ManagedPythonDownloadList::new(client_builder, cache, python_downloads_json_url)
                 .await?;
         self.warn_if_outdated_prerelease(request, &download_list);
 

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -97,6 +97,7 @@ pub(crate) async fn find(
         .download_and_warn_if_outdated_prerelease(
             &python_request,
             client_builder,
+            cache,
             python_downloads_json_url,
         )
         .await?;

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
 
 use uv_cache::Cache;
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, CachedClient};
 use uv_configuration::Concurrency;
 use uv_errors::{ErrorOptions, write_error_chain_with_options};
 use uv_fs::Simplified;
@@ -239,6 +239,7 @@ pub(crate) async fn install(
         pypy_install_mirror,
         python_downloads_json_url,
         client_builder,
+        cache,
         default,
         python_downloads,
         no_config,
@@ -298,6 +299,7 @@ async fn perform_install(
     pypy_install_mirror: Option<String>,
     python_downloads_json_url: Option<String>,
     client_builder: BaseClientBuilder<'_>,
+    cache: &Cache,
     default: bool,
     python_downloads: PythonDownloads,
     no_config: bool,
@@ -337,11 +339,13 @@ async fn perform_install(
     let mut is_default_install = false;
     let mut is_unspecified_upgrade = false;
     let retry_policy = client_builder.retry_policy();
+    let cached_client = CachedClient::new(client_builder.build()?);
+    let download_list =
+        ManagedPythonDownloadList::new(&cached_client, cache, python_downloads_json_url.as_deref())
+            .await?;
     // Python downloads are performing their own retries to catch stream errors, disable the
     // default retries to avoid the middleware from performing uncontrolled retries.
     let client = client_builder.retries(0).build()?;
-    let download_list =
-        ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
     // TODO(zanieb): We use this variable to special-case .python-version files, but it'd be nice to
     // have generalized request source tracking instead
     let mut is_from_python_version_file = false;

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
 
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, CachedClient};
+use uv_client::BaseClientBuilder;
 use uv_configuration::Concurrency;
 use uv_errors::{ErrorOptions, write_error_chain_with_options};
 use uv_fs::Simplified;
@@ -339,10 +339,12 @@ async fn perform_install(
     let mut is_default_install = false;
     let mut is_unspecified_upgrade = false;
     let retry_policy = client_builder.retry_policy();
-    let cached_client = CachedClient::new(client_builder.build()?);
-    let download_list =
-        ManagedPythonDownloadList::new(&cached_client, cache, python_downloads_json_url.as_deref())
-            .await?;
+    let download_list = ManagedPythonDownloadList::new(
+        &client_builder,
+        cache,
+        python_downloads_json_url.as_deref(),
+    )
+    .await?;
     // Python downloads are performing their own retries to catch stream errors, disable the
     // default retries to avoid the middleware from performing uncontrolled retries.
     let client = client_builder.retries(0).build()?;

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -9,7 +9,7 @@ use itertools::Either;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, CachedClient};
+use uv_client::BaseClientBuilder;
 use uv_fs::Simplified;
 use uv_python::downloads::{
     Error as PythonDownloadError, ManagedPythonDownloadList, PythonDownloadRequest,
@@ -79,9 +79,8 @@ pub(crate) async fn list(
         PythonDownloadRequest::from_request(request.as_ref().unwrap_or(&PythonRequest::Any))
     };
 
-    let client = CachedClient::new(client_builder.build()?);
     let download_list =
-        ManagedPythonDownloadList::new(&client, cache, python_downloads_json_url.as_deref())
+        ManagedPythonDownloadList::new(client_builder, cache, python_downloads_json_url.as_deref())
             .await?;
     let mut output = BTreeSet::new();
     if let Some(base_download_request) = base_download_request {

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -9,7 +9,7 @@ use itertools::Either;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use uv_cache::Cache;
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, CachedClient};
 use uv_fs::Simplified;
 use uv_python::downloads::{
     Error as PythonDownloadError, ManagedPythonDownloadList, PythonDownloadRequest,
@@ -79,9 +79,10 @@ pub(crate) async fn list(
         PythonDownloadRequest::from_request(request.as_ref().unwrap_or(&PythonRequest::Any))
     };
 
-    let client = client_builder.build()?;
+    let client = CachedClient::new(client_builder.build()?);
     let download_list =
-        ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
+        ManagedPythonDownloadList::new(&client, cache, python_downloads_json_url.as_deref())
+            .await?;
     let mut output = BTreeSet::new();
     if let Some(base_download_request) = base_download_request {
         let download_request = match kinds {

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use uv_python::downloads::ManagedPythonDownloadList;
 
 use uv_cache::Cache;
-use uv_client::BaseClientBuilder;
+use uv_client::{BaseClientBuilder, CachedClient};
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_fs::Simplified;
 use uv_python::{
@@ -98,10 +98,11 @@ pub(crate) async fn pin(
         if let Some(file) = version_file? {
             let mut pins = file.versions().peekable();
             let download_list = if virtual_project.is_some() && pins.peek().is_some() {
-                let download_list_client = client_builder.build()?;
+                let download_list_client = CachedClient::new(client_builder.build()?);
                 Some(
                     ManagedPythonDownloadList::new(
                         &download_list_client,
+                        cache,
                         install_mirrors.python_downloads_json_url.as_deref(),
                     )
                     .await?,

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use uv_python::downloads::ManagedPythonDownloadList;
 
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, CachedClient};
+use uv_client::BaseClientBuilder;
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_fs::Simplified;
 use uv_python::{
@@ -98,10 +98,9 @@ pub(crate) async fn pin(
         if let Some(file) = version_file? {
             let mut pins = file.versions().peekable();
             let download_list = if virtual_project.is_some() && pins.peek().is_some() {
-                let download_list_client = CachedClient::new(client_builder.build()?);
                 Some(
                     ManagedPythonDownloadList::new(
-                        &download_list_client,
+                        &client_builder,
                         cache,
                         install_mirrors.python_downloads_json_url.as_deref(),
                     )

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1080,6 +1080,34 @@ async fn retry_read_timeout_index() {
 }
 
 #[tokio::test]
+async fn retry_read_timeout_python_downloads_json() {
+    let context = uv_test::test_context!("3.12");
+
+    let (server, _guard) = read_timeout_server();
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--python-downloads-json-url")
+        .arg(&server)
+        // Speed the test up with the minimum testable values
+        .env(EnvVars::UV_HTTP_TIMEOUT, "1")
+        .env(EnvVars::UV_HTTP_RETRIES, "1"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Error while fetching remote python downloads json from 'http://[LOCALHOST]/'
+      Caused by: Request failed after 1 retry in [TIME]
+      Caused by: Failed to download http://[LOCALHOST]/
+      Caused by: error decoding response body for url (http://[LOCALHOST]/)
+      Caused by: request or response body error
+      Caused by: operation timed out
+    ");
+}
+
+#[tokio::test]
 async fn retry_read_timeout_stream() {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/python/python_list.rs
+++ b/crates/uv/tests/python/python_list.rs
@@ -680,7 +680,7 @@ async fn python_list_remote_python_downloads_json_url() -> Result<()> {
 
     ----- stderr -----
     error: Error while fetching remote python downloads json from 'http://[LOCALHOST]/404'
-      Caused by: Failed to download http://[LOCALHOST]/404
+      Caused by: Failed to fetch: `http://[LOCALHOST]/404`
       Caused by: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/404)
     ");
 


### PR DESCRIPTION
Use the `CachedClient` for `--python-downloads-json-url` too, with the usual rules around freshness.

https://github.com/astral-sh/uv/pull/16542#discussion_r2522906275