### PR TITLE
Use explicit credentials cache instead of global static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5666,6 +5666,7 @@ dependencies = [
  "tokio",
  "toml_edit 0.23.7",
  "tracing",
+ "uv-auth",
  "uv-cache-key",
  "uv-configuration",
  "uv-distribution",

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -1,12 +1,5 @@
-use std::sync::{Arc, LazyLock};
-
-use tracing::trace;
-
-use uv_redacted::DisplaySafeUrl;
-
-use crate::credentials::Authentication;
 pub use access_token::AccessToken;
-use cache::CredentialsCache;
+pub use cache::CredentialsCache;
 pub use credentials::{Credentials, Username};
 pub use index::{AuthPolicy, Index, Indexes};
 pub use keyring::KeyringProvider;
@@ -29,32 +22,3 @@ mod pyx;
 mod realm;
 mod service;
 mod store;
-
-// TODO(zanieb): Consider passing a cache explicitly throughout
-
-/// Global authentication cache for a uv invocation
-///
-/// This is used to share credentials across uv clients.
-pub(crate) static CREDENTIALS_CACHE: LazyLock<CredentialsCache> =
-    LazyLock::new(CredentialsCache::default);
-
-/// Populate the global authentication store with credentials on a URL, if there are any.
-///
-/// Returns `true` if the store was updated.
-pub fn store_credentials_from_url(url: &DisplaySafeUrl) -> bool {
-    if let Some(credentials) = Credentials::from_url(url) {
-        trace!("Caching credentials for {url}");
-        CREDENTIALS_CACHE.insert(url, Arc::new(Authentication::from(credentials)));
-        true
-    } else {
-        false
-    }
-}
-
-/// Populate the global authentication store with credentials on a URL, if there are any.
-///
-/// Returns `true` if the store was updated.
-pub fn store_credentials(url: &DisplaySafeUrl, credentials: Credentials) {
-    trace!("Caching credentials for {url}");
-    CREDENTIALS_CACHE.insert(url, Arc::new(Authentication::from(credentials)));
-}

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uv-auth = { workspace = true }
 uv-cache-key = { workspace = true }
 uv-configuration = { workspace = true }
 uv-distribution = { workspace = true }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -15,7 +15,7 @@ use tokio::sync::{Mutex, Semaphore};
 use tracing::{Instrument, debug, info_span, instrument, trace, warn};
 use url::Url;
 
-use uv_auth::{Indexes, PyxTokenStore};
+use uv_auth::{CredentialsCache, Indexes, PyxTokenStore};
 use uv_cache::{Cache, CacheBucket, CacheEntry, WheelCache};
 use uv_configuration::IndexStrategy;
 use uv_configuration::KeyringProviderType;
@@ -148,8 +148,30 @@ impl<'a> RegistryClientBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> RegistryClient {
-        self.index_locations.cache_index_credentials();
+    /// Add all authenticated sources to the cache.
+    pub fn cache_index_credentials(&mut self) {
+        for index in self.index_locations.known_indexes() {
+            if let Some(credentials) = index.credentials() {
+                trace!(
+                    "Read credentials for index {}",
+                    index
+                        .name
+                        .as_ref()
+                        .map(ToString::to_string)
+                        .unwrap_or_else(|| index.url.to_string())
+                );
+                if let Some(root_url) = index.root_url() {
+                    self.base_client_builder
+                        .store_credentials(&root_url, credentials.clone());
+                }
+                self.base_client_builder
+                    .store_credentials(index.raw_url(), credentials);
+            }
+        }
+    }
+
+    pub fn build(mut self) -> RegistryClient {
+        self.cache_index_credentials();
         let index_urls = self.index_locations.index_urls();
 
         // Build a base client
@@ -180,8 +202,8 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     /// Share the underlying client between two different middleware configurations.
-    pub fn wrap_existing(self, existing: &BaseClient) -> RegistryClient {
-        self.index_locations.cache_index_credentials();
+    pub fn wrap_existing(mut self, existing: &BaseClient) -> RegistryClient {
+        self.cache_index_credentials();
         let index_urls = self.index_locations.index_urls();
 
         // Wrap in any relevant middleware and handle connectivity.
@@ -267,6 +289,10 @@ impl RegistryClient {
     /// Return the timeout this client is configured with, in seconds.
     pub fn timeout(&self) -> Duration {
         self.timeout
+    }
+
+    pub fn credentials_cache(&self) -> &CredentialsCache {
+        self.client.uncached().credentials_cache()
     }
 
     /// Return the appropriate index URLs for the given [`PackageName`].

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -492,6 +492,7 @@ impl BuildContext for BuildDispatch<'_> {
             environment_variables,
             build_output,
             self.concurrency.builds,
+            self.client.credentials_cache(),
             self.preview,
         )
         .boxed_local()

--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, LazyLock, RwLock};
 use itertools::Either;
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
-use tracing::trace;
 use url::{ParseError, Url};
 use uv_auth::RealmRef;
 use uv_cache_key::CanonicalUrl;
@@ -437,26 +436,6 @@ impl<'a> IndexLocations {
                     .chain(self.flat_index.iter().rev())
                     .chain(self.indexes.iter().rev()),
             )
-        }
-    }
-
-    /// Add all authenticated sources to the cache.
-    pub fn cache_index_credentials(&self) {
-        for index in self.known_indexes() {
-            if let Some(credentials) = index.credentials() {
-                trace!(
-                    "Read credentials for index {}",
-                    index
-                        .name
-                        .as_ref()
-                        .map(ToString::to_string)
-                        .unwrap_or_else(|| index.url.to_string())
-                );
-                if let Some(root_url) = index.root_url() {
-                    uv_auth::store_credentials(&root_url, credentials.clone());
-                }
-                uv_auth::store_credentials(index.raw_url(), credentials);
-            }
         }
     }
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -554,7 +554,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         pyproject_toml: &PyProjectToml,
     ) -> Result<Option<RequiresDist>, Error> {
         self.builder
-            .source_tree_requires_dist(path, pyproject_toml)
+            .source_tree_requires_dist(
+                path,
+                pyproject_toml,
+                self.client.unmanaged.credentials_cache(),
+            )
             .await
     }
 

