### PR TITLE
Make cargo test on macos also run with `test:extended`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       test-ecosystem: ${{ steps.plan.outputs.test_ecosystem }}
       test-integration: ${{ steps.plan.outputs.test_integration }}
       test-system: ${{ steps.plan.outputs.test_system }}
+      test-macos: ${{ steps.plan.outputs.test_macos }}
       build-docker: ${{ steps.plan.outputs.build_docker }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -44,6 +45,7 @@ jobs:
           HAS_INTEGRATION_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:integration') }}
           HAS_SYSTEM_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:system') }}
           HAS_EXTENDED_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:extended') }}
+          HAS_MACOS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:macos') }}
           HAS_BUILD_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'build:skip') }}
           HAS_BUILD_SKIP_RELEASE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'build:skip-release') }}
           HAS_BUILD_RELEASE_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'build:release') }}
@@ -54,6 +56,7 @@ jobs:
           [[ "$HAS_INTEGRATION_LABEL" == "true" ]] && has_integration_label=1
           [[ "$HAS_SYSTEM_LABEL" == "true" ]] && has_system_label=1
           [[ "$HAS_EXTENDED_LABEL" == "true" ]] && has_extended_label=1
+          [[ "$HAS_MACOS_LABEL" == "true" ]] && has_macos_label=1
           [[ "$HAS_BUILD_SKIP_LABEL" == "true" ]] && has_build_skip_label=1
           [[ "$HAS_BUILD_SKIP_RELEASE_LABEL" == "true" ]] && has_build_skip_release_label=1
           [[ "$HAS_BUILD_RELEASE_LABEL" == "true" ]] && has_build_release_label=1
@@ -100,6 +103,7 @@ jobs:
           [[ ! $has_skip_label ]] && test_ecosystem=1
           [[ $has_integration_label || $has_extended_label || $on_main_branch ]] && test_integration=1
           [[ $has_system_label || $has_extended_label || $on_main_branch || $system_workflow_changed ]] && test_system=1
+          [[ $has_macos_label || $has_extended_label || $on_main_branch ]] && test_macos=1
           [[ ! $has_skip_label && $docker_build_changed ]] && build_docker=1
 
           # Output (convert 1/empty to true/false for GHA)
@@ -117,6 +121,7 @@ jobs:
             out test_ecosystem          "$test_ecosystem"
             out test_integration        "$test_integration"
             out test_system             "$test_system"
+            out test_macos              "$test_macos"
             out build_docker            "$build_docker"
           } >> "$GITHUB_OUTPUT"
 
@@ -168,6 +173,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
+      test-macos: ${{ needs.plan.outputs.test-macos }}
 
   test-windows-trampolines:
     needs: plan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
         required: false
         type: string
         default: "true"
+      test-macos:
+        required: false
+        type: string
+        default: "false"
 
 permissions: {}
 
@@ -76,12 +80,7 @@ jobs:
   cargo-test-macos:
     timeout-minutes: 20
     # Only run macOS tests on main without opt-in
-    if: >-
-      ${{
-        contains(github.event.pull_request.labels.*.name, 'test:macos') ||
-        contains(github.event.pull_request.labels.*.name, 'test:extended') ||
-        github.ref == 'refs/heads/main'
-      }}
+    if: ${{ inputs.test-macos == 'true' }}
     runs-on: depot-macos-14
     name: "cargo test on macos"
     steps:


### PR DESCRIPTION
## Summary

Currently we require `macos:test` explicitly even when `test:extended` is set, but from discussions it seems `test:extended` should also trigger `test:macos` so this change adds that.

Couldn't find any less repetitive way to do this.

## Test Plan

CI.
