### PR TITLE
Respect dropped (but explicit) indexes in dependency groups

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1969,7 +1969,12 @@ impl Lock {
             // not be available as top-level configuration (i.e., if they're defined within a
             // workspace member), but we already validated that the dependencies are up-to-date, so
             // we can consider them "available".
-            for requirement in &package.metadata.requires_dist {
+            for requirement in package
+                .metadata
+                .requires_dist
+                .iter()
+                .chain(package.metadata.dependency_groups.values().flatten())
+            {
                 if let RequirementSource::Registry {
                     index: Some(index), ..
                 } = &requirement.source


### PR DESCRIPTION
## Summary

There are a class of outcomes whereby an index might not be included in "allowed indexes", but could still correctly appear in a lockfile. In the linked case, we have two `default = true` indexes, and one of them is also named. We omit the second `default = true` index from the list of "allowed indexes", but since it's named, a dependency can reference it explicitly. We handle this correctly for `project.dependencies`, but the handling was incorrectly omitting dependency groups.

Closes https://github.com/astral-sh/uv/issues/16843.
