### PR TITLE
fix: add ad-hoc code signing for Python binaries on macOS

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -294,7 +294,11 @@ impl PythonInstallation {
         }
 
         if let Err(e) = installed.ensure_dylib_patched() {
-            e.warn_user(&installed);
+            e.warn_user_dylib(&installed);
+        }
+
+        if let Err(e) = installed.ensure_codesigned() {
+            e.warn_user_codesign(&installed);
         }
 
         Ok(Self {

--- a/crates/uv-python/src/macos_dylib.rs
+++ b/crates/uv-python/src/macos_dylib.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{io::ErrorKind, path::PathBuf};
 
 use uv_fs::Simplified as _;
@@ -31,6 +32,42 @@ pub fn patch_dylib_install_name(dylib: PathBuf) -> Result<(), Error> {
     Ok(())
 }
 
+/// Ad-hoc sign a binary to satisfy macOS Gatekeeper requirements.
+///
+/// On macOS Sequoia and later, binaries with the `com.apple.provenance` extended
+/// attribute may be rejected by Gatekeeper unless they are properly signed.
+/// This function applies an ad-hoc signature (no identity) to the binary,
+/// which clears any cached Gatekeeper rejection and allows the binary to execute.
+///
+/// See <https://github.com/astral-sh/uv/issues/16726> for more information.
+pub fn adhoc_codesign(path: &Path) -> Result<(), Error> {
+    let output = match std::process::Command::new("codesign")
+        .args(["--force", "--sign", "-"])
+        .arg(path)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) => {
+            let e = if e.kind() == ErrorKind::NotFound {
+                Error::MissingCodesign
+            } else {
+                e.into()
+            };
+            return Err(e);
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(Error::CodesignError {
+            path: path.to_path_buf(),
+            stderr,
+        });
+    }
+
+    Ok(())
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error(transparent)]
@@ -44,11 +81,20 @@ For more information, see: https://developer.apple.com/xcode/")]
     MissingInstallNameTool,
     #[error("Failed to update the install name of the Python dynamic library located at `{}`", dylib.user_display())]
     RenameError { dylib: PathBuf, stderr: String },
+    #[error("`codesign` is not available on this system.
+This utility is part of macOS Developer Tools. Please ensure that the Xcode Command Line Tools are installed by running:
+
+    xcode-select --install
+
+For more information, see: https://developer.apple.com/xcode/")]
+    MissingCodesign,
+    #[error("Failed to ad-hoc sign the binary located at `{}`", path.user_display())]
+    CodesignError { path: PathBuf, stderr: String },
 }
 
 impl Error {
     /// Emit a user-friendly warning about the patching failure.
-    pub fn warn_user(&self, installation: &ManagedPythonInstallation) {
+    pub fn warn_user_dylib(&self, installation: &ManagedPythonInstallation) {
         let error = if tracing::enabled!(tracing::Level::DEBUG) {
             format!("\nUnderlying error: {self}")
         } else {
@@ -56,6 +102,20 @@ impl Error {
         };
         warn_user!(
             "Failed to patch the install name of the dynamic library for {}. This may cause issues when building Python native extensions.{}",
+            installation.executable(false).simplified_display(),
+            error
+        );
+    }
+
+    /// Emit a user-friendly warning about the code signing failure.
+    pub fn warn_user_codesign(&self, installation: &ManagedPythonInstallation) {
+        let error = if tracing::enabled!(tracing::Level::DEBUG) {
+            format!("\nUnderlying error: {self}")
+        } else {
+            String::new()
+        };
+        warn_user!(
+            "Failed to ad-hoc sign the Python executable for {}. This may cause issues on macOS Sequoia and later.{}",
             installation.executable(false).simplified_display(),
             error
         );

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -534,7 +534,10 @@ pub(crate) async fn install(
         installation.ensure_canonical_executables()?;
         installation.ensure_build_file()?;
         if let Err(e) = installation.ensure_dylib_patched() {
-            e.warn_user(installation);
+            e.warn_user_dylib(installation);
+        }
+        if let Err(e) = installation.ensure_codesigned() {
+            e.warn_user_codesign(installation);
         }
 
         let upgradeable = (default || is_default_install)


### PR DESCRIPTION
## Summary

On macOS Sequoia and later, binaries with the `com.apple.provenance` extended attribute may be rejected by Gatekeeper (SIGKILL) unless they are properly signed. This adds ad-hoc code signing to Python binaries after installation to ensure they can execute without issues.

## Changes

- Added `adhoc_codesign()` function in `crates/uv-python/src/macos_dylib.rs`
- Added `MissingCodesign` and `CodesignError` error variants for better error handling
- Added `ensure_codesigned()` method in `crates/uv-python/src/managed.rs`
- Updated `installation.rs` and `commands/python/install.rs` to call `ensure_codesigned()` after installation

The fix applies `codesign --force -s -` to the Python executable after installation, which clears any cached Gatekeeper rejection and allows the binary to run.

## Test Plan

- [x] `cargo test --package uv-python` - all 112 tests pass
- [x] `cargo clippy --all` - no warnings
- [x] `cargo fmt --check` - passes

Fixes #16726
Fixes #16003