### PR TITLE
Better error handling for `uv publish`

### DIFF
--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -322,7 +322,9 @@ impl ProgressReporter {
                         Direction::Download => "Downloaded",
                         Direction::Upload => "Uploaded",
                         Direction::Extract => "Extracted",
-                    },
+                    }
+                    .bold()
+                    .cyan(),
                     progress.message()
                 );
             }


### PR DESCRIPTION
* Use `is_transient_network_error` as we do in all other cases, see also https://github.com/astral-sh/uv/pull/16245
* Don't report success in the progress reporter if the upload failed
