### PR TITLE
Enforce latest-version in `@latest` requests

### DIFF
--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -133,7 +133,7 @@ pub(crate) async fn pip_list(
             prerelease,
             exclude_newer: &exclude_newer,
             tags: Some(tags),
-            requires_python: &requires_python,
+            requires_python: Some(&requires_python),
         };
 
         let reporter = LatestVersionReporter::from(printer).with_length(results.len() as u64);

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -115,7 +115,7 @@ pub(crate) async fn pip_tree(
             prerelease,
             exclude_newer: &exclude_newer,
             tags: Some(tags),
-            requires_python: &requires_python,
+            requires_python: Some(&requires_python),
         };
 
         let reporter = LatestVersionReporter::from(printer).with_length(packages.len() as u64);

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -220,6 +220,9 @@ pub(crate) enum ProjectError {
     DependencyGroup(#[from] DependencyGroupError),
 
     #[error(transparent)]
+    Client(#[from] uv_client::Error),
+
+    #[error(transparent)]
     Python(#[from] uv_python::Error),
 
     #[error(transparent)]

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -232,7 +232,7 @@ pub(crate) async fn tree(
                 capabilities: &capabilities,
                 prerelease: lock.prerelease_mode(),
                 exclude_newer: &lock.exclude_newer(),
-                requires_python: lock.requires_python(),
+                requires_python: Some(lock.requires_python()),
                 tags: None,
             };
 


### PR DESCRIPTION
## Summary

Given `uv tool install {name}@latest`, we make revalidation requests for `{name}`, but we don't actually add a "latest" constraint when resolving -- we just assume that since the package is unpinned, and we're fetching the latest available versions, the resolver will select the latest version. 

However, imagine a package in which the latest version requires Python 3.13 or later, but prior versions support Python 3.9 and up. If we happen to select Python 3.9 ahead of resolution, and the user requests `{name}@latest`, we would backtrack to the non-latest version due to the Python mismatch.

This PR modifies `uv tool install` and `uv tool run` to first determine the latest version, then provide it as a constraint when resolving.
