### PR TITLE
Fix comment about `uv export` formats

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -9,6 +9,7 @@ doc-valid-idents = [
   "ROCm",
   "XPU",
   "PowerShell",
+  "CycloneDX",
   "UV_DEV",
   "UV_FROZEN",
   "UV_ISOLATED",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4770,7 +4770,6 @@ pub struct TreeArgs {
 
 #[derive(Args)]
 pub struct ExportArgs {
-    #[expect(clippy::doc_markdown)]
     /// The format to which `uv.lock` should be exported.
     ///
     /// Supports `requirements.txt`, `pylock.toml` (PEP 751) and CycloneDX v1.5 JSON output formats.


### PR DESCRIPTION
## Summary

This corrects a comment in the documentation to match the work done in #16523, and to match the documentation for `--format`, which states:

```
    /// Supports `requirements.txt`, `pylock.toml` (PEP 751) and CycloneDX v1.5 JSON output formats.
```

## Test Plan

N/A