### PR TITLE
Fix infinite loop when `SSL_CERT_FILE` is a directory

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -421,14 +421,31 @@ impl<'a> BaseClientBuilder<'a> {
         // Certificate loading support is delegated to `rustls-native-certs`.
         // See https://github.com/rustls/rustls-native-certs/blob/813790a297ad4399efe70a8e5264ca1b420acbec/src/lib.rs#L118-L125
         let ssl_cert_file_exists = env::var_os(EnvVars::SSL_CERT_FILE).is_some_and(|path| {
-            let path_exists = Path::new(&path).exists();
-            if !path_exists {
-                warn_user_once!(
-                    "Ignoring invalid `SSL_CERT_FILE`. File does not exist: {}.",
-                    path.simplified_display().cyan()
-                );
+            let path = Path::new(&path);
+            match path.metadata() {
+                Ok(metadata) if metadata.is_file() => true,
+                Ok(_) => {
+                    warn_user_once!(
+                        "Ignoring invalid `SSL_CERT_FILE`. Path is not a file: {}.",
+                        path.simplified_display().cyan()
+                    );
+                    false
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    warn_user_once!(
+                        "Ignoring invalid `SSL_CERT_FILE`. Path does not exist: {}.",
+                        path.simplified_display().cyan()
+                    );
+                    false
+                }
+                Err(err) => {
+                    warn_user_once!(
+                        "Ignoring invalid `SSL_CERT_FILE`. Path is not accessible: {} ({err}).",
+                        path.simplified_display().cyan()
+                    );
+                    false
+                }
             }
-            path_exists
         });
 
         // Checks for the presence of `SSL_CERT_DIR`.


### PR DESCRIPTION
Closes #17494

See https://github.com/rustls/pki-types/issues/98 for details.

I've posted an upstream fix https://github.com/rustls/pki-types/pull/99 but given the severity I think we should defensively patch this here as well.