### PR TITLE
Add a nextest setup hook and optional code signing for tests on macOS

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,5 @@
+experimental = ["setup-scripts"]
+
 [profile.default]
 # Mark tests that take longer than 10s as slow.
 # Terminate after 120s as a stop-gap measure to terminate on deadlock.
@@ -44,3 +46,11 @@ platform = 'cfg(target_os = "windows")'
 filter = 'test(/^python_install::/) + test(/^python_update::/) + test(/^python_find::/)'
 test-group = 'io-bound'
 priority = 1 # Start earlier so these can complete before the end
+
+[scripts.setup.setup-hook-unix]
+command = "scripts/nextest-setup-hook-unix.sh"
+
+[[profile.default.scripts]]
+platform = { host = "cfg(unix)" }
+filter = "all()"
+setup = "setup-hook-unix"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,48 @@ Cloudflare Pages.
 
 After making changes to the documentation, [format the markdown files](#formatting) using Prettier.
 
+## Development code signing on macOS
+
+Code signing can only be performed by Astral team members.
+
+Code signing on macOS can improve developer experience when running tests, e.g., when running tests
+that access the macOS keychain, a signed binary can be approved once but an unsigned binary will
+need to be approved on each re-compile.
+
+### Acquiring a development certificate
+
+1. Generate a
+   [request for the certificate](https://developer.apple.com/help/account/certificates/create-a-certificate-signing-request)
+2. Create a certificate in the
+   [Apple Developer portal](https://developer.apple.com/account/resources/certificates/list)
+3. Download and install the certificate to your login keychain
+
+   ```shell
+   security import ~/Downloads/mac_development.cer -k ~/Library/Keychains/login.keychain-db
+   ```
+
+4. Identify your code signing identity
+
+   ```shell
+   security find-identity -v -p codesigning
+   ```
+
+5. If the above fails to find your identity, install the intermediate certificates
+
+   ```shell
+   curl -sLO "https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer"
+   security import AppleWWDRCAG3.cer -k ~/Library/Keychains/login.keychain-db
+   rm AppleWWDRCAG3.cer
+   ```
+
+6. Set `UV_TEST_CODESIGN_IDENTITY`
+
+   ```shell
+   export UV_TEST_CODESIGN_IDENTITY="Mac Developer: Your Name (TEAM_ID)"
+   ```
+
+Note `UV_TEST_CODESIGN_IDENTITY` is only supported via `nextest`.
+
 ## Releases
 
 Releases can only be performed by Astral team members.

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Sign macOS binaries with a code signing identity.
+#
+# Usage:
+#
+#   Sign binaries with the given identity:
+#
+#       $ ./scripts/codesign-macos.sh <identity> <target>...
+#
+#   For example:
+#
+#       $ ./scripts/codesign-macos.sh "Mac Developer: Your Name (TEAM_ID)" target/debug/uv
+#
+#   Use `security find-identity -v -p codesigning` to list available identities.
+
+set -euo pipefail
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Not on macOS, skipping" >&2
+  exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: codesign-macos.sh <identity> <target>..." >&2
+  exit 1
+fi
+
+identity="$1"
+shift
+
+for target in "$@"; do
+  if [[ -f "$target" ]]; then
+    codesign --force --sign "$identity" "$target"
+  fi
+done

--- a/scripts/nextest-setup-hook-unix.sh
+++ b/scripts/nextest-setup-hook-unix.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Nextest setup hook.
+#
+# Runs before tests execute. Add any pre-test setup steps here.
+#
+# Usage:
+#
+#   This script is run automatically by nextest before tests. It is configured in
+#   `.config/nextest.toml` as a setup script.
+
+set -euo pipefail
+
+# macOS code signing
+#
+# On macOS, binaries must be signed to access the system keychain without prompts after each re-compile.
+# This is required when running tests with the `native-auth` feature.
+# Set UV_TEST_CODESIGN_IDENTITY to enable signing. See `scripts/codesign-macos.sh`.
+if [[ "$(uname)" == "Darwin" && -n "${UV_TEST_CODESIGN_IDENTITY:-}" ]]; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  targets=()
+
+  for bin in target/debug/uv target/debug/uvx; do
+    [[ -f "$bin" ]] && targets+=("$bin")
+  done
+
+  while IFS= read -r -d '' bin; do
+    targets+=("$bin")
+  done < <(find target/debug/deps -type f -perm +111 ! -name "*.d" ! -name "*.dylib" -print0 2>/dev/null || true)
+
+  if [[ ${#targets[@]} -gt 0 ]]; then
+    "$SCRIPT_DIR/codesign-macos.sh" "$UV_TEST_CODESIGN_IDENTITY" "${targets[@]}"
+  fi
+fi


### PR DESCRIPTION
Uses a nextest setup hook to sign the uv and test binaries before running the tests. This allows you to grant permission to the test suite _once_ when running native authentication tests on macOS. Otherwise, you get prompted on every access on every binary change.