### PR TITLE
fix(frozen): clarify missing workspace member rename case

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -143,7 +143,7 @@ pub(crate) enum ProjectError {
     MissingLockfile(MissingLockfileSource),
 
     #[error(
-        "The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `{0}`. To update the lockfile, run `uv lock`."
+        "The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `{0}`. This can happen after renaming `project.name`. To update the lockfile, run `uv lock`."
     )]
     LockWorkspaceMismatch(PackageName),
 

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -4726,7 +4726,7 @@ fn export_lock_workspace_mismatch_with_frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `foo`. To update the lockfile, run `uv lock`.
+    error: The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `foo`. This can happen after renaming `project.name`. To update the lockfile, run `uv lock`.
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary
- improve the `--frozen` lock/workspace mismatch error message for missing workspace members
- explicitly mention that this can happen after renaming `project.name`
- update the corresponding integration snapshot

Fixes #12661

## Validation
- `cargo fmt --all --check`
- `cargo check -p uv`
- attempted `cargo test -p uv --test it export::export_lock_workspace_mismatch_with_frozen -- --exact` (fails in this environment because Python 3.12 is not installed for tests)
