### PR TITLE
Fix file patterns of maturin in renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -134,7 +134,9 @@
     // Maturin version used in maturin-action
     {
       customType: "regex",
-      managerFilePatterns: ["/.github/workflows/build-binaries\\.yml$/"],
+      managerFilePatterns: [
+        "/.github/workflows/build-release-binaries\\.yml$/",
+      ],
       matchStrings: ["maturin-version: (?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       depNameTemplate: "maturin",
       packageNameTemplate: "PyO3/maturin",


### PR DESCRIPTION
`build-binaries.yml` was renamed to `build-release-binaries.yaml` in #17388.