### PR TITLE
Store wheel filename in install directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6260,6 +6260,7 @@ dependencies = [
 name = "uv-distribution-filename"
 version = "0.0.16"
 dependencies = [
+ "either",
  "insta",
  "memchr",
  "rkyv",

--- a/crates/uv-distribution-filename/Cargo.toml
+++ b/crates/uv-distribution-filename/Cargo.toml
@@ -22,6 +22,7 @@ uv-pep440 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-small-str = { workspace = true }
 
+either = { workspace = true }
 memchr = { workspace = true }
 rkyv = { workspace = true, features = ["smallvec-1"] }
 serde = { workspace = true }

--- a/crates/uv-install-wheel/src/install.rs
+++ b/crates/uv-install-wheel/src/install.rs
@@ -144,6 +144,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
             cache_info,
             build_info,
             installer,
+            filename,
             &mut record,
         )?;
     }

--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use uv_cache_info::CacheInfo;
 use uv_cache_key::{CanonicalUrl, RepositoryUrl};
-use uv_distribution_filename::ExpandedTags;
+use uv_distribution_filename::WheelTags;
 use uv_distribution_types::{
     BuildInfo, BuildVariables, ConfigSettings, ExtraBuildRequirement, ExtraBuildRequires,
     ExtraBuildVariables, InstalledDirectUrlDist, InstalledDist, InstalledDistKind,
@@ -414,14 +414,13 @@ fn extra_build_variables_for<'settings>(
 
 /// Generate a hint for explaining tag compatibility issues.
 // TODO(zanieb): We should refactor this to share logic with `generate_wheel_compatibility_hint`
-fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> Option<String> {
+fn generate_dist_compatibility_hint(wheel_tags: &WheelTags, tags: &Tags) -> Option<String> {
     let TagCompatibility::Incompatible(incompatible_tag) = wheel_tags.compatibility(tags) else {
         return None;
     };
 
     match incompatible_tag {
         IncompatibleTag::Python => {
-            let wheel_tags = wheel_tags.python_tags();
             let current_tag = tags.python_tag();
 
             if let Some(current) = current_tag {
@@ -434,6 +433,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution is compatible with {}, but you're using {}",
                     wheel_tags
+                        .python_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {
@@ -447,6 +447,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution requires {}",
                     wheel_tags
+                        .python_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {
@@ -492,7 +493,6 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
             ))
         }
         IncompatibleTag::Abi => {
-            let wheel_tags = wheel_tags.abi_tags();
             let current_tag = tags.abi_tag();
             if let Some(current) = current_tag {
                 let message = if let Some(pretty) = current.pretty() {
@@ -503,6 +503,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution is compatible with {}, but you're using {}",
                     wheel_tags
+                        .abi_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {
@@ -516,6 +517,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution requires {}",
                     wheel_tags
+                        .abi_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {
@@ -527,7 +529,6 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
             }
         }
         IncompatibleTag::Platform => {
-            let wheel_tags = wheel_tags.platform_tags();
             let current_tag = tags.platform_tag();
 
             if let Some(current) = current_tag {
@@ -539,6 +540,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution is compatible with {}, but you're on {}",
                     wheel_tags
+                        .platform_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {
@@ -552,6 +554,7 @@ fn generate_dist_compatibility_hint(wheel_tags: &ExpandedTags, tags: &Tags) -> O
                 Some(format!(
                     "The distribution requires {}",
                     wheel_tags
+                        .platform_tags()
                         .map(|tag| if let Some(pretty) = tag.pretty() {
                             format!("{pretty} (`{tag}`)")
                         } else {

--- a/crates/uv/tests/it/pip_show.rs
+++ b/crates/uv/tests/it/pip_show.rs
@@ -512,6 +512,7 @@ fn show_files() {
       requests-2.31.0.dist-info/REQUESTED
       requests-2.31.0.dist-info/WHEEL
       requests-2.31.0.dist-info/top_level.txt
+      requests-2.31.0.dist-info/uv_wheel.json
       requests/__init__.py
       requests/__version__.py
       requests/_internal_utils.py


### PR DESCRIPTION
## Summary

At install time, we verify that the wheel tags (as extracted from the wheel filename) match the current platform. After the wheel is installed, though, we check whether the installed wheel is compatible with the current platform by relying on the tags from the `WHEEL` file. This leads to churn when the `WHEEL` file is incorrect (most recently, in https://github.com/astral-sh/uv/issues/17711). This is typically a bug in the build / publishing setup for a given wheel, but I dislike that we have this internal inconsistency whereby uv will install a wheel but then decide later that it's incompatible.

Instead, we now write the filename to `uv_wheel.json`.

Closes https://github.com/astral-sh/uv/issues/17711.
