### PR TITLE
Gate some tests added in 0.9.23 on the pypi feature

### DIFF
--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -708,6 +708,7 @@ async fn proxy_invalid_url_not_a_url_in_uv_toml() {
 }
 
 /// Test that valid proxy URL in uv.toml routes requests through the proxy.
+#[cfg(feature = "pypi")]
 #[tokio::test]
 async fn proxy_valid_url_in_uv_toml() {
     let context = TestContext::new("3.12");
@@ -766,6 +767,7 @@ async fn proxy_valid_url_in_uv_toml() {
 }
 
 /// Test that https-proxy in uv.toml routes HTTPS requests through a CONNECT tunnel proxy.
+#[cfg(feature = "pypi")]
 #[test]
 fn proxy_https_proxy_in_uv_toml() {
     let context = TestContext::new("3.12");
@@ -802,6 +804,7 @@ fn proxy_https_proxy_in_uv_toml() {
 }
 
 /// Test that no-proxy in uv.toml bypasses the proxy for specified hosts.
+#[cfg(feature = "pypi")]
 #[tokio::test]
 async fn proxy_no_proxy_in_uv_toml() {
     let context = TestContext::new("3.12");
@@ -869,6 +872,7 @@ no-proxy = ["{target_host}"]
 }
 
 /// Test that proxy URLs without a scheme in uv.toml default to http://.
+#[cfg(feature = "pypi")]
 #[tokio::test]
 async fn proxy_schemeless_url_in_uv_toml() {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Makes it easier to run integration tests in offline environments by gating four new tests on the `pypi` feature. All of these tests fail in offline environments when they try to make HTTPS requests to PyPI.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
Applied as a patch to Fedora’s [`uv` package](https://src.fedoraproject.org/rpms/uv); built and ran integration tests in an offline environment.