### PR TITLE
Revert "Attempt to fix the Claude Code session start hook"

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# Read hook input from stdin (JSON with session info)
-INPUT=$(cat)
-SOURCE=$(echo "$INPUT" | jq -r '.source // "startup"')
-
-# Skip on resume - tools are already installed from the initial session
-if [ "$SOURCE" = "resume" ]; then
-  exit 0
-fi
-
 # Dispatch to web hook if running remotely
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
   exec "$(dirname "$0")/session-start-web.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "",
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
This reverts #17505 — I think there's another Claude Code bug that's causing the session start hook to be skipped.
