### PR TITLE
fix(install): limit preparer concurrency to prevent file handle exhaustion

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -256,6 +256,7 @@ mod resolver {
                 client,
                 &build_context,
                 concurrency.downloads_semaphore.clone(),
+                concurrency.builds_semaphore.clone(),
             ),
         )?;
 

--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -256,7 +256,7 @@ mod resolver {
                 client,
                 &build_context,
                 concurrency.downloads_semaphore.clone(),
-                concurrency.builds_semaphore.clone(),
+                concurrency.source_distribution_semaphore.clone(),
             ),
         )?;
 

--- a/crates/uv-configuration/src/concurrency.rs
+++ b/crates/uv-configuration/src/concurrency.rs
@@ -24,6 +24,8 @@ pub struct Concurrency {
     pub downloads_semaphore: Arc<Semaphore>,
     /// A global semaphore to limit the number of concurrent builds.
     pub builds_semaphore: Arc<Semaphore>,
+    /// A global semaphore to limit the number of concurrent source distribution preparations.
+    pub source_distribution_semaphore: Arc<Semaphore>,
 }
 
 /// Custom `Debug` to hide semaphore fields from `--show-settings` output.
@@ -56,6 +58,7 @@ impl Concurrency {
             installs,
             downloads_semaphore: Arc::new(Semaphore::new(downloads)),
             builds_semaphore: Arc::new(Semaphore::new(builds)),
+            source_distribution_semaphore: Arc::new(Semaphore::new(builds)),
         }
     }
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -268,6 +268,7 @@ impl BuildContext for BuildDispatch<'_> {
                 self.client,
                 self,
                 self.concurrency.downloads_semaphore.clone(),
+                self.concurrency.builds_semaphore.clone(),
             )
             .with_build_stack(build_stack),
         )?;
@@ -361,6 +362,7 @@ impl BuildContext for BuildDispatch<'_> {
                     self.client,
                     self,
                     self.concurrency.downloads_semaphore.clone(),
+                    self.concurrency.builds_semaphore.clone(),
                 )
                 .with_build_stack(build_stack),
                 self.concurrency.downloads,

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -363,6 +363,7 @@ impl BuildContext for BuildDispatch<'_> {
                     self.concurrency.downloads_semaphore.clone(),
                 )
                 .with_build_stack(build_stack),
+                self.concurrency.downloads,
             );
 
             debug!(

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -268,7 +268,7 @@ impl BuildContext for BuildDispatch<'_> {
                 self.client,
                 self,
                 self.concurrency.downloads_semaphore.clone(),
-                self.concurrency.builds_semaphore.clone(),
+                self.concurrency.source_distribution_semaphore.clone(),
             )
             .with_build_stack(build_stack),
         )?;
@@ -362,10 +362,9 @@ impl BuildContext for BuildDispatch<'_> {
                     self.client,
                     self,
                     self.concurrency.downloads_semaphore.clone(),
-                    self.concurrency.builds_semaphore.clone(),
+                    self.concurrency.source_distribution_semaphore.clone(),
                 )
                 .with_build_stack(build_stack),
-                self.concurrency.downloads,
             );
 
             debug!(

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -63,10 +63,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         client: &'a RegistryClient,
         build_context: &'a Context,
         downloads_semaphore: Arc<Semaphore>,
+        builds_semaphore: Arc<Semaphore>,
     ) -> Self {
         Self {
             build_context,
-            builder: SourceDistributionBuilder::new(build_context),
+            builder: SourceDistributionBuilder::new(build_context, builds_semaphore),
             client: ManagedClient::new(client, downloads_semaphore),
             reporter: None,
         }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -63,11 +63,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         client: &'a RegistryClient,
         build_context: &'a Context,
         downloads_semaphore: Arc<Semaphore>,
-        builds_semaphore: Arc<Semaphore>,
+        source_distribution_semaphore: Arc<Semaphore>,
     ) -> Self {
         Self {
             build_context,
-            builder: SourceDistributionBuilder::new(build_context, builds_semaphore),
+            builder: SourceDistributionBuilder::new(build_context, source_distribution_semaphore),
             client: ManagedClient::new(client, downloads_semaphore),
             reporter: None,
         }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -145,6 +145,25 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         }
     }
 
