### PR TITLE
Allow comma-separated values for `--extra` option

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1432,7 +1432,7 @@ pub struct PipCompileArgs {
     /// Include optional dependencies from the specified extra name; may be provided more than once.
     ///
     /// Only applies to `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
-    #[arg(short = 'E', long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    #[arg(long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
     pub extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.
@@ -1789,7 +1789,7 @@ pub struct PipSyncArgs {
     /// Include optional dependencies from the specified extra name; may be provided more than once.
     ///
     /// Only applies to `pylock.toml`, `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
-    #[arg(short = 'E', long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    #[arg(long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
     pub extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.
@@ -2158,7 +2158,7 @@ pub struct PipInstallArgs {
     /// Include optional dependencies from the specified extra name; may be provided more than once.
     ///
     /// Only applies to `pylock.toml`, `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
-    #[arg(short = 'E', long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    #[arg(long, value_delimiter = ',', conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
     pub extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.
@@ -3456,7 +3456,6 @@ pub struct RunArgs {
     ///
     /// This option is only available when running in a project.
     #[arg(
-        short = 'E',
         long,
         conflicts_with = "all_extras",
         conflicts_with = "only_group",
@@ -3785,7 +3784,6 @@ pub struct SyncArgs {
     /// Note that all optional dependencies are always included in the resolution; this option only
     /// affects the selection of packages to install.
     #[arg(
-        short = 'E',
         long,
         conflicts_with = "all_extras",
         conflicts_with = "only_group",
@@ -4797,7 +4795,7 @@ pub struct ExportArgs {
     /// Include optional dependencies from the specified extra name.
     ///
     /// May be provided more than once.
-    #[arg(short = 'E', long, value_delimiter = ',', conflicts_with = "all_extras", conflicts_with = "only_group", value_parser = extra_name_with_clap_error)]
+    #[arg(long, value_delimiter = ',', conflicts_with = "all_extras", conflicts_with = "only_group", value_parser = extra_name_with_clap_error)]
     pub extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -9297,7 +9297,7 @@ fn sync_all_extras() -> Result<()> {
 }
 
 #[test]
-fn sync_extra_short_form() -> Result<()> {
+fn sync_extra_comma_separated() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -9317,18 +9317,6 @@ fn sync_extra_short_form() -> Result<()> {
 
     context.lock().assert().success();
 
-    uv_snapshot!(context.filters(), context.sync().arg("-E").arg("types"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 5 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + typing-extensions==4.10.0
-    "#);
-
     uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("types,async"), @r#"
     success: true
     exit_code: 0
@@ -9336,21 +9324,12 @@ fn sync_extra_short_form() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Prepared 3 packages in [TIME]
-    Installed 3 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
      + sniffio==1.3.1
-    "#);
-
-    uv_snapshot!(context.filters(), context.sync().arg("-E").arg("types,async"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 5 packages in [TIME]
-    Audited 4 packages in [TIME]
+     + typing-extensions==4.10.0
     "#);
 
     Ok(())


### PR DESCRIPTION
Resolves (partially) https://github.com/astral-sh/uv/issues/17511

This diff enables comma-separated values for `--extra`, allowing `uv sync --extra foo,bar` as an alternative to `uv sync --extra foo --extra bar`.