### PR TITLE
docs: remove misleading FLASH_ATTENTION_SKIP_CUDA_BUILD recommendation

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -276,7 +276,10 @@ This will ensure that `deepspeed` is built with the same version of `torch` that
 project environment.
 
 Similarly, to build `flash-attn` with `torch` as an additional build dependency, include the
-following in your `pyproject.toml`:
+following in your `pyproject.toml`.
+
+We strongly recommend **explicitly pinning** both `torch` and `flash-attn` to known compatible
+versions. This ensures that `uv` selects a combination for which a pre-built wheel exists.
 
 ```toml title="pyproject.toml"
 [project]
@@ -285,22 +288,25 @@ version = "0.1.0"
 description = "..."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["flash-attn", "torch"]
+dependencies = [
+    "flash-attn==2.8.3",
+    "torch==2.9.0"
+]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]
 
-[tool.uv.extra-build-variables]
-flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
 ```
 
-!!! note
+!!! warning
 
-    The `FLASH_ATTENTION_SKIP_CUDA_BUILD` environment variable ensures that `flash-attn` is installed
-    from a compatible, pre-built wheel, rather than attempting to build it from source, which requires
-    access to the CUDA development toolkit. If the CUDA toolkit is not available, the environment variable
-    can be omitted, and `flash-attn` will be installed from a pre-built wheel if one is available for the
-    current platform, Python version, and PyTorch version.
+    `flash-attn` will automatically attempt to download a pre-built wheel if one matches the installed
+    PyTorch version.
+
+    Do **not** set the `FLASH_ATTENTION_SKIP_CUDA_BUILD` environment variable unless absolutely
+    necessary. While it disables local compilation, it can lead to a **silent failure** if a matching
+    wheel is not found: `setup.py` will skip the CUDA extension compilation and install a non-functional
+    (hollow) Python package.
 
 Similarly, [`deep_gemm`](https://github.com/deepseek-ai/DeepGEMM) follows the same pattern:
 


### PR DESCRIPTION
## Summary

**Description:**

This PR updates the `flash-attn` installation guide to prevent users from accidentally creating broken environments.

**The Problem:**
The documentation previously recommended setting `FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE"` to "ensure" a wheel installation. However, based on an analysis of `flash-attn`'s `setup.py`:
1.  **It is redundant:** The setup script (`CachedWheelsCommand`) automatically prefers downloading wheels before attempting any compilation, even without this variable.
2.  **It is dangerous:** If `uv` resolves to a version combination (e.g., latest Torch) for which no official wheel exists, setting this variable causes `setup.py` to **silently skip CUDA compilation** and successfully install a "hollow" package containing only Python files. This leads to confusing `ImportError: No module named 'flash_attn_2_cuda'` errors at runtime.

**Changes:**
- Removed `[tool.uv.extra-build-variables]` from the example `pyproject.toml`.
- Replaced the note with a warning about the risks of silent failures.
- Emphasized explicit version pinning as the correct way to ensure wheel compatibility.

**Related Issue:**
Fixes #17794

