### PR TITLE
Add helpful error message for 'uv activate'

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2489,6 +2489,29 @@ where
                             ContextValue::String("uv pip show".to_string()),
                         );
                     }
+                    "activate" => {
+                        // Handle "activate" with a helpful error message
+                        // instead of the generic unknown command error
+                        eprintln!(
+                            "{} `uv activate` is not supported. To activate a virtual environment, use:",
+                            "error".red().bold()
+                        );
+                        #[cfg(unix)]
+                        {
+                            eprintln!("  {}", "source .venv/bin/activate".green());
+                        }
+                        #[cfg(windows)]
+                        {
+                            eprintln!("  {}", ".venv\\Scripts\\activate".green());
+                            eprintln!("  {}", ".venv\\Scripts\\Activate.ps1".green());
+                        }
+                        eprintln!(
+                            "\n{} Create a virtual environment with: {}",
+                            "hint".bold().cyan(),
+                            "uv venv".green()
+                        );
+                        return ExitStatus::Error.into();
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
When users try to run 'uv activate', show a helpful error message
instead of the generic unknown command error. The message explains
that 'uv activate' is not supported and provides instructions on
how to activate a virtual environment.

This is most probably address the issue: https://github.com/astral-sh/uv/issues/16993