### PR TITLE
docs: Add MLflow integration guide

### DIFF
--- a/docs/guides/integration/index.md
+++ b/docs/guides/integration/index.md
@@ -10,6 +10,7 @@ Learn how to integrate uv with other software:
 - [Using in GitLab CI/CD](./gitlab.md)
 - [Using with alternative package indexes](./alternative-indexes.md)
 - [Installing PyTorch](./pytorch.md)
+- [Using with MLflow](./mlflow.md)
 - [Building a FastAPI application](./fastapi.md)
 - [Using with AWS Lambda](./aws-lambda.md)
 - [Using with Coiled](./coiled.md)

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -80,8 +80,8 @@ These map directly to uv's `--group`, `--only-group`, and `--extra` flags. Param
 
 ## Environment restoration
 
-When loading a logged model, MLflow automatically detects the uv lock file artifact and restores
-the environment using `uv sync --frozen --no-dev`. This happens transparently when you call
+When loading a logged model, MLflow automatically detects the uv lock file artifact and restores the
+environment using `uv sync --frozen --no-dev`. This happens transparently when you call
 `mlflow.pyfunc.load_model()` -- no manual intervention is needed.
 
 If uv is not available at load time, MLflow falls back to `pip install -r requirements.txt`.

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -125,9 +125,19 @@ mlflow.pyfunc.log_model(
 )
 ```
 
+## Disabling uv integration
+
+If you need to fall back to MLflow's default import-based dependency inference, disable uv
+auto-detection entirely:
+
+```bash
+export MLFLOW_UV_AUTO_DETECT=false
+```
+
 ## Disabling uv file logging
 
-For large projects where logging uv files as artifacts is not desired, disable it with:
+For large projects where logging uv files as artifacts is not desired (but you still want uv-based
+dependency inference), disable file logging:
 
 ```bash
 export MLFLOW_LOG_UV_FILES=false

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -29,7 +29,7 @@ import mlflow
 # MLflow automatically detects uv.lock + pyproject.toml
 # and captures dependencies via `uv export`
 mlflow.pyfunc.log_model(
-    artifact_path="model",
+    name="model",
     python_model=my_model,
 )
 ```
@@ -42,41 +42,11 @@ pinned `requirements.txt` that exactly matches your lock file.
 In addition to exporting dependencies, MLflow logs your uv project files as artifacts for full
 reproducibility:
 
-- `uv.lock` — The complete lock file with all resolved dependencies
-- `pyproject.toml` — Your project configuration
-- `.python-version` — The Python version specification (if present)
+- `uv.lock` -- The complete lock file with all resolved dependencies
+- `pyproject.toml` -- Your project configuration
+- `.python-version` -- The Python version specification (if present)
 
 These artifacts enable anyone to recreate your exact environment using `uv sync --frozen`.
-
-## Configuring dependency groups
-
-MLflow supports uv's dependency groups and extras. You can pass them directly as parameters to
-`log_model` or `save_model`:
-
-```python
-mlflow.pyfunc.log_model(
-    artifact_path="model",
-    python_model=my_model,
-    uv_groups=["serving"],          # maps to uv's --group flag
-    uv_extras=["cuda", "optimization"],  # maps to uv's --extra flag
-)
-```
-
-Alternatively, you can set them via environment variables:
-
-```bash
-# Include specific dependency groups
-export MLFLOW_UV_GROUPS="dev,test"
-
-# Include only specific groups (exclude default dependencies)
-export MLFLOW_UV_ONLY_GROUPS="ml"
-
-# Include optional extras
-export MLFLOW_UV_EXTRAS="cuda,optimization"
-```
-
-These map directly to uv's `--group`, `--only-group`, and `--extra` flags. Parameters passed to
-`log_model`/`save_model` take precedence over environment variables.
 
 ## Environment restoration
 
@@ -131,7 +101,7 @@ parameter to point to the directory containing your `uv.lock` and `pyproject.tom
 
 ```python
 mlflow.pyfunc.log_model(
-    artifact_path="model",
+    name="model",
     python_model=my_model,
     uv_project_path="../my-subproject",  # Directory containing uv.lock + pyproject.toml
 )
@@ -196,8 +166,8 @@ train = [
 ]
 ```
 
