### PR TITLE
Clarify UV_HTTP_TIMEOUT format in error message for streaming timeout

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1203,12 +1203,13 @@ impl RegistryClient {
 
     /// Handle a specific `reqwest` error, and convert it to [`io::Error`].
     fn handle_response_errors(&self, err: reqwest::Error) -> std::io::Error {
+        let current_timeout = self.timeout().as_secs();
+        let suggested_timeout = current_timeout * 2;
         if err.is_timeout() {
             std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout ({}s).\nTry increasing UV_HTTP_TIMEOUT to a larger integer value (in seconds), e.g., UV_HTTP_TIMEOUT=60",
-                    self.timeout().as_secs()
+                    "Failed to download distribution due to network timeout ({current_timeout}s).\nTry increasing ``UV_HTTP_TIMEOUT`` to a larger value, e.g., ``UV_HTTP_TIMEOUT={suggested_timeout}``"
                 ),
             )
         } else {

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -89,12 +89,13 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
     /// Handle a specific `reqwest` error, and convert it to [`io::Error`].
     fn handle_response_errors(&self, err: reqwest::Error) -> io::Error {
+        let current_timeout = self.client.unmanaged.timeout().as_secs();
+        let suggested_timeout = current_timeout * 2;
         if err.is_timeout() {
             io::Error::new(
                 io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout ({}s).\nTry increasing UV_HTTP_TIMEOUT to a larger integer value (in seconds), e.g., UV_HTTP_TIMEOUT=60",
-                    self.client.unmanaged.timeout().as_secs()
+                    "Failed to download distribution due to network timeout ({current_timeout}s).\nTry increasing ``UV_HTTP_TIMEOUT`` to a larger value, e.g., ``UV_HTTP_TIMEOUT={suggested_timeout}``"
                 ),
             )
         } else {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

Relevant issues: #16940 

### Problem
The error message for network streaming timeouts is misleading about the expected format:
```
Failed to download distribution due to network timeout.
Try increasing UV_HTTP_TIMEOUT (current value: 30s).
```
This suggests users should set values like ``120s`` or ``180s``, but the actual required format is a plain integer representing seconds.

### Solution
This PR updates the hint to be clearer about the input format, changing it from ``Try increasing UV_HTTP_TIMEOUT (current value: {}s).`` to ``Try increasing UV_HTTP_TIMEOUT to a larger integer value (in seconds), e.g., UV_HTTP_TIMEOUT=60``