### PR TITLE
[Draft] Clarify duration environment variable format at parse time

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1207,7 +1207,7 @@ impl RegistryClient {
             std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",
+                    "Failed to download distribution due to network timeout ({}s).\nTry increasing UV_HTTP_TIMEOUT to a larger integer value (in seconds), e.g., UV_HTTP_TIMEOUT=60",
                     self.timeout().as_secs()
                 ),
             )

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -93,7 +93,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             io::Error::new(
                 io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",
+                    "Failed to download distribution due to network timeout ({}s).\nTry increasing UV_HTTP_TIMEOUT to a larger integer value (in seconds), e.g., UV_HTTP_TIMEOUT=60",
                     self.client.unmanaged.timeout().as_secs()
                 ),
             )

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -607,7 +607,10 @@ impl EnvironmentOptions {
                 EnvVars::UV_REQUEST_TIMEOUT,
                 true,
             )?)
-            .or(parse_integer_environment_variable(EnvVars::HTTP_TIMEOUT, true)?)
+            .or(parse_integer_environment_variable(
+                EnvVars::HTTP_TIMEOUT,
+                true,
+            )?)
             .map(Duration::from_secs);
 
         Ok(Self {
@@ -619,9 +622,15 @@ impl EnvironmentOptions {
                 EnvVars::UV_PYTHON_INSTALL_REGISTRY,
             )?,
             concurrency: Concurrency {
-                downloads: parse_integer_environment_variable(EnvVars::UV_CONCURRENT_DOWNLOADS, false)?,
+                downloads: parse_integer_environment_variable(
+                    EnvVars::UV_CONCURRENT_DOWNLOADS,
+                    false,
+                )?,
                 builds: parse_integer_environment_variable(EnvVars::UV_CONCURRENT_BUILDS, false)?,
-                installs: parse_integer_environment_variable(EnvVars::UV_CONCURRENT_INSTALLS, false)?,
+                installs: parse_integer_environment_variable(
+                    EnvVars::UV_CONCURRENT_INSTALLS,
+                    false,
+                )?,
             },
             install_mirrors: PythonInstallMirrors {
                 python_install_mirror: parse_string_environment_variable(
@@ -652,7 +661,6 @@ impl EnvironmentOptions {
         })
     }
 }
-
 
 /// Parse a boolean environment variable.
 ///
@@ -728,11 +736,14 @@ fn parse_string_environment_variable(name: &'static str) -> Result<Option<String
 }
 
 /// Parse an integer environment variable.
-/// 
+///
 /// If `is_duration` is `true`, this function will check if the value ends with "s" and provide
 /// a helpful error message, as duration environment variables expect an integer value in seconds
 /// (not a string like "60s").
-fn parse_integer_environment_variable<T>(name: &'static str, is_duration: bool) -> Result<Option<T>, Error>
+fn parse_integer_environment_variable<T>(
+    name: &'static str,
+    is_duration: bool,
+) -> Result<Option<T>, Error>
 where
     T: std::str::FromStr + Copy,
     <T as std::str::FromStr>::Err: std::fmt::Display,
@@ -759,9 +770,7 @@ where
         return Err(Error::InvalidEnvironmentVariable {
             name: name.to_string(),
             value: value.clone(),
-            err: format!(
-                "expected an integer value in seconds (e.g., 30), not a string with units (e.g., 30s)"
-            ),
+            err: "expected an integer value in seconds (e.g., 30), not a string with units (e.g., 30s)".to_string(),
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

### Problem
If any of the duration environment variables (``UV_HTTP_TIMEOUT``, ``UV_UPLOAD_HTTP_TIMEOUT``, etc) is set to a value that ends in ``s``, the current error message is misleading about the expected format.

Current error message, before this PR:
<img width="730" height="26" alt="Screen Shot 2025-12-02 at 10 52 10 PM" src="https://github.com/user-attachments/assets/e569932c-211a-4751-9e46-d346b6166726" />

### Proposed Solution
At parse time, emit the following special error message if any of the duration environment variables are set to a value that ends in ``s``: ``expected an integer value in seconds (e.g., 30), not a string with units (e.g., 30s)``

Improved error message, after this PR:
<img width="726" height="39" alt="Screen Shot 2025-12-02 at 10 50 36 PM" src="https://github.com/user-attachments/assets/8337ab87-223a-452e-84e5-e710f2c67537" />

## Test Plan

<!-- How was it tested? -->
1. I built the uv binary with `cargo build --package uv --bin uv`
2. I tested the error message with `UV_HTTP_TIMEOUT=120s ./target/debug/uv pip list`