### PR TITLE
Skip benchmarks when Rust code is unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       test-windows-trampoline: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (steps.changed.outputs.trampoline_any_changed == 'true' || github.ref == 'refs/heads/main') }}
       # Save Rust cache if on main or if cache-relevant files changed (Cargo files, toolchain, workflows)
       save-rust-cache: ${{ github.ref == 'refs/heads/main' || steps.changed.outputs.cache_changed == 'true' }}
+      # Run benchmarks only if Rust code changed
+      run-bench: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') && (steps.changed.outputs.rust_code_changed == 'true' || github.ref == 'refs/heads/main') }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -48,6 +50,7 @@ jobs:
           PUBLISH_CHANGED=false
           TRAMPOLINE_CHANGED=false
           CACHE_CHANGED=false
+          RUST_CODE_CHANGED=false
 
           while IFS= read -r file; do
             # Check if the schema file changed (e.g., in a release PR)
@@ -78,6 +81,12 @@ jobs:
             if [[ "${file}" == "Cargo.lock" || "${file}" == "Cargo.toml" || "${file}" == "rust-toolchain.toml" || "${file}" == ".cargo/config.toml" || "${file}" =~ ^crates/.*/Cargo\.toml$ || "${file}" =~ ^\.github/workflows/.*\.yml$ ]]; then
               echo "Detected cache-relevant change: ${file}"
               CACHE_CHANGED=true
+            fi
+
+            # Check if Rust code changed (for benchmarks)
+            if [[ "${file}" =~ \.rs$ ]] || [[ "${file}" =~ Cargo\.toml$ ]] || [[ "${file}" == "Cargo.lock" ]] || [[ "${file}" == "rust-toolchain.toml" ]] || [[ "${file}" =~ ^\.cargo/ ]]; then
+              echo "Detected Rust code change: ${file}"
+              RUST_CODE_CHANGED=true
             fi
 
             if [[ "${file}" =~ ^docs/ ]]; then
@@ -111,6 +120,7 @@ jobs:
           echo "publish_changed=${PUBLISH_CHANGED}" >> "${GITHUB_OUTPUT}"
           echo "trampoline_any_changed=${TRAMPOLINE_CHANGED}" >> "${GITHUB_OUTPUT}"
           echo "cache_changed=${CACHE_CHANGED}" >> "${GITHUB_OUTPUT}"
+          echo "rust_code_changed=${RUST_CODE_CHANGED}" >> "${GITHUB_OUTPUT}"
 
   check-fmt:
     uses: ./.github/workflows/check-fmt.yml
@@ -208,7 +218,7 @@ jobs:
 
   bench:
     needs: plan
-    if: ${{ needs.plan.outputs.test-code == 'true' }}
+    if: ${{ needs.plan.outputs.run-bench == 'true' }}
     uses: ./.github/workflows/bench.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Ignore that the file matching is a little redundant with other checks, I'll consolidate those in a subsequent pull request.