### PR TITLE
Support referencing indexes by name via `--index` and `--default-index`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
 use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Result, anyhow};
@@ -19,12 +19,12 @@ use uv_configuration::{
     ProjectBuildBackend, TargetTriple, TrustedHost, TrustedPublishing, VersionControlSystem,
 };
 use uv_distribution_types::{
-    ConfigSettingEntry, ConfigSettingPackageEntry, Index, IndexUrl, Origin, PipExtraIndex,
-    PipFindLinks, PipIndex,
+    ConfigSettingEntry, ConfigSettingPackageEntry, Index, IndexName, IndexSourceError, IndexUrl,
+    Origin, PipExtraIndex, PipFindLinks, PipIndex,
 };
 use uv_normalize::{ExtraName, GroupName, PackageName, PipGroupName};
-use uv_pep508::{MarkerTree, Requirement};
-use uv_preview::MaybePreviewFeature;
+use uv_pep508::{MarkerTree, Requirement, VerbatimUrl};
+use uv_preview::{MaybePreviewFeature, PreviewFeature};
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_redacted::DisplaySafeUrl;
@@ -35,6 +35,7 @@ use uv_resolver::{
 use uv_settings::PythonInstallMirrors;
 use uv_static::EnvVars;
 use uv_torch::TorchMode;
+use uv_warnings::warn_user_once;
 use uv_workspace::pyproject_mut::AddBoundsKind;
 
 pub mod comma;
@@ -1346,40 +1347,133 @@ fn parse_find_links(input: &str) -> Result<Maybe<PipFindLinks>, String> {
     }
 }
 
-/// Parse an `--index` argument into a [`Vec<Index>`], mapping the empty string to an empty Vec.
+/// An unresolved index passed by the user by its name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedIndex {
+    name: IndexName,
+    default: bool,
+}
+
+impl UnresolvedIndex {
+    /// Resolve an index name against the effective filesystem configuration.
+    fn resolve(self, indexes: &[Index], preview_enabled: bool) -> Result<Index> {
+        let Self { name, default } = self;
+        let path_exists = Path::new(name.as_ref()).exists();
+
+        // Outside preview, an existing path retains its current interpretation.
+        if preview_enabled || !path_exists {
+            if let Some(index) = indexes
+                .iter()
+                .find(|index| index.name.as_ref() == Some(&name))
+            {
+                if !preview_enabled {
+                    warn_user_once!(
+                        "Referencing an index by name is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+                        PreviewFeature::IndexByName
+                    );
+                }
+
+                let mut index = index.clone();
+                // Keep relative paths anchored to their configuration file without marking them
+                // as absolute when CLI settings are rebased or written back to a project.
+                if let IndexUrl::Path(url) = index.url()
+                    && !url.was_given_absolute()
+                {
+                    index.url = IndexUrl::from(VerbatimUrl::from_url(index.raw_url().clone()));
+                }
+
+                return Ok(Index {
+                    default,
+                    explicit: false,
+                    origin: Some(Origin::Cli),
+                    ..index
+                });
+            }
+
+            if preview_enabled && !path_exists {
+                return Err(anyhow!("Could not find an index named `{name}`"));
+            }
+        }
+
+        Ok(Index {
+            default,
+            origin: Some(Origin::Cli),
+            ..Index::from_str(name.as_ref())?
+        })
+    }
+}
+
+/// A potentially unresolved index.
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexArg {
+    /// A usable index with a URL.
+    Resolved(Index),
+    /// An unresolved index specification.
+    Unresolved(UnresolvedIndex),
+}
+
+impl IndexArg {
+    fn new(value: &str, default: bool) -> Result<Self, IndexSourceError> {
+        if let Ok(name) = IndexName::from_str(value) {
+            return Ok(Self::Unresolved(UnresolvedIndex { name, default }));
+        }
+
+        let index = Index::from_str(value)?;
+        Ok(Self::Resolved(Index {
+            default,
+            origin: Some(Origin::Cli),
+            ..index
+        }))
+    }
+
+    /// Parse an index passed via `--index`.
+    fn from_index(value: &str) -> Result<Self, IndexSourceError> {
+        Self::new(value, false)
+    }
+
+    /// Parse an index passed via `--default-index`.
+    fn from_default_index(value: &str) -> Result<Self, IndexSourceError> {
+        Self::new(value, true)
+    }
+
+    /// Resolve the argument against indexes from the effective configuration.
+    fn resolve(self, indexes: &[Index]) -> Result<Index> {
+        match self {
+            Self::Resolved(index) => Ok(index),
+            Self::Unresolved(index) => {
+                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))
+            }
+        }
+    }
+}
+
+/// Parse an `--index` argument into a [`Vec<IndexArg>`], mapping the empty string to an empty Vec.
 ///
 /// This function splits the input on all whitespace characters rather than a single delimiter,
 /// which is necessary to parse environment variables like `PIP_EXTRA_INDEX_URL`.
 /// The standard `clap::Args` `value_delimiter` only supports single-character delimiters.
-fn parse_indices(input: &str) -> Result<Vec<Maybe<Index>>, String> {
+fn parse_indices(input: &str) -> Result<Vec<Maybe<IndexArg>>, String> {
     if input.trim().is_empty() {
         return Ok(Vec::new());
     }
     let mut indices = Vec::new();
     for token in input.split_whitespace() {
-        match Index::from_str(token) {
-            Ok(index) => indices.push(Maybe::Some(Index {
-                default: false,
-                origin: Some(Origin::Cli),
-                ..index
-            })),
+        match IndexArg::from_index(token) {
+            Ok(index) => indices.push(Maybe::Some(index)),
             Err(e) => return Err(e.to_string()),
         }
     }
     Ok(indices)
 }
 
-/// Parse a `--default-index` argument into an [`Index`], mapping the empty string to `None`.
-fn parse_default_index(input: &str) -> Result<Maybe<Index>, String> {
+/// Parse a `--default-index` argument into an [`IndexArg`], mapping the empty string to `None`.
+fn parse_default_index(input: &str) -> Result<Maybe<IndexArg>, String> {
     if input.is_empty() {
         Ok(Maybe::None)
     } else {
-        match Index::from_str(input) {
-            Ok(index) => Ok(Maybe::Some(Index {
-                default: true,
-                origin: Some(Origin::Cli),
-                ..index
-            })),
+        match IndexArg::from_default_index(input) {
+            Ok(index) => Ok(Maybe::Some(index)),
             Err(err) => Err(err.to_string()),
         }
     }
@@ -6634,10 +6728,13 @@ pub struct IndexArgs {
     /// `--default-index` (which defaults to PyPI). When multiple `--index` flags are provided,
     /// earlier values take priority.
     ///
-    /// Index names are not supported as values. Relative paths must be disambiguated from index
-    /// names with `./` or `../` on Unix or `.\\`, `..\\`, `./` or `../` on Windows.
+    /// Indexes configured in `uv.toml` or `pyproject.toml` may be selected by name. Enable the
+    /// `index-by-name` preview feature to prefer index names over relative paths.
+    ///
+    /// Relative paths can be disambiguated from index names with `./` or `../` on Unix or `.\\`,
+    /// `..\\`, `./` or `../` on Windows.
     //
-    // The nested Vec structure (`Vec<Vec<Maybe<Index>>>`) is required for clap's
+    // The nested Vec structure (`Vec<Vec<Maybe<IndexArg>>>`) is required for clap's
     // value parsing mechanism, which processes one value at a time, in order to handle
     // `UV_INDEX` the same way pip handles `PIP_EXTRA_INDEX_URL`.
     #[arg(
@@ -6647,7 +6744,7 @@ pub struct IndexArgs {
         value_parser = parse_indices,
         help_heading = "Index options"
     )]
-    pub index: Option<Vec<Vec<Maybe<Index>>>>,
+    pub index: Option<Vec<Vec<Maybe<IndexArg>>>>,
 
     /// The URL of the default package index (by default: <https://pypi.org/simple>).
     ///
@@ -6656,6 +6753,9 @@ pub struct IndexArgs {
     ///
     /// The index given by this flag is given lower priority than all other indexes specified via
     /// the `--index` flag.
+    ///
+    /// Indexes configured in `uv.toml` or `pyproject.toml` may be selected by name. Enable the
+    /// `index-by-name` preview feature to prefer index names over relative paths.
     #[arg(
         long,
         env = EnvVars::UV_DEFAULT_INDEX,
@@ -6663,7 +6763,7 @@ pub struct IndexArgs {
         value_parser = parse_default_index,
         help_heading = "Index options"
     )]
-    pub default_index: Option<Maybe<Index>>,
+    pub default_index: Option<Maybe<IndexArg>>,
 
     /// (Deprecated: use `--default-index` instead) The URL of the Python package index (by default:
     /// <https://pypi.org/simple>).

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1439,12 +1439,16 @@ impl IndexArg {
 
     /// Resolve the argument against indexes from the effective configuration.
     fn resolve(self, indexes: &[Index]) -> Result<Index> {
-        match self {
-            Self::Resolved(index) => Ok(index),
+        let index = match self {
+            Self::Resolved(index) => index,
             Self::Unresolved(index) => {
-                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))
+                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))?
             }
-        }
+        };
+
+        index.url().warn_on_disambiguated_relative_path();
+
+        Ok(index)
     }
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6723,7 +6723,7 @@ pub struct GenerateShellCompletionArgs {
 
 #[derive(Args)]
 pub struct IndexArgs {
-    /// The URLs to use when resolving dependencies, in addition to the default index.
+    /// The indexes to use when resolving dependencies, in addition to the default index.
     ///
     /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
     /// directory laid out in the same format.
@@ -6750,7 +6750,7 @@ pub struct IndexArgs {
     )]
     pub index: Option<Vec<Vec<Maybe<IndexArg>>>>,
 
-    /// The URL of the default package index (by default: <https://pypi.org/simple>).
+    /// The default package index (by default: <https://pypi.org/simple>).
     ///
     /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
     /// directory laid out in the same format.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1409,12 +1409,16 @@ impl IndexArg {
 
     /// Resolve the argument against indexes from the effective configuration.
     fn resolve(self, indexes: &[Index]) -> Result<Index> {
-        match self {
-            Self::Resolved(index) => Ok(index),
+        let index = match self {
+            Self::Resolved(index) => index,
             Self::Unresolved(index) => {
-                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))
+                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))?
             }
-        }
+        };
+
+        index.url().warn_on_disambiguated_relative_path();
+
+        Ok(index)
     }
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
 use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Result, anyhow};
