### PR TITLE
Fix default handling in PEP 792 status markers

### DIFF
--- a/crates/uv-pypi-types/src/project_status.rs
+++ b/crates/uv-pypi-types/src/project_status.rs
@@ -54,7 +54,9 @@ impl<'de> Deserialize<'de> for Status {
 #[derive(Clone, Debug, Default, Deserialize, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 #[rkyv(derive(Debug))]
 pub struct ProjectStatus {
+    #[serde(default)]
     pub status: Status,
+    #[serde(default)]
     pub reason: Option<SmallString>,
 }
 
@@ -75,6 +77,31 @@ mod tests {
         assert_eq!(Status::new("acTiVe"), None);
     }
 
+    /// An empty project status should default to Active with no reason.
+    #[test]
+    fn test_deserialize_empty() {
+        let json = "{}";
+
+        let project_status: ProjectStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(project_status.status, Status::Active);
+        assert_eq!(project_status.reason, None);
+    }
+
+    /// A project status with explicitly null reason should default to Active with no reason.
+    #[test]
+    fn test_deserialize_null() {
+        let json = r#"
+        {
+            "reason": null
+        }
+        "#;
+
+        let project_status: ProjectStatus = serde_json::from_str(json).unwrap();
+        assert_eq!(project_status.status, Status::Active);
+        assert_eq!(project_status.reason, None);
+    }
+
+    /// A project status with known status and reason.
     #[test]
     fn test_deserialize() {
         let json = r#"
@@ -92,6 +119,7 @@ mod tests {
         );
     }
 
+    /// A project status with an unknown status should default to Active.
     #[test]
     fn test_deserialize_unknown_status() {
         let json = r#"


### PR DESCRIPTION
## Summary

`"project-status": {}` is a perfectly valid PEP 792 status response, which just means "default status" (active) and "no reason given." We previously didn't handle that correctly because we didn't tell serde it could use the default impls to fill in missing fields. Now we do.

See #17631.

Part of #15254.

## Test Plan

Added two testcases for this.