### PR TITLE
Bump ambient-id to 0.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ambient-id"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c211637568dac6885fe10628aade8c3340c516e47460671bcafee0a3fb8d43"
+checksum = "e61320f0a8ca54a235b0e49307b16dcade6eecd441b1f8a8c7ca9204056cb17c"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ uv-warnings = { version = "0.0.19", path = "crates/uv-warnings" }
 uv-windows = { version = "0.0.19", path = "crates/uv-windows" }
 uv-workspace = { version = "0.0.19", path = "crates/uv-workspace" }
 
-ambient-id = { version = "0.0.8", default-features = false, features = ["astral-reqwest-middleware"] }
+ambient-id = { version = "0.0.10", default-features = false, features = ["astral-reqwest-middleware"] }
 anstream = { version = "0.6.15" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }


### PR DESCRIPTION
## Summary

Just keeps us on tip for our own dep.

## Test Plan

No functional changes.