### PR TITLE
Fix parent path handling with bare scripts

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1605,7 +1605,7 @@ impl RunCommand {
 
     /// Return the directory containing the script, if any.
     fn script_dir(&self) -> Option<&Path> {
-        match self {
+        let parent = match self {
             Self::PythonScript(target, _)
             | Self::PythonGuiScript(target, _)
             | Self::PythonZipapp(target, _) => target.parent(),
@@ -1617,7 +1617,9 @@ impl RunCommand {
             | Self::PythonRemote(..)
             | Self::External(..)
             | Self::Empty => None,
-        }
+        };
+        // The parent is `Some("")` for bare filenames.
+        parent.filter(|parent| !parent.as_os_str().is_empty())
     }
 }
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -6220,3 +6220,31 @@ fn run_target_workspace_discovery() -> Result<()> {
 
     Ok(())
 }
+
+/// Test that `--preview-features target-workspace-discovery` works with a bare script
+/// filename (no directory component), which would otherwise cause `Path::parent()` to
+/// return an empty path.
+#[test]
+fn run_target_workspace_discovery_bare_script() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("script.py")
+        .write_str(r"print('success')")?;
+
+    // With the preview feature and a bare filename, the script should run without error.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--preview-features")
+        .arg("target-workspace-discovery")
+        .arg("script.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    success
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}


### PR DESCRIPTION
Rust gotcha: the parent of a bare filename (e.g. script.py) is Some(""), not None, and calling std::path::absolute on it fails.
