### PR TITLE
Refactor uv retrayble strategy to use a single code path

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -131,14 +131,11 @@ impl Error {
         if let Self::NetworkErrorWithRetries { retries, .. } = self {
             return retries + 1;
         }
-        // TODO(jack): let-chains are stable as of Rust 1.88. We should use them here as soon as
-        // our rust-version is high enough.
-        if let Self::NetworkMiddlewareError(_, anyhow_error) = self {
-            if let Some(RetryError::WithRetries { retries, .. }) =
+        if let Self::NetworkMiddlewareError(_, anyhow_error) = self
+            && let Some(RetryError::WithRetries { retries, .. }) =
                 anyhow_error.downcast_ref::<RetryError>()
-            {
-                return retries + 1;
-            }
+        {
+            return retries + 1;
         }
         1
     }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -83,8 +83,8 @@ async fn simple_io_err() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to fetch: `[SERVER]/tqdm/`
-      Caused by: Request failed after 3 retries
+    error: Request failed after 3 retries
+      Caused by: Failed to fetch: `[SERVER]/tqdm/`
       Caused by: error sending request for url ([SERVER]/tqdm/)
       Caused by: client error (SendRequest)
       Caused by: connection closed before message completed
@@ -141,8 +141,8 @@ async fn find_links_io_error() {
 
     ----- stderr -----
     error: Failed to read `--find-links` URL: [SERVER]/
-      Caused by: Failed to fetch: `[SERVER]/`
       Caused by: Request failed after 3 retries
+      Caused by: Failed to fetch: `[SERVER]/`
       Caused by: error sending request for url ([SERVER]/)
       Caused by: client error (SendRequest)
       Caused by: connection closed before message completed
@@ -200,8 +200,8 @@ async fn direct_url_io_error() {
 
     ----- stderr -----
       × Failed to download `tqdm @ [SERVER]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
-      ├─▶ Failed to fetch: `[SERVER]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
       ├─▶ Request failed after 3 retries
+      ├─▶ Failed to fetch: `[SERVER]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl`
       ├─▶ error sending request for url ([SERVER]/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl)
       ├─▶ client error (SendRequest)
       ╰─▶ connection closed before message completed


### PR DESCRIPTION
Refactoring that allows uv's retryable strategy to return `Some(Retryable::Fatal)`, also helpful for https://github.com/astral-sh/uv/pull/16245