### PR TITLE
Fix Python version resolution for exact patch version matches

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2810,9 +2810,6 @@ impl VersionRequest {
                     interpreter.python_minor(),
                     interpreter.python_patch(),
                 ) == (*major, *minor, *patch)
-                    // When a patch version is included, we treat it as a request for a stable
-                    // release
-                    && interpreter.python_version().pre().is_none()
                     && variant.matches_interpreter(interpreter)
             }
             Self::Range(specifiers, variant) => {
@@ -2937,9 +2934,6 @@ impl VersionRequest {
             }
             Self::MajorMinorPatch(self_major, self_minor, self_patch, _) => {
                 (*self_major, *self_minor, *self_patch) == (major, minor, patch)
-                    // When a patch version is included, we treat it as a request for a stable
-                    // release
-                    && prerelease.is_none()
             }
             Self::Range(specifiers, _) => specifiers.contains(
                 &Version::new([u64::from(major), u64::from(minor), u64::from(patch)])


### PR DESCRIPTION
## Summary

Fixes #16175

The prerelease filtering for `MajorMinorPatch` version requests was inconsistent with `Range` version matching behavior. When a user requested a specific version like `3.14.0`, the code would reject `3.14.0rc3` even if no stable release was available.

## Changes

Removed the strict prerelease rejection for exact patch version matches in `crates/uv-python/src/discovery.rs`.

## Rationale

This makes behavior consistent with range matching which already handles prereleases appropriately. During Python's prerelease cycles (like Python 3.14), users should be able to request specific versions and get prerelease versions if no stable release is available yet.

The previous behavior was overly strict and inconsistent with how range specifications work:
- `>=3.14` would match `3.14.0rc3` ✓
- `3.14.0` would NOT match `3.14.0rc3` ✗

After this change, both behave consistently.

## Test Plan

- Verified the change compiles successfully
- Confirmed the logic aligns with the existing range matching behavior