### PR TITLE
Fix typo in 0.9.20 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 Released on 2025-12-29.
 
-This is a re-release of 0.9.20, with internal crate versions incremented to enable publishing to crates.io.
+This is a re-release of 0.9.19, with internal crate versions incremented to enable publishing to crates.io.
 
 ## 0.9.19
 


### PR DESCRIPTION
Since it was a re-release of 0.9.19, not 0.9.20.
