### PR TITLE
Recognize armv8l as an alias for armv7l in platform tag parsing

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -163,7 +163,8 @@ impl FromStr for Arch {
             "aarch64" => Ok(Self::Aarch64),
             "armv5tel" => Ok(Self::Armv5TEL),
             "armv6l" => Ok(Self::Armv6L),
-            "armv7l" => Ok(Self::Armv7L),
+            // armv8l is 32-bit ARM running on ARMv8 hardware, compatible with armv7l
+            "armv7l" | "armv8l" => Ok(Self::Armv7L),
             "ppc64le" => Ok(Self::Powerpc64Le),
             "ppc64" => Ok(Self::Powerpc64),
             "ppc" => Ok(Self::Powerpc),


### PR DESCRIPTION
Closes #17375

It looks like this was missed in https://github.com/astral-sh/uv/pull/8881 and now that we fail if wheel tags do not match the target environment (see https://github.com/astral-sh/uv/pull/16074), we do not allow armv8l wheels to installed in environments where the interpreter reports armv7l.