### PR TITLE
Update UV_VERSION in docs for GitLab CI/CD

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -13,7 +13,7 @@ Select a variant that is suitable for your workflow.
 
 ```yaml title="gitlab-ci.yml"
 variables:
-  UV_VERSION: "0.9"
+  UV_VERSION: "0.9.16"
   PYTHON_VERSION: "3.12"
   BASE_LAYER: bookworm-slim
   # GitLab CI creates a separate mountpoint for the build directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ version_files = [
   "docs/guides/integration/docker.md",
   "docs/guides/integration/pre-commit.md",
   "docs/guides/integration/github.md",
+  "docs/guides/integration/gitlab.md",
   "docs/guides/integration/aws-lambda.md",
   "docs/concepts/build-backend.md",
   "docs/concepts/projects/init.md",


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
## Summary
Update the `UV_VERSION`, such that a `copy-to-clipboard` action and pasting into a `.gitlab-ci.yml` is not 4 minor versions behind, as it happened to me a couple of times.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
I ran `mkdocs serve` and it worked (I literally only changed one character)
<!-- How was it tested? -->
