### PR TITLE
Remove test from `generate_json_schema` module

### DIFF
--- a/crates/uv-dev/src/generate_json_schema.rs
+++ b/crates/uv-dev/src/generate_json_schema.rs
@@ -134,31 +134,3 @@ fn generate() -> Result<String> {
 
     Ok(output)
 }
-
-#[cfg(test)]
-mod tests {
-    use std::env;
-
-    use anyhow::Result;
-
-    use uv_static::EnvVars;
-
-    use crate::generate_all::Mode;
-
-    use super::{Args, main};
-
-    #[test]
-    fn test_generate_json_schema() -> Result<()> {
-        // Skip this test in CI to avoid redundancy with the dedicated CI job
-        if env::var_os(EnvVars::CI).is_some() {
-            return Ok(());
-        }
-
-        let mode = if env::var(EnvVars::UV_UPDATE_SCHEMA).as_deref() == Ok("1") {
-            Mode::Write
-        } else {
-            Mode::Check
-        };
-        main(&Args { mode })
-    }
-}


### PR DESCRIPTION
This is a local-only test and we don't expect the JSON schema to be up-to-date at all times now