### PR TITLE
Broadcast WM_SETTINGCHANGE on uv tool update-shell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ uuid = { version = "1.16.0" }
 version-ranges = { version = "0.1.3", package = "astral-version-ranges" }
 walkdir = { version = "2.5.0" }
 which = { version = "8.0.0", features = ["regex"] }
-windows = { version = "0.59.0", features = ["std", "Win32_Globalization", "Win32_System_LibraryLoader", "Win32_System_Console", "Win32_System_Kernel", "Win32_System_Diagnostics_Debug", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_Registry", "Win32_System_IO", "Win32_System_Ioctl"] }
+windows = { version = "0.59.0", features = ["std", "Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Registry", "Win32_UI_WindowsAndMessaging"] }
 windows-registry = { version = "0.5.0" }
 wiremock = { version = "0.6.4" }
 wmi = { version = "0.16.0", default-features = false }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/17331

Certain applications on windows expect to be notified when environment variables change such as conhost.exe (traditional cmd.exe host).
Without this notification conhost.exe will not pick up changes to environment variables regardless of how many times conhost.exe is re-launched after running `uv tool update-shell`.

## Test Plan

Before this change

1. Removed `%USERPROFILE%\.local\bin` from environment variables via UI (which sends `WM_SETTINGCHANGE`)
2. Launched `%SYSTEMROOT%\System32\conhost.exe` and attempted to run any tool preivously installed. It fails to find any.
3. Ran `uv tool update-shell`. Confirmed `HKEY_CURRENT_USER\Environment\Path` was updated in registry.
4. Launched new `%SYSTEMROOT%\System32\conhost.exe` session. **Fails to find installed tools**.

After this change

1. Removed `%USERPROFILE%\.local\bin` from environment variables via UI (which sends `WM_SETTINGCHANGE`)
2. Launched `%SYSTEMROOT%\System32\conhost.exe` and attempted to run any tool preivously installed. It fails to find any.
3. Ran `uv tool update-shell`. Confirmed `HKEY_CURRENT_USER\Environment\Path` was updated in registry.
4. Launched new `%SYSTEMROOT%\System32\conhost.exe` session. **Finds the installed tools**.