### PR TITLE
Move the "Export" guide to the projects concept section

### DIFF
--- a/docs/concepts/projects/export.md
+++ b/docs/concepts/projects/export.md
@@ -8,9 +8,8 @@ description: Exporting a lockfile to different formats
 uv can export a lockfile to different formats for integration with other tools and workflows. The
 `uv export` command supports multiple output formats, each suited to different use cases.
 
-For more details on lockfiles and how they're created, see the
-[project layout](../concepts/projects/layout.md) and
-[locking and syncing](../concepts/projects/sync.md) documentation.
+For more details on lockfiles and how they're created, see the [project layout](./layout.md) and
+[locking and syncing](./sync.md) documentation.
 
 ## Overview of export formats
 
@@ -81,7 +80,7 @@ which is useful for security auditing, compliance, and supply chain transparency
 
 !!! important
 
-    Support for exporting to CycloneDX is in [preview](../concepts/preview.md), and may change in any future release.
+    Support for exporting to CycloneDX is in [preview](../preview.md), and may change in any future release.
 
 ### What is CycloneDX?
 
@@ -111,8 +110,8 @@ following custom properties on components:
 
 ## Next steps
 
-To learn more about lockfiles and exporting, see the
-[locking and syncing](../concepts/projects/sync.md) documentation and the
-[command reference](../reference/cli.md#uv-export).
+To learn more about lockfiles and exporting, see the [locking and syncing](./sync.md) documentation
+and the [command reference](../../reference/cli.md#uv-export).
 
-Or, read on to learn how to [build and publish your project to a package index](./package.md).
+Or, read on to learn how to
+[build and publish your project to a package index](../../guides/package.md).

--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -195,8 +195,8 @@ $ uv export --format pylock.toml
 $ uv export --format cyclonedx1.5
 ```
 
-See the [export guide](../../guides/export.md) for comprehensive documentation on all export formats
-and their use cases.
+See the [export guide](./export.md) for comprehensive documentation on all export formats and their
+use cases.
 
 ## Partial installations
 

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -18,8 +18,8 @@ Because it is very common to run tools without installing them, a `uvx` alias is
 refer to `uvx` instead of `uv tool run`.
 
 Tools can also be installed with `uv tool install`, in which case their executables are
-[available on the `PATH`](#the-path) — an isolated virtual environment is still used, but it is not
-removed when the command completes.
+[available on the `PATH`](#tool-executables) — an isolated virtual environment is still used, but it
+is not removed when the command completes.
 
 ## Execution vs installation
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -215,8 +215,8 @@ RUN uv run some_script.py
 
 ### Using installed tools
 
-To use installed tools, ensure the [tool bin directory](../../concepts/tools.md#the-bin-directory)
-is on the path:
+To use installed tools, ensure the [tool bin directory](../../concepts/tools.md#tool-executables) is
+on the path:
 
 ```dockerfile title="Dockerfile"
 ENV PATH=/root/.local/bin:$PATH

--- a/docs/guides/package.md
+++ b/docs/guides/package.md
@@ -45,7 +45,7 @@ Alternatively, `uv build <SRC>` will build the package in the specified director
 
 The `uv version` command provides conveniences for updating the version of your package before you
 publish it.
-[See the project docs for reading your package's version](./projects.md#managing-version).
+[See the project docs for reading your package's version](./projects.md#viewing-your-version).
 
 To update to an exact version, provide it as a positional argument:
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -272,4 +272,5 @@ To learn more about working on projects with uv, see the
 [projects concept](../concepts/projects/index.md) page and the
 [command reference](../reference/cli.md#uv).
 
-Or, read on to learn how to [export a uv lockfile to different formats](./export.md).
+Or, read on to learn how to
+[export a uv lockfile to different formats](../concepts/projects/export.md).

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -82,6 +82,7 @@ plugins:
         "configuration/files.md": "concepts/configuration-files.md"
         "configuration/indexes.md": "concepts/indexes.md"
         "configuration/environment.md": "reference/environment.md"
+        "guides/export.md": "concepts/projects/export.md"
   - llmstxt:
       markdown_description: |
         You can use uv to install Python dependencies, run scripts, manage virtual environments,
@@ -101,7 +102,6 @@ plugins:
           - guides/scripts.md
           - guides/tools.md
           - guides/projects.md
-          - guides/export.md
           - guides/package.md
         Integrations:
           - guides/integration/docker.md
@@ -124,6 +124,7 @@ plugins:
           - concepts/projects/sync.md
           - concepts/projects/config.md
           - concepts/projects/build.md
+          - concepts/projects/export.md
           - concepts/projects/workspaces.md
         Features:
           - concepts/tools.md
@@ -178,7 +179,6 @@ nav:
       - Running scripts: guides/scripts.md
       - Using tools: guides/tools.md
       - Working on projects: guides/projects.md
-      - Exporting lockfiles: guides/export.md
       - Publishing packages: guides/package.md
       - Migration:
           - guides/migration/index.md
@@ -208,6 +208,7 @@ nav:
           - Locking and syncing: concepts/projects/sync.md
           - Configuring projects: concepts/projects/config.md
           - Building distributions: concepts/projects/build.md
+          - Exporting lockfiles: concepts/projects/export.md
           - Using workspaces: concepts/projects/workspaces.md
       - Tools: concepts/tools.md
       - Python versions: concepts/python-versions.md


### PR DESCRIPTION
I consider this a bit too advanced to be in the top-level guides