### PR TITLE
Assume tar.gz for packages without extension

### DIFF
--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -1822,10 +1822,8 @@ mod test {
             filters => filters
         }, {
             insta::assert_snapshot!(errors, @r###"
-            Couldn't parse requirement in `<REQUIREMENTS_TXT>` at position 3
-            Expected direct URL (`https://localhost:8080/`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-            https://localhost:8080/
-            ^^^^^^^^^^^^^^^^^^^^^^^
+            Unsupported editable requirement in `<REQUIREMENTS_TXT>`
+            Editable must refer to a local directory, not an HTTPS URL: `https://localhost:8080/`
             "###);
         });
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -9082,24 +9082,29 @@ fn invalid_extension() {
     "###);
 }
 
-/// Install a package without unsupported extension.
+/// Install a package from a GitHub tarball API URL without extension
+/// See <https://github.com/astral-sh/uv/issues/17425>
 #[test]
-fn no_extension() {
+#[cfg(feature = "git")]
+fn github_tarball_url_no_extension() {
     let context = TestContext::new(DEFAULT_PYTHON_VERSION);
 
+    // Test with a real GitHub tarball URL (public repository)
     uv_snapshot!(context.filters(), context.pip_install()
-        .arg("ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6")
+        .arg("uv-public-pypackage @ https://api.github.com/repos/astral-test/uv-public-pypackage/tarball/0dacfd662c64cb4ceb16e6cf65a157a8b715b979")
         , @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse: `ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`
-      Caused by: Expected direct URL (`https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6`) to end in a supported file extension: `.whl`, `.tar.gz`, `.zip`, `.tar.bz2`, `.tar.lz`, `.tar.lzma`, `.tar.xz`, `.tar.zst`, `.tar`, `.tbz`, `.tgz`, `.tlz`, or `.txz`
-    ruff @ https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from https://api.github.com/repos/astral-test/uv-public-pypackage/tarball/0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
 }
 
 /// Regression test for: <https://github.com/astral-sh/uv/pull/6646>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This fixes issue with installing packages that contain URLs without explicit file extensions 

The example are GitHub releases that can be references with URLs like https://api.github.com/repos/pyro-ppl/pyro/tarball/dev (real example at https://github.com/pyro-ppl/pyro-api/blob/master/setup.py#L36).

If extension is not specified, we assume it is a tar.gz file, as it's a common pattern for GitHub.

Fixes: 17425
Co-authored-by: Copilot Agent

## Test Plan

<!-- How was it tested? -->

I added test with installing a package without file extension..
