### PR TITLE
Update Rust toolchain to 1.93 and MSRV to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.91"
 homepage = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
 authors = ["uv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,8 @@ RUN case "$TARGETPLATFORM" in \
   *) exit 1 ;; \
   esac
 
-# Temporarily using nightly-2025-11-02 for bundled musl v1.2.5
-# Ref: https://github.com/rust-lang/rust/pull/142682
-# TODO(samypr100): Remove when toolchain updates to 1.93
-COPY <<EOF rust-toolchain.toml
-[toolchain]
-channel = "nightly-2025-11-02"
-EOF
 # Update rustup whenever we bump the rust version
-# COPY rust-toolchain.toml rust-toolchain.toml
+COPY rust-toolchain.toml rust-toolchain.toml
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target $(cat rust_target.txt) --profile minimal --default-toolchain none
 ENV PATH="$HOME/.cargo/bin:$PATH"
 # Install the toolchain then the musl target

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
-# TODO(samypr100): When updating to 1.93, adjust Dockerfile to remove nightly-2025-11-02
 [toolchain]
-channel = "1.92.0"
+channel = "1.93"


### PR DESCRIPTION
## Summary

Updates Rust Toolchain to [1.93](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/) and bumps MSRV to [1.91](https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/) per versioning policy.

This also drops the nighly patch on Dockerfile introduced in https://github.com/astral-sh/uv/pull/16584
