### PR TITLE
Set file timestamp from mirror source

### DIFF
--- a/scripts/create-python-mirror.py
+++ b/scripts/create-python-mirror.py
@@ -15,9 +15,11 @@ Example usage:
 
 import argparse
 import asyncio
+import datetime
 import hashlib
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
@@ -171,6 +173,14 @@ async def download_file(
             with open(dest, "wb") as f:
                 async for chunk in response.aiter_bytes():
                     f.write(chunk)
+            last_modified = response.headers.get("Last-Modified")
+            if last_modified is not None:
+                last_modified = datetime.datetime.strptime(
+                    last_modified, "%a, %d %b %Y %H:%M:%S %Z"
+                )
+            if last_modified is not None:
+                file_time = last_modified.timestamp()
+                os.utime(dest, (file_time, file_time))
 
         if expected_sha256 and sha256_checksum(dest) != expected_sha256:
             error_msg = f"SHA-256 mismatch for {dest}. Deleting corrupted file."


### PR DESCRIPTION
The create-python-mirror.py script will now set the timestamp of the downloaded files.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Set the timestamp of the downloaded files as found on the originating server.

## Test Plan

Basically run the mirror script and afterwards check the timestamp of newly
downloaded files. The timestamps will be different from the current time.
Files that were already present (with correct checksum) will not be changed.
