### PR TITLE
Add manylinux to armv6l match

### DIFF
--- a/crates/uv-platform-tags/src/platform_tag.rs
+++ b/crates/uv-platform-tags/src/platform_tag.rs
@@ -376,7 +376,13 @@ impl PlatformTag {
     pub fn is_armv6l(&self) -> bool {
         matches!(
             self,
-            Self::Linux {
+            Self::Manylinux {
+                arch: Arch::Armv6L,
+                ..
+            } | Self::Manylinux2014 {
+                arch: Arch::Armv6L,
+                ..
+            } | Self::Linux {
                 arch: Arch::Armv6L,
                 ..
             } | Self::Musllinux {


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/uv/pull/17317/changes#r2662205930. I omitted these because we technically don't allow this for manylinux, but this seems more consistent.
