### PR TITLE
Remove ua-parser from mypy overrides: it's typed

### DIFF
--- a/test/ecosystem/warehouse/pyproject.toml
+++ b/test/ecosystem/warehouse/pyproject.toml
@@ -234,7 +234,6 @@ module = [
   "requests_aws4auth.*", # https://github.com/tedder/requests-aws4auth/issues/53
   "rfc3986.*",
   "transaction.*",
-  "ua_parser.*", # https://github.com/ua-parser/uap-python/issues/110
   "venusian.*",
   "whitenoise.*",
   "zope.sqlalchemy.*",


### PR DESCRIPTION
I'll be honest I don't entirely understand what this does so it might be necessary to move the package to some other location in the file, or to subset it, but the section is headlined "these modules do not yet have types available" and that's definitely not the case for ua-parser: the 1.0 API is fully typed, the "legacy" 0.x API (the `ua_parser.user_agent_parser` submodule specifically) is not.

The issue linked is about using mypy*c* to generate a binary wheel, not about mypy / typechecking.