### PR TITLE
Clarify uv python upgrade message when no managed installs exist

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -408,7 +408,7 @@ async fn perform_install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade) => {
                 writeln!(
                     printer.stderr(),
-                    "There are no installed versions to upgrade"
+                    "No managed Python installations were found to upgrade"
                 )?;
             }
             PythonUpgrade::Enabled(PythonUpgradeSource::Install) => {
@@ -750,7 +750,7 @@ async fn perform_install(
         {
             writeln!(
                 printer.stderr(),
-                "There are no installed versions to upgrade"
+                "No managed Python installations were found to upgrade"
             )?;
         } else if let [request] = requests.as_slice() {
             // Convert to the inner request

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,7 +106,7 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    There are no installed versions to upgrade
+    No managed Python installations were found to upgrade
     ");
 
     // Install earlier patch versions for different minor versions


### PR DESCRIPTION
## Summary

Clarifies the no-op output from `uv python upgrade` when no managed Python installations are present.

Before this change, `uv python upgrade` could emit:

- `There are no installed versions to upgrade`

That wording can be interpreted in two ways:

1. No managed Python installations were found.
2. Installed versions are already up-to-date.

This change makes the outcome explicit:

- `No managed Python installations were found to upgrade`

## Changes

- Updated the upgrade message in `perform_install` for both no-request branches.
- Updated integration snapshot expectation in `python_upgrade_without_version`.

## Verification

- `cargo test -p uv --test it python_upgrade_without_version`
- Result: `1 passed, 0 failed`

Closes #16783.
