### PR TITLE
Remove .gitignore from project file list

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -29,7 +29,6 @@ $ uv init
 uv will create the following files:
 
 ```text
-├── .gitignore
 ├── .python-version
 ├── README.md
 ├── main.py


### PR DESCRIPTION
Removed .gitignore from the list of created files.

No issue created as quite a small change. Running `uv init` does **not** create a `.gitignore` file, therefore this list is slightly misleading.

~~Test Plan~~