### PR TITLE
Only save Rust cache on `main` or when cache-relevant files change

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      save-rust-cache:
+        required: false
+        type: string
+        default: "true"
 
 permissions: {}
 
@@ -22,6 +27,8 @@ jobs:
           persist-credentials: false
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         run: rustup show
@@ -98,6 +105,8 @@ jobs:
           persist-credentials: false
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         run: rustup show

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      save-rust-cache:
+        required: false
+        type: string
+        default: "true"
 
 permissions: {}
 
@@ -22,6 +27,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Build"
         run: cargo build --profile no-debug
@@ -47,6 +54,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Build"
         run: cargo build --profile no-debug
@@ -77,6 +86,8 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Build"
         run: cargo build --profile no-debug --target x86_64-unknown-linux-musl --bin uv --bin uvx
@@ -102,6 +113,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Build"
         run: cargo build --profile no-debug --bin uv --bin uvx
 
@@ -126,6 +139,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Build"
         run: cargo build --profile no-debug --bin uv --bin uvx
 
@@ -158,6 +173,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Build"
         working-directory: ${{ env.UV_WORKSPACE }}
@@ -193,6 +209,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install cross target"
         run: rustup target add aarch64-pc-windows-msvc
@@ -230,6 +247,8 @@ jobs:
       - name: "Install mold"
         uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - run: cargo +${MSRV} build --profile no-debug
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
@@ -244,6 +263,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Cross build"
         run: |
           # Install cross from `freebsd-firecracker`

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -4,6 +4,10 @@ on:
       schema-changed:
         required: true
         type: string
+      save-rust-cache:
+        required: false
+        type: string
+        default: "true"
 
 permissions: {}
 
@@ -24,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Generate all"
         run: cargo dev generate-all --mode dry-run
       - name: "Check sysconfig mappings"

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -4,6 +4,10 @@ on:
       code-changed:
         required: true
         type: string
+      save-rust-cache:
+        required: false
+        type: string
+        default: "true"
 
 permissions: {}
 
@@ -98,7 +102,7 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
       - name: "Check uv_build dependencies"
         uses: EmbarkStudios/cargo-deny-action@76cd80eb775d7bbbd2d80292136d74d39e1b4918 # v2.0.14
         with:
@@ -130,6 +134,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         run: rustup component add clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       test-publish: ${{ steps.changed.outputs.publish_changed == 'true' || github.ref == 'refs/heads/main' }}
       # Run trampoline checks if trampoline-related code changed
       test-windows-trampoline: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (steps.changed.outputs.trampoline_any_changed == 'true' || github.ref == 'refs/heads/main') }}
+      # Save Rust cache if on main or if cache-relevant files changed (Cargo files, toolchain, workflows)
+      save-rust-cache: ${{ github.ref == 'refs/heads/main' || steps.changed.outputs.cache_changed == 'true' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -45,6 +47,7 @@ jobs:
           RELEASE_BUILD_CHANGED=false
           PUBLISH_CHANGED=false
           TRAMPOLINE_CHANGED=false
+          CACHE_CHANGED=false
 
           while IFS= read -r file; do
             # Check if the schema file changed (e.g., in a release PR)
@@ -69,6 +72,12 @@ jobs:
             if [[ "${file}" =~ ^crates/uv-trampoline/ ]] || [[ "${file}" =~ ^crates/uv-trampoline-builder/ ]]; then
               echo "Detected trampoline change: ${file}"
               TRAMPOLINE_CHANGED=true
+            fi
+
+            # Check if cache-relevant files changed (Cargo files, toolchain, workflows)
+            if [[ "${file}" == "Cargo.lock" || "${file}" == "Cargo.toml" || "${file}" == "rust-toolchain.toml" || "${file}" == ".cargo/config.toml" || "${file}" =~ ^crates/.*/Cargo\.toml$ || "${file}" =~ ^\.github/workflows/.*\.yml$ ]]; then
+              echo "Detected cache-relevant change: ${file}"
+              CACHE_CHANGED=true
             fi
 
             if [[ "${file}" =~ ^docs/ ]]; then
@@ -101,6 +110,7 @@ jobs:
           echo "release_build_changed=${RELEASE_BUILD_CHANGED}" >> "${GITHUB_OUTPUT}"
           echo "publish_changed=${PUBLISH_CHANGED}" >> "${GITHUB_OUTPUT}"
           echo "trampoline_any_changed=${TRAMPOLINE_CHANGED}" >> "${GITHUB_OUTPUT}"
+          echo "cache_changed=${CACHE_CHANGED}" >> "${GITHUB_OUTPUT}"
 
   check-fmt:
     uses: ./.github/workflows/check-fmt.yml
@@ -110,6 +120,7 @@ jobs:
     uses: ./.github/workflows/check-lint.yml
     with:
       code-changed: ${{ needs.plan.outputs.test-code }}
+      save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
   check-docs:
     needs: plan
@@ -141,11 +152,14 @@ jobs:
     uses: ./.github/workflows/check-generated-files.yml
     with:
       schema-changed: ${{ needs.plan.outputs.check-schema }}
+      save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
   test:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
     uses: ./.github/workflows/test.yml
+    with:
+      save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
   test-windows-trampolines:
     needs: plan
@@ -156,6 +170,8 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
     uses: ./.github/workflows/build-dev-binaries.yml
+    with:
+      save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
   test-smoke:
     needs: build-dev-binaries
@@ -195,6 +211,8 @@ jobs:
     if: ${{ needs.plan.outputs.test-code == 'true' }}
     uses: ./.github/workflows/bench.yml
     secrets: inherit
+    with:
+      save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
 
   # This job cannot be moved into a reusable workflow because it includes coverage for uploading
   # attestations and PyPI does not support attestations in reusable workflows.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      save-rust-cache:
+        required: false
+        type: string
+        default: "true"
 
 permissions: {}
 
@@ -28,6 +33,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         run: rustup show
@@ -80,6 +87,8 @@ jobs:
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
 
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         run: rustup show
@@ -141,6 +150,7 @@ jobs:
           workspaces: ${{ env.UV_WORKSPACE }}
           # Use the same cache entry across the partitions
           add-job-id-key: false
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
 
       - name: "Install Rust toolchain"
         working-directory: ${{ env.UV_WORKSPACE }}


### PR DESCRIPTION
The goal here is to reduce cache consumption and contention by avoiding cache saves on pull requests unless the pull request makes a change that requires a new cache entry.