### PR TITLE
Package by default: Add in preview

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3391,6 +3391,8 @@ pub struct InitArgs {
     /// Disables creating extra files like `README.md`, the `src/` tree, `.python-version` files,
     /// etc.
     ///
+    /// A `[build-system]` table is only created with `--package` or `--build-backend`.
+    ///
     /// When combined with `--script`, the script will only contain the inline metadata header.
     #[arg(long)]
     pub bare: bool,
@@ -3405,7 +3407,7 @@ pub struct InitArgs {
     ///
     /// Defines a `[build-system]` for the project.
     ///
-    /// This is the default behavior when using `--lib` or `--build-backend`.
+    /// This is the default behavior, the option exists for backwards compatibility.
     ///
     /// When using `--app`, this will include a `[project.scripts]` entrypoint and use a `src/`
     /// project structure.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3407,7 +3407,9 @@ pub struct InitArgs {
     ///
     /// Defines a `[build-system]` for the project.
     ///
-    /// This is the default behavior, the option exists for backwards compatibility.
+    /// This is the default behavior when using `--lib` or `--build-backend`, or when the
+    /// `packaged-init` preview feature is enabled. It will become the default unconditionally in
+    /// the future.
     ///
     /// When using `--app`, this will include a `[project.scripts]` entrypoint and use a `src/`
     /// project structure.

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -256,6 +256,7 @@ pub enum PreviewFeature {
     MalwareCheck = 1 << 31,
     VenvSafeClear = 1 << 32,
     Check = 1 << 33,
+    PackagedInit = 1 << 34,
 }
 
 impl PreviewFeature {
@@ -296,6 +297,7 @@ impl PreviewFeature {
             Self::MalwareCheck => "malware-check",
             Self::VenvSafeClear => "venv-safe-clear",
             Self::Check => "check-command",
+            Self::PackagedInit => "packaged-init",
         }
     }
 }
@@ -349,6 +351,7 @@ impl FromStr for PreviewFeature {
             "malware-check" => Self::MalwareCheck,
             "venv-safe-clear" => Self::VenvSafeClear,
             "check" | "check-command" => Self::Check,
+            "packaged-init" => Self::PackagedInit,
             _ => return Err(PreviewFeatureParseError),
         })
     }

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -821,7 +821,7 @@ impl InitProjectKind {
         // read conditional includes that depend on the repository path.
         init_vcs(path, vcs)?;
 
-        // Do no fill in `authors` for non-packaged applications unless explicitly requested.
+        // Do not fill in `authors` for non-packaged applications unless explicitly requested.
         let author_from = author_from.unwrap_or_else(|| {
             if package {
                 AuthorFrom::default()
@@ -976,7 +976,7 @@ impl InitProjectKind {
         // read conditional includes that depend on the repository path.
         init_vcs(path, vcs)?;
 
-        // Do no fill in `authors` for non-packaged applications unless explicitly requested.
+        // Do not fill in `authors` for non-packaged applications unless explicitly requested.
         let author_from = author_from.unwrap_or_else(|| match self {
             Self::ApplicationWithLibrary | Self::Library | Self::BareWithBuildSystem => {
                 AuthorFrom::default()

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -283,6 +283,7 @@ async fn init_script(
 async fn init_project(
     path: &Path,
     name: &PackageName,
+    // TODO(konsti): Remove when stabilizing.
     package: bool,
     project_kind: InitProjectKind,
     bare: bool,
@@ -725,33 +726,35 @@ pub(crate) enum InitKind {
     Script,
 }
 
-impl Default for InitKind {
-    fn default() -> Self {
-        Self::Project(InitProjectKind::default())
-    }
-}
-
 /// The kind of Python project to initialize (either an application or a library).
 #[derive(Debug, Copy, Clone, Default)]
 pub(crate) enum InitProjectKind {
-    /// Initialize a Python application.
+    /// A python package with a `main` function in a `__init__.py` and a script entrypoint pointing
+    /// to that.
     #[default]
+    ApplicationWithLibrary,
+    /// A flat application with a `main.py`.
     Application,
-    /// Initialize a Python library.
+    /// A python package, no entrypoint.
     Library,
-}
-
-impl InitKind {
-    /// Returns `true` if the project should be packaged by default.
-    pub(crate) fn packaged_by_default(self) -> bool {
-        matches!(self, Self::Project(InitProjectKind::Library))
-    }
+    /// Initialize only a `pyproject.toml`
+    Bare,
+    /// Initialize only a `pyproject.toml` with `[build-system]` table (but without associated
+    /// source files).
+    BareWithBuildSystem,
+    // TODO(konsti): Remove when stabilizing.
+    /// Initialize a Python application.
+    ApplicationOld,
+    // TODO(konsti): Remove when stabilizing.
+    /// Initialize a Python library.
+    LibraryOld,
 }
 
 impl InitProjectKind {
     /// Initialize this project kind at the target path.
+    // TODO(konsti): Remove when stabilizing packaged-init.
     #[expect(clippy::fn_params_excessive_bools)]
-    fn init(
+    fn init_old(
         self,
         name: &PackageName,
         path: &Path,
@@ -766,7 +769,7 @@ impl InitProjectKind {
         package: bool,
     ) -> Result<()> {
         match self {
-            Self::Application => Self::init_application(
+            Self::ApplicationOld => Self::init_application_old(
                 name,
                 path,
                 requires_python,
@@ -779,7 +782,7 @@ impl InitProjectKind {
                 no_readme,
                 package,
             ),
-            Self::Library => Self::init_library(
+            Self::LibraryOld => Self::init_library_old(
                 name,
                 path,
                 requires_python,
@@ -792,12 +795,14 @@ impl InitProjectKind {
                 no_readme,
                 package,
             ),
+            _ => unreachable!(),
         }
     }
 
     /// Initialize a Python application at the target path.
+    // TODO(konsti): Remove when stabilizing packaged-init.
     #[expect(clippy::fn_params_excessive_bools)]
-    fn init_application(
+    fn init_application_old(
         name: &PackageName,
         path: &Path,
         requires_python: &RequiresPython,
@@ -879,8 +884,9 @@ impl InitProjectKind {
     }
 
     /// Initialize a library project at the target path.
+    // TODO(konsti): Remove when stabilizing packaged-init.
     #[expect(clippy::fn_params_excessive_bools)]
-    fn init_library(
+    fn init_library_old(
         name: &PackageName,
         path: &Path,
         requires_python: &RequiresPython,
@@ -928,6 +934,122 @@ impl InitProjectKind {
             generate_package_scripts(name, path, build_backend, true)?;
         }
 
+        Ok(())
+    }
+
+    /// Initialize this project kind at the target path.
+    #[expect(clippy::fn_params_excessive_bools)]
+    fn init(
+        self,
+        name: &PackageName,
+        path: &Path,
+        requires_python: &RequiresPython,
+        description: Option<&str>,
+        no_description: bool,
+        bare: bool,
+        vcs: Option<VersionControlSystem>,
+        build_backend: Option<ProjectBuildBackend>,
+        author_from: Option<AuthorFrom>,
+        no_readme: bool,
+        package: bool,
+    ) -> Result<()> {
+        // TODO(konsti): Remove when stabilizing.
+        if matches!(self, Self::ApplicationOld | Self::LibraryOld) {
+            return self.init_old(
+                name,
+                path,
+                requires_python,
+                description,
+                no_description,
+                bare,
+                vcs,
+                build_backend,
+                author_from,
+                no_readme,
+                package,
+            );
+        }
+
+        fs_err::create_dir_all(path)?;
+
+        // Initialize the version control system first so that Git configuration can properly
+        // read conditional includes that depend on the repository path.
+        init_vcs(path, vcs)?;
+
+        // Do no fill in `authors` for non-packaged applications unless explicitly requested.
+        let author_from = author_from.unwrap_or_else(|| match self {
+            Self::ApplicationWithLibrary | Self::Library | Self::BareWithBuildSystem => {
+                AuthorFrom::default()
+            }
+            Self::Application | Self::Bare => AuthorFrom::None,
+            Self::ApplicationOld | Self::LibraryOld => unreachable!(),
+        });
+        let author = get_author_info(path, author_from);
+
+        // Create the `pyproject.toml`
+        let mut pyproject = pyproject_project(
+            name,
+            requires_python,
+            author.as_ref(),
+            description,
+            no_description,
+            no_readme || bare,
+        );
+
+        match self {
+            // Create only the most barebones `pyproject.toml`, no build system
+            Self::Bare => {}
+            // Create only a barebones `pyproject.toml`, but with a build system table
+            Self::BareWithBuildSystem => {
+                // Add a build system
+                let build_backend = build_backend.unwrap_or(ProjectBuildBackend::Uv);
+                pyproject.push('\n');
+                pyproject.push_str(&pyproject_build_system(name, build_backend));
+            }
+            Self::ApplicationWithLibrary => {
+                // Since it'll be packaged, we can add a `[project.scripts]` entry
+                pyproject.push('\n');
+                pyproject.push_str(&pyproject_project_scripts(name, name.as_str(), "main"));
+
+                // Add a build system
+                let build_backend = build_backend.unwrap_or(ProjectBuildBackend::Uv);
+                pyproject.push('\n');
+                pyproject.push_str(&pyproject_build_system(name, build_backend));
+                pyproject_build_backend_prerequisites(name, path, build_backend)?;
+
+                // Generate `src` files with app-style `main()` in `__init__.py`
+                generate_package_scripts(name, path, build_backend, false)?;
+            }
+            Self::Application => {
+                let main_contents = indoc::formatdoc! {r#"
+                    def main():
+                        print("Hello from {name}!")
+
+
+                    if __name__ == "__main__":
+                        main()
+                "#};
+
+                // Create `main.py` if it doesn't exist
+                // (This isn't intended to be a particularly special or magical filename, just nice)
+                // TODO(zanieb): Only create `main.py` if there are no other Python files?
+                let main_py = path.join("main.py");
+                if !main_py.try_exists()? && !bare {
+                    fs_err::write(path.join("main.py"), main_contents)?;
+                }
+            }
+            Self::Library => {
+                let build_backend = build_backend.unwrap_or(ProjectBuildBackend::Uv);
+                pyproject.push('\n');
+                pyproject.push_str(&pyproject_build_system(name, build_backend));
+                pyproject_build_backend_prerequisites(name, path, build_backend)?;
+
+                // Generate `src` files
+                generate_package_scripts(name, path, build_backend, true)?;
+            }
+            _ => unreachable!(),
+        }
+        fs_err::write(path.join("pyproject.toml"), pyproject)?;
         Ok(())
     }
 }
@@ -1151,7 +1273,6 @@ fn generate_package_scripts(
     let pkg_dir = src_dir.join(&*module_name);
     fs_err::create_dir_all(&pkg_dir)?;
 
-    // Python script for pure-python packaged apps or libs
     let pure_python_script = if is_lib {
         indoc::formatdoc! {r#"
         def hello() -> str:

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2123,7 +2123,7 @@ async fn run_project(
         ProjectCommand::Init(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args =
-                settings::InitSettings::resolve(args, filesystem, environment, globals.preview);
+                settings::InitSettings::resolve(args, filesystem, environment, globals.preview)?;
             show_settings!(args);
 
             // The `--project` arg is being deprecated for `init` with a warning now and an error in preview.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2122,7 +2122,8 @@ async fn run_project(
     match *project_command {
         ProjectCommand::Init(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::InitSettings::resolve(args, filesystem, environment);
+            let args =
+                settings::InitSettings::resolve(args, filesystem, environment, globals.preview);
             show_settings!(args);
 
             // The `--project` arg is being deprecated for `init` with a warning now and an error in preview.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -47,7 +47,7 @@ use uv_install_wheel::LinkMode;
 use uv_normalize::{ExtraName, PackageName, PipGroupName};
 use uv_pep440::Version;
 use uv_pep508::{MarkerTree, RequirementOrigin};
-use uv_preview::Preview;
+use uv_preview::{Preview, PreviewFeature};
 use uv_pypi_types::SupportedEnvironments;
 use uv_python::{Prefix, PythonDownloads, PythonPreference, PythonVersion, Target};
 use uv_redacted::DisplaySafeUrl;
@@ -441,6 +441,7 @@ impl InitSettings {
         args: InitArgs,
         filesystem: Option<FilesystemOptions>,
         environment: EnvironmentOptions,
+        preview: Preview,
     ) -> Self {
         let InitArgs {
             path,
@@ -465,21 +466,6 @@ impl InitSettings {
             ..
         } = args;
 
-        let kind = match (app, lib, script) {
-            (true, false, false) => InitKind::Project(InitProjectKind::Application),
-            (false, true, false) => InitKind::Project(InitProjectKind::Library),
-            (false, false, true) => InitKind::Script,
-            (false, false, false) => InitKind::default(),
-            (_, _, _) => unreachable!("`app`, `lib`, and `script` are mutually exclusive"),
-        };
-
-        let package = flag(
-            package || build_backend.is_some(),
-            no_package || r#virtual,
-            "virtual",
-        )
-        .unwrap_or(kind.packaged_by_default());
-
         let bare = resolve_flag(bare, "bare", environment.init_bare).is_enabled();
 
         let filesystem_install_mirrors = filesystem
@@ -487,6 +473,83 @@ impl InitSettings {
             .unwrap_or_default();
 
         let no_description = no_description || (bare && description.is_none());
+
+        let (kind, package) = if preview.is_enabled(PreviewFeature::PackagedInit) {
+            let package_flag = flag(
+                package || build_backend.is_some(),
+                no_package || r#virtual,
+                "virtual",
+            );
+
+            let kind = if script {
+                InitKind::Script
+            } else if bare {
+                if package_flag == Some(true) || lib {
+                    InitKind::Project(InitProjectKind::BareWithBuildSystem)
+                } else {
+                    InitKind::Project(InitProjectKind::Bare)
+                }
+            } else {
+                // Merge `--app` and `--lib`.
+                let app_lib_kind = match (app, lib) {
+                    (false, false) => InitProjectKind::ApplicationWithLibrary,
+                    (true, false) => InitProjectKind::Application,
+                    (false, true) => InitProjectKind::Library,
+                    (true, true) => unreachable!("`app` and `lib` are mutually exclusive"),
+                };
+
+                // Apply overrides from `--package`/`--no-package`.
+                let app_lib_kind = match (app_lib_kind, package_flag) {
+                    (InitProjectKind::ApplicationWithLibrary, None | Some(true)) => {
+                        InitProjectKind::ApplicationWithLibrary
+                    }
+                    (InitProjectKind::ApplicationWithLibrary, Some(false)) => {
+                        InitProjectKind::Application
+                    }
+                    // The user specifically asked for `--app`, so no library.
+                    (InitProjectKind::Application, None | Some(false)) => {
+                        InitProjectKind::Application
+                    }
+                    (InitProjectKind::Application, Some(true)) => {
+                        InitProjectKind::ApplicationWithLibrary
+                    }
+                    (InitProjectKind::Library, None | Some(true)) => InitProjectKind::Library,
+                    (InitProjectKind::Library, Some(false)) => {
+                        unreachable!("`lib` and `no_package` are mutually exclusive")
+                    }
+                    (InitProjectKind::Bare | InitProjectKind::BareWithBuildSystem, _) => {
+                        unreachable!()
+                    }
+                    (InitProjectKind::ApplicationOld | InitProjectKind::LibraryOld, _) => {
+                        unreachable!()
+                    }
+                };
+                InitKind::Project(app_lib_kind)
+            };
+
+            // Packaging is encoded in `kind`; `package` is only consumed by the old paths.
+            (kind, false)
+        } else {
+            // TODO(konsti): Remove when stabilizing packaged-init.
+            let kind = match (app, lib, script) {
+                (true, false, false) => InitKind::Project(InitProjectKind::ApplicationOld),
+                (false, true, false) => InitKind::Project(InitProjectKind::LibraryOld),
+                (false, false, true) => InitKind::Script,
+                (false, false, false) => InitKind::Project(InitProjectKind::ApplicationOld),
+                (_, _, _) => unreachable!("`app`, `lib`, and `script` are mutually exclusive"),
+            };
+
+            let package = flag(
+                package || build_backend.is_some(),
+                no_package || r#virtual,
+                "virtual",
+            )
+            .unwrap_or(matches!(
+                kind,
+                InitKind::Project(InitProjectKind::LibraryOld)
+            ));
+            (kind, package)
+        };
 
         Self {
             path,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -5,10 +5,10 @@ use std::process;
 use std::str::FromStr;
 use std::time::Duration;
 
+use anyhow::{Result, bail};
 use rustc_hash::FxHashSet;
-use uv_audit::{VulnerabilityID, VulnerabilityServiceFormat};
 
-use crate::commands::{PythonUpgrade, PythonUpgradeSource};
+use uv_audit::{VulnerabilityID, VulnerabilityServiceFormat};
 use uv_auth::Service;
 use uv_cache::{CacheArgs, Refresh};
 use uv_cli::comma::CommaSeparatedRequirements;
@@ -66,8 +66,10 @@ use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::{DependencyType, ExtraBuildDependencies};
 use uv_workspace::pyproject_mut::AddBoundsKind;
 
-use crate::commands::ToolRunCommand;
-use crate::commands::{InitKind, InitProjectKind, pip::operations::Modifications};
+use crate::commands::pip::operations::Modifications;
+use crate::commands::{
+    InitKind, InitProjectKind, PythonUpgrade, PythonUpgradeSource, ToolRunCommand,
+};
 
 /// The default publish URL.
 const PYPI_PUBLISH_URL: &str = "https://upload.pypi.org/legacy/";
@@ -442,7 +444,7 @@ impl InitSettings {
         filesystem: Option<FilesystemOptions>,
         environment: EnvironmentOptions,
         preview: Preview,
-    ) -> Self {
+    ) -> Result<Self> {
         let InitArgs {
             path,
             name,
@@ -475,6 +477,13 @@ impl InitSettings {
         let no_description = no_description || (bare && description.is_none());
 
         let (kind, package) = if preview.is_enabled(PreviewFeature::PackagedInit) {
+            if r#virtual && lib {
+                bail!("`--virtual` and `--lib` are mutually exclusive");
+            }
+            if r#virtual && build_backend.is_some() {
+                bail!("`--virtual` and `--build-backend` are mutually exclusive");
+            }
+
             let package_flag = flag(
                 package || build_backend.is_some(),
                 no_package || r#virtual,
@@ -495,7 +504,7 @@ impl InitSettings {
                     (false, false) => InitProjectKind::ApplicationWithLibrary,
                     (true, false) => InitProjectKind::Application,
                     (false, true) => InitProjectKind::Library,
-                    (true, true) => unreachable!("`app` and `lib` are mutually exclusive"),
+                    (true, true) => bail!("`app` and `lib` are mutually exclusive"),
                 };
 
                 // Apply overrides from `--package`/`--no-package`.
@@ -515,7 +524,7 @@ impl InitSettings {
                     }
                     (InitProjectKind::Library, None | Some(true)) => InitProjectKind::Library,
                     (InitProjectKind::Library, Some(false)) => {
-                        unreachable!("`lib` and `no_package` are mutually exclusive")
+                        bail!("`lib` and `no_package` are mutually exclusive");
                     }
                     (InitProjectKind::Bare | InitProjectKind::BareWithBuildSystem, _) => {
                         unreachable!()
@@ -536,7 +545,7 @@ impl InitSettings {
                 (false, true, false) => InitKind::Project(InitProjectKind::LibraryOld),
                 (false, false, true) => InitKind::Script,
                 (false, false, false) => InitKind::Project(InitProjectKind::ApplicationOld),
-                (_, _, _) => unreachable!("`app`, `lib`, and `script` are mutually exclusive"),
+                (_, _, _) => bail!("`app`, `lib`, and `script` are mutually exclusive"),
             };
 
             let package = flag(
@@ -551,7 +560,7 @@ impl InitSettings {
             (kind, package)
         };
 
-        Self {
+        Ok(Self {
             path,
             name,
             package,
@@ -569,7 +578,7 @@ impl InitSettings {
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
-        }
+        })
     }
 }
 

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -2910,6 +2910,7 @@ fn preview_features() {
     +            MalwareCheck,
     +            VenvSafeClear,
     +            Check,
+    +            PackagedInit,
     +        ],
          },
          python_preference: Managed,


### PR DESCRIPTION
Switch the (preview) default for `uv init` to a src-package. The package by default has an entrypoint by the name of the package that can be run with `uv init foo`.

There's effectively three layouts with this change:

* package with entrypoint (packaged application, the default)
* package without entrypoint (pure lib)
* flat `main.py` application (pure app)

These are selected from among the existing `--app`/`--lib` and `--package`/`--no-package` flags, as to not cause too much churn. `--build-backend` still implies `--package`, with `--app --build-backend` doesn't change. `--bare` doesn't add a build system by default.

Testing is a bit awkward, cause there's now all the stable tests and a separate test for the preview behavior, while we'll have to update the stable tests upon stabilization. You can see the effect of stabilization in https://github.com/astral-sh/uv/pull/19197.

| kind      | package        | template                                                 |
|-----------|----------------|----------------------------------------------------------|
| (default) | (default)      | entrypoint + package exposing `hello()`                  |
| (default) | `--package`    | entrypoint + package exposing `hello()`                  |
| (default) | `--no-package` | `main.py` with `main()`                                  |
| `--app`   | (default)      | `main.py` with `main()`                                  |
| `--app`   | `--package`    | entrypoint + package exposing `hello()` |
| `--app`   | `--no-package` | `main.py` with `main()`                                  |
| `--lib`   | (default)      | package exposing `hello()`                               |
| `--lib`   | `--package`    | package exposing `hello()`                               |
| `--lib`   | `--no-package` | Error: libraries are always packaged                     |

**Navigation**

There are three branches:

* main <- konsti/package-by-default
  https://github.com/astral-sh/uv/pull/17841
* konsti/package-by-default <- konsti/package-by-default-doc-changes
  https://github.com/astral-sh/uv/pull/19026
* konsti/package-by-default <- konsti/package-by-default-stabilize
  https://github.com/astral-sh/uv/pull/19197


**~~Open~~ Decided design questions**

* Should the default layout fill out the authors table?
  No, the authors field isn't helpful here.
* Should `--bare` also create a (by itself broken) build system by default, without setting `--package` or `--build-backend`?
  No, we want something that works, and not creating a build backend is very bare. It's slightly inconsistent that effectively `--bare` is no-package by default, but that's better than the alternatives and explainable as `--bare` being no-most-things.