### PR TITLE
Fix wheel rejections on freethreading+debug builds

### DIFF
--- a/crates/uv-distribution-filename/src/wheel.rs
+++ b/crates/uv-distribution-filename/src/wheel.rs
@@ -470,4 +470,13 @@ mod tests {
         ).unwrap();
         insta::assert_snapshot!(filename.cache_key(), @"1.2.3.4.5.6.7.8.9.0.1.2.3.4.5.6.7.8.9.0.1.2.1.2-80bf8598e9647cf7");
     }
+
+    /// Don't drop the freethreading tag when there is a debug tag.
+    #[test]
+    fn freethreading_debug() {
+        let filename = "correctionlib-2.8.0-cp314-cp314td-macosx_26_0_arm64.whl";
+        let parsed = WheelFilename::from_str(filename).unwrap();
+        // TODO(konsti): We should preserve the debug tag too, but that requires cache changes.
+        insta::assert_snapshot!(parsed.to_string(), @"correctionlib-2.8.0-cp314-cp314t-macosx_26_0_arm64.whl");
+    }
 }

--- a/crates/uv-platform-tags/src/abi_tag.rs
+++ b/crates/uv-platform-tags/src/abi_tag.rs
@@ -208,8 +208,10 @@ impl FromStr for AbiTag {
             // Ex) `cp39m`, `cp310t`
             let version_end = cp.find(|c: char| !c.is_ascii_digit()).unwrap_or(cp.len());
             let version_str = &cp[..version_end];
+            let abi_suffixes = &cp[version_end..];
             let (major, minor) = parse_python_version(version_str, "CPython", s)?;
-            let gil_disabled = cp.ends_with('t');
+            // TODO(konsti): Handle all ABI tags
+            let gil_disabled = abi_suffixes.contains('t');
             Ok(Self::CPython {
                 gil_disabled,
                 python_version: (major, minor),


### PR DESCRIPTION
This is the minimal fix for https://github.com/astral-sh/uv/issues/17635. We still display the wheel without debug, but it unbreaks freethreading+debug in general.