### PR TITLE
Use `Cow<str>` for deserialization map keys in `PypiFile` and `PyxFile`

### DIFF
--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -81,8 +81,8 @@ impl<'de> Deserialize<'de> for PypiFile {
                 let mut url = None;
                 let mut yanked = None;
 
-                while let Some(key) = access.next_key::<&str>()? {
-                    match key {
+                while let Some(key) = access.next_key::<Cow<'_, str>>()? {
+                    match &*key {
                         "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata" => {
                             if core_metadata.is_none() {
                                 core_metadata = access.next_value()?;
@@ -181,8 +181,8 @@ impl<'de> Deserialize<'de> for PyxFile {
                 let mut yanked = None;
                 let mut zstd = None;
 
-                while let Some(key) = access.next_key::<&str>()? {
-                    match key {
+                while let Some(key) = access.next_key::<Cow<'_, str>>()? {
+                    match &*key {
                         "core-metadata" | "dist-info-metadata" | "data-dist-info-metadata" => {
                             if core_metadata.is_none() {
                                 core_metadata = access.next_value()?;


### PR DESCRIPTION
Use `Cow<'_, str>` when deserializing map keys. This allows serde to borrow strings directly from the input in the common case (no escaping needed), while still correctly handling cases where de-escaping is required.

Addresses feedback from #17221