### PR TITLE
Refactor `pip::operations::install`

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2140,13 +2140,26 @@ pub(crate) async fn sync_environment(
         preview,
     );
 
-    // Sync the environment.
-    pip::operations::install(
+    let start = std::time::Instant::now();
+
+    let plan = pip::operations::plan(
         resolution,
         site_packages,
         InstallationStrategy::Permissive,
         modifications,
         reinstall,
+        build_options,
+        &hasher,
+        tags,
+        &build_dispatch,
+        cache,
+        &venv,
+    )?;
+
+    // Sync the environment.
+    pip::operations::install(
+        resolution,
+        plan,
         build_options,
         link_mode,
         compile_bytecode,
@@ -2163,6 +2176,7 @@ pub(crate) async fn sync_environment(
         dry_run,
         printer,
         preview,
+        start,
     )
     .await?;
 
@@ -2408,13 +2422,27 @@ pub(crate) async fn update_environment(
         Err(err) => return Err(err.into()),
     };
 
-    // Sync the environment.
-    let changelog = pip::operations::install(
+    let start = std::time::Instant::now();
+
+    // Make a plan
+    let plan = pip::operations::plan(
         &resolution,
         site_packages,
         InstallationStrategy::Permissive,
         modifications,
         reinstall,
+        build_options,
+        &hasher,
+        &tags,
+        &build_dispatch,
+        cache,
+        &venv,
+    )?;
+
+    // Sync the environment.
+    let changelog = pip::operations::install(
+        &resolution,
+        plan,
         build_options,
         *link_mode,
         *compile_bytecode,
@@ -2431,6 +2459,7 @@ pub(crate) async fn update_environment(
         dry_run,
         printer,
         preview,
+        start,
     )
     .await?;
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -824,13 +824,26 @@ pub(super) async fn do_sync(
 
     let site_packages = SitePackages::from_environment(venv)?;
 
-    // Sync the environment.
-    operations::install(
+    let start = std::time::Instant::now();
+
+    let plan = operations::plan(
         &resolution,
         site_packages,
         InstallationStrategy::Strict,
         modifications,
         reinstall,
+        build_options,
+        &hasher,
+        &tags,
+        &build_dispatch,
+        cache,
+        venv,
+    )?;
+
+    // Sync the environment.
+    operations::install(
+        &resolution,
+        plan,
         build_options,
         link_mode,
         compile_bytecode,
@@ -847,6 +860,7 @@ pub(super) async fn do_sync(
         dry_run,
         printer,
         preview,
+        start,
     )
     .await?;
 


### PR DESCRIPTION
## Summary

Move the planning stage to a separate function.

Also a small refactor of `report_dry_run`.

I don't think this is necessarily worth it. I think a better approach is just to return the plan from install either always or when dry running (currently it returns an empty change-log instead).

## Test Plan

Test suite.