### PR TITLE
Use version constraints for default ruff version in `uv format`

### DIFF
--- a/crates/uv-bin-install/src/lib.rs
+++ b/crates/uv-bin-install/src/lib.rs
@@ -21,7 +21,7 @@ use uv_distribution_filename::SourceDistExtension;
 use uv_cache::{Cache, CacheBucket, CacheEntry, Error as CacheError};
 use uv_client::{BaseClient, RetryState};
 use uv_extract::{Error as ExtractError, stream};
-use uv_pep440::Version;
+use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_platform::Platform;
 use uv_redacted::DisplaySafeUrl;
 
@@ -32,11 +32,19 @@ pub enum Binary {
 }
 
 impl Binary {
-    /// Get the default version for this binary.
-    pub fn default_version(&self) -> Version {
+    /// Get the default version constraints for this binary.
+    ///
+    /// Returns a version range constraint (e.g., `>=0.15,<0.16`) rather than a pinned version,
+    /// allowing patch version updates without requiring a uv release.
+    pub fn default_constraints(&self) -> VersionSpecifiers {
         match self {
             // TODO(zanieb): Figure out a nice way to automate updating this
-            Self::Ruff => Version::new([0, 15, 0]),
+            Self::Ruff => [
+                VersionSpecifier::greater_than_equal_version(Version::new([0, 15])),
+                VersionSpecifier::less_than_version(Version::new([0, 16])),
+            ]
+            .into_iter()
+            .collect(),
         }
     }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5079,7 +5079,7 @@ pub struct FormatArgs {
     /// Accepts either a version (e.g., `0.8.2`) which will be treated as an exact pin,
     /// a version specifier (e.g., `>=0.8.0`), or `latest` to use the latest available version.
     ///
-    /// By default, a pinned version of Ruff will be used.
+    /// By default, a constrained version range of Ruff will be used (e.g., `>=0.15,<0.16`).
     #[arg(long, value_hint = ValueHint::Other)]
     pub version: Option<String>,
 

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1288,7 +1288,7 @@ impl TestContext {
         command.arg("format");
         self.add_shared_options(&mut command, false);
         // Override to a more recent date for ruff version resolution
-        command.env(EnvVars::UV_EXCLUDE_NEWER, "2025-01-01T00:00:00Z");
+        command.env(EnvVars::UV_EXCLUDE_NEWER, "2026-03-01T00:00:00Z");
         command
     }
 

--- a/crates/uv/tests/it/format.rs
+++ b/crates/uv/tests/it/format.rs
@@ -517,7 +517,7 @@ fn format_version_constraints() -> Result<()> {
 
     ----- stderr -----
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format` to disable this warning.
-    ruff 0.8.4
+    ruff 0.15.0
     ");
 
     Ok(())
@@ -550,7 +550,7 @@ fn format_version_latest() -> Result<()> {
 
     ----- stderr -----
     warning: `uv format` is experimental and may change without warning. Pass `--preview-features format` to disable this warning.
-    ruff 0.8.4
+    ruff 0.15.0
     ");
 
     Ok(())


### PR DESCRIPTION
Change the default ruff version from a pin at `0.15.0` to a constraint `>=0.15,<0.16`, allowing patch updates without a uv release. We'll bump this constraint if there are no breaking formatter changes.