### PR TITLE
Don't open lock files for writing

### DIFF
--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -253,11 +253,7 @@ impl LockedFile {
         }
 
         // If path already exists, return it.
-        if let Ok(file) = fs_err::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path.as_ref())
-        {
+        if let Ok(file) = fs_err::OpenOptions::new().read(true).open(path.as_ref()) {
             return Ok(file);
         }
 
@@ -278,7 +274,6 @@ impl LockedFile {
                 if err.error.kind() == std::io::ErrorKind::AlreadyExists {
                     fs_err::OpenOptions::new()
                         .read(true)
-                        .write(true)
                         .open(path.as_ref())
                         .map_err(Into::into)
                 } else if matches!(
@@ -300,7 +295,6 @@ impl LockedFile {
                     // bits, it's less likely to ever matter.
                     let file = fs_err::OpenOptions::new()
                         .read(true)
-                        .write(true)
                         .create(true)
                         .open(path.as_ref())?;
 


### PR DESCRIPTION
## Summary

When opening lock files, don't open them for writing to avoid needing the write permission in the future.

Related: #17646

## Test Plan

Test suite ran.