+    async fn commit_canonical_local_revision_pointer(
+        &self,
+        lock_shard: &CacheShard,
+        pointer: LocalRevisionPointer,
+        hashes: HashPolicy<'_>,
+    ) -> Result<LocalRevisionPointer, Error> {
+        let entry = lock_shard.entry(LOCAL_REVISION);
+        if let Some(canonical) = LocalRevisionPointer::read_from(&entry)? {
+            if *canonical.cache_info() == *pointer.cache_info()
+                && canonical.revision().has_digests(hashes)
+            {
+                return Ok(canonical);
+            }
+        }
+
+        pointer.write_to(&entry).await?;
+        Ok(pointer)
+    }
+
     /// Download and build a [`SourceDist`].
     pub(crate) async fn download_and_build(
         &self,
@@ -927,12 +946,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         hashes: HashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Fetch the revision for the source distribution.
-        let LocalRevisionPointer {
-            cache_info,
-            revision,
-        } = self
+        let provisional = self
             .archive_revision(source, resource, cache_shard, hashes)
             .await?;
+        let cache_info = provisional.cache_info().clone();
+        let revision = provisional.revision().clone();
 
         // Before running the build, check that the hashes match.
         if !revision.satisfies(hashes) {
@@ -981,10 +999,32 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
                 .await?
         };
+        let provisional = LocalRevisionPointer {
+            cache_info,
+            revision,
+        };
 
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        let canonical = self
+            .commit_canonical_local_revision_pointer(lock_shard, provisional, hashes)
+            .await?;
+        let cache_info = canonical.cache_info().clone();
+        let revision = canonical.revision().clone();
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_entry = cache_shard.entry(SOURCE);
+        let revision = if source_entry.path().is_dir() {
+            revision
+        } else {
+            self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
+                .await?
+        };
+        let cache_shard = build_info
+            .cache_shard()
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
         if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
@@ -1049,9 +1089,11 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         hashes: HashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
         // Fetch the revision for the source distribution.
-        let LocalRevisionPointer { revision, .. } = self
+        let provisional = self
             .archive_revision(source, resource, cache_shard, hashes)
             .await?;
+        let cache_info = provisional.cache_info().clone();
+        let revision = provisional.revision().clone();
 
         // Before running the build, check that the hashes match.
         if !revision.satisfies(hashes) {
@@ -1100,10 +1142,28 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
                 .await?
         };
+        let provisional = LocalRevisionPointer {
+            cache_info,
+            revision,
+        };
 
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        let canonical = self
+            .commit_canonical_local_revision_pointer(lock_shard, provisional, hashes)
+            .await?;
+        let revision = canonical.into_revision();
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_entry = cache_shard.entry(SOURCE);
+        let revision = if source_entry.path().is_dir() {
+            revision
+        } else {
+            self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
+                .await?
+        };
+        let metadata_entry = cache_shard.entry(METADATA);
 
         // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
         if let Some(metadata) = self
@@ -1243,14 +1303,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Include the hashes and cache info in the revision.
         let revision = revision.with_hashes(HashDigests::from(hashes));
 
-        // Persist the revision.
-        let pointer = LocalRevisionPointer {
+        Ok(LocalRevisionPointer {
             cache_info,
             revision,
-        };
-        pointer.write_to(&revision_entry).await?;
-
-        Ok(pointer)
+        })
     }
 
     /// Build a source distribution from a local source tree (i.e., directory), either editable or

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -65,9 +65,8 @@ pub(crate) struct SourceDistributionBuilder<'a, T: BuildContext> {
     build_context: &'a T,
     build_stack: Option<&'a BuildStack>,
     reporter: Option<Arc<dyn Reporter>>,
-    /// Limits the number of concurrent source distribution builds and metadata generation tasks.
-    /// These tasks can hold an advisory cache shard lock open and may open many additional file
-    /// descriptors while invoking build backends.
+    /// Limits concurrent source distribution preparation work.
+    /// This bounds tasks that may hold shard locks and open many file descriptors.
     concurrency_limit: Arc<Semaphore>,
 }
 
@@ -515,8 +514,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
         let lock_shard = cache_shard;
-        let revision_shard = lock_shard.shard(revision.id());
-        let source_dist_entry = revision_shard.entry(SOURCE);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_dist_entry = cache_shard.entry(SOURCE);
 
         // We don't track any cache information for URL-based source distributions; they're assumed
         // to be immutable.
@@ -530,8 +529,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             BuildInfo::from_settings(&config_settings, extra_build_deps, extra_build_variables);
         let cache_shard = build_info
             .cache_shard()
-            .map(|digest| revision_shard.shard(digest))
-            .unwrap_or(revision_shard);
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         // If the cache contains a compatible wheel, return it.
         if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
@@ -662,8 +661,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
         let lock_shard = cache_shard;
-        let revision_shard = lock_shard.shard(revision.id());
-        let source_dist_entry = revision_shard.entry(SOURCE);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_dist_entry = cache_shard.entry(SOURCE);
 
         // If the metadata is static, return it.
         let dynamic =
@@ -679,7 +678,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             };
 
         // If the cache contains compatible metadata, return it.
