### PR TITLE
Make `--no-project` alias visible in `uv init --help`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3431,7 +3431,7 @@ pub struct InitArgs {
     /// Avoid discovering a workspace and create a standalone project.
     ///
     /// By default, uv searches for workspaces in the current directory or any parent directory.
-    #[arg(long, alias = "no-project")]
+    #[arg(long, visible_alias = "no-project")]
     pub no_workspace: bool,
 
     /// The Python interpreter to use to determine the minimum supported Python version.

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -1952,6 +1952,39 @@ fn init_no_workspace_warning() {
     });
 }
 
+/// `--no-project` is an alias for `--no-workspace`.
+#[test]
+fn init_no_project_alias() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg("--no-project").arg("--name").arg("project"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Initialized project `project`
+    ");
+
+    let workspace = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            workspace, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#
+        );
+    });
+}
+
 #[test]
 fn init_project_inside_project() -> Result<()> {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
## Summary

Change `alias` to `visible_alias` so that `--no-project` shows up in the help output for `uv init`. 

Previously, the alias worked but was not documented, causing user confusion:

**Before:**
```
--no-workspace                   Avoid discovering a workspace and create a standalone project
```

**After:**
```
--no-workspace                   Avoid discovering a workspace and create a standalone project
                                 [aliases: --no-project]
```

Also adds a test to verify the alias works identically to `--no-workspace`.

## Test Plan

- `cargo test -p uv --test it -- init_no_project_alias` - new test passes
- `cargo test -p uv --test it -- init` - all init tests pass
- `./target/debug/uv init --help` - alias now visible

Closes #17715.