### PR TITLE
Move do not upload publish note out of the guide into concepts

### DIFF
--- a/docs/concepts/projects/build.md
+++ b/docs/concepts/projects/build.md
@@ -57,3 +57,18 @@ that the downloaded `setuptools` distribution matches the specified hash:
 ```console
 $ uv build --build-constraint constraints.txt --require-hashes
 ```
+
+## Preventing publish to PyPI
+
+If you have internal packages that you do not want to be published, you can mark them as private:
+
+```toml
+[project]
+classifiers = ["Private :: Do Not Upload"]
+```
+
+This setting makes PyPI reject your uploaded package from publishing. It does not affect security or
+privacy settings on alternative registries.
+
+We also recommend only generating [per-project PyPI API tokens](https://pypi.org/help/#apitoken):
+Without a PyPI token matching the project, it can't be accidentally published.

--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -18,22 +18,6 @@ build it by default. This means that your project may not be ready for distribut
 the effect of declaring a build system in the
 [project concept](../concepts/projects/config.md#build-systems) documentation.
 
-!!! note
-
-    If you have internal packages that you do not want to be published, you can mark them as
-    private:
-
-    ```toml
-    [project]
-    classifiers = ["Private :: Do Not Upload"]
-    ```
-
-    This setting makes PyPI reject your uploaded package from publishing. It does not affect
-    security or privacy settings on alternative registries.
-
-    We also recommend only generating [per-project PyPI API tokens](https://pypi.org/help/#apitoken):
-    Without a PyPI token matching the project, it can't be accidentally published.
-
 ## Building your package
 
 Build your package with `uv build`:


### PR DESCRIPTION
This feels a little out of place here and it seems nice to be able to link to it.