-        let metadata_entry = revision_shard.entry(METADATA);
+        let metadata_entry = cache_shard.entry(METADATA);
 
         if let Some(metadata) = self
             .read_matching_cached_metadata(source, &metadata_entry)
@@ -691,7 +690,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             });
         }
 
-        // Otherwise, we need a source distribution.
+        // Otherwise, we need a wheel.
         let revision = if source_dist_entry.path().is_dir() {
             revision
         } else {
@@ -777,8 +776,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             BuildInfo::from_settings(&config_settings, extra_build_deps, extra_build_variables);
         let cache_shard = build_info
             .cache_shard()
-            .map(|digest| revision_shard.shard(digest))
-            .unwrap_or(revision_shard);
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         let task = self
             .reporter
@@ -947,8 +946,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
         let lock_shard = cache_shard;
-        let revision_shard = lock_shard.shard(revision.id());
-        let source_entry = revision_shard.entry(SOURCE);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_entry = cache_shard.entry(SOURCE);
 
         // If there are build settings or extra build dependencies, we need to scope to a cache shard.
         let config_settings = self.config_settings_for(source.name());
@@ -958,8 +957,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             BuildInfo::from_settings(&config_settings, extra_build_deps, extra_build_variables);
         let cache_shard = build_info
             .cache_shard()
-            .map(|digest| revision_shard.shard(digest))
-            .unwrap_or(revision_shard);
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         // If the cache contains a compatible wheel, return it.
         if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
@@ -1066,8 +1065,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
         let lock_shard = cache_shard;
-        let revision_shard = lock_shard.shard(revision.id());
-        let source_entry = revision_shard.entry(SOURCE);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_entry = cache_shard.entry(SOURCE);
 
         // If the metadata is static, return it.
         let dynamic = match StaticMetadata::read(source, source_entry.path(), None).await? {
@@ -1082,7 +1081,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         };
 
         // If the cache contains compatible metadata, return it.
-        let metadata_entry = revision_shard.entry(METADATA);
+        let metadata_entry = cache_shard.entry(METADATA);
 
         if let Some(metadata) = self
             .read_matching_cached_metadata(source, &metadata_entry)
@@ -1155,8 +1154,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             BuildInfo::from_settings(&config_settings, extra_build_deps, extra_build_variables);
         let cache_shard = build_info
             .cache_shard()
-            .map(|digest| revision_shard.shard(digest))
-            .unwrap_or(revision_shard);
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         // Otherwise, we need to build a wheel.
         let task = self

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -164,6 +164,17 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         Ok(pointer)
     }
 
