### PR TITLE
Move MSRV to platform support section

### DIFF
--- a/docs/reference/policies/platforms.md
+++ b/docs/reference/policies/platforms.md
@@ -72,3 +72,13 @@ uv has Tier 3 support for:
 - Pyodide
 
 uv "should work" with these implementations, but stability may vary.
+
+## Minimum supported Rust version
+
+The minimum supported Rust version required to compile uv is listed in the `rust-version` key of the
+`[workspace.package]` section in `Cargo.toml`. It may change in any release (minor or patch). It
+will never be newer than N-2 Rust versions, where N is the latest stable version. For example, if
+the latest stable Rust version is 1.85, uv's minimum supported Rust version will be at most 1.83.
+
+This is only relevant to users who build uv from source. Installing uv from the Python package index
+usually installs a pre-built binary and does not require Rust compilation.

--- a/docs/reference/policies/versioning.md
+++ b/docs/reference/policies/versioning.md
@@ -37,13 +37,3 @@ Cache versions are considered internal to uv, and so may be changed in a minor o
 The `uv.lock` schema version is considered part of the public API, and so will only be incremented
 in a minor release as a breaking change. See
 [Lockfile versioning](../../concepts/resolution.md#lockfile-versioning) for more.
-
-## Minimum supported Rust version
-
-The minimum supported Rust version required to compile uv is listed in the `rust-version` key of the
-`[workspace.package]` section in `Cargo.toml`. It may change in any release (minor or patch). It
-will never be newer than N-2 Rust versions, where N is the latest stable version. For example, if
-the latest stable Rust version is 1.85, uv's minimum supported Rust version will be at most 1.83.
-
-This is only relevant to users who build uv from source. Installing uv from the Python package index
-usually installs a pre-built binary and does not require Rust compilation.


### PR DESCRIPTION
This fits with our other support policies, it's not a part of the uv versioning policy.