### PR TITLE
chore: remove bookworm, alpine 3.21, and py38 published images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -170,19 +170,16 @@ jobs:
         # Mapping of base image followed by a comma followed by one or more base tags (comma separated)
         # Note, org.opencontainers.image.version label will use the first base tag (use the most specific tag first)
         image-mapping:
-          - alpine:3.22,alpine3.22,alpine
-          - alpine:3.21,alpine3.21
+          - alpine:3.23,alpine3.23,alpine
+          - alpine:3.22,alpine3.22
           - debian:trixie-slim,trixie-slim,debian-slim
           - buildpack-deps:trixie,trixie,debian
-          - debian:bookworm-slim,bookworm-slim
-          - buildpack-deps:bookworm,bookworm
           - python:3.14-alpine3.23,python3.14-alpine3.23,python3.14-alpine
           - python:3.13-alpine3.23,python3.13-alpine3.23,python3.13-alpine
           - python:3.12-alpine3.23,python3.12-alpine3.23,python3.12-alpine
           - python:3.11-alpine3.23,python3.11-alpine3.23,python3.11-alpine
           - python:3.10-alpine3.23,python3.10-alpine3.23,python3.10-alpine
           - python:3.9-alpine3.22,python3.9-alpine3.22,python3.9-alpine
-          - python:3.8-alpine3.20,python3.8-alpine3.20,python3.8-alpine
           - python:3.14-trixie,python3.14-trixie
           - python:3.13-trixie,python3.13-trixie
           - python:3.12-trixie,python3.12-trixie
@@ -195,20 +192,6 @@ jobs:
           - python:3.11-slim-trixie,python3.11-trixie-slim
           - python:3.10-slim-trixie,python3.10-trixie-slim
           - python:3.9-slim-trixie,python3.9-trixie-slim
-          - python:3.14-bookworm,python3.14-bookworm
-          - python:3.13-bookworm,python3.13-bookworm
-          - python:3.12-bookworm,python3.12-bookworm
-          - python:3.11-bookworm,python3.11-bookworm
-          - python:3.10-bookworm,python3.10-bookworm
-          - python:3.9-bookworm,python3.9-bookworm
-          - python:3.8-bookworm,python3.8-bookworm
-          - python:3.14-slim-bookworm,python3.14-bookworm-slim
-          - python:3.13-slim-bookworm,python3.13-bookworm-slim
-          - python:3.12-slim-bookworm,python3.12-bookworm-slim
-          - python:3.11-slim-bookworm,python3.11-bookworm-slim
-          - python:3.10-slim-bookworm,python3.10-bookworm-slim
-          - python:3.9-slim-bookworm,python3.9-bookworm-slim
-          - python:3.8-slim-bookworm,python3.8-bookworm-slim
     steps:
       # Login to DockerHub (when not pushing, it's to avoid rate-limiting)
       - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -38,29 +38,30 @@ The following distroless images are available:
 And the following derived images are available:
 
 <!-- prettier-ignore -->
-- Based on `alpine:3.22`:
+- Based on `alpine:3.23`:
     - `ghcr.io/astral-sh/uv:alpine`
+    - `ghcr.io/astral-sh/uv:alpine3.23`
+- Based on `alpine:3.22`:
     - `ghcr.io/astral-sh/uv:alpine3.22`
-- Based on `alpine:3.21`:
-    - `ghcr.io/astral-sh/uv:alpine3.21`
 - Based on `debian:trixie-slim`:
     - `ghcr.io/astral-sh/uv:debian-slim`
     - `ghcr.io/astral-sh/uv:trixie-slim`
-- Based on `debian:bookworm-slim`:
-    - `ghcr.io/astral-sh/uv:bookworm-slim`
 - Based on `buildpack-deps:trixie`:
     - `ghcr.io/astral-sh/uv:debian`
     - `ghcr.io/astral-sh/uv:trixie`
-- Based on `buildpack-deps:bookworm`:
-    - `ghcr.io/astral-sh/uv:bookworm`
 - Based on `python3.x-alpine`:
     - `ghcr.io/astral-sh/uv:python3.14-alpine`
+    - `ghcr.io/astral-sh/uv:python3.14-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.13-alpine`
+    - `ghcr.io/astral-sh/uv:python3.13-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.12-alpine`
+    - `ghcr.io/astral-sh/uv:python3.12-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.11-alpine`
+    - `ghcr.io/astral-sh/uv:python3.11-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.10-alpine`
+    - `ghcr.io/astral-sh/uv:python3.10-alpine3.23`
     - `ghcr.io/astral-sh/uv:python3.9-alpine`
-    - `ghcr.io/astral-sh/uv:python3.8-alpine`
+    - `ghcr.io/astral-sh/uv:python3.9-alpine3.22`
 - Based on `python3.x-trixie`:
     - `ghcr.io/astral-sh/uv:python3.14-trixie`
     - `ghcr.io/astral-sh/uv:python3.13-trixie`
@@ -75,22 +76,6 @@ And the following derived images are available:
     - `ghcr.io/astral-sh/uv:python3.11-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.10-trixie-slim`
     - `ghcr.io/astral-sh/uv:python3.9-trixie-slim`
-- Based on `python3.x-bookworm`:
-    - `ghcr.io/astral-sh/uv:python3.14-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.13-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.12-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.11-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.10-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.9-bookworm`
-    - `ghcr.io/astral-sh/uv:python3.8-bookworm`
-- Based on `python3.x-slim-bookworm`:
-    - `ghcr.io/astral-sh/uv:python3.14-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.10-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.9-bookworm-slim`
-    - `ghcr.io/astral-sh/uv:python3.8-bookworm-slim`
 <!-- prettier-ignore-end -->
 
 As with the distroless image, each derived image is published with uv version tags as


### PR DESCRIPTION
This is a copy of https://github.com/astral-sh/uv/pull/16520 on #17661 