+    fn read_canonical_http_revision(
+        &self,
+        lock_shard: &CacheShard,
+        hashes: HashPolicy<'_>,
+    ) -> Result<Option<Revision>, Error> {
+        let entry = lock_shard.entry(HTTP_REVISION);
+        Ok(HttpRevisionPointer::read_from(&entry)?
+            .map(HttpRevisionPointer::into_revision)
+            .filter(|revision| revision.has_digests(hashes)))
+    }
+
     /// Download and build a [`SourceDist`].
     pub(crate) async fn download_and_build(
         &self,
@@ -595,6 +606,38 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+        let revision = self
+            .read_canonical_http_revision(lock_shard, hashes)?
+            .unwrap_or(revision);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_dist_entry = cache_shard.entry(SOURCE);
+        let revision = if source_dist_entry.path().is_dir() {
+            revision
+        } else {
+            self.heal_url_revision(
+                source,
+                ext,
+                url,
+                index,
+                &source_dist_entry,
+                revision,
+                hashes,
+                client,
+            )
+            .await?
+        };
+        if let Some(subdirectory) = subdirectory {
+            if !source_dist_entry.path().join(subdirectory).is_dir() {
+                return Err(Error::MissingSubdirectory(
+                    url.clone(),
+                    subdirectory.to_path_buf(),
+                ));
+            }
+        }
+        let cache_shard = build_info
+            .cache_shard()
+            .map(|digest| cache_shard.shard(digest))
+            .unwrap_or(cache_shard);
 
         // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
         if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
@@ -739,6 +782,35 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+        let revision = self
+            .read_canonical_http_revision(lock_shard, hashes)?
+            .unwrap_or(revision);
+        let cache_shard = lock_shard.shard(revision.id());
+        let source_dist_entry = cache_shard.entry(SOURCE);
+        let revision = if source_dist_entry.path().is_dir() {
+            revision
+        } else {
+            self.heal_url_revision(
+                source,
+                ext,
+                url,
+                index,
+                &source_dist_entry,
+                revision,
+                hashes,
+                client,
+            )
+            .await?
+        };
+        if let Some(subdirectory) = subdirectory {
+            if !source_dist_entry.path().join(subdirectory).is_dir() {
+                return Err(Error::MissingSubdirectory(
+                    url.clone(),
+                    subdirectory.to_path_buf(),
+                ));
+            }
+        }
+        let metadata_entry = cache_shard.entry(METADATA);
 
         // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
         if let Some(metadata) = self

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -165,7 +165,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     }
 
     fn read_canonical_http_revision(
-        &self,
         lock_shard: &CacheShard,
         hashes: HashPolicy<'_>,
     ) -> Result<Option<Revision>, Error> {
@@ -606,9 +605,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
-        let revision = self
-            .read_canonical_http_revision(lock_shard, hashes)?
-            .unwrap_or(revision);
+        let revision = Self::read_canonical_http_revision(lock_shard, hashes)?.unwrap_or(revision);
         let cache_shard = lock_shard.shard(revision.id());
         let source_dist_entry = cache_shard.entry(SOURCE);
         let revision = if source_dist_entry.path().is_dir() {
@@ -782,9 +779,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Acquire the concurrency permit and advisory lock.
         let _permit = self.acquire_concurrency_permit().await;
         let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
-        let revision = self
-            .read_canonical_http_revision(lock_shard, hashes)?
-            .unwrap_or(revision);
+        let revision = Self::read_canonical_http_revision(lock_shard, hashes)?.unwrap_or(revision);
         let cache_shard = lock_shard.shard(revision.id());
         let source_dist_entry = cache_shard.entry(SOURCE);
         let revision = if source_dist_entry.path().is_dir() {
@@ -1582,7 +1577,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 return Ok(ArchiveMetadata::from(
                     Metadata::from_workspace(
                         metadata,
-                        resource.install_path.as_ref(),
+                        resource.install_path,
                         None,
                         self.build_context.locations(),
                         self.build_context.sources().clone(),
@@ -1625,7 +1620,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             return Ok(ArchiveMetadata::from(
                 Metadata::from_workspace(
                     metadata,
-                    resource.install_path.as_ref(),
+                    resource.install_path,
                     None,
                     self.build_context.locations(),
                     self.build_context.sources().clone(),
@@ -1769,7 +1764,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         }
 
         // Determine the last-modified time of the source distribution.
-        let cache_info = CacheInfo::from_directory(&resource.install_path)?;
+        let cache_info = CacheInfo::from_directory(resource.install_path)?;
         Ok(Self::read_matching_local_revision_pointer(
             source,
             &entry,

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -14,6 +14,8 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use tokio::sync::{Semaphore, SemaphorePermit};
+
 use fs_err::tokio as fs;
 use futures::{FutureExt, TryStreamExt};
 use reqwest::{Response, StatusCode};
@@ -63,6 +65,10 @@ pub(crate) struct SourceDistributionBuilder<'a, T: BuildContext> {
     build_context: &'a T,
     build_stack: Option<&'a BuildStack>,
     reporter: Option<Arc<dyn Reporter>>,
+    /// Limits the number of concurrent source distribution builds and metadata generation tasks.
+    /// These tasks can hold an advisory cache shard lock open and may open many additional file
+    /// descriptors while invoking build backends.
+    concurrency_limit: Arc<Semaphore>,
 }
 
 /// The name of the file that contains the revision ID for a remote distribution, encoded via `MsgPack`.
@@ -79,11 +85,12 @@ pub(crate) const SOURCE: &str = "src";
 
 impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Initialize a [`SourceDistributionBuilder`] from a [`BuildContext`].
-    pub(crate) fn new(build_context: &'a T) -> Self {
+    pub(crate) fn new(build_context: &'a T, concurrency_limit: Arc<Semaphore>) -> Self {
         Self {
             build_context,
             build_stack: None,
             reporter: None,
+            concurrency_limit,
         }
     }
 
@@ -102,6 +109,40 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         Self {
             reporter: Some(reporter),
             ..self
+        }
+    }
+
+    /// Acquire a permit from the concurrency limiter before acquiring a cache lock.
+    async fn acquire_concurrency_permit(&self) -> SemaphorePermit<'_> {
+        self.concurrency_limit
+            .acquire()
+            .await
+            .expect("concurrency semaphore should not be closed")
+    }
+
+    /// Read cached metadata if it exists and matches the expected source identity.
+    async fn read_matching_cached_metadata(
+        &self,
+        source: &BuildableSource<'_>,
+        metadata_entry: &CacheEntry,
+    ) -> Option<CachedMetadata> {
+        match CachedMetadata::read(metadata_entry).await {
+            Ok(Some(metadata)) => {
+                if metadata.matches(source.name(), source.version()) {
+                    debug!("Using cached metadata for: {source}");
+                    Some(metadata)
+                } else {
+                    debug!(
+                        "Cached metadata does not match expected name and version for: {source}"
+                    );
+                    None
+                }
+            }
+            Ok(None) => None,
+            Err(err) => {
+                debug!("Failed to deserialize cached metadata for: {source} ({err})");
+                None
+            }
         }
     }
 
@@ -457,8 +498,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         hashes: HashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
-        let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
-
         // Fetch the revision for the source distribution.
         let revision = self
             .url_revision(source, ext, url, index, cache_shard, hashes, client)
@@ -475,6 +514,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
+        let lock_shard = cache_shard;
         let cache_shard = cache_shard.shard(revision.id());
         let source_dist_entry = cache_shard.entry(SOURCE);
 
@@ -534,6 +574,24 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             }
         }
 
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
+        let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
+        if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
+            .ok()
+            .flatten()
+            .filter(|file| file.matches(source.name(), source.version()))
+        {
+            return Ok(BuiltWheelMetadata::from_file(
+                file,
+                revision.into_hashes(),
+                cache_info,
+                build_info,
+            ));
+        }
+
         let task = self
             .reporter
             .as_ref()
@@ -587,8 +645,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         hashes: HashPolicy<'_>,
         client: &ManagedClient<'_>,
     ) -> Result<ArchiveMetadata, Error> {
-        let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
-
         // Fetch the revision for the source distribution.
         let revision = self
             .url_revision(source, ext, url, index, cache_shard, hashes, client)
@@ -605,6 +661,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
+        let lock_shard = cache_shard;
         let cache_shard = cache_shard.shard(revision.id());
         let source_dist_entry = cache_shard.entry(SOURCE);
 
@@ -623,24 +680,18 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // If the cache contains compatible metadata, return it.
         let metadata_entry = cache_shard.entry(METADATA);
-        match CachedMetadata::read(&metadata_entry).await {
-            Ok(Some(metadata)) => {
-                if metadata.matches(source.name(), source.version()) {
-                    debug!("Using cached metadata for: {source}");
-                    return Ok(ArchiveMetadata {
-                        metadata: Metadata::from_metadata23(metadata.into()),
-                        hashes: revision.into_hashes(),
-                    });
-                }
-                debug!("Cached metadata does not match expected name and version for: {source}");
-            }
-            Ok(None) => {}
-            Err(err) => {
-                debug!("Failed to deserialize cached metadata for: {source} ({err})");
-            }
+
+        if let Some(metadata) = self
+            .read_matching_cached_metadata(source, &metadata_entry)
+            .await
+        {
+            return Ok(ArchiveMetadata {
+                metadata: Metadata::from_metadata23(metadata.into()),
+                hashes: revision.into_hashes(),
+            });
         }
 
-        // Otherwise, we need a wheel.
+        // Otherwise, we need a source distribution.
         let revision = if source_dist_entry.path().is_dir() {
             revision
         } else {
@@ -665,6 +716,21 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     subdirectory.to_path_buf(),
                 ));
             }
+        }
+
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
+        let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
+        if let Some(metadata) = self
+            .read_matching_cached_metadata(source, &metadata_entry)
+            .await
+        {
+            return Ok(ArchiveMetadata {
+                metadata: Metadata::from_metadata23(metadata.into()),
+                hashes: revision.into_hashes(),
+            });
         }
 
         // Otherwise, we either need to build the metadata.
@@ -861,8 +927,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         tags: &Tags,
         hashes: HashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
-        let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
-
         // Fetch the revision for the source distribution.
         let LocalRevisionPointer {
             cache_info,
@@ -882,6 +946,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
+        let lock_shard = cache_shard;
         let cache_shard = cache_shard.shard(revision.id());
         let source_entry = cache_shard.entry(SOURCE);
 
@@ -917,6 +982,24 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
                 .await?
         };
+
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
+        let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
+        if let Some(file) = BuiltWheelFile::find_in_cache(tags, &cache_shard)
+            .ok()
+            .flatten()
+            .filter(|file| file.matches(source.name(), source.version()))
+        {
+            return Ok(BuiltWheelMetadata::from_file(
+                file,
+                revision.into_hashes(),
+                cache_info,
+                build_info,
+            ));
+        }
 
         let task = self
             .reporter
@@ -966,8 +1049,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         hashes: HashPolicy<'_>,
     ) -> Result<ArchiveMetadata, Error> {
-        let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
-
         // Fetch the revision for the source distribution.
         let LocalRevisionPointer { revision, .. } = self
             .archive_revision(source, resource, cache_shard, hashes)
@@ -984,6 +1065,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // Scope all operations to the revision. Within the revision, there's no need to check for
         // freshness, since entries have to be fresher than the revision itself.
+        let lock_shard = cache_shard;
         let cache_shard = cache_shard.shard(revision.id());
         let source_entry = cache_shard.entry(SOURCE);
 
@@ -1001,21 +1083,15 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // If the cache contains compatible metadata, return it.
         let metadata_entry = cache_shard.entry(METADATA);
-        match CachedMetadata::read(&metadata_entry).await {
-            Ok(Some(metadata)) => {
-                if metadata.matches(source.name(), source.version()) {
-                    debug!("Using cached metadata for: {source}");
-                    return Ok(ArchiveMetadata {
-                        metadata: Metadata::from_metadata23(metadata.into()),
-                        hashes: revision.into_hashes(),
-                    });
-                }
-                debug!("Cached metadata does not match expected name and version for: {source}");
-            }
-            Ok(None) => {}
-            Err(err) => {
-                debug!("Failed to deserialize cached metadata for: {source} ({err})");
-            }
+
+        if let Some(metadata) = self
+            .read_matching_cached_metadata(source, &metadata_entry)
+            .await
+        {
+            return Ok(ArchiveMetadata {
+                metadata: Metadata::from_metadata23(metadata.into()),
+                hashes: revision.into_hashes(),
+            });
         }
 
         // Otherwise, we need a source distribution.
@@ -1025,6 +1101,21 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             self.heal_archive_revision(source, resource, &source_entry, revision, hashes)
                 .await?
         };
+
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
+        let _lock = lock_shard.lock().await.map_err(Error::CacheLock)?;
+
+        // Re-check the cache under lock to avoid duplicate builds across concurrent tasks.
+        if let Some(metadata) = self
+            .read_matching_cached_metadata(source, &metadata_entry)
+            .await
+        {
+            return Ok(ArchiveMetadata {
+                metadata: Metadata::from_metadata23(metadata.into()),
+                hashes: revision.into_hashes(),
+            });
+        }
 
         // If the backend supports `prepare_metadata_for_build_wheel`, use it.
         if let Some(metadata) = self
@@ -1186,7 +1277,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             },
         );
 
-        // Acquire the advisory lock.
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
         // Fetch the revision for the source distribution.
@@ -1310,7 +1402,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             },
         );
 
