### PR TITLE
Avoid checking formatting of all files during windows trampoline checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
 
       - name: "rustfmt"
         working-directory: ${{ env.UV_WORKSPACE }}/crates/uv-trampoline
-        run: cargo fmt --all --check
+        run: cargo fmt --check
 
       - name: "Clippy"
         working-directory: ${{ env.UV_WORKSPACE }}/crates/uv-trampoline


### PR DESCRIPTION
I've noticed this escapes the trampoline crates so these fail whenever there's bad formatting in the workspace.