### PR TITLE
Speed up cache size command

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -935,10 +935,6 @@ pub struct SizeArgs {
     /// Display the cache size in human-readable format (e.g., `1.2 GiB` instead of raw bytes).
     #[arg(long = "human", short = 'H', alias = "human-readable")]
     pub human: bool,
-
-    /// Number of threads to use when calculating the cache size
-    #[arg(long)]
-    pub threads: Option<usize>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/cache_size.rs
+++ b/crates/uv/src/commands/cache_size.rs
@@ -13,7 +13,6 @@ use uv_warnings::warn_user;
 pub(crate) fn cache_size(
     cache: &Cache,
     human_readable: bool,
-    threads: Option<usize>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -33,12 +32,7 @@ pub(crate) fn cache_size(
         return Ok(ExitStatus::Success);
     }
 
-    let mut disk_usage = DiskUsage::new(vec![cache.root().to_path_buf()]);
-
-    if let Some(n) = threads {
-        tracing::info!("Using {} threads to calculate cache size", n);
-        disk_usage = disk_usage.num_workers(n);
-    }
+    let disk_usage = DiskUsage::new(vec![cache.root().to_path_buf()]);
 
     let total_bytes = disk_usage.count_ignoring_errors();
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1088,7 +1088,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }) => commands::cache_dir(&cache, printer),
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Size(args),
-        }) => commands::cache_size(&cache, args.human, args.threads, printer, globals.preview),
+        }) => commands::cache_size(&cache, args.human, printer, globals.preview),
         Commands::Build(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::BuildSettings::resolve(args, filesystem, environment);

--- a/crates/uv/tests/it/cache_size.rs
+++ b/crates/uv/tests/it/cache_size.rs
@@ -57,24 +57,3 @@ fn cache_size_with_packages_human() {
     ----- stderr -----
     ");
 }
-
-/// Test that `cache size --threads 2` uses the correct number of threads, via a `info` log statement.
-#[test]
-fn cache_size_with_packages_threads() {
-    let context = TestContext::new("3.12");
-
-    // Install a requirement to populate the cache.
-    context.pip_install().arg("iniconfig").assert().success();
-
-    // Check cache size with `--threads 2`
-    uv_snapshot!(context.with_filtered_cache_size().filters(), context.cache_size().arg("--preview").arg("--threads").arg("2").arg("-v"), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    [SIZE]
-
-    ----- stderr -----
-    DEBUG uv [VERSION] ([COMMIT] DATE)
-    INFO Using 2 threads to calculate cache size
-    ");
-}


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

`uv cache size` can be quite slow. Here i use https://github.com/sharkdp/diskus to walk the cache directory with in multiple threads.

Add cli option to set the number of threads and default to ` std::thread::available_parallelism()` or 1.

## Test Plan

Added cli statement with info log test.

I believe this is a fair test, where i set cache dir to a large directory.

```bash
matthew@matthew-main ~/develop/personal/uv                                                                                                                                                                                                                 [14:17:50]                                                                                                                                                                                                                                       [±cache-size-speed-up ✓▴]
> $ uv cache size --preview-features cache-size -H --cache-dir ~/develop/                                                                                                                                                                   [±cache-size-speed-up ✓▴]
75.7GiB

matthew@matthew-main ~/develop/personal/uv                                                                                                                                                                                                                 [14:18:24]
> $ hyperfine 'uv cache size --preview-features cache-size -H --cache-dir ~/develop/' 'target/debug/uv cache size --preview-features cache-size -H --cache-dir ~/develop/'                                                                  [±cache-size-speed-up ✓▴]
Benchmark 1: uv cache size --preview-features cache-size -H --cache-dir ~/develop/
  Time (mean ± σ):      1.059 s ±  0.014 s    [User: 0.171 s, System: 0.884 s]
  Range (min … max):    1.048 s …  1.097 s    10 runs

Benchmark 2: target/debug/uv cache size --preview-features cache-size -H --cache-dir ~/develop/
  Time (mean ± σ):     413.8 ms ±  17.1 ms    [User: 5789.2 ms, System: 1682.0 ms]
  Range (min … max):   386.3 ms … 441.6 ms    10 runs

Summary
  target/debug/uv cache size --preview-features cache-size -H --cache-dir ~/develop/ ran
    2.56 ± 0.11 times faster than uv cache size --preview-features cache-size -H --cache-dir ~/develop/  
```