-        // Acquire the advisory lock.
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
         // Fetch the revision for the source distribution.
@@ -1324,39 +1417,31 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // If the cache contains compatible metadata, return it.
         let metadata_entry = cache_shard.entry(METADATA);
-        match CachedMetadata::read(&metadata_entry).await {
-            Ok(Some(metadata)) => {
-                if metadata.matches(source.name(), source.version()) {
-                    debug!("Using cached metadata for: {source}");
-
-                    // If necessary, mark the metadata as dynamic.
-                    let metadata = if dynamic {
-                        ResolutionMetadata {
-                            dynamic: true,
-                            ..metadata.into()
-                        }
-                    } else {
-                        metadata.into()
-                    };
-                    return Ok(ArchiveMetadata::from(
-                        Metadata::from_workspace(
-                            metadata,
-                            resource.install_path,
-                            None,
-                            self.build_context.locations(),
-                            self.build_context.sources().clone(),
-                            self.build_context.workspace_cache(),
-                            credentials_cache,
-                        )
-                        .await?,
-                    ));
+        if let Some(metadata) = self
+            .read_matching_cached_metadata(source, &metadata_entry)
+            .await
+        {
+            // If necessary, mark the metadata as dynamic.
+            let metadata = if dynamic {
+                ResolutionMetadata {
+                    dynamic: true,
+                    ..metadata.into()
                 }
-                debug!("Cached metadata does not match expected name and version for: {source}");
-            }
-            Ok(None) => {}
-            Err(err) => {
-                debug!("Failed to deserialize cached metadata for: {source} ({err})");
-            }
+            } else {
+                metadata.into()
+            };
+            return Ok(ArchiveMetadata::from(
+                Metadata::from_workspace(
+                    metadata,
+                    resource.install_path.as_ref(),
+                    None,
+                    self.build_context.locations(),
+                    self.build_context.sources().clone(),
+                    self.build_context.workspace_cache(),
+                    credentials_cache,
+                )
+                .await?,
+            ));
         }
 
         // If the backend supports `prepare_metadata_for_build_wheel`, use it.
@@ -1615,7 +1700,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         );
         let metadata_entry = cache_shard.entry(METADATA);
 
-        // Acquire the advisory lock.
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
         // We don't track any cache information for Git-based source distributions; they're assumed
@@ -1830,7 +1916,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         );
         let metadata_entry = cache_shard.entry(METADATA);
 
