### PR TITLE
Upgrade rustls-pki-types to 1.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4088,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "4910321ebe4151be888e35fe062169554e74aad01beafed60410131420ceffbc"
 dependencies = [
  "web-time",
  "zeroize",


### PR DESCRIPTION
Pulls the upstream fix for #17494 (https://github.com/rustls/pki-types/releases/tag/v%2F1.13.3)

Most other significant changes are in https://github.com/rustls/pki-types/releases/tag/v%2F1.13.0