### PR TITLE
Add `-t` shortform for `--target` to `uv pip` subcommands

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1919,7 +1919,7 @@ pub struct PipSyncArgs {
     /// environment and only searches for a Python interpreter to use for package resolution.
     /// If a suitable Python interpreter cannot be found, uv will install one.
     /// To disable this, add `--no-python-downloads`.
-    #[arg(long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// Install packages into `lib`, `bin`, and other top-level folders under the specified
@@ -2296,7 +2296,7 @@ pub struct PipInstallArgs {
     /// environment and only searches for a Python interpreter to use for package resolution.
     /// If a suitable Python interpreter cannot be found, uv will install one.
     /// To disable this, add `--no-python-downloads`.
-    #[arg(long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// Install packages into `lib`, `bin`, and other top-level folders under the specified
@@ -2512,7 +2512,7 @@ pub struct PipUninstallArgs {
     pub no_break_system_packages: bool,
 
     /// Uninstall packages from the specified `--target` directory.
-    #[arg(long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// Uninstall packages from the specified `--prefix` directory.
@@ -2579,7 +2579,7 @@ pub struct PipFreezeArgs {
     pub no_system: bool,
 
     /// List packages from the specified `--target` directory.
-    #[arg(long, conflicts_with_all = ["prefix", "paths"], value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with_all = ["prefix", "paths"], value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// List packages from the specified `--prefix` directory.
@@ -2663,7 +2663,7 @@ pub struct PipListArgs {
     pub no_system: bool,
 
     /// List packages from the specified `--target` directory.
-    #[arg(long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// List packages from the specified `--prefix` directory.
@@ -2789,7 +2789,7 @@ pub struct PipShowArgs {
     pub no_system: bool,
 
     /// Show a package from the specified `--target` directory.
-    #[arg(long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
+    #[arg(short = 't', long, conflicts_with = "prefix", value_hint = ValueHint::DirPath)]
     pub target: Option<PathBuf>,
 
     /// Show a package from the specified `--prefix` directory.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This adds `-t` to `uv pip` to preserve drop-in compatibility with pip's `-t` shortform

Closes #17495

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Just interactively checked to make sure it works in the same places as `--test`
```bash
uv pip install -t test ansible
uv pip list -t test
echo 'ansible' > requirements.txt
uv pip sync -t test requirements.txt
```