### PR TITLE
Improve wording in `Concepts/Projects/Creating projects` documentation

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -10,7 +10,7 @@ flag can be used to create a project for a library instead.
 
 uv will create a project in the working directory, or, in a target directory by providing a name,
 e.g., `uv init foo`. The working directory can be modified with the `--directory` option, which will
-cause the target directory path will be interpreted relative to the specified working directory. If
+cause the target directory path to be interpreted relative to the specified working directory. If
 there's already a project in the target directory, i.e., if there's a `pyproject.toml`, uv will exit
 with an error.
 


### PR DESCRIPTION
 
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
The sentence

 "The working directory can be modified with the --directory option, which will cause the target directory path will be interpreted..." 

contains a redundant "will". 

Correction: It should read: 
"...which will cause the target directory path to be interpreted..." or "...which causes the target directory path to be interpreted..."

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Not applicable 
<!-- How was it tested? -->
