### PR TITLE
Avoid rendering `pyproject.toml` examples for more system-level settings

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -212,6 +212,7 @@ pub struct GlobalOptions {
     #[option(
         default = "false",
         value_type = "bool",
+        uv_toml_only = true,
         example = r#"
             native-tls = true
         "#
@@ -243,6 +244,7 @@ pub struct GlobalOptions {
     #[option(
         default = "None",
         value_type = "str",
+        uv_toml_only = true,
         example = r#"
             cache-dir = "./.uv_cache"
         "#
@@ -1040,6 +1042,7 @@ pub struct PythonInstallMirrors {
     #[option(
         default = "None",
         value_type = "str",
+        uv_toml_only = true,
         example = r#"
             python-install-mirror = "https://github.com/astral-sh/python-build-standalone/releases/download"
         "#
@@ -1056,6 +1059,7 @@ pub struct PythonInstallMirrors {
     #[option(
         default = "None",
         value_type = "str",
+        uv_toml_only = true,
         example = r#"
             pypy-install-mirror = "https://downloads.python.org/pypy"
         "#
@@ -1066,6 +1070,7 @@ pub struct PythonInstallMirrors {
     #[option(
         default = "None",
         value_type = "str",
+        uv_toml_only = true,
         example = r#"
             python-downloads-json-url = "/etc/uv/python-downloads.json"
         "#


### PR DESCRIPTION
Following #16918, mark additional system-level settings as `uv_toml_only` so they don't appear in the `pyproject.toml` documentation examples:

- `native-tls`
- `cache-dir`
- `python-install-mirror`
- `pypy-install-mirror`
- `python-downloads-json-url`

Eventually, we'll want to ban these in the `pyproject.toml` without some opt-in.