-By default, MLflow only exports the core project dependencies from `[project].dependencies`. Custom
-groups like `train` are not included unless you explicitly set `MLFLOW_UV_GROUPS="train"`.
+By default, MLflow exports the core project dependencies from `[project].dependencies` and does not
+include dev or custom dependency groups.
 
 ## Troubleshooting
 
@@ -221,6 +191,6 @@ This shows exactly what MLflow will capture.
 Environment variables must be set before running your script:
 
 ```bash
-export MLFLOW_UV_GROUPS="serving"
+export MLFLOW_UV_AUTO_DETECT=false
 python train.py
 ```

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -113,14 +113,27 @@ jobs:
 
 The `--frozen` flag ensures CI uses exactly the same dependencies as your local environment.
 
-## Disabling uv integration
+## Monorepo support
 
-If you need to fall back to MLflow's default import-based dependency inference, you can disable uv
-detection:
+For monorepos where `uv.lock` is not in the current working directory, use the `uv_lock` parameter:
+
+```python
+mlflow.pyfunc.log_model(
+    artifact_path="model",
+    python_model=my_model,
+    uv_lock="../uv.lock",  # Path to lock file
+)
+```
+
+## Disabling uv file logging
+
+For large projects where logging uv files as artifacts is not desired, disable it with:
 
 ```bash
-export MLFLOW_UV_AUTO_DETECT=false
+export MLFLOW_LOG_UV_FILES=false
 ```
+
+MLflow will still use uv for dependency inference but won't copy the lock files as artifacts.
 
 ## Best practices
 
@@ -161,12 +174,8 @@ train = [
 ]
 ```
 
-Then log models without the training group:
-
-```bash
-export MLFLOW_UV_ONLY_GROUPS=""  # Exclude all groups, use only core dependencies
-uv run python log_model.py
-```
+By default, MLflow only exports the core project dependencies from `[project].dependencies`. Custom
+groups like `train` are not included unless you explicitly set `MLFLOW_UV_GROUPS="train"`.
 
 ## Troubleshooting
 
@@ -187,9 +196,9 @@ This shows exactly what MLflow will capture.
 
 ### Environment variable not taking effect
 
-Environment variables must be set before importing MLflow:
+Environment variables must be set before running your script:
 
 ```bash
