### PR TITLE
feat: parametrize --no-sync flag in pyproject.toml or uv.toml

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -359,6 +359,22 @@ pub struct GlobalOptions {
         "#
     )]
     pub allow_insecure_host: Option<Vec<TrustedHost>>,
+    /// Avoid syncing the project's environment with the project's dependencies.
+    ///
+    /// By default, `uv run`, `uv add`, `uv remove`, and `uv version` will
+    /// sync the project environment after resolving.
+    ///
+    /// When set to `true`, uv will skip syncing the project environment, even if changes have been
+    /// made to the project dependencies or lock file. This can be useful when you want to avoid
+    /// installing dependencies in environments where the dependencies are managed externally.
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = r#"
+            no-sync = true
+        "#
+    )]
+    pub no_sync: Option<bool>,
 }
 
 /// Settings relevant to all installer operations.
@@ -2158,6 +2174,7 @@ pub struct OptionsWire {
     concurrent_downloads: Option<NonZeroUsize>,
     concurrent_builds: Option<NonZeroUsize>,
     concurrent_installs: Option<NonZeroUsize>,
+    no_sync: Option<bool>,
 
     // #[serde(flatten)]
     // top_level: ResolverInstallerOptions
@@ -2260,6 +2277,7 @@ impl From<OptionsWire> for Options {
             concurrent_downloads,
             concurrent_builds,
             concurrent_installs,
+            no_sync,
             index,
             index_url,
             extra_index_url,
@@ -2338,6 +2356,7 @@ impl From<OptionsWire> for Options {
                 no_proxy,
                 // Used twice for backwards compatibility
                 allow_insecure_host: allow_insecure_host.clone(),
+                no_sync,
             },
             top_level: ResolverInstallerSchema {
                 index,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -620,7 +620,24 @@ impl RunSettings {
         // Resolve flags from CLI and environment variables.
         let locked = resolve_flag(locked, "locked", environment.locked);
         let frozen = resolve_flag(frozen, "frozen", environment.frozen);
-        let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
+
+        // Resolve no_sync from CLI, environment variable, and filesystem config.
+        let no_sync = if no_sync {
+            Flag::from_cli("no-sync")
+        } else {
+            let env_flag = resolve_flag(false, "no-sync", environment.no_sync);
+            if env_flag.is_enabled() {
+                env_flag
+            } else if filesystem
+                .as_ref()
+                .and_then(|fs| fs.globals.no_sync)
+                .unwrap_or(false)
+            {
+                Flag::from_config("no-sync")
+            } else {
+                Flag::disabled()
+            }
+        };
 
         // Check for conflicts between locked and frozen.
         check_conflicts(locked, frozen);
@@ -1940,7 +1957,24 @@ impl AddSettings {
         // Resolve flags from CLI and environment variables.
         let locked = resolve_flag(locked, "locked", environment.locked);
         let frozen = resolve_flag(frozen, "frozen", environment.frozen);
-        let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
+
+        // Resolve no_sync from CLI, environment variable, and filesystem config.
+        let no_sync = if no_sync {
+            Flag::from_cli("no-sync")
+        } else {
+            let env_flag = resolve_flag(false, "no-sync", environment.no_sync);
+            if env_flag.is_enabled() {
+                env_flag
+            } else if filesystem
+                .as_ref()
+                .and_then(|fs| fs.globals.no_sync)
+                .unwrap_or(false)
+            {
+                Flag::from_config("no-sync")
+            } else {
+                Flag::disabled()
+            }
+        };
 
         // Check for conflicts between locked and frozen.
         check_conflicts(locked, frozen);
@@ -2063,7 +2097,24 @@ impl RemoveSettings {
         // Resolve flags from CLI and environment variables.
         let locked = resolve_flag(locked, "locked", environment.locked);
         let frozen = resolve_flag(frozen, "frozen", environment.frozen);
-        let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
+
+        // Resolve no_sync from CLI, environment variable, and filesystem config.
+        let no_sync = if no_sync {
+            Flag::from_cli("no-sync")
+        } else {
+            let env_flag = resolve_flag(false, "no-sync", environment.no_sync);
+            if env_flag.is_enabled() {
+                env_flag
+            } else if filesystem
+                .as_ref()
+                .and_then(|fs| fs.globals.no_sync)
+                .unwrap_or(false)
+            {
+                Flag::from_config("no-sync")
+            } else {
+                Flag::disabled()
+            }
+        };
 
         // Check for conflicts between locked and frozen.
         check_conflicts(locked, frozen);
@@ -2145,7 +2196,24 @@ impl VersionSettings {
         // Resolve flags from CLI and environment variables.
         let locked = resolve_flag(locked, "locked", environment.locked);
         let frozen = resolve_flag(frozen, "frozen", environment.frozen);
-        let no_sync = resolve_flag(no_sync, "no-sync", environment.no_sync);
+
+        // Resolve no_sync from CLI, environment variable, and filesystem config.
+        let no_sync = if no_sync {
+            Flag::from_cli("no-sync")
+        } else {
+            let env_flag = resolve_flag(false, "no-sync", environment.no_sync);
+            if env_flag.is_enabled() {
+                env_flag
+            } else if filesystem
+                .as_ref()
+                .and_then(|fs| fs.globals.no_sync)
+                .unwrap_or(false)
+            {
+                Flag::from_config("no-sync")
+            } else {
+                Flag::disabled()
+            }
+        };
 
         // Check for conflicts between locked and frozen.
         check_conflicts(locked, frozen);


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
https://github.com/astral-sh/uv/issues/12429

Users can now configure no-sync in their pyproject.toml:

```
[tool.uv]
no-sync = true
```

Or in uv.toml: `no-sync = true`

This makes uv run, uv add, uv remove, and uv version skip environment synchronization by default.

## Rationale

Our uv workspace has a bit of a conundrum - we install dependencies that depend on pytorch by default, but want to support both cpu and gpu builds.  we handle this by using "extra" deps for CPU or GPU versions. The issue is that when we then use `uv run` extras aren't included by default which causes GPU torch to get installed by default.

So what happens for us is that we run `uv sync --extras ... --group ...` once and then use `uv run --no-sync` everywhere. Really I'd like to be able to sync deps once, get the env I want, and then be able to run & only update when I want to update.

It's possible we just have our pyproject.toml set up in the wrong way, but I think there are definitely scenarios where --no-sync is useful default behavior.

```
[project.optional-dependencies]
cpu = [
    "torch>=2.4.1",
    "torchvision>=0.19.1",
    "onnxtr[cpu-headless]==0.6.0",
    "onnxruntime==1.20.1",
]
cuda = [
    "torch>=2.4.1",
    "torchvision>=0.19.1",
    "onnxtr[gpu-headless]==0.6.0",
    "onnxruntime-gpu==1.20.1",
]

[tool.uv.sources]
torch = [
    { index = "pytorch-cpu", extra = "cpu" },
    { index = "pytorch-cu124", extra = "cuda" },
]
torchvision = [
    { index = "pytorch-cpu", extra = "cpu" },
    { index = "pytorch-cu124", extra = "cuda" },
]

[[tool.uv.index]]
name = "pytorch-cpu"
url = "https://download.pytorch.org/whl/cpu"
explicit = true

[[tool.uv.index]]
name = "pytorch-cu124"
url = "https://download.pytorch.org/whl/cu124"
explicit = true
```

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
