### PR TITLE
Fix Pyston wheel compatibility tags

### DIFF
--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -46,6 +46,16 @@ if hasattr(sys, "implementation"):
             r"\1.\2",
             sys.implementation.cache_tag,
         )
+    elif implementation_name == "pyston":
+        # Pyston reports the CPython version as sys.implementation.version,
+        # so we need to discover the Pyston version from the cache_tag
+        import re
+
+        implementation_version = re.sub(
+            r"pyston-(\d)(\d+)",
+            r"\1.\2",
+            sys.implementation.cache_tag,
+        )
     else:
         implementation_version = format_full_version(sys.implementation.version)
 else:


### PR DESCRIPTION
This was discovered by https://github.com/astral-sh/uv/pull/16074, where the wrong tag now fails the Pyston integration test.

I'm not sure what the exact schema of the cache tag is, but since the project is dead, I don't expect any new non-matching versions to follow.