### PR TITLE
auth: use the globally constructed client builder

### DIFF
--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -17,7 +17,6 @@ use uv_preview::Preview;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
-use crate::settings::NetworkSettings;
 
 // We retry no more than this many times when polling for login status.
 const STATUS_RETRY_LIMIT: u32 = 60;
@@ -28,7 +27,7 @@ pub(crate) async fn login(
     username: Option<String>,
     password: Option<String>,
     token: Option<String>,
-    network_settings: &NetworkSettings,
+    client_builder: BaseClientBuilder<'_>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -41,16 +40,9 @@ pub(crate) async fn login(
             bail!("Cannot specify a password when logging in to pyx");
         }
 
-        let client = BaseClientBuilder::new(
-            network_settings.connectivity,
-            network_settings.native_tls,
-            network_settings.allow_insecure_host.clone(),
-            preview,
-            network_settings.timeout,
-            network_settings.retries,
-        )
-        .auth_integration(AuthIntegration::NoAuthMiddleware)
-        .build();
+        let client = client_builder
+            .auth_integration(AuthIntegration::NoAuthMiddleware)
+            .build();
 
         let access_token = pyx_login_with_browser(&pyx_store, &client, &printer).await?;
         let jwt = PyxJwt::decode(&access_token)?;

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -9,7 +9,6 @@ use uv_distribution_types::IndexUrl;
 use uv_pep508::VerbatimUrl;
 use uv_preview::Preview;
 
-use crate::settings::NetworkSettings;
 use crate::{commands::ExitStatus, printer::Printer};
 
 /// Logout from a service.
@@ -18,13 +17,13 @@ use crate::{commands::ExitStatus, printer::Printer};
 pub(crate) async fn logout(
     service: Service,
     username: Option<String>,
-    network_settings: &NetworkSettings,
+    client_builder: BaseClientBuilder<'_>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
     let pyx_store = PyxTokenStore::from_settings()?;
     if pyx_store.is_known_domain(service.url()) {
-        return pyx_logout(&pyx_store, network_settings, printer, preview).await;
+        return pyx_logout(&pyx_store, client_builder, printer).await;
     }
 
     let backend = AuthBackend::from_settings(preview).await?;
@@ -93,20 +92,11 @@ pub(crate) async fn logout(
 /// Log out via the [`PyxTokenStore`], invalidating the existing tokens.
 async fn pyx_logout(
     store: &PyxTokenStore,
-    network_settings: &NetworkSettings,
+    client_builder: BaseClientBuilder<'_>,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     // Initialize the client.
-    let client = BaseClientBuilder::new(
-        network_settings.connectivity,
-        network_settings.native_tls,
-        network_settings.allow_insecure_host.clone(),
-        preview,
-        network_settings.timeout,
-        network_settings.retries,
-    )
-    .build();
+    let client = client_builder.build();
 
     // Retrieve the token store.
     let Some(tokens) = store.read().await? else {

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -11,13 +11,12 @@ use uv_preview::Preview;
 use crate::commands::ExitStatus;
 use crate::commands::auth::login;
 use crate::printer::Printer;
-use crate::settings::NetworkSettings;
 
 /// Show the token that will be used for a service.
 pub(crate) async fn token(
     service: Service,
     username: Option<String>,
-    network_settings: &NetworkSettings,
+    client_builder: BaseClientBuilder<'_>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -26,16 +25,9 @@ pub(crate) async fn token(
         if username.is_some() {
             bail!("Cannot specify a username when logging in to pyx");
         }
-        let client = BaseClientBuilder::new(
-            network_settings.connectivity,
-            network_settings.native_tls,
-            network_settings.allow_insecure_host.clone(),
-            preview,
-            network_settings.timeout,
-            network_settings.retries,
-        )
-        .auth_integration(AuthIntegration::NoAuthMiddleware)
-        .build();
+        let client = client_builder
+            .auth_integration(AuthIntegration::NoAuthMiddleware)
+            .build();
 
         pyx_refresh(&pyx_store, &client, printer).await?;
         return Ok(ExitStatus::Success);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -479,12 +479,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             command: AuthCommand::Login(args),
         }) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::AuthLoginSettings::resolve(
-                args,
-                &cli.top_level.global_args,
-                filesystem.as_ref(),
-                &environment,
-            );
+            let args = settings::AuthLoginSettings::resolve(args);
             show_settings!(args);
 
             commands::auth_login(
@@ -492,7 +487,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.username,
                 args.password,
                 args.token,
-                &args.network_settings,
+                client_builder,
                 printer,
                 globals.preview,
             )
@@ -502,18 +497,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             command: AuthCommand::Logout(args),
         }) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::AuthLogoutSettings::resolve(
-                args,
-                &cli.top_level.global_args,
-                filesystem.as_ref(),
-                &environment,
-            );
+            let args = settings::AuthLogoutSettings::resolve(args);
             show_settings!(args);
 
             commands::auth_logout(
                 args.service,
                 args.username,
-                &args.network_settings,
+                client_builder,
                 printer,
                 globals.preview,
             )
@@ -523,18 +513,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             command: AuthCommand::Token(args),
         }) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::AuthTokenSettings::resolve(
-                args,
-                &cli.top_level.global_args,
-                filesystem.as_ref(),
-                &environment,
-            );
+            let args = settings::AuthTokenSettings::resolve(args);
             show_settings!(args);
 
             commands::auth_token(
                 args.service,
                 args.username,
-                &args.network_settings,
+                client_builder,
                 printer,
                 globals.preview,
             )
