### PR TITLE
Fix Python discovery regression in python list command

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -136,7 +136,7 @@ pub(crate) async fn list(
             PythonListKinds::Installed | PythonListKinds::Default => {
                 Some(find_python_installations(
                 request.as_ref().unwrap_or(&PythonRequest::Any),
-                EnvironmentPreference::OnlySystem,
+                EnvironmentPreference::Any,
                 python_preference,
                 cache,
                 preview,


### PR DESCRIPTION
## Summary

Fixes #16077

The `uv python list` command was using `EnvironmentPreference::OnlySystem` which caused all interpreters to be rejected with 'only system interpreters allowed' error, particularly affecting Windows users after upgrading to 0.8.0.

## Changes

Changed `EnvironmentPreference::OnlySystem` to `EnvironmentPreference::Any` in `crates/uv/src/commands/python/list.rs`.

## Rationale

A listing command should show all available Python interpreters, not just system ones. The previous behavior was too restrictive and broke expected functionality on Windows.

## Test Plan

- Verified the change compiles successfully
- Tested that `python list` now shows all available interpreters including those in virtual environments