### PR TITLE
Bump alpine published image to 3.23

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -170,8 +170,8 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.22,alpine3.22,alpine
-          - alpine:3.21,alpine3.21
+          - alpine:3.23,alpine3.23,alpine
+          - alpine:3.22,alpine3.22
           - debian:trixie-slim,trixie-slim,debian-slim
           - buildpack-deps:trixie,trixie,debian
           - debian:bookworm-slim,bookworm-slim

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -38,11 +38,11 @@ The following distroless images are available:
 And the following derived images are available:
 
 <!-- prettier-ignore -->
-- Based on `alpine:3.22`:
+- Based on `alpine:3.23`:
     - `ghcr.io/astral-sh/uv:alpine`
+    - `ghcr.io/astral-sh/uv:alpine3.23`
+- Based on `alpine:3.22`:
     - `ghcr.io/astral-sh/uv:alpine3.22`
-- Based on `alpine:3.21`:
-    - `ghcr.io/astral-sh/uv:alpine3.21`
 - Based on `debian:trixie-slim`:
     - `ghcr.io/astral-sh/uv:debian-slim`
     - `ghcr.io/astral-sh/uv:trixie-slim`
@@ -55,12 +55,19 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:bookworm`
 - Based on `python3.x-alpine`:
     - `ghcr.io/astral-sh/uv:python3.14-alpine`
+    - `ghcr.io/astral-sh/uv:python3.14-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.13-alpine`
+    - `ghcr.io/astral-sh/uv:python3.13-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.12-alpine`
+    - `ghcr.io/astral-sh/uv:python3.12-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.11-alpine`
+    - `ghcr.io/astral-sh/uv:python3.11-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.10-alpine`
+    - `ghcr.io/astral-sh/uv:python3.10-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.9-alpine`
+    - `ghcr.io/astral-sh/uv:python3.9-alpine3.22`
     - `ghcr.io/astral-sh/uv:python3.8-alpine`
+    - `ghcr.io/astral-sh/uv:python3.8-alpine3.20`
 - Based on `python3.x-trixie`:
     - `ghcr.io/astral-sh/uv:python3.14-trixie`
     - `ghcr.io/astral-sh/uv:python3.13-trixie`


### PR DESCRIPTION
## Summary

Removes Alpine 3.21.

Follow up to https://github.com/astral-sh/uv/pull/17100#discussion_r2614315352

Similar to https://github.com/astral-sh/uv/pull/16520, but no removals beyond Alpine 3.21

## Test Plan

Built locally.
