### PR TITLE
fix(tool run): use --from context for requirement resolution failures

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -351,8 +351,14 @@ pub(crate) async fn run(
         }
 
         Err(ProjectError::Requirements(err)) => {
+            let context = match (explicit_from, with.is_empty()) {
+                (true, true) => "--from",
+                (false, false) => "--with",
+                (true, false) => "--from`/`--with",
+                (false, true) => "tool",
+            };
             let err = miette::Report::msg(format!("{err}"))
-                .context("Failed to resolve `--with` requirement");
+                .context(format!("Failed to resolve `{context}` requirement"));
             eprint!("{err:?}");
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1819,6 +1819,24 @@ fn tool_run_with_editable() -> anyhow::Result<()> {
       ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
     ");
 
+    // If invalid, we should reference `--from`.
+    uv_snapshot!(context.filters(), context
+        .tool_run()
+        .arg("--from")
+        .arg("./foo")
+        .arg("flask")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir
+        .as_os_str()).env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to resolve `--from` requirement
+      ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
+    ");
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- fix `uv tool run` / `uvx` requirement error context so `--from` failures are reported as: `Failed to resolve --from requirement`
- keep existing `--with` wording for `--with` failures
- add an integration snapshot test for invalid `--from` input

Closes #16303

## Testing
- `cargo fmt --all --check`
- `cargo check -p uv`
- `cargo test -p uv tool_run_with_editable -- --nocapture` *(fails in this environment because Python 3.12 test runtime is unavailable: "Could not find Python 3.12 for test")*