@@ -19,12 +19,12 @@ use uv_configuration::{
     ProjectBuildBackend, TargetTriple, TrustedHost, TrustedPublishing, VersionControlSystem,
 };
 use uv_distribution_types::{
-    ConfigSettingEntry, ConfigSettingPackageEntry, Index, IndexUrl, Origin, PipExtraIndex,
-    PipFindLinks, PipIndex,
+    ConfigSettingEntry, ConfigSettingPackageEntry, Index, IndexName, IndexSourceError, IndexUrl,
+    Origin, PipExtraIndex, PipFindLinks, PipIndex,
 };
 use uv_normalize::{ExtraName, GroupName, PackageName, PipGroupName};
-use uv_pep508::{MarkerTree, Requirement};
-use uv_preview::MaybePreviewFeature;
+use uv_pep508::{MarkerTree, Requirement, VerbatimUrl};
+use uv_preview::{MaybePreviewFeature, PreviewFeature};
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
 use uv_redacted::DisplaySafeUrl;
@@ -35,6 +35,7 @@ use uv_resolver::{
 use uv_settings::PythonInstallMirrors;
 use uv_static::EnvVars;
 use uv_torch::TorchMode;
+use uv_warnings::warn_user_once;
 use uv_workspace::pyproject_mut::AddBoundsKind;
 
 pub mod comma;
@@ -1316,40 +1317,133 @@ fn parse_find_links(input: &str) -> Result<Maybe<PipFindLinks>, String> {
     }
 }
 
-/// Parse an `--index` argument into a [`Vec<Index>`], mapping the empty string to an empty Vec.
+/// An unresolved index passed by the user by its name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedIndex {
+    name: IndexName,
+    default: bool,
+}
+
+impl UnresolvedIndex {
+    /// Resolve an index name against the effective filesystem configuration.
+    fn resolve(self, indexes: &[Index], preview_enabled: bool) -> Result<Index> {
+        let Self { name, default } = self;
+        let path_exists = Path::new(name.as_ref()).exists();
+
+        // Outside preview, an existing path retains its current interpretation.
+        if preview_enabled || !path_exists {
+            if let Some(index) = indexes
+                .iter()
+                .find(|index| index.name.as_ref() == Some(&name))
+            {
+                if !preview_enabled {
+                    warn_user_once!(
+                        "Referencing an index by name is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
+                        PreviewFeature::IndexByName
+                    );
+                }
+
+                let mut index = index.clone();
+                // Keep relative paths anchored to their configuration file without marking them
+                // as absolute when CLI settings are rebased or written back to a project.
+                if let IndexUrl::Path(url) = index.url()
+                    && !url.was_given_absolute()
+                {
+                    index.url = IndexUrl::from(VerbatimUrl::from_url(index.raw_url().clone()));
+                }
+
+                return Ok(Index {
+                    default,
+                    explicit: false,
+                    origin: Some(Origin::Cli),
+                    ..index
+                });
+            }
+
+            if preview_enabled && !path_exists {
+                return Err(anyhow!("Could not find an index named `{name}`"));
+            }
+        }
+
+        Ok(Index {
+            default,
+            origin: Some(Origin::Cli),
+            ..Index::from_str(name.as_ref())?
+        })
+    }
+}
+
+/// A potentially unresolved index.
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexArg {
+    /// A usable index with a URL.
+    Resolved(Index),
+    /// An unresolved index specification.
+    Unresolved(UnresolvedIndex),
+}
+
+impl IndexArg {
+    fn new(value: &str, default: bool) -> Result<Self, IndexSourceError> {
+        if let Ok(name) = IndexName::from_str(value) {
+            return Ok(Self::Unresolved(UnresolvedIndex { name, default }));
+        }
+
+        let index = Index::from_str(value)?;
+        Ok(Self::Resolved(Index {
+            default,
+            origin: Some(Origin::Cli),
+            ..index
+        }))
+    }
+
+    /// Parse an index passed via `--index`.
+    fn from_index(value: &str) -> Result<Self, IndexSourceError> {
+        Self::new(value, false)
+    }
+
+    /// Parse an index passed via `--default-index`.
+    fn from_default_index(value: &str) -> Result<Self, IndexSourceError> {
+        Self::new(value, true)
+    }
+
+    /// Resolve the argument against indexes from the effective configuration.
+    fn resolve(self, indexes: &[Index]) -> Result<Index> {
+        match self {
+            Self::Resolved(index) => Ok(index),
+            Self::Unresolved(index) => {
+                index.resolve(indexes, uv_preview::is_enabled(PreviewFeature::IndexByName))
+            }
+        }
+    }
+}
+
+/// Parse an `--index` argument into a [`Vec<IndexArg>`], mapping the empty string to an empty Vec.
 ///
 /// This function splits the input on all whitespace characters rather than a single delimiter,
 /// which is necessary to parse environment variables like `PIP_EXTRA_INDEX_URL`.
 /// The standard `clap::Args` `value_delimiter` only supports single-character delimiters.
