### PR TITLE
Use uv reqwest client for self update

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -749,6 +749,14 @@ impl BaseClient {
     pub fn credentials_cache(&self) -> &CredentialsCache {
         &self.credentials_cache
     }
+
+    /// The reqwest client without middleware.
+    ///
+    /// This strips important features such as retries and authenticating. Only use when passing
+    /// a middleware-enabled client isn't possible.
+    pub fn raw_client(&self) -> &Client {
+        &self.raw_client
+    }
 }
 
 /// Wrapper around [`ClientWithMiddleware`] that manages redirects.

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -36,7 +36,9 @@ pub(crate) async fn self_update(
     }
 
     let mut updater = AxoUpdater::new_for("uv");
-    updater.disable_installer_output();
+    updater
+        .set_client(client_builder.build().raw_client().clone())
+        .disable_installer_output();
 
     if let Some(ref token) = token {
         updater.set_github_token(token);


### PR DESCRIPTION
Currently, axoupdater is using a plain reqwest client, not using uv's TLS settings.