### PR TITLE
Re-enable pyx integration tests

### DIFF
--- a/scripts/publish/test_publish.py
+++ b/scripts/publish/test_publish.py
@@ -176,8 +176,8 @@ local_targets: dict[str, TargetConfiguration] = {
     ),
     "pyx-token": TargetConfiguration(
         "astral-test-token",
-        "https://astral-sh-staging-api.pyx.dev/v1/upload/uv-publish-integration/main",
-        "https://astral-sh-staging-api.pyx.dev/simple/uv-publish-integration/main/",
+        "https://api.pyx.dev/v1/upload/astral-test/main",
+        "https://api.pyx.dev/simple/astral-test/main/",
     ),
 }
 
@@ -199,8 +199,6 @@ all_targets: dict[str, TargetConfiguration] = local_targets | {
 
 # Temporarily disable codeberg on CI due to unreliability.
 all_targets.pop("codeberg", None)
-# Temporarily disable pyx staging tests due to broken environment.
-all_targets.pop("pyx-token", None)
 
 
 def get_latest_version(target: str, client: httpx.Client) -> Version | None:
@@ -643,9 +641,7 @@ def target_configuration(target: str) -> tuple[dict[str, str], list[str]]:
     elif target == "pyx-token":
         extra_args = []
         env = {
-            "UV_API_KEY": os.environ["UV_TEST_PUBLISH_PYX_TOKEN"],
-            # So that uv accesses the right API for check-url.
-            "PYX_API_URL": "https://astral-sh-staging-api.pyx.dev",
+            "PYX_API_KEY": os.environ["UV_TEST_PUBLISH_PYX_TOKEN"],
         }
     else:
         raise ValueError(f"Unknown target: {target}")


### PR DESCRIPTION
Re-enables the recently-disabled pyx integration tests, and moves them to a more stable environment.

## Test plan

the publishing tests attached to this PR should be green, and they should publish to the new location in pyx.