### PR TITLE
Don't panic on metadata read error

### DIFF
--- a/crates/uv-metadata/src/lib.rs
+++ b/crates/uv-metadata/src/lib.rs
@@ -250,7 +250,7 @@ pub async fn read_metadata_async_stream<R: futures::AsyncRead + Unpin>(
         if is_metadata_entry(&path, filename)? {
             let mut reader = entry.reader_mut().compat();
             let mut contents = Vec::new();
-            reader.read_to_end(&mut contents).await.unwrap();
+            reader.read_to_end(&mut contents).await.map_err(Error::Io)?;
 
             // Validate the CRC of any file we unpack
             // (It would be nice if async_zip made it harder to Not do this...)


### PR DESCRIPTION
## Summary

Help troubleshoot #17898.

Not quite ideal to be shoehorning everything into the Io error variant but for this one case it seemed somewhat fitting.

## Test Plan

Not easy to test automatically in our suite.
