### PR TITLE
Increase the size of binary build runners

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -227,7 +227,7 @@ jobs:
 
   windows:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: depot-windows-2022-8
+    runs-on: github-windows-2022-x86_64-8
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
Summary from asking Claude to compare the runtime

```
  | Job                       | Before | After | Saved | Reduction |
  |---------------------------|--------|-------|-------|-----------|
  | macos-aarch64             | 19.1m  | 9.8m  | 9.2m  | 48%       |
  | macos-x86_64              | 15.1m  | 9.2m  | 5.9m  | 39%       |
  | linux-arm (aarch64)       | 18.6m  | 12.2m | 6.4m  | 34%       |
  | linux-arm (armv7)         | 17.4m  | 11.5m | 5.9m  | 34%       |
  | musllinux-cross (aarch64) | 19.3m  | 13.2m | 6.1m  | 32%       |
  | linux-arm (arm)           | 16.6m  | 11.4m | 5.2m  | 31%       |
  | musllinux-cross (armv7)   | 16.4m  | 10.8m | 5.6m  | 34%       |
```
The longest-running affected job went from 19.3m → 13.2m (saved 6.1 minutes, 32% faster).