-fn parse_indices(input: &str) -> Result<Vec<Maybe<Index>>, String> {
+fn parse_indices(input: &str) -> Result<Vec<Maybe<IndexArg>>, String> {
     if input.trim().is_empty() {
         return Ok(Vec::new());
     }
     let mut indices = Vec::new();
     for token in input.split_whitespace() {
-        match Index::from_str(token) {
-            Ok(index) => indices.push(Maybe::Some(Index {
-                default: false,
-                origin: Some(Origin::Cli),
-                ..index
-            })),
+        match IndexArg::from_index(token) {
+            Ok(index) => indices.push(Maybe::Some(index)),
             Err(e) => return Err(e.to_string()),
         }
     }
     Ok(indices)
 }
 
-/// Parse a `--default-index` argument into an [`Index`], mapping the empty string to `None`.
-fn parse_default_index(input: &str) -> Result<Maybe<Index>, String> {
+/// Parse a `--default-index` argument into an [`IndexArg`], mapping the empty string to `None`.
+fn parse_default_index(input: &str) -> Result<Maybe<IndexArg>, String> {
     if input.is_empty() {
         Ok(Maybe::None)
     } else {
-        match Index::from_str(input) {
-            Ok(index) => Ok(Maybe::Some(Index {
-                default: true,
-                origin: Some(Origin::Cli),
-                ..index
-            })),
+        match IndexArg::from_default_index(input) {
+            Ok(index) => Ok(Maybe::Some(index)),
             Err(err) => Err(err.to_string()),
         }
     }
@@ -6568,10 +6662,13 @@ pub struct IndexArgs {
     /// `--default-index` (which defaults to PyPI). When multiple `--index` flags are provided,
     /// earlier values take priority.
     ///
-    /// Index names are not supported as values. Relative paths must be disambiguated from index
-    /// names with `./` or `../` on Unix or `.\\`, `..\\`, `./` or `../` on Windows.
+    /// Indexes configured in `uv.toml` or `pyproject.toml` may be selected by name. Enable the
+    /// `index-by-name` preview feature to prefer index names over relative paths.
+    ///
+    /// Relative paths can be disambiguated from index names with `./` or `../` on Unix or `.\\`,
+    /// `..\\`, `./` or `../` on Windows.
     //
-    // The nested Vec structure (`Vec<Vec<Maybe<Index>>>`) is required for clap's
+    // The nested Vec structure (`Vec<Vec<Maybe<IndexArg>>>`) is required for clap's
     // value parsing mechanism, which processes one value at a time, in order to handle
     // `UV_INDEX` the same way pip handles `PIP_EXTRA_INDEX_URL`.
     #[arg(
@@ -6581,7 +6678,7 @@ pub struct IndexArgs {
         value_parser = parse_indices,
         help_heading = "Index options"
     )]
-    pub index: Option<Vec<Vec<Maybe<Index>>>>,
+    pub index: Option<Vec<Vec<Maybe<IndexArg>>>>,
 
     /// The URL of the default package index (by default: <https://pypi.org/simple>).
     ///
@@ -6590,6 +6687,9 @@ pub struct IndexArgs {
     ///
     /// The index given by this flag is given lower priority than all other indexes specified via
     /// the `--index` flag.
+    ///
+    /// Indexes configured in `uv.toml` or `pyproject.toml` may be selected by name. Enable the
+    /// `index-by-name` preview feature to prefer index names over relative paths.
     #[arg(
         long,
         env = EnvVars::UV_DEFAULT_INDEX,
@@ -6597,7 +6697,7 @@ pub struct IndexArgs {
         value_parser = parse_default_index,
         help_heading = "Index options"
     )]
-    pub default_index: Option<Maybe<Index>>,
+    pub default_index: Option<Maybe<IndexArg>>,
 
     /// (Deprecated: use `--default-index` instead) The URL of the Python package index (by default:
     /// <https://pypi.org/simple>).

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -240,11 +240,16 @@ impl TryFrom<RefreshArgs> for Refresh {
     }
 }
 
-impl TryFrom<ResolverArgs> for PipOptions {
-    type Error = anyhow::Error;
+/// Convert command-line arguments into [`PipOptions`].
+pub trait IntoPipOptions {
+    /// Convert command-line arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions>;
+}
 
-    fn try_from(args: ResolverArgs) -> anyhow::Result<Self> {
-        let ResolverArgs {
+impl IntoPipOptions for ResolverArgs {
+    /// Convert resolver arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+        let Self {
             index_args,
             upgrade,
             no_upgrade,
@@ -285,7 +290,7 @@ impl TryFrom<ResolverArgs> for PipOptions {
                     no_sources,
                     no_sources_package,
                 },
-        } = args;
+        } = self;
 
         if !upgrade_group.is_empty() {
             bail!(ArgumentError(format!(
@@ -294,7 +299,7 @@ impl TryFrom<ResolverArgs> for PipOptions {
             )));
         }
 
-        Ok(Self {
+        Ok(PipOptions {
             upgrade: flag(upgrade, no_upgrade, "upgrade")?,
             upgrade_package: Some(upgrade_package),
             index_strategy,
@@ -325,16 +330,15 @@ impl TryFrom<ResolverArgs> for PipOptions {
             } else {
                 Some(no_sources_package)
             },
-            ..Self::try_from(index_args)?
+            ..index_args.into_pip_options()?
         })
     }
 }
 
-impl TryFrom<InstallerArgs> for PipOptions {
-    type Error = anyhow::Error;
-
-    fn try_from(args: InstallerArgs) -> anyhow::Result<Self> {
-        let InstallerArgs {
+impl IntoPipOptions for InstallerArgs {
+    /// Convert installer arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+        let Self {
             index_args,
             reinstall:
                 ReinstallArgs {
@@ -370,9 +374,9 @@ impl TryFrom<InstallerArgs> for PipOptions {
                     no_sources,
                     no_sources_package,
                 },
-        } = args;
+        } = self;
 
-        Ok(Self {
+        Ok(PipOptions {
             reinstall: flag(reinstall, no_reinstall, "reinstall")?,
             reinstall_package: Some(reinstall_package),
             index_strategy,
@@ -395,16 +399,15 @@ impl TryFrom<InstallerArgs> for PipOptions {
             } else {
                 Some(no_sources_package)
             },
-            ..Self::try_from(index_args)?
+            ..index_args.into_pip_options()?
         })
     }
 }
 
-impl TryFrom<ResolverInstallerArgs> for PipOptions {
-    type Error = anyhow::Error;
-
-    fn try_from(args: ResolverInstallerArgs) -> anyhow::Result<Self> {
-        let ResolverInstallerArgs {
+impl IntoPipOptions for ResolverInstallerArgs {
+    /// Convert resolver and installer arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+        let Self {
             index_args,
             upgrade,
             no_upgrade,
@@ -456,7 +459,7 @@ impl TryFrom<ResolverInstallerArgs> for PipOptions {
                     no_sources,
                     no_sources_package,
                 },
-        } = args;
+        } = self;
 
         if !upgrade_group.is_empty() {
             bail!(ArgumentError(format!(
@@ -465,7 +468,7 @@ impl TryFrom<ResolverInstallerArgs> for PipOptions {
             )));
         }
 
-        Ok(Self {
+        Ok(PipOptions {
             upgrade: flag(upgrade, no_upgrade, "upgrade")?,
             upgrade_package: Some(upgrade_package),
             reinstall: flag(reinstall, no_reinstall, "reinstall")?,
@@ -499,16 +502,15 @@ impl TryFrom<ResolverInstallerArgs> for PipOptions {
             } else {
                 Some(no_sources_package)
             },
-            ..Self::try_from(index_args)?
+            ..index_args.into_pip_options()?
         })
     }
 }
 
-impl TryFrom<FetchArgs> for PipOptions {
-    type Error = anyhow::Error;
-
-    fn try_from(args: FetchArgs) -> anyhow::Result<Self> {
-        let FetchArgs {
+impl IntoPipOptions for FetchArgs {
+    /// Convert package-fetch arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+        let Self {
             index_args,
             registry_client:
                 RegistryClientArgs {
@@ -520,14 +522,14 @@ impl TryFrom<FetchArgs> for PipOptions {
                     exclude_newer: ExcludeNewerArgs { exclude_newer },
                     exclude_newer_package,
                 },
-        } = args;
+        } = self;
 
-        Ok(Self {
+        Ok(PipOptions {
             index_strategy,
             keyring_provider,
             exclude_newer,
             exclude_newer_package: exclude_newer_package.map(ExcludeNewerPackage::from_iter),
-            ..Self::try_from(index_args)?
+            ..index_args.into_pip_options()?
         })
     }
 }
@@ -567,12 +569,11 @@ impl IndexArgs {
     }
 }
 
-impl TryFrom<IndexArgs> for PipOptions {
-    type Error = anyhow::Error;
-
-    fn try_from(args: IndexArgs) -> anyhow::Result<Self> {
-        Ok(Self::from(
-            args.resolve().relative_to(&env::current_dir()?)?,
+impl IntoPipOptions for IndexArgs {
+    /// Convert index arguments into pip options.
+    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+        Ok(PipOptions::from(
+            self.resolve().relative_to(&env::current_dir()?)?,
         ))
     }
 }

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -6,7 +6,7 @@ use anyhow::bail;
 
 use uv_cache::Refresh;
 use uv_configuration::{BuildIsolation, Reinstall, Upgrade};
-use uv_distribution_types::{ConfigSettings, PackageConfigSettings, Requirement};
+use uv_distribution_types::{ConfigSettings, Index, PackageConfigSettings, Requirement};
 use uv_resolver::{ExcludeNewerPackage, PrereleaseMode, PrereleasePackage};
 use uv_settings::{
     Combine, EnvFlag, IndexOptions, PipOptions, ResolverInstallerOptions, ResolverOptions,
@@ -242,13 +242,13 @@ impl TryFrom<RefreshArgs> for Refresh {
 
 /// Convert command-line arguments into [`PipOptions`].
 pub trait IntoPipOptions {
-    /// Convert command-line arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions>;
+    /// Convert command-line arguments into pip options using the effective configuration.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions>;
 }
 
 impl IntoPipOptions for ResolverArgs {
-    /// Convert resolver arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+    /// Convert resolver arguments into pip options using the effective configuration.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions> {
         let Self {
             index_args,
             upgrade,
@@ -330,14 +330,14 @@ impl IntoPipOptions for ResolverArgs {
             } else {
                 Some(no_sources_package)
             },
-            ..index_args.into_pip_options()?
+            ..index_args.into_pip_options(configured_indexes)?
         })
     }
 }
 
 impl IntoPipOptions for InstallerArgs {
-    /// Convert installer arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+    /// Convert installer arguments into pip options using the effective configuration.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions> {
         let Self {
             index_args,
             reinstall:
@@ -399,14 +399,14 @@ impl IntoPipOptions for InstallerArgs {
             } else {
                 Some(no_sources_package)
             },
-            ..index_args.into_pip_options()?
+            ..index_args.into_pip_options(configured_indexes)?
         })
     }
 }
 
 impl IntoPipOptions for ResolverInstallerArgs {
-    /// Convert resolver and installer arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+    /// Convert resolver and installer arguments into pip options using the effective configuration.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions> {
         let Self {
             index_args,
             upgrade,
@@ -502,14 +502,14 @@ impl IntoPipOptions for ResolverInstallerArgs {
             } else {
                 Some(no_sources_package)
             },
-            ..index_args.into_pip_options()?
+            ..index_args.into_pip_options(configured_indexes)?
         })
     }
 }
 
 impl IntoPipOptions for FetchArgs {
-    /// Convert package-fetch arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+    /// Convert package-fetch arguments into pip options using the effective configuration.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions> {
         let Self {
             index_args,
             registry_client:
@@ -529,14 +529,14 @@ impl IntoPipOptions for FetchArgs {
             keyring_provider,
             exclude_newer,
             exclude_newer_package: exclude_newer_package.map(ExcludeNewerPackage::from_iter),
-            ..index_args.into_pip_options()?
+            ..index_args.into_pip_options(configured_indexes)?
         })
     }
 }
 
 impl IndexArgs {
     /// Resolve the index arguments shared by pip, resolver, and installer settings.
-    fn resolve(self) -> IndexOptions {
+    fn resolve(self, configured_indexes: &[Index]) -> anyhow::Result<IndexOptions> {
         let Self {
             default_index,
             index,
@@ -548,16 +548,21 @@ impl IndexArgs {
 
         let default_index = default_index
             .and_then(Maybe::into_option)
+            .map(|index| index.resolve(configured_indexes))
+            .transpose()?
             .map(|index| vec![index]);
-        let index = index.map(|indexes| {
-            indexes
-                .into_iter()
-                .flatten()
-                .filter_map(Maybe::into_option)
-                .collect()
-        });
+        let index = index
+            .map(|indexes| {
+                indexes
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Maybe::into_option)
+                    .map(|index| index.resolve(configured_indexes))
+                    .collect::<anyhow::Result<Vec<_>>>()
+            })
+            .transpose()?;
 
-        IndexOptions {
+        Ok(IndexOptions {
             index: default_index.combine(index),
             index_url: index_url.and_then(Maybe::into_option),
             extra_index_url: extra_index_url
@@ -565,15 +570,16 @@ impl IndexArgs {
             no_index: no_index.then_some(true),
             find_links: find_links
                 .map(|links| links.into_iter().filter_map(Maybe::into_option).collect()),
-        }
+        })
     }
 }
 
 impl IntoPipOptions for IndexArgs {
-    /// Convert index arguments into pip options.
-    fn into_pip_options(self) -> anyhow::Result<PipOptions> {
+    /// Convert index arguments into pip options, resolving configured index names.
+    fn into_pip_options(self, configured_indexes: &[Index]) -> anyhow::Result<PipOptions> {
         Ok(PipOptions::from(
-            self.resolve().relative_to(&env::current_dir()?)?,
+            self.resolve(configured_indexes)?
+                .relative_to(&env::current_dir()?)?,
         ))
     }
 }
@@ -582,6 +588,7 @@ impl IntoPipOptions for IndexArgs {
 pub fn resolver_options(
     resolver_args: ResolverArgs,
     build_args: BuildOptionsArgs,
+    configured_indexes: &[Index],
 ) -> anyhow::Result<ResolverOptions> {
     let ResolverArgs {
         index_args,
@@ -635,7 +642,7 @@ pub fn resolver_options(
     } = build_args;
 
     ResolverOptions {
-        indexes: index_args.resolve(),
+        indexes: index_args.resolve(configured_indexes)?,
         upgrade: Upgrade::from_args(
             flag(upgrade, no_upgrade, "upgrade")?,
             upgrade_package.into_iter().map(Requirement::from).collect(),
@@ -696,6 +703,7 @@ pub fn resolver_options(
 pub fn resolver_installer_options(
     resolver_installer_args: ResolverInstallerArgs,
     build_args: BuildOptionsArgs,
+    configured_indexes: &[Index],
 ) -> anyhow::Result<ResolverInstallerOptions> {
     let ResolverInstallerArgs {
         index_args,
@@ -760,7 +768,7 @@ pub fn resolver_installer_options(
     } = build_args;
 
     ResolverInstallerOptions {
-        indexes: index_args.resolve(),
+        indexes: index_args.resolve(configured_indexes)?,
         upgrade: Upgrade::from_args(
             flag(upgrade, no_upgrade, "upgrade")?,
             upgrade_package.into_iter().map(Requirement::from).collect(),

--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -122,6 +122,7 @@ mod tests {
         - `extra-build-dependencies`: Allows specifying additional dependencies for package builds.
         - `format-command`: Allows using `uv format`.
         - `gcs-endpoint`: Allows signing requests to configured Google Cloud Storage endpoints.
+        - `index-by-name`: Allows selecting configured package indexes by name with `--index` and `--default-index`.
         - `index-exclude-newer`: Allows setting `exclude-newer` on configured package indexes.
         - `index-hash-algorithm`: Allows requiring a hash algorithm for configured package indexes.
         - `init-project-flag`: Rejects the deprecated `--project` option in `uv init`.

--- a/crates/uv-dev/src/generate_preview_features_reference.rs
+++ b/crates/uv-dev/src/generate_preview_features_reference.rs
@@ -121,6 +121,7 @@ mod tests {
         - `extra-build-dependencies`: Allows specifying additional dependencies for package builds.
         - `format-command`: Allows using `uv format`.
         - `gcs-endpoint`: Allows signing requests to configured Google Cloud Storage endpoints.
+        - `index-by-name`: Allows selecting configured package indexes by name with `--index` and `--default-index`.
         - `index-exclude-newer`: Allows setting `exclude-newer` on configured package indexes.
         - `index-hash-algorithm`: Allows requiring a hash algorithm for configured package indexes.
         - `init-project-flag`: Rejects the deprecated `--project` option in `uv init`.

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -331,6 +331,8 @@ pub enum PreviewFeature {
     LockWithoutMetadata,
     /// Uses the new `tar-codec` encoding/decoding backend, instead of `astral-tokio-tar`.
     TarCodec,
+    /// Allows selecting configured package indexes by name with `--index` and `--default-index`.
+    IndexByName,
 }
 
 impl Display for PreviewFeature {

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -327,6 +327,8 @@ pub enum PreviewFeature {
     LockfileFormatCheck,
     /// Omit `package.metadata` from `uv.lock`.
     LockWithoutMetadata,
+    /// Allows selecting configured package indexes by name with `--index` and `--default-index`.
+    IndexByName,
 }
 
 impl Display for PreviewFeature {

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -32,12 +32,12 @@ impl EnvVars {
     pub const UV_OFFLINE: &'static str = "UV_OFFLINE";
 
     /// Equivalent to the `--default-index` command-line argument. If set, uv will use
-    /// this URL as the default index when searching for packages.
+    /// this index as the default index when searching for packages.
     #[attr_added_in("0.4.23")]
     pub const UV_DEFAULT_INDEX: &'static str = "UV_DEFAULT_INDEX";
 
     /// Equivalent to the `--index` command-line argument. If set, uv will use this
-    /// space-separated list of URLs as additional indexes when searching for packages.
+    /// space-separated list of additional indexes when searching for packages.
     #[attr_added_in("0.4.23")]
     pub const UV_INDEX: &'static str = "UV_INDEX";
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -28,7 +28,7 @@ use uv_cli::{
     HashCheckingArgs, PackageExcludeNewerArgs, PublishArgs, PythonDirArgs, RegistryClientArgs,
     ResolverArgs, ResolverInstallerArgs, ToolUpgradeArgs,
     options::{
-        Flag, FlagSource, check_conflicts, flag, resolve_flag, resolve_flag_pair,
+        Flag, FlagSource, IntoPipOptions, check_conflicts, flag, resolve_flag, resolve_flag_pair,
         resolver_installer_options, resolver_options,
     },
 };
@@ -3524,7 +3524,7 @@ impl PipCompileSettings {
                     )?,
                     annotation_style,
                     torch_backend,
-                    ..PipOptions::try_from(resolver)?
+                    ..resolver.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3630,7 +3630,7 @@ impl PipSyncSettings {
                     all_extras: flag(all_extras, no_all_extras, "all-extras")?,
                     group: Some(group),
                     torch_backend,
-                    ..PipOptions::try_from(installer)?
+                    ..installer.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3816,7 +3816,7 @@ impl PipInstallSettings {
                     require_hashes: flag(require_hashes, no_require_hashes, "require-hashes")?,
                     verify_hashes: flag(verify_hashes, no_verify_hashes, "verify-hashes")?,
                     torch_backend,
-                    ..PipOptions::try_from(installer)?
+                    ..installer.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3978,7 +3978,7 @@ impl PipListSettings {
                     strict: flag(strict, no_strict, "strict")?,
                     target,
                     prefix,
-                    ..PipOptions::try_from(fetch)?
+                    ..fetch.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -4079,7 +4079,7 @@ impl PipTreeSettings {
                     python: python.and_then(Maybe::into_option),
                     system: flag(system, no_system, "system")?,
                     strict: flag(strict, no_strict, "strict")?,
-                    ..PipOptions::try_from(fetch)?
+                    ..fetch.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -4330,7 +4330,7 @@ impl VenvSettings {
                     exclude_newer_package: exclude_newer_package
                         .map(ExcludeNewerPackage::from_iter),
                     link_mode,
-                    ..PipOptions::try_from(index_args)?
+                    ..index_args.into_pip_options()?
                 },
                 filesystem,
                 environment,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -939,7 +939,14 @@ impl ToolRunSettings {
         let filesystem_options = filesystem.map(FilesystemOptions::into_options);
 
         let options = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(
+                installer,
+                build,
+                filesystem_options
+                    .as_ref()
+                    .and_then(|options| options.top_level.index.as_deref())
+                    .unwrap_or_default(),
+            )?,
             &environment,
         )
         .combine(ResolverInstallerOptions::from(
@@ -1064,7 +1071,14 @@ impl ToolInstallSettings {
         let filesystem_options = filesystem.map(FilesystemOptions::into_options);
 
         let options = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(
+                installer,
+                build,
+                filesystem_options
+                    .as_ref()
+                    .and_then(|options| options.top_level.index.as_deref())
+                    .unwrap_or_default(),
+            )?,
             &environment,
         )
         .combine(ResolverInstallerOptions::from(
@@ -1200,7 +1214,7 @@ impl ToolUpgradeSettings {
         };
 
         let args = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?,
             environment,
         );
         let filesystem = filesystem.map(FilesystemOptions::into_options);
@@ -2343,19 +2357,6 @@ impl AddSettings {
             DependencyType::Production
         };
 
-        // Warn user if an ambiguous relative path was passed as a value for
-        // `--index` or `--default-index`.
-        for index in installer
-            .index_args
-            .default_index
-            .iter()
-            .chain(installer.index_args.index.iter().flatten().flatten())
-        {
-            if let Maybe::Some(index) = index {
-                index.url().warn_on_disambiguated_relative_path();
-            }
-        }
-
         // If the user passed an `--index-url` or `--extra-index-url`, warn.
         if installer
             .index_args
@@ -2450,8 +2451,15 @@ impl AddSettings {
             no_editable_package,
         );
         let refresh = Refresh::try_from(refresh)?;
-        let options = resolver_installer_options(installer, build)?;
+        let options =
+            resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?;
         let indexes = options.indexes.index.clone().unwrap_or_default();
+
+        // Warn user if an ambiguous relative path was passed as a value for
+        // `--index` or `--default-index`.
+        for index in &indexes {
+            index.url().warn_on_disambiguated_relative_path();
+        }
 
         Ok(Self {
             lock_check: resolve_lock_check(locked),
@@ -3524,7 +3532,7 @@ impl PipCompileSettings {
                     )?,
                     annotation_style,
                     torch_backend,
-                    ..resolver.into_pip_options()?
+                    ..resolver.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3630,7 +3638,7 @@ impl PipSyncSettings {
                     all_extras: flag(all_extras, no_all_extras, "all-extras")?,
                     group: Some(group),
                     torch_backend,
-                    ..installer.into_pip_options()?
+                    ..installer.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3816,7 +3824,7 @@ impl PipInstallSettings {
                     require_hashes: flag(require_hashes, no_require_hashes, "require-hashes")?,
                     verify_hashes: flag(verify_hashes, no_verify_hashes, "verify-hashes")?,
                     torch_backend,
-                    ..installer.into_pip_options()?
+                    ..installer.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3978,7 +3986,7 @@ impl PipListSettings {
                     strict: flag(strict, no_strict, "strict")?,
                     target,
                     prefix,
-                    ..fetch.into_pip_options()?
+                    ..fetch.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -4079,7 +4087,7 @@ impl PipTreeSettings {
                     python: python.and_then(Maybe::into_option),
                     system: flag(system, no_system, "system")?,
                     strict: flag(strict, no_strict, "strict")?,
-                    ..fetch.into_pip_options()?
+                    ..fetch.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -4330,7 +4338,7 @@ impl VenvSettings {
                     exclude_newer_package: exclude_newer_package
                         .map(ExcludeNewerPackage::from_iter),
                     link_mode,
-                    ..index_args.into_pip_options()?
+                    ..index_args.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -4413,6 +4421,13 @@ fn resolve_prerelease(global: PrereleaseMode, mut package: PrereleasePackage) ->
     }
 }
 
+/// Return the indexes from the effective filesystem configuration.
+fn configured_indexes(filesystem: Option<&FilesystemOptions>) -> &[Index] {
+    filesystem
+        .and_then(|options| options.top_level.index.as_deref())
+        .unwrap_or_default()
+}
+
 impl ResolverSettings {
     /// Resolve the [`ResolverSettings`] from the CLI, environment, and filesystem configuration.
     fn resolve(
@@ -4421,7 +4436,7 @@ impl ResolverSettings {
         filesystem: Option<FilesystemOptions>,
         environment: &EnvironmentOptions,
     ) -> Result<Self> {
-        let args = resolver_options(args, build)?;
+        let args = resolver_options(args, build, configured_indexes(filesystem.as_ref()))?;
 
         Ok(Self::combine(args, filesystem, environment))
     }
@@ -4525,7 +4540,8 @@ impl ResolverInstallerSettings {
         filesystem: Option<FilesystemOptions>,
         environment: &EnvironmentOptions,
     ) -> Result<Self> {
-        let args = resolver_installer_options(args, build)?;
+        let args =
+            resolver_installer_options(args, build, configured_indexes(filesystem.as_ref()))?;
 
         Ok(Self::combine(args, filesystem, environment))
     }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2455,12 +2455,6 @@ impl AddSettings {
             resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?;
         let indexes = options.indexes.index.clone().unwrap_or_default();
 
-        // Warn user if an ambiguous relative path was passed as a value for
-        // `--index` or `--default-index`.
-        for index in &indexes {
-            index.url().warn_on_disambiguated_relative_path();
-        }
-
         Ok(Self {
             lock_check: resolve_lock_check(locked),
             frozen: resolve_frozen(frozen),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -935,7 +935,14 @@ impl ToolRunSettings {
         let filesystem_options = filesystem.map(FilesystemOptions::into_options);
 
         let options = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(
+                installer,
+                build,
+                filesystem_options
+                    .as_ref()
+                    .and_then(|options| options.top_level.index.as_deref())
+                    .unwrap_or_default(),
+            )?,
             &environment,
         )
         .combine(ResolverInstallerOptions::from(
@@ -1060,7 +1067,14 @@ impl ToolInstallSettings {
         let filesystem_options = filesystem.map(FilesystemOptions::into_options);
 
         let options = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(
+                installer,
+                build,
+                filesystem_options
+                    .as_ref()
+                    .and_then(|options| options.top_level.index.as_deref())
+                    .unwrap_or_default(),
+            )?,
             &environment,
         )
         .combine(ResolverInstallerOptions::from(
@@ -1196,7 +1210,7 @@ impl ToolUpgradeSettings {
         };
 
         let args = resolver_installer_options_with_environment(
-            resolver_installer_options(installer, build)?,
+            resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?,
             environment,
         );
         let filesystem = filesystem.map(FilesystemOptions::into_options);
@@ -2279,19 +2293,6 @@ impl AddSettings {
             DependencyType::Production
         };
 
-        // Warn user if an ambiguous relative path was passed as a value for
-        // `--index` or `--default-index`.
-        for index in installer
-            .index_args
-            .default_index
-            .iter()
-            .chain(installer.index_args.index.iter().flatten().flatten())
-        {
-            if let Maybe::Some(index) = index {
-                index.url().warn_on_disambiguated_relative_path();
-            }
-        }
-
         // If the user passed an `--index-url` or `--extra-index-url`, warn.
         if installer
             .index_args
@@ -2386,8 +2387,15 @@ impl AddSettings {
             no_editable_package,
         );
         let refresh = Refresh::try_from(refresh)?;
-        let options = resolver_installer_options(installer, build)?;
+        let options =
+            resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?;
         let indexes = options.indexes.index.clone().unwrap_or_default();
+
+        // Warn user if an ambiguous relative path was passed as a value for
+        // `--index` or `--default-index`.
+        for index in &indexes {
+            index.url().warn_on_disambiguated_relative_path();
+        }
 
         Ok(Self {
             lock_check: resolve_lock_check(locked),
@@ -3439,7 +3447,7 @@ impl PipCompileSettings {
                     )?,
                     annotation_style,
                     torch_backend,
-                    ..resolver.into_pip_options()?
+                    ..resolver.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3545,7 +3553,7 @@ impl PipSyncSettings {
                     all_extras: flag(all_extras, no_all_extras, "all-extras")?,
                     group: Some(group),
                     torch_backend,
-                    ..installer.into_pip_options()?
+                    ..installer.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3731,7 +3739,7 @@ impl PipInstallSettings {
                     require_hashes: flag(require_hashes, no_require_hashes, "require-hashes")?,
                     verify_hashes: flag(verify_hashes, no_verify_hashes, "verify-hashes")?,
                     torch_backend,
-                    ..installer.into_pip_options()?
+                    ..installer.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3893,7 +3901,7 @@ impl PipListSettings {
                     strict: flag(strict, no_strict, "strict")?,
                     target,
                     prefix,
-                    ..fetch.into_pip_options()?
+                    ..fetch.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -3994,7 +4002,7 @@ impl PipTreeSettings {
                     python: python.and_then(Maybe::into_option),
                     system: flag(system, no_system, "system")?,
                     strict: flag(strict, no_strict, "strict")?,
-                    ..fetch.into_pip_options()?
+                    ..fetch.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -4245,7 +4253,7 @@ impl VenvSettings {
                     exclude_newer_package: exclude_newer_package
                         .map(ExcludeNewerPackage::from_iter),
                     link_mode,
-                    ..index_args.into_pip_options()?
+                    ..index_args.into_pip_options(configured_indexes(filesystem.as_ref()))?
                 },
                 filesystem,
                 environment,
@@ -4328,6 +4336,13 @@ fn resolve_prerelease(global: PrereleaseMode, mut package: PrereleasePackage) ->
     }
 }
 
+/// Return the indexes from the effective filesystem configuration.
+fn configured_indexes(filesystem: Option<&FilesystemOptions>) -> &[Index] {
+    filesystem
+        .and_then(|options| options.top_level.index.as_deref())
+        .unwrap_or_default()
+}
+
 impl ResolverSettings {
     /// Resolve the [`ResolverSettings`] from the CLI, environment, and filesystem configuration.
     fn resolve(
@@ -4336,7 +4351,7 @@ impl ResolverSettings {
         filesystem: Option<FilesystemOptions>,
         environment: &EnvironmentOptions,
     ) -> Result<Self> {
-        let args = resolver_options(args, build)?;
+        let args = resolver_options(args, build, configured_indexes(filesystem.as_ref()))?;
 
         Ok(Self::combine(args, filesystem, environment))
     }
@@ -4440,7 +4455,8 @@ impl ResolverInstallerSettings {
         filesystem: Option<FilesystemOptions>,
         environment: &EnvironmentOptions,
     ) -> Result<Self> {
-        let args = resolver_installer_options(args, build)?;
+        let args =
+            resolver_installer_options(args, build, configured_indexes(filesystem.as_ref()))?;
 
         Ok(Self::combine(args, filesystem, environment))
     }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -28,7 +28,7 @@ use uv_cli::{
     HashCheckingArgs, PackageExcludeNewerArgs, PublishArgs, PythonDirArgs, RegistryClientArgs,
     ResolverArgs, ResolverInstallerArgs, ToolUpgradeArgs,
     options::{
-        Flag, FlagSource, check_conflicts, flag, resolve_flag, resolve_flag_pair,
+        Flag, FlagSource, IntoPipOptions, check_conflicts, flag, resolve_flag, resolve_flag_pair,
         resolver_installer_options, resolver_options,
     },
 };
@@ -3439,7 +3439,7 @@ impl PipCompileSettings {
                     )?,
                     annotation_style,
                     torch_backend,
-                    ..PipOptions::try_from(resolver)?
+                    ..resolver.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3545,7 +3545,7 @@ impl PipSyncSettings {
                     all_extras: flag(all_extras, no_all_extras, "all-extras")?,
                     group: Some(group),
                     torch_backend,
-                    ..PipOptions::try_from(installer)?
+                    ..installer.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3731,7 +3731,7 @@ impl PipInstallSettings {
                     require_hashes: flag(require_hashes, no_require_hashes, "require-hashes")?,
                     verify_hashes: flag(verify_hashes, no_verify_hashes, "verify-hashes")?,
                     torch_backend,
-                    ..PipOptions::try_from(installer)?
+                    ..installer.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3893,7 +3893,7 @@ impl PipListSettings {
                     strict: flag(strict, no_strict, "strict")?,
                     target,
                     prefix,
-                    ..PipOptions::try_from(fetch)?
+                    ..fetch.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -3994,7 +3994,7 @@ impl PipTreeSettings {
                     python: python.and_then(Maybe::into_option),
                     system: flag(system, no_system, "system")?,
                     strict: flag(strict, no_strict, "strict")?,
-                    ..PipOptions::try_from(fetch)?
+                    ..fetch.into_pip_options()?
                 },
                 filesystem,
                 environment,
@@ -4245,7 +4245,7 @@ impl VenvSettings {
                     exclude_newer_package: exclude_newer_package
                         .map(ExcludeNewerPackage::from_iter),
                     link_mode,
-                    ..PipOptions::try_from(index_args)?
+                    ..index_args.into_pip_options()?
                 },
                 filesystem,
                 environment,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2391,12 +2391,6 @@ impl AddSettings {
             resolver_installer_options(installer, build, configured_indexes(filesystem.as_ref()))?;
         let indexes = options.indexes.index.clone().unwrap_or_default();
 
-        // Warn user if an ambiguous relative path was passed as a value for
-        // `--index` or `--default-index`.
-        for index in &indexes {
-            index.url().warn_on_disambiguated_relative_path();
-        }
-
         Ok(Self {
             lock_check: resolve_lock_check(locked),
             frozen: resolve_frozen(frozen),

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -10968,6 +10968,7 @@ async fn add_index_with_non_existent_relative_path_with_same_name_as_index() -> 
 fn add_index_by_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    // `explicit` and `default` are supported together; use both to test overriding behaviour.
     let initial = indoc! {r#"
         [project]
         name = "project"
@@ -10977,13 +10978,13 @@ fn add_index_by_name() -> Result<()> {
 
         [[tool.uv.index]]
         name = "internal"
-        url = "https://test.pypi.org/simple"
+        url = "https://example.invalid/simple"
         explicit = true
         default = true
     "#};
     pyproject_toml.write_str(initial)?;
 
-    // Without preview, a configured name is used only when no matching path exists.
+    // Without preview, selecting a configured index by name emits a warning.
     uv_snapshot!(context.filters(), context.add()
         .arg("iniconfig")
         .arg("--index").arg("internal")
@@ -11019,7 +11020,7 @@ fn add_index_by_name() -> Result<()> {
 
         [[tool.uv.index]]
         name = "internal"
-        url = "https://test.pypi.org/simple"
+        url = "https://example.invalid/simple"
         explicit = true
         default = true
 
@@ -11031,7 +11032,7 @@ fn add_index_by_name() -> Result<()> {
     Ok(())
 }
 
-/// Keep a configured local index relative when selecting it by name.
+/// Keep a named local index relative to its project when invoked from another directory.
 #[test]
 fn add_index_by_name_with_relative_path() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -11056,7 +11057,7 @@ fn add_index_by_name_with_relative_path() -> Result<()> {
     packages.create_dir_all()?;
     packages.child("placeholder").touch()?;
 
-    // Select the configured local index by name from outside the project directory.
+    // Base the relative index URL at the project, not the invocation directory.
     uv_snapshot!(context.filters(), context.add()
         .arg("iniconfig")
         .arg("--index").arg("local")
@@ -11070,7 +11071,7 @@ fn add_index_by_name_with_relative_path() -> Result<()> {
 
     let pyproject_toml = fs_err::read_to_string(pyproject_toml.path())?;
 
-    // Preserve the relative index URL and pin the dependency to the configured index.
+    // Preserve the relative URL spelling and pin the dependency to the configured index.
     insta::with_settings!({
         filters => context.filters(),
     }, {

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -10963,6 +10963,139 @@ async fn add_index_with_non_existent_relative_path_with_same_name_as_index() -> 
     Ok(())
 }
 
+/// Add a dependency using a configured index selected by name.
+#[test]
+fn add_index_by_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let initial = indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#};
+    pyproject_toml.write_str(initial)?;
+
+    // Without preview, a configured name is used only when no matching path exists.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("internal")
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Referencing an index by name is experimental and may change without warning. Pass `--preview-features index-by-name` to disable this warning.
+    ");
+
+    pyproject_toml.write_str(initial)?;
+
+    // Enabling preview suppresses the warning.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("internal")
+        .arg("--preview-features").arg("index-by-name")
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ");
+
+    // Preserve the existing index configuration and pin the dependency to it.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("pyproject.toml"), @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig",
+        ]
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+
+        [tool.uv.sources]
+        iniconfig = { index = "internal" }
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Keep a configured local index relative when selecting it by name.
+#[test]
+fn add_index_by_name_with_relative_path() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.create_dir_all()?;
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "wheels"
+        format = "flat"
+    "#})?;
+
+    let packages = project.child("wheels");
+    packages.create_dir_all()?;
+    packages.child("placeholder").touch()?;
+
+    // Select the configured local index by name from outside the project directory.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("local")
+        .arg("--preview-features").arg("index-by-name")
+        .arg("--project").arg(project.path())
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(pyproject_toml.path())?;
+
+    // Preserve the relative index URL and pin the dependency to the configured index.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig",
+        ]
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "wheels"
+        format = "flat"
+
+        [tool.uv.sources]
+        iniconfig = { index = "local" }
+        "#);
+    });
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn add_index_empty_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -10938,6 +10938,139 @@ async fn add_index_with_non_existent_relative_path_with_same_name_as_index() -> 
     Ok(())
 }
 
+/// Add a dependency using a configured index selected by name.
+#[test]
+fn add_index_by_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    let initial = indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#};
+    pyproject_toml.write_str(initial)?;
+
+    // Without preview, a configured name is used only when no matching path exists.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("internal")
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    warning: Referencing an index by name is experimental and may change without warning. Pass `--preview-features index-by-name` to disable this warning.
+    ");
+
+    pyproject_toml.write_str(initial)?;
+
+    // Enabling preview suppresses the warning.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("internal")
+        .arg("--preview-features").arg("index-by-name")
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ");
+
+    // Preserve the existing index configuration and pin the dependency to it.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(context.read("pyproject.toml"), @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig",
+        ]
+
+        [[tool.uv.index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+
+        [tool.uv.sources]
+        iniconfig = { index = "internal" }
+        "#);
+    });
+
+    Ok(())
+}
+
+/// Keep a configured local index relative when selecting it by name.
+#[test]
+fn add_index_by_name_with_relative_path() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.create_dir_all()?;
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "wheels"
+        format = "flat"
+    "#})?;
+
+    let packages = project.child("wheels");
+    packages.create_dir_all()?;
+    packages.child("placeholder").touch()?;
+
+    // Select the configured local index by name from outside the project directory.
+    uv_snapshot!(context.filters(), context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("local")
+        .arg("--preview-features").arg("index-by-name")
+        .arg("--project").arg(project.path())
+        .arg("--frozen"), @"
+    exit_code: 0 (success)
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(pyproject_toml.path())?;
+
+    // Preserve the relative index URL and pin the dependency to the configured index.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig",
+        ]
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "wheels"
+        format = "flat"
+
+        [tool.uv.sources]
+        iniconfig = { index = "local" }
+        "#);
+    });
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn add_index_empty_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3286,6 +3286,38 @@ fn index_by_name() -> anyhow::Result<()> {
         assert_eq!(named, explicit, "{argument}");
     }
 
+    let commands: [fn(&TestContext) -> Command; 4] = [
+        TestContext::lock,
+        TestContext::sync,
+        TestContext::venv,
+        TestContext::pip_list,
+    ];
+
+    for command in commands {
+        for argument in ["--index", "--default-index"] {
+            let named = capture_uv_snapshot!(
+                context.filters(),
+                add_shared_args(command(&context))
+                    .arg("--show-settings")
+                    .arg(argument)
+                    .arg("internal")
+                    .arg("--preview-features")
+                    .arg("index-by-name")
+            );
+            let explicit = capture_uv_snapshot!(
+                context.filters(),
+                add_shared_args(command(&context))
+                    .arg("--show-settings")
+                    .arg(argument)
+                    .arg("internal=https://test.pypi.org/simple")
+                    .arg("--preview-features")
+                    .arg("index-by-name")
+            );
+
+            assert_eq!(named, explicit, "{argument}");
+        }
+    }
+
     let explicit = capture_uv_snapshot!(
         context.filters(),
         show_settings()

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -1,10 +1,11 @@
 use std::process::Command;
+use std::rc::Rc;
 
 use assert_fs::prelude::*;
 use url::Url;
 use uv_static::EnvVars;
 
-use uv_test::{capture_uv_snapshot, diff_uv_snapshot, uv_snapshot};
+use uv_test::{TestContext, capture_uv_snapshot, diff_uv_snapshot, uv_snapshot};
 
 /// Add shared arguments to a command.
 ///
@@ -3231,6 +3232,327 @@ fn index_priority() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn named_index_context() -> anyhow::Result<(Rc<TestContext>, impl Fn() -> Command)> {
+    let context = Rc::new(uv_test::test_context!("3.12"));
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#})?;
+
+    let command_context = Rc::clone(&context);
+    let settings = move || {
+        let mut command = add_shared_args(command_context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
+
+    Ok((context, settings))
+}
+
+/// Named index arguments must resolve identically to their explicit CLI spellings.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name() -> anyhow::Result<()> {
+    let (context, show_settings) = named_index_context()?;
+
+    for argument in ["--index", "--default-index"] {
+        let named = capture_uv_snapshot!(
+            context.filters(),
+            show_settings()
+                .arg(argument)
+                .arg("internal")
+                .arg("--preview-features")
+                .arg("index-by-name")
+        );
+        let explicit = capture_uv_snapshot!(
+            context.filters(),
+            show_settings()
+                .arg(argument)
+                .arg("internal=https://test.pypi.org/simple")
+                .arg("--preview-features")
+                .arg("index-by-name")
+        );
+
+        // Selecting a name must match spelling out its URL with the same CLI role.
+        assert_eq!(named, explicit, "{argument}");
+    }
+
+    let explicit = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+    );
+
+    // Without preview, configured names resolve identically but produce a preview warning.
+    diff_uv_snapshot!(context.filters(), &explicit, show_settings()
+        .arg("--index")
+        .arg("internal"), @"
+    ...
+             reinstall: None,
+         },
+     }
+    +
+    +----- stderr -----
+    +warning: Referencing an index by name is experimental and may change without warning. Pass `--preview-features index-by-name` to disable this warning.
+    ...
+    ");
+
+    // With preview, an unknown name is reported as an index rather than a missing path.
+    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
+        .arg("requirements.in")
+        .arg("--index")
+        .arg("missing")
+        .arg("--preview-features")
+        .arg("index-by-name"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Could not find an index named `missing`
+    ");
+
+    Ok(())
+}
+
+/// Preview determines whether a named index or matching directory takes precedence.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_with_matching_path() -> anyhow::Result<()> {
+    let (context, show_settings) = named_index_context()?;
+    context.temp_dir.child("internal").create_dir_all()?;
+
+    let path = capture_uv_snapshot!(
+        context.filters(),
+        show_settings().arg("--index").arg("./internal")
+    );
+
+    // Without preview, an existing path takes precedence over the configured name.
+    diff_uv_snapshot!(context.filters(), &path, show_settings()
+        .arg("--index")
+        .arg("internal"), @"
+    ...
+                                     fragment: None,
+                                 },
+                                 given: Some(
+    -                                \"./internal\",
+    +                                \"internal\",
+                                 ),
+                                 expanded: false,
+                             },
+    ...
+    ");
+
+    let named = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+    let explicit = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+
+    // With preview, the configured name takes precedence over the existing path.
+    assert_eq!(named, explicit);
+
+    Ok(())
+}
+
+/// User-configured named indexes retain settings that cannot be expressed on the CLI.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_from_user_configuration() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let user_configuration = context.user_config_dir.child("uv");
+    user_configuration.create_dir_all()?;
+    user_configuration
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+        authenticate = "always"
+    "#})?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
+
+    let index = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+
+    // User-configured names must preserve index settings that the CLI cannot express.
+    diff_uv_snapshot!(context.filters(), &index, show_settings()
+        .arg("--index")
+        .arg("internal")
+        .arg("--preview-features")
+        .arg("index-by-name"), @"
+    ...
+                         ),
+                         format: Simple,
+                         publish_url: None,
+    -                    authenticate: Auto,
+    +                    authenticate: Always,
+                         ignore_error_codes: None,
+                         cache_control: None,
+                         hash_algorithm: None,
+    ...
+    ");
+
+    Ok(())
+}
+
+/// Tool commands resolve configured indexes by name.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn tool_index_by_name() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let configuration = context.temp_dir.child("uv.toml");
+    configuration.write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#})?;
+
+    let tools: [fn(&TestContext) -> Command; 3] = [
+        TestContext::tool_run,
+        TestContext::tool_install,
+        TestContext::tool_upgrade,
+    ];
+
+    for tool in tools {
+        let show_settings = || {
+            let mut command = add_shared_args(tool(&context));
+            command
+                .arg("--show-settings")
+                .arg("--config-file")
+                .arg(configuration.path())
+                .arg("--preview-features")
+                .arg("index-by-name");
+            command
+        };
+
+        for argument in ["--index", "--default-index"] {
+            let named = capture_uv_snapshot!(
+                context.filters(),
+                show_settings()
+                    .arg(argument)
+                    .arg("internal")
+                    .arg("iniconfig")
+            );
+            let explicit = capture_uv_snapshot!(
+                context.filters(),
+                show_settings()
+                    .arg(argument)
+                    .arg("internal=https://test.pypi.org/simple")
+                    .arg("iniconfig")
+            );
+
+            assert_eq!(named, explicit, "{argument}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Named relative indexes remain relative to their configuration under `--directory`.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_with_directory() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12").with_filter((
+        r#"given: Some\(\s+"file://[^"]+/configuration/configured-index",\s+\)"#,
+        "given: None",
+    ));
+    let configuration_directory = context.temp_dir.child("configuration");
+    configuration_directory.create_dir_all()?;
+    let configuration_file = configuration_directory.child("uv.toml");
+    configuration_file.write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "./configured-index"
+        explicit = true
+        default = true
+    "#})?;
+
+    let project_directory = context.temp_dir.child("project");
+    project_directory.create_dir_all()?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command
+            .arg("requirements.in")
+            .arg("--show-settings")
+            .arg("--config-file")
+            .arg(configuration_file.path())
+            .arg("--directory")
+            .arg("project")
+            .arg("--preview-features")
+            .arg("index-by-name");
+        command
+    };
+
+    let configured_index = configuration_directory.child("configured-index");
+    let configured_index = Url::from_file_path(configured_index.path()).map_err(|()| {
+        anyhow::anyhow!("Failed to convert the configured index path to a file URL")
+    })?;
+    let configured_index = format!("internal={configured_index}");
+
+    for argument in ["--index", "--default-index"] {
+        let named = capture_uv_snapshot!(
+            context.filters(),
+            show_settings().arg(argument).arg("internal")
+        );
+        let explicit = capture_uv_snapshot!(
+            context.filters(),
+            show_settings().arg(argument).arg(&configured_index)
+        );
+
+        // Resolving the configured name must preserve its original configuration directory.
+        assert_eq!(named, explicit, "{argument}");
+    }
+
+    Ok(())
+}
+
 /// Verify hashes by default.
 #[test]
 #[cfg_attr(
@@ -3418,6 +3740,7 @@ fn preview_features() {
     +            LockfileFormatCheck,
     +            LockWithoutMetadata,
     +            TarCodec,
+    +            IndexByName,
     +        ],
          },
          python_preference: Managed,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::rc::Rc;
 
 use assert_fs::prelude::*;
 use url::Url;
@@ -3232,29 +3231,6 @@ fn index_priority() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn named_index_context() -> anyhow::Result<(Rc<TestContext>, impl Fn() -> Command)> {
-    let context = Rc::new(uv_test::test_context!("3.12"));
-    context
-        .temp_dir
-        .child("uv.toml")
-        .write_str(indoc::indoc! {r#"
-        [[index]]
-        name = "internal"
-        url = "https://test.pypi.org/simple"
-        explicit = true
-        default = true
-    "#})?;
-
-    let command_context = Rc::clone(&context);
-    let settings = move || {
-        let mut command = add_shared_args(command_context.pip_compile());
-        command.arg("requirements.in").arg("--show-settings");
-        command
-    };
-
-    Ok((context, settings))
-}
-
 /// Named index arguments must resolve identically to their explicit CLI spellings.
 #[test]
 #[cfg_attr(
@@ -3262,7 +3238,24 @@ fn named_index_context() -> anyhow::Result<(Rc<TestContext>, impl Fn() -> Comman
     ignore = "Configuration tests are not yet supported on Windows"
 )]
 fn index_by_name() -> anyhow::Result<()> {
-    let (context, show_settings) = named_index_context()?;
+    let context = uv_test::test_context!("3.12");
+    // `explicit` and `default` are supported together; use both to test overriding behaviour.
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://example.invalid/simple"
+        explicit = true
+        default = true
+    "#})?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
 
     for argument in ["--index", "--default-index"] {
         let named = capture_uv_snapshot!(
@@ -3277,7 +3270,7 @@ fn index_by_name() -> anyhow::Result<()> {
             context.filters(),
             show_settings()
                 .arg(argument)
-                .arg("internal=https://test.pypi.org/simple")
+                .arg("internal=https://example.invalid/simple")
                 .arg("--preview-features")
                 .arg("index-by-name")
         );
@@ -3309,7 +3302,7 @@ fn index_by_name() -> anyhow::Result<()> {
                 add_shared_args(command(&context))
                     .arg("--show-settings")
                     .arg(argument)
-                    .arg("internal=https://test.pypi.org/simple")
+                    .arg("internal=https://example.invalid/simple")
                     .arg("--preview-features")
                     .arg("index-by-name")
             );
@@ -3322,7 +3315,7 @@ fn index_by_name() -> anyhow::Result<()> {
         context.filters(),
         show_settings()
             .arg("--index")
-            .arg("internal=https://test.pypi.org/simple")
+            .arg("internal=https://example.invalid/simple")
     );
 
     // Without preview, configured names resolve identically but produce a preview warning.
@@ -3361,7 +3354,21 @@ fn index_by_name() -> anyhow::Result<()> {
     ignore = "Configuration tests are not yet supported on Windows"
 )]
 fn index_by_name_with_matching_path() -> anyhow::Result<()> {
-    let (context, show_settings) = named_index_context()?;
+    let context = uv_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://example.invalid/simple"
+    "#})?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
     context.temp_dir.child("internal").create_dir_all()?;
 
     let path = capture_uv_snapshot!(
@@ -3404,7 +3411,7 @@ fn index_by_name_with_matching_path() -> anyhow::Result<()> {
         context.filters(),
         show_settings()
             .arg("--index")
-            .arg("internal=https://test.pypi.org/simple")
+            .arg("internal=https://example.invalid/simple")
             .arg("--preview-features")
             .arg("index-by-name")
     );
@@ -3430,9 +3437,7 @@ fn index_by_name_from_user_configuration() -> anyhow::Result<()> {
         .write_str(indoc::indoc! {r#"
         [[index]]
         name = "internal"
-        url = "https://test.pypi.org/simple"
-        explicit = true
-        default = true
+        url = "https://example.invalid/simple"
         authenticate = "always"
     "#})?;
 
@@ -3446,7 +3451,7 @@ fn index_by_name_from_user_configuration() -> anyhow::Result<()> {
         context.filters(),
         show_settings()
             .arg("--index")
-            .arg("internal=https://test.pypi.org/simple")
+            .arg("internal=https://example.invalid/simple")
             .arg("--preview-features")
             .arg("index-by-name")
     );
@@ -3481,10 +3486,11 @@ fn index_by_name_from_user_configuration() -> anyhow::Result<()> {
 fn tool_index_by_name() -> anyhow::Result<()> {
     let context = uv_test::test_context!("3.12");
     let configuration = context.temp_dir.child("uv.toml");
+    // `explicit` and `default` are supported together; use both to test overriding behaviour.
     configuration.write_str(indoc::indoc! {r#"
         [[index]]
         name = "internal"
-        url = "https://test.pypi.org/simple"
+        url = "https://example.invalid/simple"
         explicit = true
         default = true
     "#})?;
@@ -3519,7 +3525,7 @@ fn tool_index_by_name() -> anyhow::Result<()> {
                 context.filters(),
                 show_settings()
                     .arg(argument)
-                    .arg("internal=https://test.pypi.org/simple")
+                    .arg("internal=https://example.invalid/simple")
                     .arg("iniconfig")
             );
 
@@ -3548,8 +3554,6 @@ fn index_by_name_with_directory() -> anyhow::Result<()> {
         [[index]]
         name = "internal"
         url = "./configured-index"
-        explicit = true
-        default = true
     "#})?;
 
     let project_directory = context.temp_dir.child("project");

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -3337,7 +3337,7 @@ fn index_by_name_with_matching_path() -> anyhow::Result<()> {
         show_settings().arg("--index").arg("./internal")
     );
 
-    // Without preview, an existing path takes precedence over the configured name.
+    // Without preview, an existing path takes precedence and produces a disambiguation warning.
     diff_uv_snapshot!(context.filters(), &path, show_settings()
         .arg("--index")
         .arg("internal"), @"
@@ -3350,6 +3350,13 @@ fn index_by_name_with_matching_path() -> anyhow::Result<()> {
                                  ),
                                  expanded: false,
                              },
+    ...
+             reinstall: None,
+         },
+     }
+    +
+    +----- stderr -----
+    +warning: Relative paths passed to `--index` or `--default-index` should be disambiguated from index names (use `./internal`). Support for ambiguous values will be removed in the future
     ...
     ");
 

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -1,10 +1,11 @@
 use std::process::Command;
+use std::rc::Rc;
 
 use assert_fs::prelude::*;
 use url::Url;
 use uv_static::EnvVars;
 
-use uv_test::{capture_uv_snapshot, diff_uv_snapshot, uv_snapshot};
+use uv_test::{TestContext, capture_uv_snapshot, diff_uv_snapshot, uv_snapshot};
 
 /// Add shared arguments to a command.
 ///
@@ -3231,6 +3232,327 @@ fn index_priority() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn named_index_context() -> anyhow::Result<(Rc<TestContext>, impl Fn() -> Command)> {
+    let context = Rc::new(uv_test::test_context!("3.12"));
+    context
+        .temp_dir
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#})?;
+
+    let command_context = Rc::clone(&context);
+    let settings = move || {
+        let mut command = add_shared_args(command_context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
+
+    Ok((context, settings))
+}
+
+/// Named index arguments must resolve identically to their explicit CLI spellings.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name() -> anyhow::Result<()> {
+    let (context, show_settings) = named_index_context()?;
+
+    for argument in ["--index", "--default-index"] {
+        let named = capture_uv_snapshot!(
+            context.filters(),
+            show_settings()
+                .arg(argument)
+                .arg("internal")
+                .arg("--preview-features")
+                .arg("index-by-name")
+        );
+        let explicit = capture_uv_snapshot!(
+            context.filters(),
+            show_settings()
+                .arg(argument)
+                .arg("internal=https://test.pypi.org/simple")
+                .arg("--preview-features")
+                .arg("index-by-name")
+        );
+
+        // Selecting a name must match spelling out its URL with the same CLI role.
+        assert_eq!(named, explicit, "{argument}");
+    }
+
+    let explicit = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+    );
+
+    // Without preview, configured names resolve identically but produce a preview warning.
+    diff_uv_snapshot!(context.filters(), &explicit, show_settings()
+        .arg("--index")
+        .arg("internal"), @"
+    ...
+             reinstall: None,
+         },
+     }
+    +
+    +----- stderr -----
+    +warning: Referencing an index by name is experimental and may change without warning. Pass `--preview-features index-by-name` to disable this warning.
+    ...
+    ");
+
+    // With preview, an unknown name is reported as an index rather than a missing path.
+    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
+        .arg("requirements.in")
+        .arg("--index")
+        .arg("missing")
+        .arg("--preview-features")
+        .arg("index-by-name"), @"
+    exit_code: 2 (failure)
+    ----- stderr -----
+    error: Could not find an index named `missing`
+    ");
+
+    Ok(())
+}
+
+/// Preview determines whether a named index or matching directory takes precedence.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_with_matching_path() -> anyhow::Result<()> {
+    let (context, show_settings) = named_index_context()?;
+    context.temp_dir.child("internal").create_dir_all()?;
+
+    let path = capture_uv_snapshot!(
+        context.filters(),
+        show_settings().arg("--index").arg("./internal")
+    );
+
+    // Without preview, an existing path takes precedence over the configured name.
+    diff_uv_snapshot!(context.filters(), &path, show_settings()
+        .arg("--index")
+        .arg("internal"), @"
+    ...
+                                     fragment: None,
+                                 },
+                                 given: Some(
+    -                                \"./internal\",
+    +                                \"internal\",
+                                 ),
+                                 expanded: false,
+                             },
+    ...
+    ");
+
+    let named = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+    let explicit = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+
+    // With preview, the configured name takes precedence over the existing path.
+    assert_eq!(named, explicit);
+
+    Ok(())
+}
+
+/// User-configured named indexes retain settings that cannot be expressed on the CLI.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_from_user_configuration() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let user_configuration = context.user_config_dir.child("uv");
+    user_configuration.create_dir_all()?;
+    user_configuration
+        .child("uv.toml")
+        .write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+        authenticate = "always"
+    "#})?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command.arg("requirements.in").arg("--show-settings");
+        command
+    };
+
+    let index = capture_uv_snapshot!(
+        context.filters(),
+        show_settings()
+            .arg("--index")
+            .arg("internal=https://test.pypi.org/simple")
+            .arg("--preview-features")
+            .arg("index-by-name")
+    );
+
+    // User-configured names must preserve index settings that the CLI cannot express.
+    diff_uv_snapshot!(context.filters(), &index, show_settings()
+        .arg("--index")
+        .arg("internal")
+        .arg("--preview-features")
+        .arg("index-by-name"), @"
+    ...
+                         ),
+                         format: Simple,
+                         publish_url: None,
+    -                    authenticate: Auto,
+    +                    authenticate: Always,
+                         ignore_error_codes: None,
+                         cache_control: None,
+                         hash_algorithm: None,
+    ...
+    ");
+
+    Ok(())
+}
+
+/// Tool commands resolve configured indexes by name.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn tool_index_by_name() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let configuration = context.temp_dir.child("uv.toml");
+    configuration.write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "https://test.pypi.org/simple"
+        explicit = true
+        default = true
+    "#})?;
+
+    let tools: [fn(&TestContext) -> Command; 3] = [
+        TestContext::tool_run,
+        TestContext::tool_install,
+        TestContext::tool_upgrade,
+    ];
+
+    for tool in tools {
+        let show_settings = || {
+            let mut command = add_shared_args(tool(&context));
+            command
+                .arg("--show-settings")
+                .arg("--config-file")
+                .arg(configuration.path())
+                .arg("--preview-features")
+                .arg("index-by-name");
+            command
+        };
+
+        for argument in ["--index", "--default-index"] {
+            let named = capture_uv_snapshot!(
+                context.filters(),
+                show_settings()
+                    .arg(argument)
+                    .arg("internal")
+                    .arg("iniconfig")
+            );
+            let explicit = capture_uv_snapshot!(
+                context.filters(),
+                show_settings()
+                    .arg(argument)
+                    .arg("internal=https://test.pypi.org/simple")
+                    .arg("iniconfig")
+            );
+
+            assert_eq!(named, explicit, "{argument}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Named relative indexes remain relative to their configuration under `--directory`.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "Configuration tests are not yet supported on Windows"
+)]
+fn index_by_name_with_directory() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12").with_filter((
+        r#"given: Some\(\s+"file://[^"]+/configuration/configured-index",\s+\)"#,
+        "given: None",
+    ));
+    let configuration_directory = context.temp_dir.child("configuration");
+    configuration_directory.create_dir_all()?;
+    let configuration_file = configuration_directory.child("uv.toml");
+    configuration_file.write_str(indoc::indoc! {r#"
+        [[index]]
+        name = "internal"
+        url = "./configured-index"
+        explicit = true
+        default = true
+    "#})?;
+
+    let project_directory = context.temp_dir.child("project");
+    project_directory.create_dir_all()?;
+
+    let show_settings = || {
+        let mut command = add_shared_args(context.pip_compile());
+        command
+            .arg("requirements.in")
+            .arg("--show-settings")
+            .arg("--config-file")
+            .arg(configuration_file.path())
+            .arg("--directory")
+            .arg("project")
+            .arg("--preview-features")
+            .arg("index-by-name");
+        command
+    };
+
+    let configured_index = configuration_directory.child("configured-index");
+    let configured_index = Url::from_file_path(configured_index.path()).map_err(|()| {
+        anyhow::anyhow!("Failed to convert the configured index path to a file URL")
+    })?;
+    let configured_index = format!("internal={configured_index}");
+
+    for argument in ["--index", "--default-index"] {
+        let named = capture_uv_snapshot!(
+            context.filters(),
+            show_settings().arg(argument).arg("internal")
+        );
+        let explicit = capture_uv_snapshot!(
+            context.filters(),
+            show_settings().arg(argument).arg(&configured_index)
+        );
+
+        // Resolving the configured name must preserve its original configuration directory.
+        assert_eq!(named, explicit, "{argument}");
+    }
+
+    Ok(())
+}
+
 /// Verify hashes by default.
 #[test]
 #[cfg_attr(
@@ -3416,6 +3738,7 @@ fn preview_features() {
     +            IndexHashAlgorithm,
     +            LockfileFormatCheck,
     +            LockWithoutMetadata,
+    +            IndexByName,
     +        ],
          },
          python_preference: Managed,

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -50,6 +50,10 @@ $ uv lock --index pytorch=https://download.pytorch.org/whl/cpu
 $ UV_INDEX=pytorch=https://download.pytorch.org/whl/cpu uv lock
 ```
 
+With `--preview-features index-by-name`, configured indexes can be selected by name using `--index`
+or `--default-index`. Named indexes take precedence over matching paths and retain their configured
+settings, while taking the role of the selected option.
+
 ## Pinning a package to an index
 
 A package can be pinned to a specific index by specifying the index in its `tool.uv.sources` entry.

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -40,8 +40,8 @@ Index names may only contain alphanumeric characters, dashes, underscores, and p
 valid ASCII.
 
 When providing an index on the command line (with `--index` or `--default-index`) or through an
-environment variable (`UV_INDEX` or `UV_DEFAULT_INDEX`), names are optional but can be included
-using the `<name>=<url>` syntax, as in:
+environment variable (`UV_INDEX` or `UV_DEFAULT_INDEX`), use its URL, a configured name, or the
+`<name>=<url>` syntax:
 
 ```shell
 # On the command line.
@@ -50,9 +50,7 @@ $ uv lock --index pytorch=https://download.pytorch.org/whl/cpu
 $ UV_INDEX=pytorch=https://download.pytorch.org/whl/cpu uv lock
 ```
 
-With `--preview-features index-by-name`, configured indexes can be selected by name using `--index`
-or `--default-index`. Named indexes take precedence over matching paths and retain their configured
-settings, while taking the role of the selected option.
+With `--preview-features index-by-name`, configured index names take precedence over matching paths.
 
 ## Pinning a package to an index
 

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -252,6 +252,12 @@ name = "pytorch"
 url = "https://download.pytorch.org/whl/cpu"
 ```
 
+If the index is already configured, you can select it by name (this feature is in preview):
+
+```console
+$ uv add --preview-features index-by-name torch --index pytorch
+```
+
 !!! tip
 
     The above example will only work on x86-64 Linux, due to the specifics of the PyTorch index.

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -128,6 +128,8 @@ We recommend the use of `explicit = true` to ensure that the index is _only_ use
 `torchvision`, and other PyTorch-related packages, as opposed to generic dependencies like `jinja2`,
 which should continue to be sourced from the default index (PyPI).
 
+<!-- TODO(tk): Show `uv add --index <name>` once index-by-name is stable. -->
+
 Next, update the `pyproject.toml` to point `torch` and `torchvision` to the desired index:
 
 === "CPU-only"

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1825,7 +1825,8 @@
             "index-hash-algorithm",
             "lockfile-format-check",
             "lock-without-metadata",
-            "tar-codec"
+            "tar-codec",
+            "index-by-name"
           ]
         },
         {

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1823,7 +1823,8 @@
             "no-distutils-patch",
             "index-hash-algorithm",
             "lockfile-format-check",
-            "lock-without-metadata"
+            "lock-without-metadata",
+            "index-by-name"
           ]
         },
         {


### PR DESCRIPTION
## Summary

Implement #13974.

This PR makes `uv ... --index name` attempt to look up the index by name in filesystem configuration (workspace `pyproject.toml` or adjacent `uv.toml` (for project commands), then user config, then system config). The only difference is that the index will be passed with `explicit` and `default` set to `false` for that invocation.

Additionally, `uv ... --default-index name` acts in the same way, except the `default` setting is forcibly set to `true`.

This will work for `uv add --index name package...` pinning, with the same caveats that already apply when doing `uv add --index name=<location> package...`.

Without `--preview-features index-by-name`, named index references will prefer a directory of the same name, it will continue to warn about the potential ambiguity (now with all invocations, not just `uv add`). In case no index or directory of that name exists, the existing error will be emitted. Lastly, if only an index of that name exists, it will be resolved with a preview warning.

With `--preview-features index-by-name`, named index references will prefer an index of that name over any directory, but will continue to resolve to directories (with a warning as usual). In case no index or directory of that name exists, a new `index name` focused error will be emitted.

There are fundamental quirks with how `--index` and `--default-index` interact with `uv add` which mean this feature doesn't fully work as we would like. Expect some changes before it stabilises.

## Test Plan

A number of relevant tests have been added. They're trying to strike a balance between abstraction and simplicity. I found it was easier to keep track of what was actually being tested if you didn't have to dig through a haystack of setup code and snapshot every time you glanced at the tests.