### PR TITLE
Initialize S3 signer once

### DIFF
--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -66,8 +66,8 @@ static S3_ENDPOINT_REALM: LazyLock<Option<Realm>> = LazyLock::new(|| {
 pub(crate) struct S3EndpointProvider;
 
 impl S3EndpointProvider {
-    /// Returns the credentials for the S3 endpoint, if available.
-    pub(crate) fn credentials_for(url: &Url, preview: Preview) -> Option<DefaultSigner> {
+    /// Returns `true` if the URL matches the configured S3 endpoint.
+    pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> bool {
         if let Some(s3_endpoint_realm) = S3_ENDPOINT_REALM.as_ref().map(RealmRef::from) {
             if !preview.is_enabled(PreviewFeatures::S3_ENDPOINT) {
                 warn_user_once!(
@@ -79,19 +79,26 @@ impl S3EndpointProvider {
             // Treat any URL on the same domain or subdomain as available for S3 signing.
             let realm = RealmRef::from(url);
             if realm == s3_endpoint_realm || realm.is_subdomain_of(s3_endpoint_realm) {
-                // TODO(charlie): Can `reqsign` infer the region for us? Profiles, for example,
-                // often have a region set already.
-                let region = std::env::var(EnvVars::AWS_REGION)
-                    .map(Cow::Owned)
-                    .unwrap_or_else(|_| {
-                        std::env::var(EnvVars::AWS_DEFAULT_REGION)
-                            .map(Cow::Owned)
-                            .unwrap_or_else(|_| Cow::Borrowed("us-east-1"))
-                    });
-                let signer = reqsign::aws::default_signer("s3", &region);
-                return Some(signer);
+                return true;
             }
         }
-        None
+        false
+    }
+
+    /// Creates a new S3 signer with the configured region.
+    ///
+    /// This is potentially expensive as it may invoke credential helpers, so the result
+    /// should be cached.
+    pub(crate) fn create_signer() -> DefaultSigner {
+        // TODO(charlie): Can `reqsign` infer the region for us? Profiles, for example,
+        // often have a region set already.
+        let region = std::env::var(EnvVars::AWS_REGION)
+            .map(Cow::Owned)
+            .unwrap_or_else(|_| {
+                std::env::var(EnvVars::AWS_DEFAULT_REGION)
+                    .map(Cow::Owned)
+                    .unwrap_or_else(|_| Cow::Borrowed("us-east-1"))
+            });
+        reqsign::aws::default_signer("s3", &region)
     }
 }


### PR DESCRIPTION
## Summary

Right now, we initialize the signer many times concurrently.