-        // Acquire the advisory lock.
+        // Acquire the concurrency permit and advisory lock.
+        let _permit = self.acquire_concurrency_permit().await;
         let _lock = cache_shard.lock().await.map_err(Error::CacheLock)?;
 
         let path = if let Some(subdirectory) = resource.subdirectory {
@@ -1873,36 +1960,26 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map_err(Error::CacheRead)?
             .is_fresh()
         {
-            match CachedMetadata::read(&metadata_entry).await {
-                Ok(Some(metadata)) => {
-                    if metadata.matches(source.name(), source.version()) {
-                        debug!("Using cached metadata for: {source}");
-
-                        let git_member = GitWorkspaceMember {
-                            fetch_root: fetch.path(),
-                            git_source: resource,
-                        };
-                        return Ok(ArchiveMetadata::from(
-                            Metadata::from_workspace(
-                                metadata.into(),
-                                &path,
-                                Some(&git_member),
-                                self.build_context.locations(),
-                                self.build_context.sources().clone(),
-                                self.build_context.workspace_cache(),
-                                credentials_cache,
-                            )
-                            .await?,
-                        ));
-                    }
-                    debug!(
-                        "Cached metadata does not match expected name and version for: {source}"
-                    );
-                }
-                Ok(None) => {}
-                Err(err) => {
-                    debug!("Failed to deserialize cached metadata for: {source} ({err})");
-                }
+            if let Some(metadata) = self
+                .read_matching_cached_metadata(source, &metadata_entry)
+                .await
+            {
+                let git_member = GitWorkspaceMember {
+                    fetch_root: fetch.path(),
+                    git_source: resource,
+                };
+                return Ok(ArchiveMetadata::from(
+                    Metadata::from_workspace(
+                        metadata.into(),
+                        &path,
+                        Some(&git_member),
+                        self.build_context.locations(),
+                        self.build_context.sources().clone(),
+                        self.build_context.workspace_cache(),
+                        credentials_cache,
+                    )
+                    .await?,
+                ));
             }
         }
 

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -1,7 +1,7 @@
 use std::cmp::Reverse;
 use std::sync::Arc;
 
-use futures::{FutureExt, Stream, TryFutureExt, TryStreamExt, stream::FuturesUnordered};
+use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use tracing::{debug, instrument};
 
 use uv_cache::Cache;
@@ -26,6 +26,7 @@ pub struct Preparer<'a, Context: BuildContext> {
     build_options: &'a BuildOptions,
     database: DistributionDatabase<'a, Context>,
     reporter: Option<Arc<dyn Reporter>>,
+    concurrency: usize,
 }
 
 impl<'a, Context: BuildContext> Preparer<'a, Context> {
@@ -35,6 +36,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         hashes: &'a HashStrategy,
         build_options: &'a BuildOptions,
         database: DistributionDatabase<'a, Context>,
+        concurrency: usize,
     ) -> Self {
         Self {
             tags,
@@ -43,6 +45,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
             build_options,
             database,
             reporter: None,
+            concurrency,
         }
     }
 
@@ -58,6 +61,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 .database
                 .with_reporter(reporter.clone().into_distribution_reporter()),
             reporter: Some(reporter),
+            concurrency: self.concurrency,
         }
     }
 
