### PR TITLE
Bump ambient-id to 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ambient-id"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b48a3b1ad866e5034859be45edd1ebba2f097289c8a34b61623c76f10480f3"
+checksum = "b8cad022ed72ad2176498be1c097bb46e598193e92f3491ea0766980edeee168"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ uv-virtualenv = { version = "0.0.6", path = "crates/uv-virtualenv" }
 uv-warnings = { version = "0.0.6", path = "crates/uv-warnings" }
 uv-workspace = { version = "0.0.6", path = "crates/uv-workspace" }
 
-ambient-id = { version = "0.0.6", default-features = false, features = ["astral-reqwest-middleware"] }
+ambient-id = { version = "0.0.7", default-features = false, features = ["astral-reqwest-middleware"] }
 anstream = { version = "0.6.15" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }


### PR DESCRIPTION
## Summary 

This bumps our own `ambient-id` crate to 0.0.7. The only notable change in this release is BuildKite support, which means that `uv publish` will be able to do Trusted Publishing between BuildKite and Python indices that support it as a provider. Currently none do, but having client exchange support is a requirement regardless 🙂 

## Test Plan

Tested within `ambient-id` itself; the publishing integration tests within uv should ensure this doesn't regress on current TP support. Once actual BuildKite publishing is supposed on indices, I'll follow up with full integration tests for those as well.