### PR TITLE
Use DisplaySafeUrl to readact a URL in a trace log

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -1107,7 +1107,10 @@ fn retryable_on_request_failure(err: &(dyn Error + 'static)) -> Option<Retryable
     if let Some((Some(status), Some(url))) = find_source::<WrappedReqwestError>(&err)
         .map(|request_err| (request_err.status(), request_err.url()))
     {
-        trace!("Considering retry of response HTTP {status} for {url}");
+        trace!(
+            "Considering retry of response HTTP {status} for {url}",
+            url = DisplaySafeUrl::from_url(url.clone())
+        );
     } else {
         trace!("Considering retry of error: {err:?}");
     }


### PR DESCRIPTION
## Summary

Redacts a `Url` by transforming it into a `DisplaySafeUrl` before logging. This requires a clone, since `DisplaySafeUrl` is owning. Note that this doesn't use `DisplaySafeUrl::parse`, so it doesn't include the ambiguity detections we normally perform. I could add that, although that would mean inserting a fallible API on the path here.

Ideally we'd have a lint for these -- we should flag any dataflow where a `Url` value flows into an output sink (like `trace!`). Not sure how easy this would be to add, but I can look into it.

See #17343.

## Test Plan

I'm not sure what the best way to test this is -- maybe a mock server that intentionally flakes the first request to exercise the logic? Consequently I haven't added a new test yet.