-export MLFLOW_UV_GROUPS="dev"
-python -c "import mlflow; mlflow.pyfunc.log_model(...)"
+export MLFLOW_UV_GROUPS="serving"
+python train.py
 ```

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -1,0 +1,195 @@
+---
+title: Using uv with MLflow
+description:
+  A guide to using uv with MLflow for ML experiment tracking and model management, including
+  automatic dependency inference, reproducible environments, and CI/CD integration.
+---
+
+# Using uv with MLflow
+
+[MLflow](https://mlflow.org/) is a popular open-source platform for managing the end-to-end machine
+learning lifecycle, including experiment tracking, model versioning, and deployment. uv integrates
+seamlessly with MLflow to provide fast, reproducible dependency management for ML projects.
+
+!!! note
+
+    MLflow's uv integration requires MLflow version 2.20 or later.
+
+## Automatic dependency inference
+
+When you log a model with MLflow, it automatically captures your project's dependencies to ensure
+reproducibility. If MLflow detects a uv project (indicated by the presence of both `uv.lock` and
+`pyproject.toml`), it will use uv to infer dependencies instead of analyzing Python imports.
+
+This means you can log models without manually specifying dependencies:
+
+```python
+import mlflow
+
+# MLflow automatically detects uv.lock + pyproject.toml
+# and captures dependencies via `uv export`
+mlflow.pyfunc.log_model(
+    artifact_path="model",
+    python_model=my_model,
+)
+```
+
+MLflow runs `uv export --frozen --no-dev --no-hashes` to generate a pinned `requirements.txt` that
+exactly matches your lock file.
+
+## Reproducibility artifacts
+
+In addition to exporting dependencies, MLflow logs your uv project files as artifacts for full
+reproducibility:
+
+- `uv.lock` — The complete lock file with all resolved dependencies
+- `pyproject.toml` — Your project configuration
+- `.python-version` — The Python version specification (if present)
+
+These artifacts enable anyone to recreate your exact environment using `uv sync --frozen`.
+
+## Configuring dependency groups
+
+MLflow supports uv's dependency groups and extras. You can control which groups are included when
+logging models via environment variables:
+
+```bash
+# Include specific dependency groups
+export MLFLOW_UV_GROUPS="dev,test"
+
+# Include only specific groups (exclude default dependencies)
+export MLFLOW_UV_ONLY_GROUPS="ml"
+
+# Include optional extras
+export MLFLOW_UV_EXTRAS="cuda,optimization"
+```
+
+These map directly to uv's `--group`, `--only-group`, and `--extra` flags.
+
+## Environment restoration
+
+When loading a logged model, MLflow can restore the environment using uv for faster installation:
+
+```bash
+# Restore environment from logged artifacts
+uv sync --frozen
+```
+
+This is significantly faster than `pip install -r requirements.txt` because uv:
+
+- Uses parallel downloads
+- Leverages its global cache
+- Performs optimized dependency resolution
+
+## CI/CD integration
+
+For reproducible model training in CI/CD pipelines, combine uv with MLflow:
+
+```yaml
+# .github/workflows/train.yml
+name: Train Model
+
+on: [push]
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Train and log model
+        run: uv run python train.py
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+```
+
+The `--frozen` flag ensures CI uses exactly the same dependencies as your local environment.
+
+## Disabling uv integration
+
+If you need to fall back to MLflow's default import-based dependency inference, you can disable uv
+detection:
+
+```bash
+export MLFLOW_UV_AUTO_DETECT=false
+```
+
+## Best practices
+
+### Lock your dependencies before logging
+
+Always ensure your `uv.lock` is up to date before logging models:
+
+```bash
+uv lock
+uv run python train.py  # Train and log model
+```
+
+### Use frozen installs in production
+
+When deploying models, use `--frozen` to ensure exact reproducibility:
+
+```bash
+uv sync --frozen
+```
+
+### Separate training and inference dependencies
+
+Use dependency groups to keep training-only packages out of your inference environment:
+
+```toml
+# pyproject.toml
+[project]
+dependencies = [
+    "mlflow>=2.20",
+    "scikit-learn>=1.0",
+]
+
+[dependency-groups]
+train = [
+    "jupyter",
+    "matplotlib",
+    "optuna",
+]
+```
+
+Then log models without the training group:
+
+```bash
+export MLFLOW_UV_ONLY_GROUPS=""  # Exclude all groups, use only core dependencies
+uv run python log_model.py
+```
+
+## Troubleshooting
+
+### MLflow not detecting uv project
+
+Ensure both `uv.lock` and `pyproject.toml` exist in your project root. MLflow checks for both files
+to confirm it's a uv project.
+
+### Dependencies not matching expected versions
+
+Run `uv lock` to update your lock file, then verify with:
+
+```bash
+uv export --frozen --no-dev --no-hashes
+```
+
+This shows exactly what MLflow will capture.
+
+### Environment variable not taking effect
+
+Environment variables must be set before importing MLflow:
+
+```bash
+export MLFLOW_UV_GROUPS="dev"
+python -c "import mlflow; mlflow.pyfunc.log_model(...)"
+```

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -13,7 +13,7 @@ seamlessly with MLflow to provide fast, reproducible dependency management for M
 
 !!! note
 
-    MLflow's uv integration requires MLflow version 2.20 or later.
+    MLflow's uv integration requires MLflow version 3.10 or later.
 
 ## Automatic dependency inference
 
@@ -149,7 +149,7 @@ Use dependency groups to keep training-only packages out of your inference envir
 # pyproject.toml
 [project]
 dependencies = [
-    "mlflow>=2.20",
+    "mlflow>=3.10",
     "scikit-learn>=1.0",
 ]
 

--- a/docs/guides/integration/mlflow.md
+++ b/docs/guides/integration/mlflow.md
@@ -34,17 +34,17 @@ mlflow.pyfunc.log_model(
 )
 ```
 
-MLflow runs `uv export --frozen --no-dev --no-hashes --no-header --no-emit-project` to generate a
-pinned `requirements.txt` that exactly matches your lock file.
+MLflow runs `uv export --frozen --no-dev --no-hashes --no-header --no-emit-project --no-annotate` to
+generate a pinned `requirements.txt` that exactly matches your lock file.
 
 ## Reproducibility artifacts
 
 In addition to exporting dependencies, MLflow logs your uv project files as artifacts for full
 reproducibility:
 
