### PR TITLE
Set the `GH_REPO` environment variable in session startup

### DIFF
--- a/.claude/hooks/session-start-web.sh
+++ b/.claude/hooks/session-start-web.sh
@@ -9,3 +9,8 @@ fi
 
 # Install clippy and rustfmt for the active toolchain.
 rustup component add clippy rustfmt
+
+# Set GH_REPO so `gh` works even when the git remote points to a local proxy
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo 'export GH_REPO=astral-sh/uv' >> "$CLAUDE_ENV_FILE"
+fi


### PR DESCRIPTION
Otherwise, `gh` fails because it cannot determine what the target repository is.