### PR TITLE
Fix `extra != '...'` marker in `tool.uv.sources` producing impossible marker

### DIFF
--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -108,7 +108,14 @@ impl PubGrubPackage {
         // extras end up having two distinct marker expressions, which in turn
         // makes them two distinct packages. This results in PubGrub being
         // unable to unify version constraints across such packages.
-        let marker = marker.simplify_extras_with(|_| true);
+        //
+        // We use `without_extras()` rather than `simplify_extras_with(|_| true)`
+        // because the latter assumes all extras are active, which incorrectly
+        // turns `extra != 'foo'` into FALSE (an impossible marker). In contrast,
+        // `without_extras()` removes extras by OR-ing both branches, preserving
+        // the non-extra part of the marker for both `extra == '...'` and
+        // `extra != '...'` expressions.
+        let marker = marker.without_extras();
         if let Some(extra) = extra {
             Self(Arc::new(PubGrubPackageInner::Extra {
                 name,

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -23270,6 +23270,9 @@ fn lock_multiple_sources_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { virtual = "." }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
 
         [package.optional-dependencies]
         cpu = [


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #17967

I ran into this issue where a package in both `dependencies` and `optional-dependencies` with `tool.uv.sources` using `extra == '...'` / `extra != '...'` markers would get assigned an impossible marker (`python_version < '0'`) and silently never install.

After digging into it, I traced the root cause to `PubGrubPackage::from_package()` where the marker is simplified with `simplify_extras_with(|_| true)`. This assumes all extras are active — which works fine for `extra == 'foo'` (becomes true), but incorrectly turns `extra != 'foo'` into false, producing the impossible marker. The `extra != '...'` markers come up naturally from source lowering as the complement of `extra == '...'` source markers.

The fix is straightforward: replace `simplify_extras_with(|_| true)` with `without_extras()`. `without_extras()` removes extra expressions by OR-ing both branches, so it correctly preserves the non-extra part of the marker. For `extra == 'foo'`, both methods give the same result. For `extra != 'foo'`, `without_extras()` correctly yields true instead of false.

## Test Plan

- Added integration test `tool_uv_sources_extra_negation` in `crates/uv/tests/it/pip_install.rs` that verifies a dependency with `extra == '...'` source markers is correctly installed via `uv pip install -e .` (without the extra active)
- Updated snapshot for existing `lock_multiple_sources_extra` test — `iniconfig` now correctly appears in base `dependencies` in the lock file (previously it was silently dropped)
- `cargo test -p uv-resolver` — all passing
- `cargo test -p uv -- lock_multiple_sources_extra` — passing
- `cargo test -p uv -- tool_uv_sources_extra_negation` — passing
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` — no warnings
- `cargo fmt --all --check` — clean