### PR TITLE
Update Docker integration guide to prefer `COPY` over `ADD` for simple cases

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -162,13 +162,11 @@ ADD https://astral.sh/uv/0.9.13/install.sh /uv-installer.sh
 If you're using uv to manage your project, you can copy it into the image and install it:
 
 ```dockerfile title="Dockerfile"
-# Change the working directory to the `app` directory
-WORKDIR /app
-
 # Copy the project into the image
 COPY . /app
 
 # Sync the project into a new environment, asserting the lockfile is up to date
+WORKDIR /app
 RUN uv sync --locked
 ```
 


### PR DESCRIPTION
## Summary

Docker best practices recommend to use `COPY` when the additional functionality of `ADD` is not used.

See:
- https://docs.docker.com/build/building/best-practices/#add-or-copy
- https://www.docker.com/blog/docker-best-practices-understanding-the-differences-between-add-and-copy-instructions-in-dockerfiles/

## Test Plan

Docs only change
