### PR TITLE
Link to the contributing tab instead of the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ See uv's [versioning policy](https://docs.astral.sh/uv/reference/versioning/) do
 
 We are passionate about supporting contributors of all levels of experience and would love to see
 you get involved in the project. See the
-[contributing guide](https://github.com/astral-sh/uv/blob/main/CONTRIBUTING.md) to get started.
+[contributing guide](https://github.com/astral-sh/uv?tab=contributing-ov-file#contributing) to get
+started.
 
 ## FAQ
 


### PR DESCRIPTION
I'm not sure if this is strictly better? but seemed worth a try

[Rendered](https://github.com/astral-sh/uv/tree/zb/contributing?tab=readme-ov-file#contributing)