### PR TITLE
Use Bearer authentication for pyx publish test

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -431,8 +431,8 @@ def publish_project(target: str, uv: Path, client: httpx.Client):
     # If we're publishing to pyx, we need to give the httpx client
     # access to an appropriate credential.
     if target == "pyx-token":
-        client.auth = httpx.BasicAuth(
-            username="__token__", password=os.environ["UV_TEST_PUBLISH_PYX_TOKEN"]
+        client.headers.update(
+            {"Authorization": f"Bearer {os.environ['UV_TEST_PUBLISH_PYX_TOKEN']}"}
         )
 
     project_name = all_targets[target].project_name


### PR DESCRIPTION
## Summary

This is a no-op semantically, I'm using it to force the CI to run the publishing tests 🙂 

## Test Plan

See what happens in CI (and confirm it matches my local behavior).