### PR TITLE
Use `--no-verify` to skip builds during crates.io publish

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,6 +27,7 @@ jobs:
       # - uses: rust-lang/crates-io-auth-action@v1
       #   id: auth
       - name: Publish workspace crates
-        run: cargo publish --workspace
+        # Note `--no-verify` is safe because we do a publish dry-run elsewhere in CI
+        run: cargo publish --workspace --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
Otherwise, this is quite slow.