### PR TITLE
Clarify requirements file format in docs

### DIFF
--- a/docs/pip/dependencies.md
+++ b/docs/pip/dependencies.md
@@ -38,10 +38,11 @@ more details on getting started with a `pyproject.toml`.
 
 ## Using `requirements.in`
 
-It is also common to use a lightweight [requirements file format](https://pip.pypa.io/en/stable/reference/requirements-file-format/) to declare the dependencies for the
-project. Each requirement is defined on its own line. Commonly, this file is called
-`requirements.in` to distinguish it from `requirements.txt` which is used for the locked
-dependencies.
+It is also common to use a lightweight
+[requirements file format](https://pip.pypa.io/en/stable/reference/requirements-file-format/) to
+declare the dependencies for the project. Each requirement is defined on its own line. Commonly,
+this file is called `requirements.in` to distinguish it from `requirements.txt` which is used for
+the locked dependencies.
 
 To define dependencies in a `requirements.in` file:
 


### PR DESCRIPTION
## Summary

The docs for `requirements.in` currently wrongly refer to `requirements.txt` in the first sentence:
> ### Using requirements.in
>
> It is also common to use a lightweight **requirements.txt** format to declare the dependencies for the project. Each requirement is defined on its own line. Commonly, this file is called requirements.in to distinguish it from requirements.txt which is used for the locked dependencies.

The occurrence in bold should be **requirements.in** instead.
