### PR TITLE
Fix handling of `extra != ...` markers

### DIFF
--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -108,7 +108,7 @@ impl PubGrubPackage {
         // extras end up having two distinct marker expressions, which in turn
         // makes them two distinct packages. This results in PubGrub being
         // unable to unify version constraints across such packages.
-        let marker = marker.simplify_extras_with(|_| true);
+        let marker = marker.without_extras();
         if let Some(extra) = extra {
             Self(Arc::new(PubGrubPackageInner::Extra {
                 name,


### PR DESCRIPTION
This fix by Claude feels extremely dubious but it fixed a trivial example.

Investigating #17065 