### PR TITLE
Preserve absolute paths in `uv add` for local dependencies

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1605,7 +1605,7 @@ pub enum SourceError {
 }
 
 /// Check if the original user-provided path was absolute.
-/// 
+///
 /// Uses the `given()` method of `VerbatimUrl` to check the original string.
 /// If the original string is not available, defaults to checking if it's a `file://` URL
 /// with an absolute path.
@@ -1732,14 +1732,15 @@ impl Source {
                     return Ok(None);
                 }
             }
-            RequirementSource::Path { install_path, url, .. } => Self::Path {
+            RequirementSource::Path {
+                install_path, url, ..
+            } => Self::Path {
                 editable: None,
                 package: None,
                 path: PortablePathBuf::from(
                     if was_absolute_path(&url) {
                         // User provided absolute path, preserve it
-                        std::path::absolute(&install_path)
-                            .map_err(SourceError::Absolute)?
+                        std::path::absolute(&install_path).map_err(SourceError::Absolute)?
                     } else {
                         // User provided relative path, make it relative to project root
                         relative_to(&install_path, root)
@@ -1763,8 +1764,7 @@ impl Source {
                 path: PortablePathBuf::from(
                     if was_absolute_path(&url) {
                         // User provided absolute path, preserve it
-                        std::path::absolute(&install_path)
-                            .map_err(SourceError::Absolute)?
+                        std::path::absolute(&install_path).map_err(SourceError::Absolute)?
                     } else {
                         // User provided relative path, make it relative to project root
                         relative_to(&install_path, root)

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1604,6 +1604,23 @@ pub enum SourceError {
     EmptySources,
 }
 
+/// Check if the original user-provided path was absolute.
+/// 
+/// Uses the `given()` method of `VerbatimUrl` to check the original string.
+/// If the original string is not available, defaults to checking if it's a `file://` URL
+/// with an absolute path.
+fn was_absolute_path(url: &uv_pep508::VerbatimUrl) -> bool {
+    // Check the original user-provided string if available
+    if let Some(given) = url.given() {
+        // Check if the given string starts with "/" (Unix) or contains ":" (Windows drive)
+        let path_str = given.strip_prefix("file://").unwrap_or(given);
+        Path::new(path_str).is_absolute()
+    } else {
+        // Fallback: assume file:// URLs with absolute paths were originally absolute
+        url.scheme() == "file"
+    }
+}
+
 impl Source {
     pub fn from_requirement(
         name: &PackageName,
@@ -1715,14 +1732,21 @@ impl Source {
                     return Ok(None);
                 }
             }
-            RequirementSource::Path { install_path, .. } => Self::Path {
+            RequirementSource::Path { install_path, url, .. } => Self::Path {
                 editable: None,
                 package: None,
                 path: PortablePathBuf::from(
-                    relative_to(&install_path, root)
-                        .or_else(|_| std::path::absolute(&install_path))
-                        .map_err(SourceError::Absolute)?
-                        .into_boxed_path(),
+                    if was_absolute_path(&url) {
+                        // User provided absolute path, preserve it
+                        std::path::absolute(&install_path)
+                            .map_err(SourceError::Absolute)?
+                    } else {
+                        // User provided relative path, make it relative to project root
+                        relative_to(&install_path, root)
+                            .or_else(|_| std::path::absolute(&install_path))
+                            .map_err(SourceError::Absolute)?
+                    }
+                    .into_boxed_path(),
                 ),
                 marker: MarkerTree::TRUE,
                 extra: None,
@@ -1731,15 +1755,23 @@ impl Source {
             RequirementSource::Directory {
                 install_path,
                 editable: is_editable,
+                url,
                 ..
             } => Self::Path {
                 editable: editable.or(is_editable),
                 package: None,
                 path: PortablePathBuf::from(
-                    relative_to(&install_path, root)
-                        .or_else(|_| std::path::absolute(&install_path))
-                        .map_err(SourceError::Absolute)?
-                        .into_boxed_path(),
+                    if was_absolute_path(&url) {
+                        // User provided absolute path, preserve it
+                        std::path::absolute(&install_path)
+                            .map_err(SourceError::Absolute)?
+                    } else {
+                        // User provided relative path, make it relative to project root
+                        relative_to(&install_path, root)
+                            .or_else(|_| std::path::absolute(&install_path))
+                            .map_err(SourceError::Absolute)?
+                    }
+                    .into_boxed_path(),
                 ),
                 marker: MarkerTree::TRUE,
                 extra: None,

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3185,7 +3185,8 @@ fn add_path_adjacent_directory() -> Result<()> {
         .child("__init__.py")
         .touch()?;
 
-    uv_snapshot!(context.filters(), context.add().arg(dependency.path()).current_dir(project.path()), @r"
+    // Use a relative path to test adjacent directory behavior
+    uv_snapshot!(context.filters(), context.add().arg("../dependency").current_dir(project.path()), @r"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3215,7 +3216,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         ]
 
         [tool.uv.sources]
-        dependency = { path = "[TEMP_DIR]/dependency" }
+        dependency = { path = "../dependency" }
         "#
         );
     });

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3003,6 +3003,156 @@ fn add_path_no_workspace() -> Result<()> {
     Ok(())
 }
 
+/// Add a path dependency with an absolute path, which should be preserved.
+#[test]
+fn add_path_absolute() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let workspace = context.temp_dir.child("workspace");
+    workspace.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let child = context.temp_dir.child("external").child("child");
+    child.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+    context
+        .temp_dir
+        .child("external")
+        .child("child")
+        .child("src")
+        .child("child")
+        .child("__init__.py")
+        .touch()?;
+
+    // Use an absolute path
+    let absolute_path = fs_err::canonicalize(child.path())?;
+    uv_snapshot!(context.filters(), context.add().arg(&absolute_path).current_dir(workspace.path()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + child==0.1.0 (from file://[TEMP_DIR]/external/child)
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(workspace.join("pyproject.toml"))?;
+
+    // Verify the absolute path is preserved in pyproject.toml
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "child",
+        ]
+
+        [tool.uv.sources]
+        child = { path = "[TEMP_DIR]/external/child" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Add a path dependency with a relative path, which should stay relative.
+#[test]
+fn add_path_relative() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let workspace = context.temp_dir.child("workspace");
+    workspace.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let child = workspace.child("packages").child("child");
+    child.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+    workspace
+        .child("packages")
+        .child("child")
+        .child("src")
+        .child("child")
+        .child("__init__.py")
+        .touch()?;
+
+    // Use a relative path explicitly with --no-workspace to avoid workspace member addition
+    uv_snapshot!(context.filters(), context.add().arg("./packages/child").arg("--no-workspace").current_dir(workspace.path()), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + child==0.1.0 (from file://[TEMP_DIR]/workspace/packages/child)
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(workspace.join("pyproject.toml"))?;
+
+    // Verify the relative path is preserved
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "child",
+        ]
+
+        [tool.uv.sources]
+        child = { path = "packages/child" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// Add a path dependency in an adjacent directory, which should not be added to the workspace.
 #[test]
 fn add_path_adjacent_directory() -> Result<()> {
@@ -3065,7 +3215,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         ]
 
         [tool.uv.sources]
-        dependency = { path = "../dependency" }
+        dependency = { path = "[TEMP_DIR]/dependency" }
         "#
         );
     });

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7648,7 +7648,7 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
         [[package]]
         name = "c"
         version = "0.1.0"
-        source = { directory = "c" }
+        source = { directory = "[TEMP_DIR]/c" }
         "#
         );
     });
@@ -8908,7 +8908,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         [[package]]
         name = "dependency"
         version = "0.0.1"
-        source = { directory = "v1" }
+        source = { directory = "[TEMP_DIR]/v1" }
         resolution-markers = [
             "sys_platform == 'darwin'",
         ]
@@ -8922,7 +8922,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         [[package]]
         name = "dependency"
         version = "0.0.1"
-        source = { directory = "v2" }
+        source = { directory = "[TEMP_DIR]/v2" }
         resolution-markers = [
             "sys_platform != 'darwin'",
         ]
@@ -8947,8 +8947,8 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         version = "0.1.0"
         source = { virtual = "." }
         dependencies = [
-            { name = "dependency", version = "0.0.1", source = { directory = "v1" }, marker = "sys_platform == 'darwin'" },
-            { name = "dependency", version = "0.0.1", source = { directory = "v2" }, marker = "sys_platform != 'darwin'" },
+            { name = "dependency", version = "0.0.1", source = { directory = "[TEMP_DIR]/v1" }, marker = "sys_platform == 'darwin'" },
+            { name = "dependency", version = "0.0.1", source = { directory = "[TEMP_DIR]/v2" }, marker = "sys_platform != 'darwin'" },
         ]
 
         [package.metadata]
@@ -12776,7 +12776,7 @@ fn lock_sources_archive() -> Result<()> {
         [[package]]
         name = "workspace"
         version = "0.1.0"
-        source = { path = "workspace.zip" }
+        source = { path = "[TEMP_DIR]/workspace.zip" }
         dependencies = [
             { name = "anyio" },
         ]
@@ -12901,7 +12901,7 @@ fn lock_sources_source_tree() -> Result<()> {
         [[package]]
         name = "workspace"
         version = "0.1.0"
-        source = { directory = "workspace" }
+        source = { directory = "[TEMP_DIR]/workspace" }
         dependencies = [
             { name = "anyio" },
         ]


### PR DESCRIPTION
When adding a local package with an absolute path like `uv add /path/to/package`, keep it absolute instead of converting to relative. Relative paths stay relative.

Fixes #17307

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->