### PR TITLE
Gate python_install tests on python-managed feature

### DIFF
--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -1259,6 +1259,7 @@ fn python_find_path() {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
 fn python_find_freethreaded_313() {
     let context: TestContext = TestContext::new_with_versions(&[])
         .with_filtered_python_keys()
@@ -1298,6 +1299,7 @@ fn python_find_freethreaded_313() {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
 fn python_find_freethreaded_314() {
     let context: TestContext = TestContext::new_with_versions(&[])
         .with_filtered_python_keys()
@@ -1375,6 +1377,7 @@ fn python_find_freethreaded_314() {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
 fn python_find_prerelease_version_specifiers() {
     let context: TestContext = TestContext::new_with_versions(&[])
         .with_filtered_python_keys()
@@ -1474,6 +1477,7 @@ fn python_find_prerelease_version_specifiers() {
 }
 
 #[test]
+#[cfg(feature = "python-managed")]
 fn python_find_prerelease_with_patch_request() {
     let context: TestContext = TestContext::new_with_versions(&[])
         .with_filtered_python_keys()


### PR DESCRIPTION
## Summary

  Gates four tests in `python_find.rs` that call `python_install()` behind the `python-managed` feature flag. These tests attempt to download Python versions from the network (free-threaded and pre-release versions) which fail in offline build environments.

  Fixes #16431

  ## Test Plan

  Verified that the gated tests match the pattern used elsewhere in the codebase where the entire `python_install` module is already gated behind `#[cfg(feature = "python-managed")]`.
