### PR TITLE
Add background autoprune to remove stale cache entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5924,6 +5924,7 @@ name = "uv-cache"
 version = "0.0.22"
 dependencies = [
  "clap",
+ "filetime",
  "fs-err",
  "nanoid",
  "rmp-serde",
@@ -5932,6 +5933,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "uv-cache-info",
  "uv-cache-key",

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -28,6 +28,7 @@ uv-static = { workspace = true }
 
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 fs-err = { workspace = true, features = ["tokio"] }
+tokio = { workspace = true }
 nanoid = { workspace = true }
 rmp-serde = { workspace = true }
 rustc-hash = { workspace = true }
@@ -37,3 +38,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
+
+[dev-dependencies]
+filetime = { workspace = true }


### PR DESCRIPTION
Fixes #5731

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements automatic cache cleanup that runs in the background during normal
uv operations. This addresses issue #5731 by preventing unbounded cache growth
without requiring user intervention.

The autoprune task:
- Spawns as a fire-and-forget background task when the cache is initialized
- Removes unreferenced archives older than 1 hour (grace period for in-flight ops)
- Requires no exclusive lock since archives are immutable and uniquely identified;
  if there's no symlink referencing an archive, no process can be using it

## Test Plan

I've added unit tests for this feature. Having said that, I'm new to this project, so I'd appreciate any suggestions for testing more thoroughly.
