### PR TITLE
feat: add properties to synthentic & project root

### DIFF
--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "git")]
 use crate::common::{READ_ONLY_GITHUB_SSH_DEPLOY_KEY, READ_ONLY_GITHUB_TOKEN, decode_token};
-use crate::common::{TestContext, apply_filters, uv_snapshot};
+use crate::common::{TestContext, apply_filters, copy_dir_ignore, uv_snapshot};
 use anyhow::{Ok, Result};
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
@@ -4918,7 +4918,13 @@ fn cyclonedx_export_basic() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -4994,7 +5000,13 @@ fn cyclonedx_export_direct_url() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5071,7 +5083,13 @@ fn cyclonedx_export_git_dependency() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5147,7 +5165,13 @@ fn cyclonedx_export_no_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "standalone-project-1@1.0.0",
           "name": "standalone-project",
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [],
@@ -5214,7 +5238,13 @@ fn cyclonedx_export_mixed_source_types() -> Result<()> {
           "type": "library",
           "bom-ref": "mixed-project-1@0.1.0",
           "name": "mixed-project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5318,7 +5348,13 @@ fn cyclonedx_export_project_extra() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5398,7 +5434,13 @@ fn cyclonedx_export_project_extra_with_optional_flag() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5535,7 +5577,13 @@ fn cyclonedx_export_with_workspace_member() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5679,7 +5727,13 @@ fn cyclonedx_export_workspace_non_root() -> Result<()> {
           "type": "library",
           "bom-ref": "child-1@0.1.0",
           "name": "child",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5780,7 +5834,13 @@ fn cyclonedx_export_workspace_with_extras() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -5850,7 +5910,13 @@ fn cyclonedx_export_workspace_with_extras() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6002,7 +6068,13 @@ fn cyclonedx_export_workspace_frozen() -> Result<()> {
         "component": {
           "type": "library",
           "bom-ref": "project-5",
-          "name": "project"
+          "name": "project",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6036,7 +6108,13 @@ fn cyclonedx_export_workspace_frozen() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       ],
       "dependencies": [
@@ -6152,7 +6230,13 @@ fn cyclonedx_export_workspace_all_packages() -> Result<()> {
         "component": {
           "type": "library",
           "bom-ref": "project-7",
-          "name": "project"
+          "name": "project",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6205,7 +6289,13 @@ fn cyclonedx_export_workspace_all_packages() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       ],
       "dependencies": [
@@ -6299,7 +6389,13 @@ fn cyclonedx_export_all_packages_non_workspace_root_dependency() -> Result<()> {
         "component": {
           "type": "library",
           "bom-ref": "my-project-3",
-          "name": "my-project"
+          "name": "my-project",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6314,7 +6410,13 @@ fn cyclonedx_export_all_packages_non_workspace_root_dependency() -> Result<()> {
           "type": "library",
           "bom-ref": "my-project-1@0.1.0",
           "name": "my-project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       ],
       "dependencies": [
@@ -6427,7 +6529,13 @@ fn cyclonedx_export_workspace_mixed_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6566,7 +6674,13 @@ fn cyclonedx_export_dependency_marker() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6663,7 +6777,13 @@ fn cyclonedx_export_multiple_dependency_markers() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6783,7 +6903,13 @@ fn cyclonedx_export_dependency_extra() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -6914,7 +7040,13 @@ fn cyclonedx_export_prune() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7093,7 +7225,13 @@ fn cyclonedx_export_group() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7158,7 +7296,13 @@ fn cyclonedx_export_group() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7205,7 +7349,13 @@ fn cyclonedx_export_group() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7303,10 +7453,26 @@ fn cyclonedx_export_non_project() -> Result<()> {
             "name": "uv",
             "version": "[VERSION]"
           }
-        ]
+        ],
+        "component": {
+          "type": "library",
+          "bom-ref": "uv-workspace-1",
+          "name": "uv-workspace",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
+        }
       },
       "components": [],
-      "dependencies": []
+      "dependencies": [
+        {
+          "ref": "uv-workspace-1",
+          "dependsOn": []
+        }
+      ]
     }
     ----- stderr -----
     warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
@@ -7332,7 +7498,18 @@ fn cyclonedx_export_non_project() -> Result<()> {
             "name": "uv",
             "version": "[VERSION]"
           }
-        ]
+        ],
+        "component": {
+          "type": "library",
+          "bom-ref": "uv-workspace-2",
+          "name": "uv-workspace",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
+        }
       },
       "components": [
         {
@@ -7346,6 +7523,10 @@ fn cyclonedx_export_non_project() -> Result<()> {
       "dependencies": [
         {
           "ref": "urllib3-1@2.2.1",
+          "dependsOn": []
+        },
+        {
+          "ref": "uv-workspace-2",
           "dependsOn": []
         }
       ]
@@ -7424,7 +7605,13 @@ fn cyclonedx_export_no_emit() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7495,7 +7682,13 @@ fn cyclonedx_export_no_emit() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7612,7 +7805,13 @@ fn cyclonedx_export_relative_path() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7700,7 +7899,13 @@ fn cyclonedx_export_cyclic_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7898,7 +8103,13 @@ fn cyclonedx_export_dev_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -7964,7 +8175,13 @@ fn cyclonedx_export_dev_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -8018,7 +8235,13 @@ fn cyclonedx_export_dev_dependencies() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -8115,7 +8338,13 @@ fn cyclonedx_export_all_packages_conflicting_workspace_members() -> Result<()> {
         "component": {
           "type": "library",
           "bom-ref": "project-3",
-          "name": "project"
+          "name": "project",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -8135,7 +8364,13 @@ fn cyclonedx_export_all_packages_conflicting_workspace_members() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       ],
       "dependencies": [
@@ -8237,7 +8472,13 @@ fn cyclonedx_export_alternative_registry() -> Result<()> {
           "type": "library",
           "bom-ref": "project-1@0.1.0",
           "name": "project",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:package:is_project_root",
+              "value": "true"
+            }
+          ]
         }
       },
       "components": [
@@ -8407,6 +8648,178 @@ fn cyclonedx_export_alternative_registry() -> Result<()> {
     }
     ----- stderr -----
     Resolved 12 packages in [TIME]
+    warning: `uv export --format=cyclonedx1.5` is experimental and may change without warning. Pass `--preview-features sbom-export` to disable this warning.
+    "#);
+
+    Ok(())
+}
+
+#[test]
+fn cyclonedx_export_virtual_workspace_fixture() -> Result<()> {
+    let context = TestContext::new("3.12").with_cyclonedx_filters();
+
+    let workspace = context.temp_dir.child("workspace");
+    copy_dir_ignore(
+        context
+            .workspace_root
+            .join("test/workspaces/albatross-virtual-workspace"),
+        &workspace,
+    )?;
+
+    // Lock from the workspace root
+    context.lock().current_dir(&workspace).assert().success();
+
+    // Export from the virtual workspace root (no [project] section) without --all-packages
+    // This should create a synthetic root in metadata.component
+    uv_snapshot!(context.filters(), context.export().arg("--format").arg("cyclonedx1.5").current_dir(&workspace), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "bomFormat": "CycloneDX",
+      "specVersion": "1.5",
+      "version": 1,
+      "serialNumber": "[SERIAL_NUMBER]",
+      "metadata": {
+        "timestamp": "[TIMESTAMP]",
+        "tools": [
+          {
+            "vendor": "Astral Software Inc.",
+            "name": "uv",
+            "version": "[VERSION]"
+          }
+        ],
+        "component": {
+          "type": "library",
+          "bom-ref": "uv-workspace-8",
+          "name": "uv-workspace",
+          "properties": [
+            {
+              "name": "uv:package:is_synthetic_root",
+              "value": "true"
+            }
+          ]
+        }
+      },
+      "components": [
+        {
+          "type": "library",
+          "bom-ref": "albatross-1@0.1.0",
+          "name": "albatross",
+          "version": "0.1.0",
+          "properties": [
+            {
+              "name": "uv:workspace:path",
+              "value": "packages/albatross"
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "bom-ref": "anyio-2@4.3.0",
+          "name": "anyio",
+          "version": "4.3.0",
+          "purl": "pkg:pypi/anyio@4.3.0"
+        },
+        {
+          "type": "library",
+          "bom-ref": "bird-feeder-3@1.0.0",
+          "name": "bird-feeder",
+          "version": "1.0.0",
+          "properties": [
+            {
+              "name": "uv:workspace:path",
+              "value": "packages/bird-feeder"
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "bom-ref": "idna-4@3.6",
+          "name": "idna",
+          "version": "3.6",
+          "purl": "pkg:pypi/idna@3.6"
+        },
+        {
+          "type": "library",
+          "bom-ref": "iniconfig-5@2.0.0",
+          "name": "iniconfig",
+          "version": "2.0.0",
+          "purl": "pkg:pypi/iniconfig@2.0.0"
+        },
+        {
+          "type": "library",
+          "bom-ref": "seeds-6@1.0.0",
+          "name": "seeds",
+          "version": "1.0.0",
+          "properties": [
+            {
+              "name": "uv:workspace:path",
+              "value": "packages/seeds"
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "bom-ref": "sniffio-7@1.3.1",
+          "name": "sniffio",
+          "version": "1.3.1",
+          "purl": "pkg:pypi/sniffio@1.3.1"
+        }
+      ],
+      "dependencies": [
+        {
+          "ref": "albatross-1@0.1.0",
+          "dependsOn": [
+            "bird-feeder-3@1.0.0",
+            "iniconfig-5@2.0.0"
+          ]
+        },
+        {
+          "ref": "anyio-2@4.3.0",
+          "dependsOn": [
+            "idna-4@3.6",
+            "sniffio-7@1.3.1"
+          ]
+        },
+        {
+          "ref": "bird-feeder-3@1.0.0",
+          "dependsOn": [
+            "anyio-2@4.3.0",
+            "seeds-6@1.0.0"
+          ]
+        },
+        {
+          "ref": "idna-4@3.6",
+          "dependsOn": []
+        },
+        {
+          "ref": "iniconfig-5@2.0.0",
+          "dependsOn": []
+        },
+        {
+          "ref": "seeds-6@1.0.0",
+          "dependsOn": [
+            "idna-4@3.6"
+          ]
+        },
+        {
+          "ref": "sniffio-7@1.3.1",
+          "dependsOn": []
+        },
+        {
+          "ref": "uv-workspace-8",
+          "dependsOn": [
+            "albatross-1@0.1.0",
+            "bird-feeder-3@1.0.0",
+            "seeds-6@1.0.0"
+          ]
+        }
+      ]
+    }
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
     warning: `uv export --format=cyclonedx1.5` is experimental and may change without warning. Pass `--preview-features sbom-export` to disable this warning.
     "#);
 


### PR DESCRIPTION
## Summary

This PR improves the CycloneDX SBOM export feature by adding metadata properties to identify synthetic and project root components. It also fixes a bug where virtual workspaces without `--all-packages` were missing a root component.

- Adds `uv:package:is_synthetic_root = true` property to synthetic root components, helping consuming tools identify when a synthetic root was added to anchor the dependency graph.
- Adds `uv:package:is_project_root = true` property to project root components, allowing tools to distinguish actual project roots.
- Fixes an issue where virtual workspaces exported without `--all-packages` were missing a `metadata.component` entry, resulting in no root anchor for the dependency graph. A synthetic root is now added in this scenario.

## Test Plan

- Added new integration test against the `albatross-virtual-workspace` fixture that verifies virtual workspaces without `--all-packages` correctly generate a synthetic root.