@@ -68,9 +72,8 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         in_flight: &'stream InFlight,
         resolution: &'stream Resolution,
     ) -> impl Stream<Item = Result<CachedDist, Error>> + 'stream {
-        distributions
-            .into_iter()
-            .map(async |dist| {
+        futures::stream::iter(distributions)
+            .map(move |dist| async move {
                 let wheel = self
                     .get_wheel((*dist).clone(), in_flight, resolution)
                     .boxed_local()
@@ -80,7 +83,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 }
                 Ok::<CachedDist, Error>(wheel)
             })
-            .collect::<FuturesUnordered<_>>()
+            .buffer_unordered(self.concurrency)
     }
 
     /// Download, build, and unzip a set of distributions.

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -774,6 +774,7 @@ async fn execute_plan(
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
             ),
+            concurrency.downloads,
         )
         .with_reporter(Arc::new(
             PrepareReporter::from(printer).with_length(remote.len() as u64),

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -160,7 +160,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                         client,
                         build_dispatch,
                         concurrency.downloads_semaphore.clone(),
-                        concurrency.builds_semaphore.clone(),
+                        concurrency.source_distribution_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -179,7 +179,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                     client,
                     build_dispatch,
                     concurrency.downloads_semaphore.clone(),
-                    concurrency.builds_semaphore.clone(),
+                    concurrency.source_distribution_semaphore.clone(),
                 ),
             )
             .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -292,7 +292,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                         client,
                         build_dispatch,
                         concurrency.downloads_semaphore.clone(),
-                        concurrency.builds_semaphore.clone(),
+                        concurrency.source_distribution_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -328,7 +328,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                     client,
                     build_dispatch,
                     concurrency.downloads_semaphore.clone(),