@@ -558,7 +543,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
 
             match args.command {
                 AuthHelperCommand::Get => {
-                    commands::auth_helper(globals.preview, &globals.network_settings, printer).await
+                    commands::auth_helper(client_builder, globals.preview, printer).await
                 }
             }
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -3877,23 +3877,14 @@ impl PublishSettings {
 pub(crate) struct AuthLogoutSettings {
     pub(crate) service: Service,
     pub(crate) username: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) network_settings: NetworkSettings,
 }
 
 impl AuthLogoutSettings {
     /// Resolve the [`AuthLogoutSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(
-        args: AuthLogoutArgs,
-        global_args: &GlobalArgs,
-        filesystem: Option<&FilesystemOptions>,
-        environment: &EnvironmentOptions,
-    ) -> Self {
+    pub(crate) fn resolve(args: AuthLogoutArgs) -> Self {
         Self {
             service: args.service,
             username: args.username,
-            network_settings: NetworkSettings::resolve(global_args, filesystem, environment),
         }
     }
 }
@@ -3903,23 +3894,14 @@ impl AuthLogoutSettings {
 pub(crate) struct AuthTokenSettings {
     pub(crate) service: Service,
     pub(crate) username: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) network_settings: NetworkSettings,
 }
 
 impl AuthTokenSettings {
     /// Resolve the [`AuthTokenSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(
-        args: AuthTokenArgs,
-        global_args: &GlobalArgs,
-        filesystem: Option<&FilesystemOptions>,
-        environment: &EnvironmentOptions,
-    ) -> Self {
+    pub(crate) fn resolve(args: AuthTokenArgs) -> Self {
         Self {
             service: args.service,
             username: args.username,
-            network_settings: NetworkSettings::resolve(global_args, filesystem, environment),
         }
     }
 }
@@ -3931,25 +3913,16 @@ pub(crate) struct AuthLoginSettings {
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
     pub(crate) token: Option<String>,
-
-    // Both CLI and configuration.
-    pub(crate) network_settings: NetworkSettings,
 }
 
 impl AuthLoginSettings {
     /// Resolve the [`AuthLoginSettings`] from the CLI and filesystem configuration.
-    pub(crate) fn resolve(
-        args: AuthLoginArgs,
-        global_args: &GlobalArgs,
-        filesystem: Option<&FilesystemOptions>,
-        environment: &EnvironmentOptions,
-    ) -> Self {
+    pub(crate) fn resolve(args: AuthLoginArgs) -> Self {
         Self {
             service: args.service,
             username: args.username,
             password: args.password,
             token: args.token,
-            network_settings: NetworkSettings::resolve(global_args, filesystem, environment),
         }
     }
 }


### PR DESCRIPTION
## Summary

Instead of each subcommand instantiating its own `BaseClientBuilder`, let's use the globally constructed one.


## Test Plan

Existing tests.
