### PR TITLE
Attempt to use reflinks by default on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,8 +85,9 @@ jobs:
           # Retry more than default to reduce flakes in CI
           UV_HTTP_RETRIES: 5
           RUST_BACKTRACE: 1
-          UV_INTERNAL__TEST_REFLINK_FS: /btrfs
-          UV_INTERNAL__TEST_TMP_FS: /tmpfs
+          UV_INTERNAL__TEST_COW_FS: /btrfs
+          UV_INTERNAL__TEST_NOCOW_FS: /tmpfs
+          UV_INTERNAL__TEST_ALT_FS: /tmpfs
         run: |
           cargo nextest run \
             --cargo-profile fast-build \
@@ -138,9 +139,10 @@ jobs:
           UV_HTTP_RETRIES: 5
           RUST_BACKTRACE: 1
           # macOS tmpdir is on APFS which supports reflink
-          UV_INTERNAL__TEST_REFLINK_FS: ${{ runner.temp }}
-          # HFS+ RAM disk does not support reflink
-          UV_INTERNAL__TEST_TMP_FS: ${{ env.HFS_MOUNT }}
+          UV_INTERNAL__TEST_COW_FS: ${{ runner.temp }}
+          # HFS+ RAM disk does not support copy-on-write and is on a different device
+          UV_INTERNAL__TEST_NOCOW_FS: ${{ env.HFS_MOUNT }}
+          UV_INTERNAL__TEST_ALT_FS: ${{ env.HFS_MOUNT }}
         run: |
           cargo nextest run \
             --cargo-profile fast-build \

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -558,20 +558,29 @@ impl EnvVars {
     #[attr_added_in("0.3.4")]
     pub const UV_INTERNAL__TEST_DIR: &'static str = "UV_INTERNAL__TEST_DIR";
 
-    /// Path to a directory on a filesystem that supports reflink / copy-on-write
-    /// (e.g., btrfs, XFS with reflink, APFS). Used by link tests to verify that
-    /// reflink operations succeed.
+    /// Path to a directory on a filesystem that supports copy-on-write, e.g., btrfs or APFS.
+    ///
+    /// When populated, uv will run additional tests that require this functionality.
     #[attr_hidden]
     #[attr_added_in("next release")]
-    pub const UV_INTERNAL__TEST_REFLINK_FS: &'static str = "UV_INTERNAL__TEST_REFLINK_FS";
+    pub const UV_INTERNAL__TEST_COW_FS: &'static str = "UV_INTERNAL__TEST_COW_FS";
 
-    /// Path to a directory on a filesystem that does **not** support reflink
-    /// (e.g., tmpfs, ext4, HFS+). Used by link tests to verify fallback behavior
-    /// when reflink is unavailable, and for cross-device tests when combined with
-    /// `UV_INTERNAL__TEST_REFLINK_FS`.
+    /// Path to a directory on a filesystem that does **not** support copy-on-write.
+    ///
+    /// When populated, uv will run additional tests that verify fallback behavior
+    /// when copy-on-write is unavailable.
     #[attr_hidden]
     #[attr_added_in("next release")]
-    pub const UV_INTERNAL__TEST_TMP_FS: &'static str = "UV_INTERNAL__TEST_TMP_FS";
+    pub const UV_INTERNAL__TEST_NOCOW_FS: &'static str = "UV_INTERNAL__TEST_NOCOW_FS";
+
+    /// Path to a directory on an alternative filesystem for testing.
+    ///
+    /// This filesystem must be a different device than the default for the test suite.
+    ///
+    /// When populated, uv will run additional tests that cover cross-filesystem linking.
+    #[attr_hidden]
+    #[attr_added_in("next release")]
+    pub const UV_INTERNAL__TEST_ALT_FS: &'static str = "UV_INTERNAL__TEST_ALT_FS";
 
     /// Used to force treating an interpreter as "managed" during tests.
     #[attr_hidden]

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -168,7 +168,7 @@ pub struct TestContext {
     _root: tempfile::TempDir,
 
     /// Extra temporary directories whose lifetimes are tied to this context (e.g., directories
-    /// on alternate filesystems created by `with_cache_on_reflink_fs` and friends).
+    /// on alternate filesystems created by [`Self::with_cache_on_cow_fs`] and friends).
     #[allow(dead_code)]
     _extra_tempdirs: Vec<tempfile::TempDir>,
 }
@@ -689,41 +689,47 @@ impl TestContext {
         self
     }
 
-    /// Move the cache directory to a reflink-capable filesystem.
+    /// Use a cache directory on the filesystem specified by
+    /// [`EnvVars::UV_INTERNAL__TEST_COW_FS`].
     ///
-    /// Returns `None` if `UV_INTERNAL__TEST_REFLINK_FS` is not set.
+    /// See the environment variable for details about the expectations.
     #[must_use]
-    pub fn with_cache_on_reflink_fs(self) -> Option<Self> {
-        let dir = env::var(EnvVars::UV_INTERNAL__TEST_REFLINK_FS).ok()?;
+    pub fn with_cache_on_cow_fs(self) -> Option<Self> {
+        let dir = env::var(EnvVars::UV_INTERNAL__TEST_COW_FS).ok()?;
         Some(self.with_cache_on_fs(&dir))
     }
 
-    /// Move the cache directory to a non-reflink filesystem.
+    /// Use a cache directory on the filesystem specified by
+    /// [`EnvVars::UV_INTERNAL__TEST_ALT_FS`].
     ///
-    /// Returns `None` if `UV_INTERNAL__TEST_TMP_FS` is not set.
+    /// See the environment variable for details about the expectations.
     #[must_use]
-    pub fn with_cache_on_tmp_fs(self) -> Option<Self> {
-        let dir = env::var(EnvVars::UV_INTERNAL__TEST_TMP_FS).ok()?;
+    pub fn with_cache_on_alt_fs(self) -> Option<Self> {
+        let dir = env::var(EnvVars::UV_INTERNAL__TEST_ALT_FS).ok()?;
         Some(self.with_cache_on_fs(&dir))
     }
 
-    /// Move the working directory (and venv) to a reflink-capable filesystem.
+    /// Use a working directory on the filesystem specified by
+    /// [`EnvVars::UV_INTERNAL__TEST_COW_FS`].
     ///
-    /// Returns `None` if `UV_INTERNAL__TEST_REFLINK_FS` is not set. The virtual environment
-    /// is **not** created; use `context.venv().assert().success()` after this.
+    /// Returns `None` if the environment variable is not set.
+    ///
+    /// Note a virtual environment is not created automatically.
     #[must_use]
-    pub fn with_working_dir_on_reflink_fs(self) -> Option<Self> {
-        let dir = env::var(EnvVars::UV_INTERNAL__TEST_REFLINK_FS).ok()?;
+    pub fn with_working_dir_on_cow_fs(self) -> Option<Self> {
+        let dir = env::var(EnvVars::UV_INTERNAL__TEST_COW_FS).ok()?;
         Some(self.with_working_dir_on_fs(&dir))
     }
 
-    /// Move the working directory (and venv) to a non-reflink filesystem.
+    /// Use a working directory on the filesystem specified by
+    /// [`EnvVars::UV_INTERNAL__TEST_ALT_FS`].
     ///
-    /// Returns `None` if `UV_INTERNAL__TEST_TMP_FS` is not set. The virtual environment
-    /// is **not** created; use `context.venv().assert().success()` after this.
+    /// Returns `None` if the environment variable is not set.
+    ///
+    /// Note a virtual environment is not created automatically.
     #[must_use]
-    pub fn with_working_dir_on_tmp_fs(self) -> Option<Self> {
-        let dir = env::var(EnvVars::UV_INTERNAL__TEST_TMP_FS).ok()?;
+    pub fn with_working_dir_on_alt_fs(self) -> Option<Self> {
+        let dir = env::var(EnvVars::UV_INTERNAL__TEST_ALT_FS).ok()?;
         Some(self.with_working_dir_on_fs(&dir))
     }
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -14199,12 +14199,12 @@ fn warn_on_lzma_wheel() {
 /// Install a package with the cache on a reflink-capable filesystem and the venv on a
 /// non-reflink filesystem. This exercises the cross-device fallback path for clone mode.
 ///
-/// Requires `UV_INTERNAL__TEST_REFLINK_FS` and `UV_INTERNAL__TEST_TMP_FS`.
+/// Requires `UV_INTERNAL__TEST_COW_FS` and `UV_INTERNAL__TEST_ALT_FS`.
 #[test]
 fn install_cross_device_cache_reflink_venv_tmp() {
     let Some(context) = uv_test::test_context!("3.12")
-        .with_cache_on_reflink_fs()
-        .and_then(TestContext::with_working_dir_on_tmp_fs)
+        .with_cache_on_cow_fs()
+        .and_then(TestContext::with_working_dir_on_alt_fs)
         .map(TestContext::with_filtered_link_mode_warning)
     else {
         return;
@@ -14233,12 +14233,12 @@ fn install_cross_device_cache_reflink_venv_tmp() {
 /// reflink-capable filesystem. This exercises the cross-device fallback path in the
 /// opposite direction.
 ///
-/// Requires `UV_INTERNAL__TEST_REFLINK_FS` and `UV_INTERNAL__TEST_TMP_FS`.
+/// Requires `UV_INTERNAL__TEST_COW_FS` and `UV_INTERNAL__TEST_ALT_FS`.
 #[test]
 fn install_cross_device_cache_tmp_venv_reflink() {
     let Some(context) = uv_test::test_context!("3.12")
-        .with_cache_on_tmp_fs()
-        .and_then(TestContext::with_working_dir_on_reflink_fs)
+        .with_cache_on_alt_fs()
+        .and_then(TestContext::with_working_dir_on_cow_fs)
         .map(TestContext::with_filtered_link_mode_warning)
     else {
         return;
@@ -14266,12 +14266,12 @@ fn install_cross_device_cache_tmp_venv_reflink() {
 /// Install a package with both cache and venv on a reflink-capable filesystem.
 /// Clone mode should succeed without fallback.
 ///
-/// Requires `UV_INTERNAL__TEST_REFLINK_FS`.
+/// Requires `UV_INTERNAL__TEST_COW_FS`.
 #[test]
 fn install_same_device_reflink() {
     let Some(context) = uv_test::test_context!("3.12")
-        .with_cache_on_reflink_fs()
-        .and_then(TestContext::with_working_dir_on_reflink_fs)
+        .with_cache_on_cow_fs()
+        .and_then(TestContext::with_working_dir_on_cow_fs)
     else {
         return;
     };
@@ -14297,12 +14297,12 @@ fn install_same_device_reflink() {
 
 /// Install with hardlink mode across filesystems — must fall back to copy.
 ///
-/// Requires `UV_INTERNAL__TEST_REFLINK_FS` and `UV_INTERNAL__TEST_TMP_FS`.
+/// Requires `UV_INTERNAL__TEST_COW_FS` and `UV_INTERNAL__TEST_ALT_FS`.
 #[test]
 fn install_cross_device_hardlink() {
     let Some(context) = uv_test::test_context!("3.12")
-        .with_cache_on_reflink_fs()
-        .and_then(TestContext::with_working_dir_on_tmp_fs)
+        .with_cache_on_cow_fs()
+        .and_then(TestContext::with_working_dir_on_alt_fs)
         .map(TestContext::with_filtered_link_mode_warning)
     else {
         return;


### PR DESCRIPTION
This was briefly discussed internally https://discord.com/channels/1039017663004942429/1343693513073623205/1451276005380718714

I'm not sure why we don't do this. I agree with the sentiment at #17722 that non-ext4 file systems are prevalent and we should at least try one reflink before falling back to hardlinks.