### PR TITLE
Use 0o666 permissions for flock files instead of 0o777

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -825,7 +825,7 @@ impl LockedFile {
             return Ok(file);
         }
 
-        // Otherwise, create a temporary file with 777 permissions. We must set
+        // Otherwise, create a temporary file with 666 permissions. We must set
         // permissions _after_ creating the file, to override the `umask`.
         let file = if let Some(parent) = path.as_ref().parent() {
             NamedTempFile::new_in(parent)?
@@ -834,7 +834,7 @@ impl LockedFile {
         };
         if let Err(err) = file
             .as_file()
-            .set_permissions(std::fs::Permissions::from_mode(0o777))
+            .set_permissions(std::fs::Permissions::from_mode(0o666))
         {
             warn!("Failed to set permissions on temporary file: {err}");
         }


### PR DESCRIPTION
This removes executable permissions while retaining global read / global write.

It's been suggested we should use 0o644 instead, dropping the global write permissions (i.e., just the owner can write), but since we're taking an exclusive lock I don't think that would work and we'd regress the issue that was solved by updating the permissions. I think we'll need to revisit the locking scheme if that's the goal, but regardless, this seems like a net improvement.