### PR TITLE
Fix documentation links for crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.89"
 homepage = "https://pypi.org/project/uv/"
-documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
 authors = ["uv"]
 license = "MIT OR Apache-2.0"

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-bench/Cargo.toml
+++ b/crates/uv-bench/Cargo.toml
@@ -7,7 +7,6 @@ authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
 

--- a/crates/uv-bin-install/Cargo.toml
+++ b/crates/uv-bin-install/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -5,7 +5,6 @@ description = "A Python build backend"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-cache-key/Cargo.toml
+++ b/crates/uv-cache-key/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-console/Cargo.toml
+++ b/crates/uv-console/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-dirs/Cargo.toml
+++ b/crates/uv-dirs/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-distribution-filename/Cargo.toml
+++ b/crates/uv-distribution-filename/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-flags/Cargo.toml
+++ b/crates/uv-flags/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-git-types/Cargo.toml
+++ b/crates/uv-git-types/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-install-wheel/Cargo.toml
+++ b/crates/uv-install-wheel/Cargo.toml
@@ -7,7 +7,6 @@ keywords = ["wheel", "python"]
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-keyring/Cargo.toml
+++ b/crates/uv-keyring/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-logging/Cargo.toml
+++ b/crates/uv-logging/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-options-metadata/Cargo.toml
+++ b/crates/uv-options-metadata/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-pep440/Cargo.toml
+++ b/crates/uv-pep440/Cargo.toml
@@ -7,7 +7,6 @@ include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md",
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0 OR BSD-2-Clause"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 

--- a/crates/uv-performance-memory-allocator/Cargo.toml
+++ b/crates/uv-performance-memory-allocator/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-platform-tags/Cargo.toml
+++ b/crates/uv-platform-tags/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-platform/Cargo.toml
+++ b/crates/uv-platform/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-preview/Cargo.toml
+++ b/crates/uv-preview/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-publish/Cargo.toml
+++ b/crates/uv-publish/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-pypi-types/Cargo.toml
+++ b/crates/uv-pypi-types/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-redacted/Cargo.toml
+++ b/crates/uv-redacted/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-requirements-txt/Cargo.toml
+++ b/crates/uv-requirements-txt/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-shell/Cargo.toml
+++ b/crates/uv-shell/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-small-str/Cargo.toml
+++ b/crates/uv-small-str/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-state/Cargo.toml
+++ b/crates/uv-state/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-static/Cargo.toml
+++ b/crates/uv-static/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -6,7 +6,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-version/Cargo.toml
+++ b/crates/uv-version/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -7,7 +7,6 @@ keywords = ["virtualenv", "venv", "python"]
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-warnings/Cargo.toml
+++ b/crates/uv-warnings/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -5,7 +5,6 @@ description = "This is a component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -5,7 +5,7 @@ description = "A Python package and project manager"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = { workspace = true }
+documentation = "https://docs.astral.sh/uv"
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/4392

We shouldn't link to PyPI, and dropping the workspace-level documentation link should mean that we get the auto-generated `docs.rs` links.