### PR TITLE
Avoid two hot String allocations in deserialization

### DIFF
--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -81,8 +81,8 @@ impl<'de> Deserialize<'de> for PypiFile {
                 let mut url = None;
                 let mut yanked = None;
 
-                while let Some(key) = access.next_key::<String>()? {
-                    match key.as_str() {
+                while let Some(key) = access.next_key::<&str>()? {
+                    match key {
                         "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata" => {
                             if core_metadata.is_none() {
                                 core_metadata = access.next_value()?;
@@ -181,8 +181,8 @@ impl<'de> Deserialize<'de> for PyxFile {
                 let mut yanked = None;
                 let mut zstd = None;
 
-                while let Some(key) = access.next_key::<String>()? {
-                    match key.as_str() {
+                while let Some(key) = access.next_key::<&str>()? {
+                    match key {
                         "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata" => {
                             if core_metadata.is_none() {
                                 core_metadata = access.next_value()?;


### PR DESCRIPTION
## Summary

Was reading this code while looking at adding PEP 792 support and noticed these: by using the borrowing deserializer instead of the owning one, we can probably save a good number of small-ish String allocations in the `PypiFile` and `PyxFile` deserializers.

(These deserializers in turn are probably pretty hot, since large installations/resolutions require pulling lots of candidates from indices.)

## Test Plan

No functional change expected; I'm not sure what the best way to microbenchmark this is. I'll try and contrive something locally.