### PR TITLE
Ignore release.yml in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,7 @@
       matchFileNames: [".github/workflows/release.yml"],
       matchManagers: ["github-actions"],
       enabled: false,
-    }
+    },
     {
       // Create dedicated branches to update references to dependencies in the documentation.
       matchFileNames: ["docs/**/*.md"],


### PR DESCRIPTION
## Summary

`release.yml` is managed by dist, so Renovate creates a lot of chaff/noise/unnecessary dirty changes when trying to bump it. See #17302 for example.

## Test Plan

NFC.