### PR TITLE
Set XDG_CONFIG_HOME in with_real_home() to isolate test config

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -1526,6 +1526,12 @@ impl TestContext {
             self.extra_env
                 .push((EnvVars::HOME.to_string().into(), home));
         }
+        // Use the test's isolated config directory to avoid reading user
+        // configuration files (like `.python-version`) that could interfere with tests.
+        self.extra_env.push((
+            EnvVars::XDG_CONFIG_HOME.into(),
+            self.user_config_dir.as_os_str().into(),
+        ));
         self
     }
 


### PR DESCRIPTION
The `with_real_home()` method sets `HOME` to the real home directory, which is required for tests that use the macOS keychain for authentication. However, this causes a problem: when `HOME` is set but `XDG_CONFIG_HOME` is not, uv resolves the config directory to `$HOME/.config/uv` per the XDG specification. This means tests would read the user's real configuration files (like `.python-version` or `uv.toml`), which can override test-specified settings and cause failures.

This PR sets `XDG_CONFIG_HOME` to the test's isolated config directory in `with_real_home()`, ensuring that even when the real HOME is needed for keychain access, configuration files are read from an isolated location.

## Test plan

- Existing tests pass
- Tests using `with_real_home()` no longer read user config files