### PR TITLE
Require fs-err 3.2.2 (for `File::set_modified`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2485,7 +2485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "642883fdc81cf2da15ee8183fa1d2c7da452414dd41541a0f3e1428069345447"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ enumflags2 = { version = "0.7.12" }
 etcetera = { version = "0.11.0" }
 fastrand = { version = "2.3.0" }
 flate2 = { version = "1.0.33", default-features = false, features = ["zlib-rs"] }
-fs-err = { version = "3.0.0", features = ["tokio"] }
+fs-err = { version = "3.2.2", features = ["tokio"] }
 futures = { version = "0.3.30" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.15" }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Update the `fs-err` dependency to 3.2.2, because `uv` uses `File::set_modified` in

https://github.com/astral-sh/uv/blob/2183c3fe1b4b8e83ea284f7b8ffbdc736f40332e/crates/uv-install-wheel/src/linker.rs#L337

and this API was added [in 3.2.2](https://github.com/andrewhickman/fs-err/blob/3.2.2/CHANGELOG.md#322).
<!-- What's the purpose of the change? What does it do, and why? -->

Version 3.2.2 was already in `Cargo.lock`, but I ran `cargo update fs-error` and it made two small changes anyway.

## Test Plan

<!-- How was it tested? -->
There’s not much to test, as this just increases the minimum version. You can verify the original problem by checking out `main` and running

```
$ cargo update fs-err --precise 3.2.1
$ cargo build
```

to see the error

```
error[E0599]: no method named `set_modified` found for struct `fs_err::File` in the current scope
   --> crates/uv-install-wheel/src/linker.rs:337:35
    |
337 |             if let Err(err) = dir.set_modified(now) {
    |                                   ^^^^^^^^^^^^ method not found in `fs_err::File`
```