### PR TITLE
Warn about PyPy being not actively developed

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -473,7 +473,7 @@ documentation for details.
 !!! note
 
     PyPy is [not actively developed anymore](https://github.com/numpy/numpy/issues/30416) and
-    supports only up to Python 3.11.
+    only supports Python versions up to 3.11
 
 PyPy distributions are provided by the [PyPy project](https://pypy.org).
 


### PR DESCRIPTION
It seems that PyPy is not being actively developed anymore and is phased out even by numpy (https://github.com/numpy/numpy/issues/30416). There's no official statement from the project, but the numpy issue is from a PyPy developer. I added a warning to avoid users assuming PyPy properly supported and developed Python distribution, and in anticipation of PyPy being eventually, slowly deprecated.