-- `uv.lock` -- The complete lock file with all resolved dependencies
-- `pyproject.toml` -- Your project configuration
-- `.python-version` -- The Python version specification (if present)
+- `uv.lock`: the complete lock file with all resolved dependencies
+- `pyproject.toml`: your project configuration
+- `.python-version`: the Python version specification (if present)
 
 These artifacts enable anyone to recreate your exact environment using `uv sync --frozen`.
 
@@ -52,7 +52,7 @@ These artifacts enable anyone to recreate your exact environment using `uv sync 
 
 When loading a logged model, MLflow automatically detects the uv lock file artifact and restores the
 environment using `uv sync --frozen --no-dev`. This happens transparently when you call
-`mlflow.pyfunc.load_model()` -- no manual intervention is needed.
+`mlflow.pyfunc.load_model()`, no manual intervention is needed.
 
 If uv is not available at load time, MLflow falls back to `pip install -r requirements.txt`.
 
@@ -146,29 +146,6 @@ When deploying models, use `--frozen` to ensure exact reproducibility:
 uv sync --frozen
 ```
 
-### Separate training and inference dependencies
-
-Use dependency groups to keep training-only packages out of your inference environment:
-
-```toml
-# pyproject.toml
-[project]
-dependencies = [
-    "mlflow>=3.10",
-    "scikit-learn>=1.0",
-]
-
-[dependency-groups]
-train = [
-    "jupyter",
-    "matplotlib",
-    "optuna",
-]
-```
-
-By default, MLflow exports the core project dependencies from `[project].dependencies` and does not
-include dev or custom dependency groups.
-
 ## Troubleshooting
 
 ### MLflow not detecting uv project
@@ -181,7 +158,7 @@ to confirm it's a uv project.
 Run `uv lock` to update your lock file, then verify with:
 
 ```bash
-uv export --frozen --no-dev --no-hashes --no-header --no-emit-project
+uv export --frozen --no-dev --no-hashes --no-header --no-emit-project --no-annotate
 ```
 
 This shows exactly what MLflow will capture.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ plugins:
           - guides/integration/gitlab.md
           - guides/integration/pre-commit.md
           - guides/integration/pytorch.md
+          - guides/integration/mlflow.md
           - guides/integration/fastapi.md
           - guides/integration/alternative-indexes.md
           - guides/integration/dependency-bots.md
@@ -196,6 +197,7 @@ nav:
           - GitLab CI/CD: guides/integration/gitlab.md
           - Pre-commit: guides/integration/pre-commit.md
           - PyTorch: guides/integration/pytorch.md
+          - MLflow: guides/integration/mlflow.md
           - FastAPI: guides/integration/fastapi.md
           - Alternative indexes: guides/integration/alternative-indexes.md
           - Dependency bots: guides/integration/dependency-bots.md


### PR DESCRIPTION
## Summary

Add documentation for using uv with MLflow, the popular open-source ML lifecycle platform (18M+ monthly PyPI downloads).

Closes #17702

## Changes

- Add `docs/guides/integration/mlflow.md` with comprehensive guide covering:
  - Automatic dependency inference from `uv.lock`
  - Reproducibility artifacts logging (`uv.lock`, `pyproject.toml`, `.python-version`)
  - Dependency groups configuration via environment variables
  - Environment restoration with `uv sync --frozen`
  - CI/CD integration patterns (GitHub Actions example)
  - Best practices for ML model logging
  - Troubleshooting section

- Update `docs/guides/integration/index.md` to include MLflow link
- Update `mkdocs.yml` navigation to include MLflow guide

## Context

MLflow recently added native uv support ([mlflow/mlflow#20344](https://github.com/mlflow/mlflow/pull/20344)), enabling automatic dependency inference from uv projects. This guide helps uv users in the ML community discover that MLflow now "just works" with their uv projects.

## Testing

- Verified markdown renders correctly
- Verified all internal links are valid
- Content follows existing integration guide patterns (similar structure to PyTorch, Jupyter guides)