### PR TITLE
Make pyx credential error message reflect the realm

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -503,14 +503,13 @@ impl Middleware for AuthMiddleware {
             .then_some(self.pyx_token_store.as_ref())
             .flatten()
         {
-            let domain = store
-                .api()
-                .domain()
-                .unwrap_or("pyx.dev")
-                .trim_start_matches("api.");
+            let login_param = match store.api().domain() {
+                None | Some("api.pyx.dev") => "pyx.dev".to_owned(),
+                Some(_) => format!("{}", Realm::from(store.api())),
+            };
             Err(Error::Middleware(format_err!(
                 "Run `{}` to authenticate uv with pyx",
-                format!("uv auth login {domain}").green()
+                format!("uv auth login {login_param}").green()
             )))
         } else {
             Err(Error::Middleware(format_err!(

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -507,9 +507,12 @@ impl Middleware for AuthMiddleware {
                 None | Some("api.pyx.dev") => "pyx.dev".to_owned(),
                 Some(_) => format!("{}", Realm::from(store.api())),
             };
+            let env_prefix = std::env::var(EnvVars::PYX_API_URL)
+                .map(|url| format!("PYX_API_URL='{url}' "))
+                .unwrap_or_else(|_| String::new());
             Err(Error::Middleware(format_err!(
                 "Run `{}` to authenticate uv with pyx",
-                format!("uv auth login {login_param}").green()
+                format!("{env_prefix}uv auth login {login_param}").green()
             )))
         } else {
             Err(Error::Middleware(format_err!(


### PR DESCRIPTION
This is unlikely to affect people who aren't pyx devs.

## Test Plan

`PYX_API_URL=http://localhost:8000 uv pip install --default-index $PYX_API_URL/simple foo` yields

```
Run `PYX_API_URL='http://localhost:8000' uv auth login http://localhost:8000` to authenticate uv with pyx
```

But the error message against production pyx.dev remains the same.
