### PR TITLE
Add a workflow to publish versions to another repository

### DIFF
--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -1,0 +1,75 @@
+# Publish uv version information to the versions repository.
+#
+# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a post-announce
+# job within `cargo-dist`.
+name: publish-versions
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish-versions:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ fromJson(inputs.plan).announcement_tag }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Set branch name"
+        run: echo "BRANCH_NAME=update-versions-$VERSION-$(date +%s)" >> $GITHUB_ENV
+
+      - name: "Clone versions repo"
+        run: git clone https://${{ secrets.ASTRAL_VERSIONS_PAT }}@github.com/astral-sh/versions.git astral-versions
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
+
+      - name: "Update versions"
+        env:
+          PLAN: ${{ inputs.plan }}
+        run: printf '%s' "$PLAN" | uv run astral-versions/scripts/publish-version.py --format cargo-dist --output astral-versions/v1
+
+      - name: "Commit versions"
+        working-directory: astral-versions
+        run: |
+          git config user.name "astral-versions-bot"
+          git config user.email "176161322+astral-versions-bot@users.noreply.github.com"
+
+          git checkout -b "$BRANCH_NAME"
+          git add -A
+          git commit -m "Update uv to version $VERSION"
+
+      - name: "Create Pull Request"
+        working-directory: astral-versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
+        run: |
+          pull_request_title="Update versions for $VERSION"
+
+          gh pr list --state open --json title --jq ".[] | select(.title == \"$pull_request_title\") | .number" | \
+            xargs -I {} gh pr close {}
+
+          git push origin "$BRANCH_NAME"
+
+          gh pr create --base main --head "$BRANCH_NAME" \
+            --title "$pull_request_title" \
+            --body "Automated versions update for $VERSION" \
+            --label "automation"
+
+      - name: "Merge Pull Request"
+        if: ${{ !fromJson(inputs.plan).announcement_tag_is_implicit }}
+        working-directory: astral-versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.ASTRAL_VERSIONS_PAT }}
+        run: |
+          # Wait for PR to be created before merging
+          sleep 10
+          gh pr merge --squash "$BRANCH_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,3 +298,12 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+
+  custom-publish-versions:
+    needs:
+      - plan
+      - announce
+    uses: ./.github/workflows/publish-versions.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -61,7 +61,7 @@ local-artifacts-jobs = ["./build-release-binaries", "./build-docker"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi", "./publish-crates"]
 # Post-announce jobs to run in CI
-post-announce-jobs = ["./publish-docs"]
+post-announce-jobs = ["./publish-docs", "./publish-versions"]
 # Custom permissions for GitHub Jobs
 github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-crates" = { contents = "read" } }
 # Whether to install an updater program


### PR DESCRIPTION
This is loosely a copy of the `publish-docs` workflow. It uses https://github.com/astral-sh/versions/blob/main/scripts/publish-version.py to add the latest version in the cargo dist plan to that repository.