### PR TITLE
Move release plan checks to a separate workflow

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_call:
+
+jobs:
+  dist-plan:
+    name: "dist plan"
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install dist
+        shell: bash
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.2/cargo-dist-installer.sh | sh"
+
+      - name: Run dist plan
+        run: |
+          dist plan --output-format=json > plan-dist-manifest.json
+          echo "dist plan completed successfully"
+          cat plan-dist-manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
     if: ${{ needs.plan.outputs.test-code == 'true' }}
     uses: ./.github/workflows/check-publish.yml
 
+  check-release:
+    needs: plan
+    if: ${{ needs.plan.outputs.run-checks == 'true' }}
+    uses: ./.github/workflows/check-release.yml
+
   check-generated-files:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       tag:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -43,7 +43,7 @@ auto-includes = false
 # Whether dist should create a Github Release or use an existing draft
 create-release = true
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+pr-run-mode = "skip"
 # Whether CI should trigger releases with dispatches instead of tag pushes
 dispatch-releases = true
 # Which phase dist should use to create the GitHub release
@@ -57,7 +57,7 @@ github-attestations-filters = ["*.json", "*.sh", "*.ps1", "*.zip", "*.tar.gz"]
 # Whether CI should include auto-generated code to build local artifacts
 build-local-artifacts = false
 # Local artifacts jobs to run in CI
-local-artifacts-jobs = ["./build-binaries", "./build-docker"]
+local-artifacts-jobs = ["./build-release-binaries", "./build-docker"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi", "./publish-crates"]
 # Post-announce jobs to run in CI


### PR DESCRIPTION
We get a bunch of redundant skipped `Release / Build binary ...` jobs in CI otherwise, and I would rather the release workflow didn't have a pull request trigger at all.

Follows #17388 