### PR TITLE
Show errors in `uv publish` with `-q` and require `-qq` to suppress them

### DIFF
--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -237,7 +237,7 @@ pub(crate) async fn publish(
                             let err: anyhow::Error = err.into();
                             write_error_chain(
                                 err.as_ref(),
-                                printer.stderr(),
+                                printer.stderr_important(),
                                 "error",
                                 AnsiColors::Red,
                             )?;
@@ -281,7 +281,7 @@ pub(crate) async fn publish(
                         if dry_run {
                             write_error_chain(
                                 err.as_ref(),
-                                printer.stderr(),
+                                printer.stderr_important(),
                                 "error",
                                 AnsiColors::Red,
                             )?;
@@ -323,7 +323,7 @@ pub(crate) async fn publish(
                             let err: anyhow::Error = err.into();
                             write_error_chain(
                                 err.as_ref(),
-                                printer.stderr(),
+                                printer.stderr_important(),
                                 "error",
                                 AnsiColors::Red,
                             )?;
@@ -390,7 +390,7 @@ pub(crate) async fn publish(
                             let err: anyhow::Error = err.into();
                             write_error_chain(
                                 err.as_ref(),
-                                printer.stderr(),
+                                printer.stderr_important(),
                                 "error",
                                 AnsiColors::Red,
                             )?;
@@ -427,7 +427,10 @@ pub(crate) async fn publish(
     let error_count = error_count.load(Ordering::Relaxed);
     if error_count > 0 {
         let failed = if error_count == 1 { "file" } else { "files" };
-        writeln!(printer.stderr(), "Found issues with {error_count} {failed}")?;
+        writeln!(
+            printer.stderr_important(),
+            "Found issues with {error_count} {failed}"
+        )?;
         return Ok(ExitStatus::Failure);
     }
 
@@ -565,7 +568,7 @@ async fn gather_credentials(
             // * The user forgot to forward the secrets as env vars (or used the wrong ones).
             // * The trusted publishing configuration is wrong.
             writeln!(
-                printer.stderr(),
+                printer.stderr_important(),
                 "Note: Neither credentials nor keyring are configured, and there was an error \
                 fetching the trusted publishing token. If you don't want to use trusted \
                 publishing, you can ignore this error, but you need to provide credentials."
@@ -576,7 +579,7 @@ async fn gather_credentials(
                 anyhow::Error::from(err)
                     .context("Trusted publishing failed")
                     .as_ref(),
-                printer.stderr(),
+                printer.stderr_important(),
                 "error",
                 AnsiColors::Red,
             )?;

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -52,6 +52,17 @@ impl Printer {
         }
     }
 
+    /// Return the [`Stderr`] for this printer, including in quiet mode.
+    pub(crate) fn stderr_important(self) -> Stderr {
+        match self {
+            Self::Silent => Stderr::Disabled,
+            Self::Quiet => Stderr::Enabled,
+            Self::Default => Stderr::Enabled,
+            Self::Verbose => Stderr::Enabled,
+            Self::NoProgress => Stderr::Enabled,
+        }
+    }
+
     /// Return the [`Stderr`] for this printer.
     pub(crate) fn stderr(self) -> Stderr {
         match self {


### PR DESCRIPTION
This allows users to use `-q` to suppress messages like "Checking ..." while still showing errors, which I needed for `--dry-run` following #17789 and https://github.com/astral-sh/uv/pull/17785