### PR TITLE
Gate `build_backend::build_with_all_metadata` on `pypi` feature

### DIFF
--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1224,6 +1224,7 @@ fn invalid_pyproject_toml() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "pypi")]
 #[test]
 fn build_with_all_metadata() -> Result<()> {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
## Summary

This test, added in 0.9.26, tries to download anyio from PyPI. This PR therefore gates it on the `pypi` feature.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
Applied as a patch to the `uv` package in Fedora and built in an offline environment.