### PR TITLE
Stabilize `uv add --bounds` and the `add-bounds` configuration option

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -103,13 +103,6 @@ pub(crate) async fn add(
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    if bounds.is_some() && !preview.is_enabled(PreviewFeature::AddBounds) {
-        warn_user_once!(
-            "The `bounds` option is in preview and may change in any future release. Pass `--preview-features {}` to disable this warning.",
-            PreviewFeature::AddBounds
-        );
-    }
-
     if !preview.is_enabled(PreviewFeature::ExtraBuildDependencies)
         && !settings.resolver.extra_build_dependencies.is_empty()
     {

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -6846,7 +6846,6 @@ fn add_script_bounds() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The `bounds` option is in preview and may change in any future release. Pass `--preview-features add-bounds` to disable this warning.
     Resolved 3 packages in [TIME]
     ");
 
@@ -14098,7 +14097,6 @@ fn add_bounds() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The `bounds` option is in preview and may change in any future release. Pass `--preview-features add-bounds` to disable this warning.
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -14138,7 +14136,6 @@ fn add_bounds() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The `bounds` option is in preview and may change in any future release. Pass `--preview-features add-bounds` to disable this warning.
     Resolved 4 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -14163,7 +14160,7 @@ fn add_bounds() -> Result<()> {
     );
 
     // Existing constraints take precedence over the bounds option
-    uv_snapshot!(context.filters(), context.add().arg("anyio").arg("--bounds").arg("minor").arg("--preview"), @"
+    uv_snapshot!(context.filters(), context.add().arg("anyio").arg("--bounds").arg("minor"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -14190,7 +14187,7 @@ fn add_bounds() -> Result<()> {
     );
 
     // Explicit constraints take precedence over the bounds option
-    uv_snapshot!(context.filters(), context.add().arg("anyio==4.2").arg("idna").arg("--bounds").arg("minor").arg("--preview"), @"
+    uv_snapshot!(context.filters(), context.add().arg("anyio==4.2").arg("idna").arg("--bounds").arg("minor"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -14221,8 +14218,8 @@ fn add_bounds() -> Result<()> {
     "#
     );
 
-    // Set bounds on the CLI and use `--preview` to silence the warning.
-    uv_snapshot!(context.filters(), context.add().arg("sniffio").arg("--bounds").arg("minor").arg("--preview"), @"
+    // Set bounds on the CLI.
+    uv_snapshot!(context.filters(), context.add().arg("sniffio").arg("--bounds").arg("minor"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -14271,7 +14268,7 @@ fn add_bounds_requirement_over_bounds_kind() -> Result<()> {
         requires-python = ">=3.12"
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("anyio==4.2").arg("idna").arg("--bounds").arg("minor").arg("--preview"), @"
+    uv_snapshot!(context.filters(), context.add().arg("anyio==4.2").arg("idna").arg("--bounds").arg("minor"), @"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
Stabilize `uv add --bounds` and the `add-bounds` configuration option.

There's not many usages of the features, but there also aren't any problem reports, and I don't expect its functionality to change unless there were bigger `uv add` and/or argument/configuration handling changes.

* https://github.com/search?q=path%3A**%2F*.toml%20add-bounds&type=code
* https://grep.app/search?regexp=true&q=uv+add.*--bounds
* https://github.com/search?q=%22uv+add%22+%22--bounds%22&type=code&p=1

Not breaking, but queuing up for 0.10 since it fits nicely with that release.