### PR TITLE
Document the new behavior for free-threaded python versions

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -339,16 +339,16 @@ uv supports discovering and installing
 [free-threaded](https://docs.python.org/3.14/glossary.html#term-free-threading) Python variants in
 CPython 3.13+.
 
-For python 3.13, free-threaded Python versions will not be selected by default. Free-threaded Python
+For Python 3.13, free-threaded Python versions will not be selected by default. Free-threaded Python
 versions will only be selected when explicitly requested, e.g., with `3.13t` or `3.13+freethreaded`.
 
-Starting with python 3.14, uv will allow use of free-threaded Python 3.14+ interpreters without
-explicit selection. The GIL-enabled build of Python will still be preferred, e.g., when performing
-an installation with `uv python install 3.14`. However, e.g., if a free-threaded interpreter comes
-before a GIL-enabled build on the PATH, it will be used.
+For Python 3.14+, uv will allow use of free-threaded Python 3.14+ interpreters without explicit
+selection. The GIL-enabled build of Python will still be preferred, e.g., when performing an
+installation with `uv python install 3.14`. However, e.g., if a free-threaded interpreter comes
+before a GIL-enabled build on the `PATH`, it will be used.
 
-If you have both the free-threaded and GIL enabled python installed, and want to require the use of
-the GIL enabled python in a project, you can use the `+gil` variant specifier.
+If both free-threaded and GIL-enabled Python versions are available on the system, and want to
+require the use of the GIL-enabled variant in a project, you can use the `+gil` variant specifier.
 
 ## Debug Python variants
 


### PR DESCRIPTION
## Summary

I noticed that after first installing the free-threaded version, then the gil version of 3.14, I wasn't able
to install greenlet, because it doesn't ship with wheels for the free-threaded version (I think it isn't
safe for it to use that interpreter). I noticed that the change made in 3.14 wasn't updated in the docs.

## Test Plan

N/A
