### PR TITLE
Use `FxHashSet<PackageName>` instead of `Vec` for `exclude` in `uv pip list`

### DIFF
--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::PathBuf;
 
 use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use rustc_hash::FxHashSet;
 use tracing::debug;
 
 use uv_cache::Cache;
@@ -23,7 +23,7 @@ use crate::printer::Printer;
 /// Enumerate the installed packages in the current environment.
 pub(crate) fn pip_freeze(
     exclude_editable: bool,
-    exclude: &HashSet<PackageName>,
+    exclude: &FxHashSet<PackageName>,
     strict: bool,
     python: Option<&str>,
     system: bool,

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 use tokio::sync::Semaphore;
 use tracing::debug;
@@ -39,7 +39,7 @@ use crate::printer::Printer;
 #[allow(clippy::fn_params_excessive_bools)]
 pub(crate) async fn pip_list(
     editable: Option<bool>,
-    exclude: &[PackageName],
+    exclude: &FxHashSet<PackageName>,
     format: &ListFormat,
     outdated: bool,
     prerelease: PrereleaseMode,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1,10 +1,11 @@
-use std::collections::HashSet;
 use std::env::VarError;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
 use std::time::Duration;
+
+use rustc_hash::FxHashSet;
 
 use crate::commands::{PythonUpgrade, PythonUpgradeSource};
 use uv_auth::Service;
@@ -3025,7 +3026,7 @@ impl PipUninstallSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct PipFreezeSettings {
     pub(crate) exclude_editable: bool,
-    pub(crate) exclude: HashSet<PackageName>,
+    pub(crate) exclude: FxHashSet<PackageName>,
     pub(crate) paths: Option<Vec<PathBuf>>,
     pub(crate) settings: PipSettings,
 }
@@ -3075,7 +3076,7 @@ impl PipFreezeSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct PipListSettings {
     pub(crate) editable: Option<bool>,
-    pub(crate) exclude: Vec<PackageName>,
+    pub(crate) exclude: FxHashSet<PackageName>,
     pub(crate) format: ListFormat,
     pub(crate) outdated: bool,
     pub(crate) settings: PipSettings,
@@ -3108,7 +3109,7 @@ impl PipListSettings {
 
         Self {
             editable: flag(editable, exclude_editable, "exclude-editable"),
-            exclude,
+            exclude: exclude.into_iter().collect(),
             format,
             outdated: flag(outdated, no_outdated, "outdated").unwrap_or(false),
             settings: PipSettings::combine(


### PR DESCRIPTION
Closes #17546 

and use `FxHashSet` instead of `HashSet` in `uv pip freeze`