### PR TITLE
Improve testsuite missing python version panic message

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -1790,7 +1790,7 @@ pub fn python_installations_for_versions(
             ) {
                 python.into_interpreter().sys_executable().to_owned()
             } else {
-                panic!("Could not find Python {python_version} for test");
+                panic!("Could not find Python {python_version} for test\nTry `cargo run python install` first, or refer to CONTRIBUTING.md");
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

When the test suite panics due to a missing python version, it now prints some helpful information to guide users to `cargo run python install` and `CONTRIBUTING.md`

~~~
---- pip_sync::incompatible_build_constraint stdout ----

thread 'pip_sync::incompatible_build_constraint' (19737) panicked at crates/uv/tests/it/common/mod.rs:1793:17:
Could not find Python 3.9 for test
Try `cargo run python install` first, or refer to CONTRIBUTING.md

~~~

## Test Plan

Uninstalled python3.9 and ran tests which depended on it.