### PR TITLE
Use inheritance for nextest CI profiles

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,29 +5,22 @@ experimental = ["setup-scripts"]
 # Terminate after 120s as a stop-gap measure to terminate on deadlock.
 slow-timeout =  { period = "10s", terminate-after = 12 }
 
-[profile.ci-linux]
-slow-timeout =  { period = "10s", terminate-after = 12 }
+[profile.ci]
 test-threads = 20
 status-level = "skip"
 final-status-level = "slow"
 failure-output = "immediate-final"
 fail-fast = false
+
+[profile.ci-linux]
+inherits = "ci"
 
 [profile.ci-macos]
-slow-timeout =  { period = "10s", terminate-after = 12 }
+inherits = "ci"
 test-threads = 12
-status-level = "skip"
-final-status-level = "slow"
-failure-output = "immediate-final"
-fail-fast = false
 
 [profile.ci-windows]
-slow-timeout =  { period = "10s", terminate-after = 12 }
-test-threads = 20
-status-level = "skip"
-final-status-level = "slow"
-failure-output = "immediate-final"
-fail-fast = false
+inherits = "ci"
 
 [test-groups]
 serial = { max-threads = 1 }


### PR DESCRIPTION
## Summary

With #17250 closed, we can now use inheritance for the nextest CI profiles.

## Test Plan

Testing in CI (needs manual review of the output to ensure the settings got applied as we expect).