### PR TITLE
Disable always-authenticate when running under Dependabot

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -10,6 +10,7 @@ use tracing::{debug, trace, warn};
 
 use uv_preview::{Preview, PreviewFeatures};
 use uv_redacted::DisplaySafeUrl;
+use uv_static::EnvVars;
 use uv_warnings::owo_colors::OwoColorize;
 
 use crate::credentials::Authentication;
@@ -352,11 +353,15 @@ impl Middleware for AuthMiddleware {
             .is_some_and(|token_store| token_store.is_known_url(request.url()));
 
         let must_authenticate = self.only_authenticated
-            || match auth_policy {
-                AuthPolicy::Auto => is_known_url,
-                AuthPolicy::Always => true,
-                AuthPolicy::Never => false,
-            };
+            || (match auth_policy {
+                    AuthPolicy::Auto => is_known_url,
+                    AuthPolicy::Always => true,
+                    AuthPolicy::Never => false,
+                }
+                // Dependabot intercepts HTTP requests and injects credentials, which means that we
+                // cannot eagerly enforce an `AuthPolicy` as we don't know whether credentials will be
+                // added outside of uv.
+                && !std::env::var(EnvVars::DEPENDABOT).is_ok_and(|value| value == "true"));
 
         let (mut retry_request, response) = if !must_authenticate {
             let url = tracing_url(&request, credentials.as_deref());

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -662,6 +662,10 @@ impl EnvVars {
     #[attr_added_in("0.8.18")]
     pub const CONDA_ROOT: &'static str = "_CONDA_ROOT";
 
+    /// Used to determine if we're running in Dependabot.
+    #[attr_added_in("next release")]
+    pub const DEPENDABOT: &'static str = "DEPENDABOT";
+
     /// If set to `1` before a virtual environment is activated, then the
     /// virtual environment name will not be prepended to the terminal prompt.
     #[attr_added_in("0.0.5")]

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -791,6 +791,11 @@ Used to determine the name of the active Conda environment.
 
 Used to detect the path of an active Conda environment.
 
+### `DEPENDABOT`
+<small class="added-in">added in `next release`</small>
+
+Used to determine if we're running in Dependabot.
+
 ### `FISH_VERSION`
 <small class="added-in">added in `0.1.28`</small>
 


### PR DESCRIPTION
Dependabot appears to run a proxy which intercepts all requests and adds credentials — credentials are _not_ provided via the CLI or environment variables and there's no way for a user to do so. This means that when `authenticate = "always"` is used (or when the index URL is on a pyx domain), uv will fail even though Dependabot may intercept the request and add credentials.

See https://github.com/dependabot/dependabot-core/#private-registry-credential-management