### PR TITLE
Improve reliability of certain managed python tests on Windows CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,6 +29,7 @@ fail-fast = false
 
 [test-groups]
 serial = { max-threads = 1 }
+io-bound = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'test(native_auth)'
@@ -37,3 +38,9 @@ test-group = 'serial'
 [[profile.default.overrides]]
 filter = 'package(uv-keyring)'
 test-group = 'serial'
+
+[[profile.ci-windows.overrides]]
+platform = 'cfg(target_os = "windows")'
+filter = 'test(/^python_install::/) + test(/^python_update::/) + test(/^python_find::/)'
+test-group = 'io-bound'
+priority = 1 # Start earlier so these can complete before the end


### PR DESCRIPTION
### Summary

Results:

| Test                                                         | Time before | Time after |       Change |
| ------------------------------------------------------------ | -----------:| ----------:| ------------:|
| install_lower_patch_automatically                            | 79.317s     | 20.093s    | **-59.200s** |
| install_multiple_patches                                     | 70.086s     | 20.126s    | **-50.000s** |
| install_no_transparent_upgrade_with_venv_patch_specification | 47.971s     |  9.607s    | **-38.400s** |
| install_transparent_patch_upgrade_uv_venv                    | 74.886s     | 12.600s    | **-62.300s** |
| install_transparent_patch_upgrade_venv_module                | 57.888s     | 10.854s    | **-47.000s** |
| python_find_prerelease                                       | 78.424s     | 18.302s    | **-60.100s** |
| python_install                                               | 47.827s     |  4.229s    | **-43.600s** |
| python_install_automatic                                     | 71.138s     | 11.836s    | **-59.300s** |
| python_install_build_version                                 | 35.983s     |  3.214s    | **-32.800s** |
| python_install_build_version_pypy                            | 80.750s     | 17.774s    | **-63.000s** |
| python_install_cached                                        |  6.752s     |  2.247s    |   -04.500s   |
| python_install_default                                       |  3.748s     |  4.202s    |   +00.454s   |
| python_install_default_from_env                              |  2.829s     |  2.190s    |   -00.639s   |
| python_install_default_prerelease                            |  1.136s     |  0.911s    |   -00.225s   |
| python_install_default_preview                               |  5.709s     |  3.601s    |   -02.110s   |
| python_install_emulated_windows_x86_on_x64                   | 90.025s     | 35.652s    | **-54.400s** |
| python_install_force                                         |  1.523s     |  1.365s    |   -00.158s   |
| python_install_freethreaded                                  | 36.136s     |  4.793s    | **-31.300s** |
| python_install_invalid_request                               |  0.299s     |  0.269s    |   -00.030s   |
| python_install_minor                                         |  1.496s     |  1.309s    |   -00.187s   |
| python_install_multiple_patch                                |  3.033s     |  1.415s    |   -01.620s   |
| python_install_no_cache                                      |  2.853s     |  2.311s    |   -00.542s   |
| python_install_prerelease                                    |  2.018s     |  2.006s    |   -00.012s   |
| python_install_preview                                       | 40.594s     |  6.870s    | **-33.700s** |
| python_install_preview_no_bin                                |  1.080s     |  1.177s    |   +00.097s   |
| python_install_preview_upgrade                               |  6.609s     |  6.295s    |   -00.314s   |
| python_install_unknown                                       |  0.211s     |  0.206s    |   -00.005s   |
| python_install_upgrade                                       |  9.153s     | 10.648s    |   +01.490s   |
| python_install_upgrade_version_file                          | 55.920s     | 12.943s    | **-43.000s** |
| python_reinstall                                             |  4.939s     |  6.225s    |   +01.290s   |
| python_reinstall_patch                                       |  2.716s     |  2.899s    |   +00.183s   |
| python_upgrade_not_allowed                                   |  0.215s     |  0.215s    |   +00.000s   |
| regression_cpython                                           | 30.779s     |  4.403s    | **-26.400s** |
| uninstall_highest_patch                                      | 40.716s     |  3.790s    | **-36.900s** |
| uninstall_last_patch                                         | 19.093s     |  2.965s    | **-16.100s** |

Comparing https://github.com/astral-sh/uv/actions/runs/20342580132/job/58446553156?pr=17177 against https://github.com/astral-sh/uv/actions/runs/20338690535/job/58431797575.

Overall test time went down from 279.163s to 258.427s - presumably not related though as this should be marginally slower. Here are some local tests (on linux):

* just python_install:
  * current config:  
    `Summary [  34.452s] 45 tests run: 44 passed (12 slow), 1 failed, 3314 skipped`
  * `threads-required = "num-test-threads"`:  
    `Summary [ 117.991s] 45 tests run: 44 passed (1 slow), 1 failed, 3314 skipped`
  * `threads-required = 4`:  
    `Summary [  48.793s] 45 tests run: 44 passed (4 slow), 1 failed, 3314 skipped`
* all tests:
  * current config:  
    `Summary [ 371.911s] 3357 tests run: 3356 passed (49 slow), 1 failed, 2 skipped`
  * `threads-required = "num-test-threads"`:  
    `Summary [ 451.323s] 3357 tests run: 3356 passed (26 slow), 1 failed, 2 skipped`
  * `threads-required = 4`:  
    `Summary [ 386.213s] 3357 tests run: 3356 passed (31 slow), 1 failed, 2 skipped`
    
(Failed test is not related)

### Conclusion

I think this is a good way to gain more reliability for these tests on all platforms, but I am not certain that we should be setting this override in the config. I think realistically you want something more like `num-test-threads / 3` rather than just `4`.