--- a/crates/uv-distribution/src/metadata/build_requires.rs
+++ b/crates/uv-distribution/src/metadata/build_requires.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
-
+use uv_auth::CredentialsCache;
 use uv_configuration::SourceStrategy;
 use uv_distribution_types::{
     ExtraBuildRequirement, ExtraBuildRequires, IndexLocations, Requirement,
@@ -42,6 +42,7 @@ impl BuildRequires {
         locations: &IndexLocations,
         sources: SourceStrategy,
         cache: &WorkspaceCache,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         let discovery = match sources {
             SourceStrategy::Enabled => DiscoveryOptions::default(),
@@ -56,7 +57,13 @@ impl BuildRequires {
             return Ok(Self::from_metadata23(metadata));
         };
 
-        Self::from_project_workspace(metadata, &project_workspace, locations, sources)
+        Self::from_project_workspace(
+            metadata,
+            &project_workspace,
+            locations,
+            sources,
+            credentials_cache,
+        )
     }
 
     /// Lower the `build-system.requires` field from a `pyproject.toml` file.
@@ -65,6 +72,7 @@ impl BuildRequires {
         project_workspace: &ProjectWorkspace,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -114,6 +122,7 @@ impl BuildRequires {
                         locations,
                         project_workspace.workspace(),
                         None,
+                        credentials_cache,
                     )
                     .map(move |requirement| match requirement {
                         Ok(requirement) => Ok(requirement.into_inner()),
@@ -139,6 +148,7 @@ impl BuildRequires {
         workspace: &Workspace,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -186,6 +196,7 @@ impl BuildRequires {
                         locations,
                         workspace,
                         None,
+                        credentials_cache,
                     )
                     .map(move |requirement| match requirement {
                         Ok(requirement) => Ok(requirement.into_inner()),
@@ -225,6 +236,7 @@ impl LoweredExtraBuildDependencies {
         workspace: &Workspace,
         index_locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         match source_strategy {
             SourceStrategy::Enabled => {
@@ -271,6 +283,7 @@ impl LoweredExtraBuildDependencies {
                                     index_locations,
                                     workspace,
                                     None,
+                                    credentials_cache,
                                 )
                                 .map(move |requirement| {
                                     match requirement {

--- a/crates/uv-distribution/src/metadata/dependency_groups.rs
+++ b/crates/uv-distribution/src/metadata/dependency_groups.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-
+use uv_auth::CredentialsCache;
 use uv_configuration::SourceStrategy;
 use uv_distribution_types::{IndexLocations, Requirement};
 use uv_normalize::{GroupName, PackageName};
@@ -57,6 +57,7 @@ impl SourcedDependencyGroups {
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
         cache: &WorkspaceCache,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         // If the `pyproject.toml` doesn't exist, fail early.
         if !pyproject_path.is_file() {
@@ -156,6 +157,7 @@ impl SourcedDependencyGroups {
                             locations,
                             project.workspace(),
                             git_member,
+                            credentials_cache,
                         )
                         .map(move |requirement| match requirement {
                             Ok(requirement) => Ok(requirement.into_inner()),

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use either::Either;
 use thiserror::Error;
-
+use uv_auth::CredentialsCache;
 use uv_distribution_filename::DistExtension;
 use uv_distribution_types::{
     Index, IndexLocations, IndexMetadata, IndexName, Origin, Requirement, RequirementSource,
@@ -44,6 +44,7 @@ impl LoweredRequirement {
         locations: &'data IndexLocations,
         workspace: &'data Workspace,
         git_member: Option<&'data GitWorkspaceMember<'data>>,
+        credentials_cache: &'data CredentialsCache,
     ) -> impl Iterator<Item = Result<Self, LoweringError>> + use<'data> + 'data {
         // Identify the source from the `tool.uv.sources` table.
         let (sources, origin) = if let Some(source) = project_sources.get(&requirement.name) {
@@ -231,7 +232,7 @@ impl LoweredRequirement {
                                 ));
                             };
                             if let Some(credentials) = index.credentials() {
-                                uv_auth::store_credentials(index.raw_url(), credentials);
+                                credentials_cache.store_credentials(index.raw_url(), credentials);
                             }
                             let index = IndexMetadata {
                                 url: index.url.clone(),
@@ -358,6 +359,7 @@ impl LoweredRequirement {
         sources: &'data BTreeMap<PackageName, Sources>,
         indexes: &'data [Index],
         locations: &'data IndexLocations,
+        credentials_cache: &'data CredentialsCache,
     ) -> impl Iterator<Item = Result<Self, LoweringError>> + 'data {
         let source = sources.get(&requirement.name).cloned();
 
@@ -466,7 +468,7 @@ impl LoweredRequirement {
                                 ));
                             };
                             if let Some(credentials) = index.credentials() {
-                                uv_auth::store_credentials(index.raw_url(), credentials);
+                                credentials_cache.store_credentials(index.raw_url(), credentials);
                             }
                             let index = IndexMetadata {
                                 url: index.url.clone(),

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use thiserror::Error;
-
+use uv_auth::CredentialsCache;
 use uv_configuration::SourceStrategy;
 use uv_distribution_types::{GitSourceUrl, IndexLocations, Requirement};
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -91,6 +91,7 @@ impl Metadata {
         locations: &IndexLocations,
         sources: SourceStrategy,
         cache: &WorkspaceCache,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let requires_dist = uv_pypi_types::RequiresDist {
@@ -112,6 +113,7 @@ impl Metadata {
             locations,
             sources,
             cache,
+            credentials_cache,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::slice;
 
 use rustc_hash::FxHashSet;
-
+use uv_auth::CredentialsCache;
 use uv_configuration::SourceStrategy;
 use uv_distribution_types::{IndexLocations, Requirement};
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -48,6 +48,7 @@ impl RequiresDist {
         locations: &IndexLocations,
         sources: SourceStrategy,
         cache: &WorkspaceCache,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         let discovery = DiscoveryOptions {
             stop_discovery_at: git_member.map(|git_member| {
@@ -69,7 +70,14 @@ impl RequiresDist {
             return Ok(Self::from_metadata23(metadata));
         };
 
-        Self::from_project_workspace(metadata, &project_workspace, git_member, locations, sources)
+        Self::from_project_workspace(
+            metadata,
+            &project_workspace,
+            git_member,
+            locations,
+            sources,
+            credentials_cache,
+        )
     }
 
     fn from_project_workspace(
@@ -78,6 +86,7 @@ impl RequiresDist {
         git_member: Option<&GitWorkspaceMember<'_>>,
         locations: &IndexLocations,
         source_strategy: SourceStrategy,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.index` entries.
         let empty = vec![];
@@ -140,6 +149,7 @@ impl RequiresDist {
                                 locations,
                                 project_workspace.workspace(),
                                 git_member,
+                                credentials_cache,
                             )
                             .map(
                                 move |requirement| match requirement {
@@ -182,6 +192,7 @@ impl RequiresDist {
                         locations,
                         project_workspace.workspace(),
                         git_member,
+                        credentials_cache,
                     )
                     .map(move |requirement| match requirement {
                         Ok(requirement) => Ok(requirement.into_inner()),
@@ -432,7 +443,7 @@ mod test {
     use anyhow::Context;
     use indoc::indoc;
     use insta::assert_snapshot;
-
+    use uv_auth::CredentialsCache;
     use uv_configuration::SourceStrategy;
     use uv_distribution_types::IndexLocations;
     use uv_normalize::PackageName;
@@ -468,6 +479,7 @@ mod test {
             None,
             &IndexLocations::default(),
             SourceStrategy::default(),
+            &CredentialsCache::new(),
         )?)
     }
 

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
 use std::pin::pin;
 use std::sync::Arc;
@@ -17,6 +18,12 @@ use tokio::sync::Notify;
 /// of this, it's common to wrap the `V` in an `Arc<V>` to make cloning cheap.
 pub struct OnceMap<K, V, S = RandomState> {
     items: DashMap<K, Value<V>, S>,
+}
+
+impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher + Clone> Debug for OnceMap<K, V, S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.items, f)
+    }
 }
 
 impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
@@ -142,6 +149,7 @@ where
     }
 }
 
+#[derive(Debug)]
 enum Value<V> {
     Waiting(Arc<Notify>),
     Filled(V),

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1445,7 +1445,7 @@ impl Lock {
         Ok(SatisfiesResult::Satisfied)
     }
 
-    /// Convert the [`Lock`] to a [`Resolution`] using the given marker environment, tags, and root.
+    /// Check whether the lock matches the project structure, requirements and configuration.
     pub async fn satisfies<Context: BuildContext>(
         &self,
         root: &Path,

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -217,6 +217,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 build_dispatch.locations(),
                 build_dispatch.sources(),
                 build_dispatch.workspace_cache(),
+                client.credentials_cache(),
             )
             .await
             .with_context(|| {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -442,6 +442,7 @@ pub(crate) async fn add(
                     project.workspace(),
                     &settings.resolver.index_locations,
                     settings.resolver.sources,
+                    client.credentials_cache(),
                 )?
             } else {
                 LoweredExtraBuildDependencies::from_non_lowered(

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use itertools::Either;
-
+use uv_auth::CredentialsCache;
 use uv_configuration::{DependencyGroupsWithDefaults, SourceStrategy};
 use uv_distribution::LoweredRequirement;
 use uv_distribution_types::{Index, IndexLocations, Requirement, RequiresPython};
@@ -343,6 +343,7 @@ impl<'lock> LockTarget<'lock> {
         requirements: Vec<uv_pep508::Requirement<VerbatimParsedUrl>>,
         locations: &IndexLocations,
         sources: SourceStrategy,
+        credentials_cache: &CredentialsCache,
     ) -> Result<Vec<Requirement>, uv_distribution::MetadataError> {
         match self {
             Self::Workspace(workspace) => {
@@ -362,6 +363,7 @@ impl<'lock> LockTarget<'lock> {
                     workspace,
                     locations,
                     sources,
+                    credentials_cache,
                 )?;
 
                 Ok(metadata
@@ -407,6 +409,7 @@ impl<'lock> LockTarget<'lock> {
                             sources,
                             indexes,
                             locations,
+                            credentials_cache,
                         )
                         .map(move |requirement| match requirement {
                             Ok(requirement) => Ok(requirement.into_inner()),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use tracing::{debug, trace, warn};
-
+use uv_auth::CredentialsCache;
 use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::cache_digest;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -2569,6 +2569,7 @@ pub(crate) fn detect_conflicts(
 pub(crate) fn script_specification(
     script: Pep723ItemRef<'_>,
     settings: &ResolverSettings,
+    credentials_cache: &CredentialsCache,
 ) -> Result<Option<RequirementsSpecification>, ProjectError> {
     let Some(dependencies) = script.metadata().dependencies.as_ref() else {
         return Ok(None);
@@ -2588,6 +2589,7 @@ pub(crate) fn script_specification(
                 script_sources,
                 script_indexes,
                 &settings.index_locations,
+                credentials_cache,
             )
             .map_ok(LoweredRequirement::into_inner)
         })
@@ -2608,6 +2610,7 @@ pub(crate) fn script_specification(
                 script_sources,
                 script_indexes,
                 &settings.index_locations,
+                credentials_cache,
             )
             .map_ok(LoweredRequirement::into_inner)
         })
@@ -2628,6 +2631,7 @@ pub(crate) fn script_specification(
                 script_sources,
                 script_indexes,
                 &settings.index_locations,
+                credentials_cache,
             )
             .map_ok(LoweredRequirement::into_inner)
         })
@@ -2645,6 +2649,7 @@ pub(crate) fn script_specification(
 pub(crate) fn script_extra_build_requires(
     script: Pep723ItemRef<'_>,
     settings: &ResolverSettings,
+    credentials_cache: &CredentialsCache,
 ) -> Result<LoweredExtraBuildDependencies, ProjectError> {
     let script_dir = script.directory()?;
     let script_indexes = script.indexes(settings.sources);
@@ -2677,6 +2682,7 @@ pub(crate) fn script_extra_build_requires(
                         script_sources,
                         script_indexes,
                         &settings.index_locations,
+                        credentials_cache,
                     )
                     .map_ok(move |requirement| ExtraBuildRequirement {
                         requirement: requirement.into_inner(),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -372,9 +372,17 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             }
 
             // Install the script requirements, if necessary. Otherwise, use an isolated environment.
-            if let Some(spec) = script_specification((&script).into(), &settings.resolver)? {
-                let script_extra_build_requires =
-                    script_extra_build_requires((&script).into(), &settings.resolver)?.into_inner();
+            if let Some(spec) = script_specification(
+                (&script).into(),
+                &settings.resolver,
+                client_builder.credentials_cache(),
+            )? {
+                let script_extra_build_requires = script_extra_build_requires(
+                    (&script).into(),
+                    &settings.resolver,
+                    client_builder.credentials_cache(),
+                )?
+                .into_inner();
                 let environment = ScriptEnvironment::get_or_init(
                     (&script).into(),
                     python.as_deref().map(PythonRequest::parse),


### PR DESCRIPTION
Fixes https://github.com/astral-sh/uv/issues/16447

Passing this around explicitly uncovers some behaviors where we pass e.g. the credentials store to reading the lockfile. The changes in this PR should preserve the existing behavior for now, they only make the locations we read from more explicit.

Labeling this PR as "Enhancement" instead of "Internal" in case this changes behavior when it shouldn't have.