### PR TITLE
Adjust release script to handle uv-trampoline lockfile changes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,3 +18,4 @@ uv run "$project_root/scripts/bump-workspace-crate-versions.py"
 
 echo "Updating lockfile..."
 cargo update -p uv
+pushd crates/uv-trampoline; cargo update -p uv-trampoline; popd


### PR DESCRIPTION
## Summary

Given `bump-workspace-crate-versions.py` will bump all crates, we also need to update uv-trampoline lockfile references to those new versions (for uv-static, uv-macros) after https://github.com/astral-sh/uv/pull/16950.

## Test Plan

Ran release script manually and verify uv-trampoline lockfile is up to date after the changes from bump-workspace-crate-versions.py