### PR TITLE
Fix status messages without TTY

### DIFF
--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -265,13 +265,7 @@ impl ProgressReporter {
                 let _ = writeln!(
                     self.printer.stderr(),
                     "{} {} {}",
-                    match direction {
-                        Direction::Download => "Downloading",
-                        Direction::Upload => "Uploading",
-                        Direction::Extract => "Extracting",
-                    }
-                    .bold()
-                    .cyan(),
+                    direction.as_str().bold().cyan(),
                     name,
                     format!("({bytes:.1}{unit})").dimmed()
                 );
@@ -324,7 +318,11 @@ impl ProgressReporter {
                 let _ = writeln!(
                     self.printer.stderr(),
                     " {} {}",
-                    direction.as_str().bold().green(),
+                    match direction {
+                        Direction::Download => "Downloaded",
+                        Direction::Upload => "Uploaded",
+                        Direction::Extract => "Extracted",
+                    },
                     progress.message()
                 );
             }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

#12175 changed the behavior of `on_request_complete` when stderr is not a tty to output `Downloading`/`Uploading` (via `Direction::as_str`). This fixes it to output `Downloaded`/`Uploaded` again.

## Test Plan

Tested locally to verify new output.

Old:
```
$ uv sync --no-cache 2>&1 | tee /dev/null
Using CPython 3.14.0
Creating virtual environment at: .venv
Resolved 12 packages in 19ms
Downloading numpy (15.8MiB)
Downloading matplotlib (9.4MiB)
Downloading fonttools (4.6MiB)
Downloading pillow (6.7MiB)
Downloading kiwisolver (1.4MiB)
 Downloading kiwisolver
 Downloading fonttools
 Downloading pillow
 Downloading matplotlib
 Downloading numpy
```
New:
```
$ uv sync --no-cache 2>&1 | tee /dev/null
Using CPython 3.14.0
Creating virtual environment at: .venv
Resolved 12 packages in 3ms
Downloading numpy (15.8MiB)
Downloading fonttools (4.6MiB)
Downloading matplotlib (9.4MiB)
Downloading kiwisolver (1.4MiB)
Downloading pillow (6.7MiB)
 Downloaded kiwisolver
 Downloaded pillow
 Downloaded fonttools
 Downloaded matplotlib
 Downloaded numpy
```