### PR TITLE
Support requirements without an extension

### DIFF
--- a/crates/uv-requirements/src/upgrade.rs
+++ b/crates/uv-requirements/src/upgrade.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::Upgrade;
 use uv_fs::CWD;
 use uv_git::ResolvedRepositoryReference;
@@ -38,13 +37,7 @@ pub async fn read_requirements_txt(
     }
 
     // Parse the requirements from the lockfile.
-    let requirements_txt = RequirementsTxt::parse(
-        output_file,
-        &*CWD,
-        // Pseudo-client for reading local-only requirements.
-        &BaseClientBuilder::default().connectivity(Connectivity::Offline),
-    )
-    .await?;
+    let requirements_txt = RequirementsTxt::parse(output_file, &*CWD).await?;
 
     // Map each entry in the lockfile to a preference.
     let preferences = requirements_txt

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -138,6 +138,7 @@ pub(crate) async fn add(
             RequirementsSource::Package(_)
             | RequirementsSource::Editable(_)
             | RequirementsSource::RequirementsTxt(_)
+            | RequirementsSource::Extensionless(_)
             | RequirementsSource::EnvironmentYml(_) => {}
         }
     }

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -140,7 +140,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             RequirementsSource::SetupCfg(_) => {
                 bail!("Adding requirements from a `setup.cfg` is not supported in `uv run`");
             }
-            RequirementsSource::RequirementsTxt(path) => {
+            RequirementsSource::Extensionless(path) => {
                 if path == Path::new("-") {
                     requirements_from_stdin = true;
                 }

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2646,8 +2646,7 @@ fn tool_run_with_incompatible_build_constraints() -> Result<()> {
 fn tool_run_with_dependencies_from_script() -> Result<()> {
     let context = TestContext::new("3.12").with_filtered_counts();
 
-    let script = context.temp_dir.child("script.py");
-    script.write_str(indoc! {r#"
+    let script_contents = indoc! {r#"
         # /// script
         # requires-python = ">=3.11"
         # dependencies = [
@@ -2656,7 +2655,13 @@ fn tool_run_with_dependencies_from_script() -> Result<()> {
         # ///
 
         import anyio
-    "#})?;
+    "#};
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(script_contents)?;
+
+    let script_without_extension = context.temp_dir.child("script-no-ext");
+    script_without_extension.write_str(script_contents)?;
 
     // script dependencies (anyio) are now installed.
     uv_snapshot!(context.filters(), context.tool_run()
@@ -2682,6 +2687,20 @@ fn tool_run_with_dependencies_from_script() -> Result<()> {
      + pathspec==0.12.1
      + platformdirs==4.2.0
      + sniffio==1.3.1
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--with-requirements")
+        .arg("script-no-ext")
+        .arg("black")
+        .arg("script-no-ext")
+        .arg("-q"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
     ");
 
     // Error when the script is not a valid PEP723 script.


### PR DESCRIPTION
## Summary

This PR un-reverts #16861 by resolving extensionless sources with a different strategy: we return an `Extensionless` variant, then infer the type when we read the file and parse the contents immediately after, thereby avoiding multiple reads.

