### PR TITLE
Add trailing newline when writing `download-metadata.json`

### DIFF
--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -835,7 +835,7 @@ def render(downloads: list[PythonDownload]) -> None:
 
     VERSIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
     # Make newlines consistent across platforms
-    VERSIONS_FILE.write_text(json.dumps(results, indent=2), newline="\n")
+    VERSIONS_FILE.write_text(json.dumps(results, indent=2) + "\n", newline="\n")
 
 
 async def find() -> None:


### PR DESCRIPTION
When we added formatting, the newline was added but it isn't written by the generator script so https://github.com/astral-sh/uv/pull/17193 removes it.