### PR TITLE
Open PRs as drafts for sync-python-releases

### DIFF
--- a/.github/workflows/sync-python-releases.yml
+++ b/.github/workflows/sync-python-releases.yml
@@ -49,3 +49,4 @@ jobs:
           title: "Sync latest Python releases"
           body: "Automated update for Python releases."
           base: "main"
+          draft: true


### PR DESCRIPTION
## Summary

This is a little goofy, but it saves us a click: when automation PRs are opened as drafts, they don't need to be cycled through closed/opened to force the CI to run. Instead, once undrafted the CI runs.

See #16505 for an example of the closed/opened cycle hack this avoids.

## Test Plan

No functional changes besides CI automation.