### PR TITLE
fix(python find): respect --project when selecting .venv

### DIFF
--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -339,6 +339,43 @@ fn python_find_project() {
     warning: The requested interpreter resolved to Python 3.10.[X], which is incompatible with the project's Python requirement: `>=3.11` (from `project.requires-python`)
     ");
 
+    // If a project environment exists, `--project` should resolve it even when invoked outside
+    // the project directory.
+    uv_snapshot!(
+        context.filters(),
+        context
+            .venv()
+            .arg("--python")
+            .arg("3.12")
+            .arg("-q")
+            .current_dir(context.temp_dir.path()),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "
+    );
+
+    #[cfg(not(windows))]
+    uv_snapshot!(
+        context.filters(),
+        context
+            .python_find()
+            .arg("--project")
+            .arg(context.temp_dir.path())
+            .current_dir(context.temp_dir.path().parent().unwrap()),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [VENV]/[BIN]/[PYTHON]
+
+    ----- stderr -----
+    "
+    );
+
     // Or `--no-project` is used
     uv_snapshot!(context.filters(), context.python_find().arg("--no-project"), @"
     success: true


### PR DESCRIPTION
## Summary
- make `uv python find` consult the workspace `.venv` for the target project resolved via `--project`
- when the project environment exists and satisfies the resolved Python request, use it directly
- keep `--system` behavior unchanged by skipping project virtualenv lookup in system-only mode
- add an integration test case under `python_find_project` covering `--project` from outside the project directory

Fixes #11990.

## Testing
- `cargo check -p uv`
- `cargo test -p uv --test it python_find::python_find_project -- --exact` *(fails in this environment: missing test Python 3.10 runtime required by the test harness)*
