### PR TITLE
Cache Python downloads by default

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -261,6 +261,7 @@ impl PythonInstallation {
                 retry_policy,
                 installations_dir,
                 &scratch_dir,
+                cache,
                 false,
                 python_install_mirror,
                 pypy_install_mirror,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -14,6 +14,7 @@ use owo_colors::{AnsiColors, OwoColorize};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
+use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_fs::Simplified;
 use uv_platform::{Arch, Libc};
@@ -188,6 +189,7 @@ pub(crate) async fn install(
     pypy_install_mirror: Option<String>,
     python_downloads_json_url: Option<String>,
     client_builder: BaseClientBuilder<'_>,
+    cache: &Cache,
     default: bool,
     python_downloads: PythonDownloads,
     no_config: bool,
@@ -470,6 +472,7 @@ pub(crate) async fn install(
                         &retry_policy,
                         installations_dir,
                         &scratch_dir,
+                        cache,
                         reinstall,
                         python_install_mirror.as_deref(),
                         pypy_install_mirror.as_deref(),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1601,6 +1601,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             let args = settings::PythonInstallSettings::resolve(args, filesystem, environment);
             show_settings!(args);
 
+            let cache = cache.init().await?;
             commands::python_install(
                 &project_dir,
                 args.install_dir,
@@ -1614,6 +1615,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.pypy_install_mirror,
                 args.python_downloads_json_url,
                 client_builder.subcommand(vec!["python".to_owned(), "install".to_owned()]),
+                &cache,
                 args.default,
                 globals.python_downloads,
                 cli.top_level.no_config,
@@ -1630,6 +1632,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
             let upgrade = commands::PythonUpgrade::Enabled(commands::PythonUpgradeSource::Upgrade);
 
+            let cache = cache.init().await?;
             commands::python_install(
                 &project_dir,
                 args.install_dir,
@@ -1643,6 +1646,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.pypy_install_mirror,
                 args.python_downloads_json_url,
                 client_builder.subcommand(vec!["python".to_owned(), "upgrade".to_owned()]),
+                &cache,
                 args.default,
                 globals.python_downloads,
                 cli.top_level.no_config,

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -2712,10 +2712,10 @@ fn python_install_no_cache() {
      - cpython-3.14.2-[PLATFORM] (python3.14)
     ");
 
-    // 3.12 isn't cached, so it can't be installed
+    // 3.12 isn't cached, so it can't be installed offline
     let mut filters = context.filters();
     filters.push((
-        "cpython-3.12.*.tar.gz",
+        r"cpython-3\.12\.\d+(%2B|\+)\d+-[a-z0-9_-]+\.tar\.gz",
         "cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz",
     ));
     filters.push((r"releases/download/\d{8}/", "releases/download/[DATE]/"));
@@ -2729,8 +2729,7 @@ fn python_install_no_cache() {
 
     ----- stderr -----
     error: Failed to install cpython-3.12.12-[PLATFORM]
-      Caused by: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz
-      Caused by: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz`
+      Caused by: An offline Python installation was requested, but cpython-3.12.12-[PLATFORM] (from https://github.com/astral-sh/python-build-standalone/releases/download/[DATE]/cpython-3.12.[PATCH]-[DATE]-[PLATFORM].tar.gz) is missing in [CACHE_DIR]/python-v0
     ");
 }
 


### PR DESCRIPTION
i.e., without requiring opt-in via `UV_PYTHON_CACHE_DIR`

Best viewed with whitespace ignored as we dedent a block https://github.com/astral-sh/uv/pull/17075/files?diff=unified&w=1