### PR TITLE
docs(timeout): clarify timeout format in error messages

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1241,7 +1241,7 @@ impl RegistryClient {
             std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",
+                    "Failed to download distribution due to network timeout (current value: {}s). Try increasing `UV_HTTP_TIMEOUT` to a larger integer value (in seconds), e.g., `UV_HTTP_TIMEOUT=60`.",
                     self.timeout().as_secs()
                 ),
             )

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -93,7 +93,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             io::Error::new(
                 io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",
+                    "Failed to download distribution due to network timeout (current value: {}s). Try increasing `UV_HTTP_TIMEOUT` to a larger integer value (in seconds), e.g., `UV_HTTP_TIMEOUT=60`.",
                     self.client.unmanaged.timeout().as_secs()
                 ),
             )

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -772,13 +772,19 @@ where
 
     match value.parse::<T>() {
         Ok(v) => Ok(Some(v)),
-        Err(err) => Err(Error::InvalidEnvironmentVariable(
-            InvalidEnvironmentVariable {
-                name: name.to_string(),
-                value,
-                err: err.to_string(),
-            },
-        )),
+        Err(err) => {
+            let mut err_str = err.to_string();
+            if name.contains("TIMEOUT") && value.ends_with('s') {
+                err_str.push_str("; expected an integer (in seconds), e.g., '60' instead of '60s'");
+            }
+            Err(Error::InvalidEnvironmentVariable(
+                InvalidEnvironmentVariable {
+                    name: name.to_string(),
+                    value,
+                    err: err_str,
+                },
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #16940.

Currently, if a network timeout occurs, uv displays the timeout as `30s`. This leads users to try setting `UV_HTTP_TIMEOUT=60s`, which fails because it expects a plain integer.

This PR:
1. Improves the error message when a network timeout occurs to explicitly state that the value should be an integer in seconds and provides an example.
2. Updates the environment variable parsing logic to provide a specific suggestion (`expected an integer (in seconds)`) when parsing any variable containing `TIMEOUT` fails and the value ends with `s`.

Verified with:
```bash
UV_HTTP_TIMEOUT=60s cargo run venv
# error: Failed to parse environment variable `UV_HTTP_TIMEOUT` with invalid value `60s`: invalid digit found in string; expected an integer (in seconds), e.g., '60' instead of '60s'
```