### PR TITLE
Update spdx dependency to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,9 +4397,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cf87c0efffc158b9dde4d6e0567a43e4383adc4c949e687a2039732db2f23a"
+checksum = "35107b1c818f4e9cb9e6c4444ca560ba03b4ee1288dcecc6d7830c2023a7609e"
 dependencies = [
  "smallvec",
 ]
@@ -5649,7 +5649,7 @@ dependencies = [
  "schemars",
  "serde",
  "sha2",
- "spdx 0.12.0",
+ "spdx 0.13.2",
  "tar",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ serde-untagged = { version = "0.1.6" }
 serde_json = { version = "1.0.128" }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
-spdx = { version = "0.12.0" }
+spdx = { version = "0.13.0" }
 syn = { version = "2.0.77" }
 sys-info = { version = "0.9.1" }
 tar = { version = "0.4.43" }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Updates the `spdx` dependency from 0.12.x to the latest release, 0.13.2.

https://github.com/EmbarkStudios/spdx/blob/0.13.2/CHANGELOG.md

Here in uv upstream, this just helps keep dependencies up to date; there isn’t any other particular specific motivation or benefit. Downstream in Fedora, this change allows me to avoid maintaining a `rust-spdx0.12` compat package.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
`cargo nextest run -- --skip python_install::python_install_pyodide`