-                    concurrency.builds_semaphore.clone(),
+                    concurrency.source_distribution_semaphore.clone(),
                 ),
             )
             .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -381,7 +381,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 client,
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
-                concurrency.builds_semaphore.clone(),
+                concurrency.source_distribution_semaphore.clone(),
             ),
         )?
         .with_reporter(Arc::new(reporter));
@@ -778,9 +778,8 @@ async fn execute_plan(
                 client,
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
-                concurrency.builds_semaphore.clone(),
+                concurrency.source_distribution_semaphore.clone(),
             ),
-            concurrency.downloads,
         )
         .with_reporter(Arc::new(
             PrepareReporter::from(printer).with_length(remote.len() as u64),

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -160,6 +160,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                         client,
                         build_dispatch,
                         concurrency.downloads_semaphore.clone(),
+                        concurrency.builds_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -178,6 +179,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                     client,
                     build_dispatch,
                     concurrency.downloads_semaphore.clone(),
+                    concurrency.builds_semaphore.clone(),
                 ),
             )
             .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -290,6 +292,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                         client,
                         build_dispatch,
                         concurrency.downloads_semaphore.clone(),
+                        concurrency.builds_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -325,6 +328,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                     client,
                     build_dispatch,
                     concurrency.downloads_semaphore.clone(),
+                    concurrency.builds_semaphore.clone(),
                 ),
             )
             .with_reporter(Arc::new(ResolverReporter::from(printer)))
@@ -377,6 +381,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 client,
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
+                concurrency.builds_semaphore.clone(),
             ),
         )?
         .with_reporter(Arc::new(reporter));
@@ -773,6 +778,7 @@ async fn execute_plan(
                 client,
                 build_dispatch,
                 concurrency.downloads_semaphore.clone(),
+                concurrency.builds_semaphore.clone(),
             ),
             concurrency.downloads,
         )

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -468,6 +468,7 @@ pub(crate) async fn add(
                         &client,
                         &build_dispatch,
                         concurrency.downloads_semaphore.clone(),
+                        concurrency.builds_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -468,7 +468,7 @@ pub(crate) async fn add(
                         &client,
                         &build_dispatch,
                         concurrency.downloads_semaphore.clone(),
-                        concurrency.builds_semaphore.clone(),
+                        concurrency.source_distribution_semaphore.clone(),
                     ),
                 )
                 .with_reporter(Arc::new(ResolverReporter::from(printer)))

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -802,7 +802,7 @@ async fn do_lock(
         &client,
         &build_dispatch,
         concurrency.downloads_semaphore.clone(),
-        concurrency.builds_semaphore.clone(),
+        concurrency.source_distribution_semaphore.clone(),
     );
 
     // If any of the resolution-determining settings changed, invalidate the lock.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -802,6 +802,7 @@ async fn do_lock(
         &client,
         &build_dispatch,
         concurrency.downloads_semaphore.clone(),
+        concurrency.builds_semaphore.clone(),
     );
 
     // If any of the resolution-determining settings changed, invalidate the lock.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1939,6 +1939,7 @@ pub(crate) async fn resolve_names(
                 &client,
                 &build_dispatch,
                 concurrency.downloads_semaphore.clone(),
+                concurrency.builds_semaphore.clone(),
             ),
         )
         .with_reporter(Arc::new(ResolverReporter::from(printer)))

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1939,7 +1939,7 @@ pub(crate) async fn resolve_names(
                 &client,
                 &build_dispatch,
                 concurrency.downloads_semaphore.clone(),
-                concurrency.builds_semaphore.clone(),
+                concurrency.source_distribution_semaphore.clone(),
             ),
         )
         .with_reporter(Arc::new(ResolverReporter::from(printer)))


### PR DESCRIPTION
## Summary

Resolves #17512 

Fixes an issue where uv could exhaust the operating system's file descriptor limit when installing projects with a large number of local dependencies, causing a "Too many open files (os error 24)" crash.

## Test Plan

1. Built uv version that has an issue
2. Issued `ulimit -n 256` to set number of allowed descriptors to a low value
3. `mkdir -p /tmp/airflow-test`
4. `git clone --depth 1 https://github.com/apache/airflow /tmp/airflow-test`
5. `cd /tmp/airflow-test`
6. `/Users/denyszhak/personal-repos/uv/target/debug/uv sync`

Bug: Hit `Too many open files (os error 24) at path "/Users/denyszhak/.cache/uv/sdists-v9/editable/136c133a3434a0fa/.tmpZtqKQt"`

7. Built uv version with the fix (source branch)
8. `/Users/denyszhak/personal-repos/uv/target/debug/uv sync`

Fix: Successfully `Resolved 922 packages in 10.82s`