### PR TITLE
Cache NVIDIA-hosted wheels by default

### DIFF
--- a/crates/uv-distribution-types/src/index_url.rs
+++ b/crates/uv-distribution-types/src/index_url.rs
@@ -875,4 +875,43 @@ mod tests {
             Some("max-age=3600")
         );
     }
+
+    #[test]
+    fn test_nvidia_default_cache_control() {
+        // Test that NVIDIA indexes get default cache control from the getter methods
+        let indexes = vec![Index {
+            name: Some(IndexName::from_str("nvidia").unwrap()),
+            url: IndexUrl::from_str("https://pypi.nvidia.com").unwrap(),
+            cache_control: None, // No explicit cache control
+            explicit: false,
+            default: false,
+            origin: None,
+            format: IndexFormat::Simple,
+            publish_url: None,
+            authenticate: uv_auth::AuthPolicy::default(),
+            ignore_error_codes: None,
+        }];
+
+        let index_urls = IndexUrls::from_indexes(indexes.clone());
+        let index_locations = IndexLocations::new(indexes, Vec::new(), false);
+
+        let nvidia_url = IndexUrl::from_str("https://pypi.nvidia.com").unwrap();
+
+        // IndexUrls should return the default for NVIDIA
+        assert_eq!(index_urls.simple_api_cache_control_for(&nvidia_url), None);
+        assert_eq!(
+            index_urls.artifact_cache_control_for(&nvidia_url),
+            Some("max-age=365000000, immutable, public")
+        );
+
+        // IndexLocations should also return the default for NVIDIA
+        assert_eq!(
+            index_locations.simple_api_cache_control_for(&nvidia_url),
+            None
+        );
+        assert_eq!(
+            index_locations.artifact_cache_control_for(&nvidia_url),
+            Some("max-age=365000000, immutable, public")
+        );
+    }
 }

--- a/crates/uv-distribution-types/src/status_code_strategy.rs
+++ b/crates/uv-distribution-types/src/status_code_strategy.rs
@@ -24,7 +24,7 @@ impl IndexStatusCodeStrategy {
     pub fn from_index_url(url: &Url) -> Self {
         if url
             .host_str()
-            .is_some_and(|host| host.ends_with("pytorch.org"))
+            .is_some_and(|host| host.eq_ignore_ascii_case("download.pytorch.org"))
         {
             // The PyTorch registry returns a 403 when a package is not found, so
             // we ignore them when deciding whether to search other indexes.


### PR DESCRIPTION
## Summary

Matches our behavior for PyTorch.

Closes https://github.com/astral-sh/uv/issues/16959.
