### PR TITLE
Revert "Bump `astral-tl` to v0.7.10 (#16887)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,12 +248,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tl"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dfa40da988ff8327db15678418b2394b0546514b7a5c9fac75e1eb3fa40550"
-dependencies = [
- "memchr",
-]
+checksum = "915b5af1203c9c635c62edcbdaa36ee54b17f84809f7769912d356c35f9a6cd7"
 
 [[package]]
 name = "astral-tokio-tar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.14.0" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "2.0.0" }
-astral-tl = { version = "0.7.10" }
+astral-tl = { version = "0.7.9" }
 tokio = { version = "1.40.0", features = ["fs", "io-util", "macros", "process", "rt", "signal", "sync"] }
 tokio-stream = { version = "0.1.16" }
 tokio-util = { version = "0.7.12", features = ["compat", "io"] }


### PR DESCRIPTION
This reverts commit 5f3d46c2413225aac68c86fa24be97c4c2c193e4 / #16887

Investigating https://github.com/astral-sh/uv/issues/16937