### PR TITLE
Use `npm ci --ignore-scripts` in update_schemastore.py

### DIFF
--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -45,7 +45,7 @@ def update_schemastore(schemastore: Path, *, root: Path) -> None:
         cwd=schemastore,
     )
 
-    # Run npm install
+    # Run npm ci
     check_call(["npm", "ci", "--ignore-scripts"], cwd=schemastore)
 
     src = schemastore.joinpath("src")


### PR DESCRIPTION
## Summary

This ensures that we fully honor SchemaStore's lockfile when installing, plus that we don't run any build-time scripts (which shouldn't be needed here).

## Test Plan

I ran `uv run update_schemastore.py` locally and confirmed that it created a branch as expected.