### PR TITLE
Add `uv workspace list --paths`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -7185,7 +7185,11 @@ pub struct WorkspaceDirArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct WorkspaceListArgs;
+pub struct WorkspaceListArgs {
+    /// Show paths instead of names.
+    #[arg(long)]
+    pub paths: bool,
+}
 
 /// See [PEP 517](https://peps.python.org/pep-0517/) and
 /// [PEP 660](https://peps.python.org/pep-0660/) for specifications of the parameters.

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use owo_colors::OwoColorize;
+use uv_fs::Simplified;
 use uv_preview::{Preview, PreviewFeatures};
 use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
@@ -14,6 +15,7 @@ use crate::printer::Printer;
 /// List workspace members
 pub(crate) async fn list(
     project_dir: &Path,
+    paths: bool,
     preview: Preview,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -28,8 +30,16 @@ pub(crate) async fn list(
     let workspace =
         Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache).await?;
 
-    for name in workspace.packages().keys() {
-        writeln!(printer.stdout(), "{}", name.cyan())?;
+    for (name, member) in workspace.packages() {
+        if paths {
+            writeln!(
+                printer.stdout(),
+                "{}",
+                member.root().simplified_display().cyan()
+            )?;
+        } else {
+            writeln!(printer.stdout(), "{}", name.cyan())?;
+        }
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1746,8 +1746,8 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             WorkspaceCommand::Dir(args) => {
                 commands::dir(args.package, &project_dir, globals.preview, printer).await
             }
-            WorkspaceCommand::List(_args) => {
-                commands::list(&project_dir, globals.preview, printer).await
+            WorkspaceCommand::List(args) => {
+                commands::list(&project_dir, args.paths, globals.preview, printer).await
             }
         },
         Commands::BuildBackend { command } => spawn_blocking(move || match command {

--- a/crates/uv/tests/it/workspace_list.rs
+++ b/crates/uv/tests/it/workspace_list.rs
@@ -24,6 +24,17 @@ fn workspace_list_simple() {
     warning: The `uv workspace list` command is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.
     "
     );
+
+    uv_snapshot!(context.filters(), context.workspace_list().arg("--paths").current_dir(&workspace), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/foo
+
+    ----- stderr -----
+    warning: The `uv workspace list` command is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.
+    "
+    );
 }
 
 /// Test list output for a root workspace (workspace with a root package).
@@ -147,6 +158,19 @@ fn workspace_list_multiple_members() {
     pkg-a
     pkg-b
     pkg-c
+
+    ----- stderr -----
+    warning: The `uv workspace list` command is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.
+    "
+    );
+
+    uv_snapshot!(context.filters(), context.workspace_list().arg("--paths").current_dir(&workspace_root), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/pkg-a
+    [TEMP_DIR]/pkg-a/pkg-b
+    [TEMP_DIR]/pkg-a/pkg-c
 
     ----- stderr -----
     warning: The `uv workspace list` command is experimental and may change without warning. Pass `--preview-features workspace-list` to disable this warning.


### PR DESCRIPTION
I initially thought I didn't need this, but in some contexts, the workspace member name is not useful at all and I just want to iterate over the paths without composing with `uv workspace dir --package <name>`