### PR TITLE
Clarify 'uv python upgrade' message when no versions exist

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -306,7 +306,7 @@ pub(crate) async fn install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {
                 writeln!(
                     printer.stderr(),
-                    "There are no installed versions to upgrade"
+                    "No Python installations found; run `uv python install` to install a Python version."
                 )?;
             }
             PythonUpgrade::Enabled(PythonUpgradeSource::Install) => {
@@ -622,7 +622,7 @@ pub(crate) async fn install(
         {
             writeln!(
                 printer.stderr(),
-                "There are no installed versions to upgrade"
+                "No Python installations found; run `uv python install` to install a Python version."
             )?;
         } else if let [request] = requests.as_slice() {
             // Convert to the inner request

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -248,6 +248,16 @@ pub(crate) async fn install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
         ) {
             is_unspecified_upgrade = true;
+
+            if existing_installations.is_empty() {
+                writeln!(
+                    printer.stderr(),
+                    "No Python installations found; use `{}` to install a Python version.",
+                    "uv python install".green()
+                )?;
+                return Ok(ExitStatus::Success);
+            }
+
             // On upgrade, derive requests for all of the existing installations
             let mut minor_version_requests = IndexSet::<InstallRequest>::default();
             for installation in &existing_installations {
@@ -303,12 +313,6 @@ pub(crate) async fn install(
 
     if requests.is_empty() {
         match upgrade {
-            PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {
-                writeln!(
-                    printer.stderr(),
-                    "No Python installations found; run `uv python install` to install a Python version."
-                )?;
-            }
             PythonUpgrade::Enabled(PythonUpgradeSource::Install) => {
                 writeln!(
                     printer.stderr(),

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -321,7 +321,7 @@ pub(crate) async fn install(
                     "No Python versions specified for upgrade; did you mean `uv python upgrade`?"
                 )?;
             }
-            PythonUpgrade::Disabled => {}
+            PythonUpgrade::Disabled | PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {}
         }
         return Ok(ExitStatus::Success);
     }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -252,7 +252,9 @@ pub(crate) async fn install(
             if existing_installations.is_empty() {
                 writeln!(
                     printer.stderr(),
-                    "No Python installations found; use `{}` to install a Python version.",
+                    "No Python installations found.\n{}{} Use {} to install a Python version.",
+                    "hint".bold().cyan(),
+                    ":".bold(),
                     "uv python install".green()
                 )?;
                 return Ok(ExitStatus::Success);

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -252,7 +252,7 @@ pub(crate) async fn install(
             if existing_installations.is_empty() {
                 writeln!(
                     printer.stderr(),
-                    "No Python installations found.\n{}{} Use {} to install a Python version.",
+                    "No Python installations found.\n{}{} Use `{}` to install a Python version.",
                     "hint".bold().cyan(),
                     ":".bold(),
                     "uv python install".green()

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -248,7 +248,6 @@ pub(crate) async fn install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
         ) {
             is_unspecified_upgrade = true;
-            
             // On upgrade, derive requests for all of the existing installations
             let mut minor_version_requests = IndexSet::<InstallRequest>::default();
             for installation in &existing_installations {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -621,15 +621,6 @@ pub(crate) async fn install(
                     "Python is already installed. Use `uv python install <request>` to install another version.",
                 )?;
             }
-        } else if matches!(
-            upgrade,
-            PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
-        ) && requests.is_empty()
-        {
-            writeln!(
-                printer.stderr(),
-                "No Python installations found; run `uv python install` to install a Python version."
-            )?;
         } else if let [request] = requests.as_slice() {
             // Convert to the inner request
             let request = &request.request;

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -248,18 +248,7 @@ pub(crate) async fn install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
         ) {
             is_unspecified_upgrade = true;
-
-            if existing_installations.is_empty() {
-                writeln!(
-                    printer.stderr(),
-                    "No Python installations found.\n{}{} Use `{}` to install a Python version.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    "uv python install".green()
-                )?;
-                return Ok(ExitStatus::Success);
-            }
-
+            
             // On upgrade, derive requests for all of the existing installations
             let mut minor_version_requests = IndexSet::<InstallRequest>::default();
             for installation in &existing_installations {
@@ -315,13 +304,22 @@ pub(crate) async fn install(
 
     if requests.is_empty() {
         match upgrade {
+            PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {
+                writeln!(
+                    printer.stderr(),
+                    "No managed Python installations found\n\n{}{} Use `{}` to install a new Python version",
+                    "hint".bold().cyan(),
+                    ":".bold(),
+                    "uv python install".green()
+                )?;
+            }
             PythonUpgrade::Enabled(PythonUpgradeSource::Install) => {
                 writeln!(
                     printer.stderr(),
                     "No Python versions specified for upgrade; did you mean `uv python upgrade`?"
                 )?;
             }
-            PythonUpgrade::Disabled | PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {}
+            PythonUpgrade::Disabled => {}
         }
         return Ok(ExitStatus::Success);
     }

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,8 +106,9 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    No Python installations found.
-    hint: Use `uv python install` to install a Python version.
+    No managed Python installations found
+
+    hint: Use `uv python install` to install a new Python version
     ");
 
     // Install earlier patch versions for different minor versions

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,7 +106,8 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    No Python installations found; use `uv python install` to install a Python version.
+    No Python installations found.
+    hint: Use `uv python install` to install a Python version.
     ");
 
     // Install earlier patch versions for different minor versions

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,7 +106,7 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    There are no installed versions to upgrade
+    No Python installations found; run `uv python install` to install a Python version.
     ");
 
     // Install earlier patch versions for different minor versions

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,7 +106,7 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    No Python installations found; run `uv python install` to install a Python version.
+    No Python installations found; use `uv python install` to install a Python version.
     ");
 
     // Install earlier patch versions for different minor versions


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolves : #16783

That message is only visible if uv found no managed Python installations. If you had Python installed (even if it was fully up-to-date), requests would not be empty, and the code would skip this block and move on to the resolution phase.

The output message "There are no installed versions to upgrade" was ambiguous. It was unclear whether `uv` could not find any installed versions or if the existing versions were simply already up-to-date as mentioned in issue.

So updated the message to 
```"No Python installations found; run `uv python install` to install a Python version.```
 to explicitly indicate when no `uv`-managed Python installations exist.

## Test Plan

Updated the existing test snapshot in `python_upgrade_without_version` to match the new output string. Verified that tests pass locally with `cargo test`.