### PR TITLE
Gate a few more tests on the pypi feature

### DIFF
--- a/crates/uv/tests/it/pip_list.rs
+++ b/crates/uv/tests/it/pip_list.rs
@@ -791,6 +791,7 @@ fn list_ignores_quiet_flag_format_freeze() {
 }
 
 #[test]
+#[cfg(feature = "pypi")]
 fn list_target() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -839,6 +840,7 @@ fn list_target() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "pypi")]
 fn list_prefix() -> Result<()> {
     let context = TestContext::new("3.12");
 

--- a/crates/uv/tests/it/pip_show.rs
+++ b/crates/uv/tests/it/pip_show.rs
@@ -536,6 +536,7 @@ fn show_files() {
 }
 
 #[test]
+#[cfg(feature = "pypi")]
 fn show_target() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -587,6 +588,7 @@ fn show_target() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "pypi")]
 fn show_prefix() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION


<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Gate a few more tests on the `pypi` feature. All of these fail in offline environments because they try to communicate with PyPI.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
Applied as a patch to Fedora’s `uv` package, version 0.9.16.