### PR TITLE
Install PyPy and GraalPy executables as `pypy` and `graalpy` instead of `python`

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -585,7 +585,8 @@ impl PythonInstallationKey {
     /// Return a canonical name for a minor versioned executable.
     pub fn executable_name_minor(&self) -> String {
         format!(
-            "python{maj}.{min}{var}{exe}",
+            "{name}{maj}.{min}{var}{exe}",
+            name = self.implementation.executable_name(),
             maj = self.major,
             min = self.minor,
             var = self.variant.executable_suffix(),
@@ -596,7 +597,8 @@ impl PythonInstallationKey {
     /// Return a canonical name for a major versioned executable.
     pub fn executable_name_major(&self) -> String {
         format!(
-            "python{maj}{var}{exe}",
+            "{name}{maj}{var}{exe}",
+            name = self.implementation.executable_name(),
             maj = self.major,
             var = self.variant.executable_suffix(),
             exe = std::env::consts::EXE_SUFFIX
@@ -606,7 +608,8 @@ impl PythonInstallationKey {
     /// Return a canonical name for an un-versioned executable.
     pub fn executable_name(&self) -> String {
         format!(
-            "python{var}{exe}",
+            "{name}{var}{exe}",
+            name = self.implementation.executable_name(),
             var = self.variant.executable_suffix(),
             exe = std::env::consts::EXE_SUFFIX
         )

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -3737,14 +3737,14 @@ fn python_install_build_version_pypy() {
 
     uv_snapshot!(context.filters(), context.python_install()
         .arg("pypy3.10")
-        .env(EnvVars::UV_PYTHON_PYPY_BUILD, "7.3.19"), @"
+        .env(EnvVars::UV_PYTHON_PYPY_BUILD, "7.3.19"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Installed Python 3.10.16 in [TIME]
-     + pypy-3.10.16-[PLATFORM] (python3.10)
+     + pypy-3.10.16-[PLATFORM] (pypy3.10)
     ");
 
     // A BUILD file should be present with the version
@@ -4215,14 +4215,14 @@ fn python_install_compile_bytecode_graalpy() {
         .with_python_download_cache();
 
     // Should work for graalpy
-    uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("graalpy-3.12"), @"
+    uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("graalpy-3.12"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Installed Python 3.12.0 in [TIME]
-     + graalpy-3.12.0-[PLATFORM] (python3.12)
+     + graalpy-3.12.0-[PLATFORM] (graalpy3.12)
     Bytecode compiled [COUNT] files in [TIME]
     ");
 }
@@ -4238,14 +4238,14 @@ fn python_install_compile_bytecode_pypy() {
         .with_python_download_cache();
 
     // Should work for pypy
-    uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("pypy-3.11"), @"
+    uv_snapshot!(context.filters(), context.python_install().arg("--compile-bytecode").arg("pypy-3.11"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Installed Python 3.11.13 in [TIME]
-     + pypy-3.11.13-[PLATFORM] (python3.11)
+     + pypy-3.11.13-[PLATFORM] (pypy3.11)
     Bytecode compiled [COUNT] files in [TIME]
     ");
 }


### PR DESCRIPTION
Copy of https://github.com/astral-sh/uv/pull/14201 for https://github.com/astral-sh/uv/pull/17661