### PR TITLE
Bump `astral-tl` to v0.7.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,12 @@ dependencies = [
 
 [[package]]
 name = "astral-tl"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b5af1203c9c635c62edcbdaa36ee54b17f84809f7769912d356c35f9a6cd7"
+checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "astral-tokio-tar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.14.0" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "2.0.0" }
-astral-tl = { version = "0.7.9" }
+astral-tl = { version = "0.7.11" }
 tokio = { version = "1.40.0", features = ["fs", "io-util", "macros", "process", "rt", "signal", "sync", "time"] }
 tokio-stream = { version = "0.1.16" }
 tokio-util = { version = "0.7.12", features = ["compat", "io"] }


### PR DESCRIPTION
## Summary

This was reverted due to a hang (https://github.com/astral-sh/uv/issues/16937) which was then resolved upstream (https://github.com/astral-sh/astral-tl/pull/16).
