### PR TITLE
Add `git ls-remote` fast path to avoid unnecessary fetches

### DIFF
--- a/crates/uv-git-types/src/gitlab.rs
+++ b/crates/uv-git-types/src/gitlab.rs
@@ -1,0 +1,135 @@
+use tracing::debug;
+use url::Url;
+
+/// A reference to a repository on GitLab (gitlab.com or self-hosted).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GitLabRepository<'a> {
+    /// The host of the GitLab instance (e.g., "gitlab.com" or "gitlab.example.com").
+    pub host: &'a str,
+    /// The full project path (e.g., "group/subgroup/project" or "user/project").
+    pub project_path: String,
+}
+
+impl<'a> GitLabRepository<'a> {
+    /// Parse a GitLab repository from a URL.
+    ///
+    /// Supports both gitlab.com and self-hosted GitLab instances.
+    /// Expects URLs like:
+    /// - `https://gitlab.com/group/project`
+    /// - `https://gitlab.com/group/subgroup/project`
+    /// - `https://gitlab.example.com/org/project`
+    pub fn parse(url: &'a Url) -> Option<Self> {
+        let host = url.host_str()?;
+
+        // Check if this looks like a GitLab instance
+        if !Self::is_gitlab_host(host) {
+            return None;
+        }
+
+        // Get the project path from URL segments
+        let segments: Vec<&str> = url.path_segments()?.collect();
+
+        // Need at least user/project or group/project
+        if segments.len() < 2 {
+            debug!("GitLab URL has too few path segments: {url}");
+            return None;
+        }
+
+        // Filter out empty segments and join them
+        let project_path: Vec<&str> = segments.into_iter().filter(|s| !s.is_empty()).collect();
+
+        if project_path.len() < 2 {
+            debug!("GitLab URL has too few path components: {url}");
+            return None;
+        }
+
+        // Join the path and trim .git suffix if present
+        let mut path = project_path.join("/");
+        if let Some(stripped) = path.strip_suffix(".git") {
+            path = stripped.to_string();
+        }
+
+        Some(Self {
+            host,
+            project_path: path,
+        })
+    }
+
+    /// Check if a host looks like a GitLab instance.
+    fn is_gitlab_host(host: &str) -> bool {
+        // Official GitLab
+        if host == "gitlab.com" {
+            return true;
+        }
+
+        // Self-hosted GitLab instances often have "gitlab" in the hostname
+        if host.contains("gitlab") {
+            return true;
+        }
+
+        false
+    }
+
+    /// Get the URL-encoded project path for API calls.
+    ///
+    /// GitLab API requires the project path to be URL-encoded, e.g.,
+    /// `group/subgroup/project` becomes `group%2Fsubgroup%2Fproject`.
+    pub fn encoded_project_path(&self) -> String {
+        self.project_path.replace('/', "%2F")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gitlab_com() {
+        let url = Url::parse("https://gitlab.com/user/project").unwrap();
+        let repo = GitLabRepository::parse(&url).unwrap();
+        assert_eq!(repo.host, "gitlab.com");
+        assert_eq!(repo.project_path, "user/project");
+    }
+
+    #[test]
+    fn test_parse_gitlab_com_with_subgroups() {
+        let url = Url::parse("https://gitlab.com/group/subgroup/project").unwrap();
+        let repo = GitLabRepository::parse(&url).unwrap();
+        assert_eq!(repo.host, "gitlab.com");
+        assert_eq!(repo.project_path, "group/subgroup/project");
+    }
+
+    #[test]
+    fn test_parse_self_hosted() {
+        let url = Url::parse("https://gitlab.example.com/org/team/project").unwrap();
+        let repo = GitLabRepository::parse(&url).unwrap();
+        assert_eq!(repo.host, "gitlab.example.com");
+        assert_eq!(repo.project_path, "org/team/project");
+    }
+
+    #[test]
+    fn test_parse_with_git_suffix() {
+        let url = Url::parse("https://gitlab.com/user/project.git").unwrap();
+        let repo = GitLabRepository::parse(&url).unwrap();
+        assert_eq!(repo.project_path, "user/project");
+    }
+
+    #[test]
+    fn test_encoded_project_path() {
+        let url = Url::parse("https://gitlab.com/group/subgroup/project").unwrap();
+        let repo = GitLabRepository::parse(&url).unwrap();
+        assert_eq!(repo.encoded_project_path(), "group%2Fsubgroup%2Fproject");
+    }
+
+    #[test]
+    fn test_parse_non_gitlab() {
+        let url = Url::parse("https://github.com/user/project").unwrap();
+        assert!(GitLabRepository::parse(&url).is_none());
+    }
+
+    #[test]
+    fn test_parse_too_few_segments() {
+        let url = Url::parse("https://gitlab.com/user").unwrap();
+        assert!(GitLabRepository::parse(&url).is_none());
+    }
+}

--- a/crates/uv-git-types/src/lib.rs
+++ b/crates/uv-git-types/src/lib.rs
@@ -1,4 +1,5 @@
 pub use crate::github::GitHubRepository;
+pub use crate::gitlab::GitLabRepository;
 pub use crate::oid::{GitOid, OidParseError};
 pub use crate::reference::GitReference;
 use std::sync::LazyLock;
@@ -8,6 +9,7 @@ use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 
 mod github;
+mod gitlab;
 mod oid;
 mod reference;
 

--- a/crates/uv-git/README.md
+++ b/crates/uv-git/README.md
@@ -1,4 +1,4 @@
-<!-- This file is generated. DO NOT EDIT -->
+~<!-- This file is generated. DO NOT EDIT -->
 
 # uv-git
 

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -1,5 +1,5 @@
 pub use crate::credentials::{GIT_STORE, store_credentials_from_url};
-pub use crate::git::{GIT, GIT_LFS, GitError};
+pub use crate::git::{GIT, GIT_LFS, GitError, git_ls_remote};
 pub use crate::resolver::{
     GitResolver, GitResolverError, RepositoryReference, ResolvedRepositoryReference,
 };

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1194,6 +1194,12 @@ impl EnvVars {
     #[attr_added_in("0.7.13")]
     pub const UV_NO_GITHUB_FAST_PATH: &'static str = "UV_NO_GITHUB_FAST_PATH";
 
+    /// Disable `git ls-remote` fast path that allows uv to check if a cached Git checkout
+    /// is up-to-date without performing a full fetch. This optimization works with any Git
+    /// host (GitHub, GitLab, Bitbucket, self-hosted, etc.).
+    #[attr_added_in("0.9.27")]
+    pub const UV_NO_GIT_LS_REMOTE_FAST_PATH: &'static str = "UV_NO_GIT_LS_REMOTE_FAST_PATH";
+
     /// Authentication token for Hugging Face requests. When set, uv will use this token
     /// when making requests to `https://huggingface.co/` and any subdomains.
     #[attr_added_in("0.8.1")]

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1358,7 +1358,17 @@ fn requirements_txt_ssh_git_username() -> Result<()> {
       ├─▶ Git operation failed
       ├─▶ failed to clone into: [PATH]
       ├─▶ failed to fetch branch, tag, or commit `d780faf0ac91257d4d5a4f0c5a0e4509608c0071`
-      ╰─▶ process didn't exit successfully: [GIT_COMMAND_ERROR]
+      ╰─▶ Git authentication failed for `ssh://git@github.com/astral-test/uv-private-pypackage.git`. Ensure you have the correct credentials configured.
+
+          For HTTPS repositories:
+            - Check your Git credential helper: `git config --global credential.helper`
+            - Or use a personal access token in the URL
+
+          For SSH repositories:
+            - Ensure your SSH key is added: `ssh-add -l`
+            - Verify SSH access: `ssh -T git@<host>`
+
+          Original error: process didn't exit successfully: [GIT_COMMAND_ERROR]
           --- stderr
           Load key "[TEMP_DIR]/fake_deploy_key": [ERROR]
           git@github.com: Permission denied (publickey).

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -2549,10 +2549,21 @@ fn install_git_private_https_pat_not_authorized() {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Git authentication failed for `https://git:****@github.com/astral-test/uv-private-pypackage`. Check your credentials and try again. Falling back to full fetch which may also fail.
       × Failed to download and build `uv-private-pypackage @ git+https://git:****@github.com/astral-test/uv-private-pypackage`
       ├─▶ Git operation failed
       ├─▶ failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
-      ╰─▶ process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
+      ╰─▶ Git authentication failed for `https://git:***@github.com/astral-test/uv-private-pypackage`. Ensure you have the correct credentials configured.
+
+          For HTTPS repositories:
+            - Check your Git credential helper: `git config --global credential.helper`
+            - Or use a personal access token in the URL
+
+          For SSH repositories:
+            - Ensure your SSH key is added: `ssh-add -l`
+            - Verify SSH access: `ssh -T git@<host>`
+
+          Original error: process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
           --- stderr
           remote: Invalid username or token. Password authentication is not supported for Git operations.
           fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
@@ -2647,10 +2658,21 @@ fn install_git_private_https_interactive() {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Git authentication failed for `https://github.com/astral-test/uv-private-pypackage`. Check your credentials and try again. Falling back to full fetch which may also fail.
       × Failed to download and build `uv-private-pypackage @ git+https://github.com/astral-test/uv-private-pypackage`
       ├─▶ Git operation failed
       ├─▶ failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
-      ╰─▶ process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
+      ╰─▶ Git authentication failed for `https://github.com/astral-test/uv-private-pypackage`. Ensure you have the correct credentials configured.
+
+          For HTTPS repositories:
+            - Check your Git credential helper: `git config --global credential.helper`
+            - Or use a personal access token in the URL
+
+          For SSH repositories:
+            - Ensure your SSH key is added: `ssh-add -l`
+            - Verify SSH access: `ssh -T git@<host>`
+
+          Original error: process didn't exit successfully: `/usr/bin/git fetch --force --update-head-ok 'https://github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
           --- stderr
           fatal: could not read Username for 'https://github.com': terminal prompts disabled
     ");


### PR DESCRIPTION
## Summary

- Add `git ls-remote` fast path optimization that checks if a cached Git checkout is up-to-date without performing a full fetch
- Works with any Git host (GitHub, GitLab, Bitbucket, self-hosted, etc.)
- Improve error messages for Git authentication and network failures with actionable guidance

## Changes

- Add `git_ls_remote` function to query remote refs efficiently
- Add `ls_remote_fast_path` method to `GitResolver`
- Integrate fast path check in `GitSource::fetch`
- Add `UV_NO_GIT_LS_REMOTE_FAST_PATH` env var to disable optimization
- Add unit tests for error detection and refspec conversion
- Add integration test for ls-remote fast path

## Test plan

- [x] Unit tests for `is_authentication_error`, `is_repository_not_found_error`, `is_network_error`
- [x] Unit test for `reference_to_refspec`
- [x] Integration test `lock_git_ls_remote_fast_path`
- [x] Manual testing with `uvx --refresh --from git+https://...` dependencies