### PR TITLE
Remove `test-defaults` from default features to fix `cargo install`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           cargo nextest run \
             --cargo-profile fast-build \
-            --features test-python-patch,native-auth,secret-service \
+            --features test-defaults,test-python-patch,native-auth,secret-service \
             --workspace \
             --profile ci-linux
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -156,7 +156,7 @@ nix = { workspace = true }
 uv-unix = { workspace = true }
 
 [features]
-default = ["performance", "uv-distribution/static", "test-defaults"]
+default = ["performance", "uv-distribution/static"]
 native-auth = []
 # Use better memory allocators, etc.
 performance = ["performance-memory-allocator"]


### PR DESCRIPTION
## Summary

- Remove `test-defaults` from the `default` feature set in `crates/uv/Cargo.toml`
- Add `test-defaults` explicitly to the Linux CI test features in `test.yml`

The `test-defaults` feature propagates features to `uv-test`, which is a dev-dependency. Since `cargo install` strips dev-dependencies, this causes installation to fail:

```
error: package `uv v0.10.0` does not have a dependency named `uv-test`
```

This was introduced by #17551 (splitting `TestContext` into a dedicated `uv-test` crate). macOS and Windows CI already use `--no-default-features` with explicit feature lists, so they are unaffected. Linux CI needed `test-defaults` added to its explicit feature list.

## Test plan

- [x] `cargo check -p uv` succeeds with the new default features
- [x] Verify `cargo install --path crates/uv` succeeds
- [ ] CI passes with `test-defaults` explicitly enabled for Linux