### PR TITLE
Install Pyodide executables as `pyodide` instead of `python`

### DIFF
--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -49,10 +49,19 @@ impl ImplementationName {
         }
     }
 
+    /// The executable name used in distributions of this implementation.
     pub fn executable_name(self) -> &'static str {
         match self {
             Self::CPython | Self::Pyodide => "python",
             Self::PyPy | Self::GraalPy => self.into(),
+        }
+    }
+
+    /// The name used when installing this implementation as an executable into the bin directory.
+    pub fn executable_install_name(self) -> &'static str {
+        match self {
+            Self::Pyodide => "pyodide",
+            _ => self.executable_name(),
         }
     }
 
@@ -77,6 +86,13 @@ impl LenientImplementationName {
     pub fn executable_name(&self) -> &str {
         match self {
             Self::Known(implementation) => implementation.executable_name(),
+            Self::Unknown(name) => name,
+        }
+    }
+
+    pub fn executable_install_name(&self) -> &str {
+        match self {
+            Self::Known(implementation) => implementation.executable_install_name(),
             Self::Unknown(name) => name,
         }
     }

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -586,7 +586,7 @@ impl PythonInstallationKey {
     pub fn executable_name_minor(&self) -> String {
         format!(
             "{name}{maj}.{min}{var}{exe}",
-            name = self.implementation.executable_name(),
+            name = self.implementation().executable_install_name(),
             maj = self.major,
             min = self.minor,
             var = self.variant.executable_suffix(),
@@ -598,7 +598,7 @@ impl PythonInstallationKey {
     pub fn executable_name_major(&self) -> String {
         format!(
             "{name}{maj}{var}{exe}",
-            name = self.implementation.executable_name(),
+            name = self.implementation().executable_install_name(),
             maj = self.major,
             var = self.variant.executable_suffix(),
             exe = std::env::consts::EXE_SUFFIX
@@ -609,7 +609,7 @@ impl PythonInstallationKey {
     pub fn executable_name(&self) -> String {
         format!(
             "{name}{var}{exe}",
-            name = self.implementation.executable_name(),
+            name = self.implementation().executable_install_name(),
             var = self.variant.executable_suffix(),
             exe = std::env::consts::EXE_SUFFIX
         )

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -3486,12 +3486,12 @@ fn python_install_pyodide() {
 
     ----- stderr -----
     Installed Python 3.13.2 in [TIME]
-     + pyodide-3.13.2-emscripten-wasm32-musl (python3.13)
+     + pyodide-3.13.2-emscripten-wasm32-musl (pyodide3.13)
     ");
 
     let bin_python = context
         .bin_dir
-        .child(format!("python3.13{}", std::env::consts::EXE_SUFFIX));
+        .child(format!("pyodide3.13{}", std::env::consts::EXE_SUFFIX));
 
     // The executable should be installed in the bin directory
     bin_python.assert(predicate::path::exists());
@@ -3562,7 +3562,7 @@ fn python_install_pyodide() {
 
     ----- stderr -----
     Installed Python 3.13.2 in [TIME]
-     + pyodide-3.13.2-emscripten-wasm32-musl (python3.13)
+     + pyodide-3.13.2-emscripten-wasm32-musl (pyodide3.13)
     ");
 
     context.python_uninstall().arg("--all").assert().success();
@@ -3575,7 +3575,7 @@ fn python_install_pyodide() {
 
     ----- stderr -----
     Installed Python 3.13.2 in [TIME]
-     + pyodide-3.13.2-emscripten-wasm32-musl (python3.13)
+     + pyodide-3.13.2-emscripten-wasm32-musl (pyodide3.13)
     ");
 
     // Find via `pyodide``
@@ -4254,7 +4254,7 @@ fn python_install_compile_bytecode_pyodide() {
 
     ----- stderr -----
     Installed Python 3.13.2 in [TIME]
-     + pyodide-3.13.2-emscripten-wasm32-musl (python3.13)
+     + pyodide-3.13.2-emscripten-wasm32-musl (pyodide3.13)
     No compatible versions to bytecode compile (skipped 1)
     ");
 


### PR DESCRIPTION
Same as #17756 for pyodide