### PR TITLE
dependencies: add section on how to upgrade all versions

### DIFF
--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -131,6 +131,24 @@ Requesting a different dependency source will update the `tool.uv.sources` table
 $ uv add "httpx @ ../httpx"
 ```
 
+## Upgrading dependencies
+
+To upgrade all dependencies to their latest compatible versions:
+
+```console
+$ uv lock --upgrade
+```
+
+This will update the `uv.lock` file with the latest versions of all packages that satisfy your
+project's constraints. The upgrade respects the version constraints defined in your
+`pyproject.toml`, so packages will only be upgraded within the allowed bounds.
+
+To upgrade a single package instead of all packages, use the `--upgrade-package` option (as
+described in the [changing dependencies](#changing-dependencies) section above).
+
+See the [lockfile](./sync.md#upgrading-locked-package-versions) documentation for more details on
+upgrading strategies.
+
 ## Platform-specific dependencies
 
 To ensure that a dependency is only installed on a specific platform or on specific Python versions,


### PR DESCRIPTION
## Summary

dependencies: add section on how to upgrade all versions
    
    * link to locking and syncing page for more details

## Test Plan

Docs, tested locally
<img width="864" height="456" alt="image" src="https://github.com/user-attachments/assets/32f6b62c-22a6-4bbe-aeef-852bb93558a8" />

tested each link as well