### PR TITLE
Isolating test from accessing global git credential helper config

### DIFF
--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2504,7 +2504,7 @@ fn install_git_private_https_pat_at_ref() {
 #[test]
 #[cfg(feature = "git")]
 fn install_git_private_https_pat_and_username() {
-    let context = TestContext::new(DEFAULT_PYTHON_VERSION).with_git_credential_helper_blocked();
+    let context = TestContext::new(DEFAULT_PYTHON_VERSION).with_unset_git_credential_helper();
     let token = decode_token(common::READ_ONLY_GITHUB_TOKEN);
     let user = "astral-test-bot";
 


### PR DESCRIPTION
## Summary
Resolves: https://github.com/astral-sh/uv/issues/1980

Added a utility function to TestContext called **with_git_credential_helper_blocked** that isolates the test from accessing the credential helper value defined in global/system git config. It does so, by writing to a file .gitconfig in the temporary home_dir that is created as part of the TestContext. 

## Test Plan
Tested it by running the test pip_install::install_git_private_https_pat_and_username, and making sure it doesn't affect the keyring. 

## Note:
The commit hash for the uv-private-package seems to have changed. Kindly, ensure that the modification related to that  is correct.

