### PR TITLE
Document interaction between index definitions and workspaces

### DIFF
--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -105,8 +105,8 @@ explicit = true
 ```
 
 Named indexes referenced via `tool.uv.sources` must be defined within the project's `pyproject.toml`
-file; indexes provided via the command-line, environment variables, or user-level configuration will
-not be recognized.
+file; indexes provided via the command-line, environment variables, or the user's or system's
+`uv.toml` will not be recognized.
 
 If the project is a member of a workspace then named indexes will also be looked up within the
 workspace's `pyproject.toml`.

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -50,6 +50,9 @@ $ uv lock --index pytorch=https://download.pytorch.org/whl/cpu
 $ UV_INDEX=pytorch=https://download.pytorch.org/whl/cpu uv lock
 ```
 
+Indexes defined within workspace members' `pyproject.toml` files are ignored for the purposes of
+dependency resolution. Only indexes defined within the workspace's `pyproject.toml` are considered.
+
 ## Pinning a package to an index
 
 A package can be pinned to a specific index by specifying the index in its `tool.uv.sources` entry.
@@ -104,6 +107,9 @@ explicit = true
 Named indexes referenced via `tool.uv.sources` must be defined within the project's `pyproject.toml`
 file; indexes provided via the command-line, environment variables, or user-level configuration will
 not be recognized.
+
+If the project is a member of a workspace then named indexes will also be looked up within the
+workspace's `pyproject.toml`.
 
 If an index is marked as both `default = true` and `explicit = true`, it will be treated as an
 explicit index (i.e., only usable via `tool.uv.sources`) while also removing PyPI as the default


### PR DESCRIPTION
## Summary

I am not 100% on the wording but I think it would be helpful to document these two tidbits on how `[[tool.uv.index]]` works in workspaces.

On an unrelated note, maybe it would make sense to warn if a workspace member's `pyproject.toml` includes non explicit indexes?

## Test Plan

Spellcheck and proofreading.
