### PR TITLE
Bump timeout for macOS tests from 15m -> 20m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
             --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
   cargo-test-macos:
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: determine_changes
     # Only run macOS tests on main without opt-in
     if: ${{ contains(github.event.pull_request.labels.*.name, 'test:macos') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This has been failing on main since fbf925ee636327bc958859ba1179fdd37bbcde6e
