### PR TITLE
Fix benchmark image reflow on documentation index page

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -255,3 +255,11 @@ modifications */
 .md-source-file__fact {
   visibility: hidden;
 }
+
+/* Fix reflow of benchmark images on index page when they load
+   See: https://github.com/astral-sh/uv/issues/6264 */
+.md-content img[src*="github.com/astral-sh/uv/assets"] {
+  height: 400px;
+  width: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
This PR fixes the layout reflow issue on the documentation index page that occurs when benchmark images load.

## Changes
- Added CSS rule to set a fixed height (400px) for benchmark images on the index page
- The fix targets images from the GitHub assets URL to prevent affecting other images
- Uses `height: 400px` with `width: auto` and `max-width: 100%` to maintain aspect ratio and responsiveness

## Testing
The fix can be tested by:
1. Building the documentation locally with `mkdocs serve`
2. Opening the documentation homepage with throttled network (to simulate slow image loading)
3. Verifying that the page no longer jumps when the benchmark image loads

Fixes #6264