### PR TITLE
fix: improve clarity of uv python upgrade output message

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -409,7 +409,7 @@ async fn perform_install(
                 if existing_installations.is_empty() {
                     writeln!(
                         printer.stderr(),
-                        "No Python versions are installed. Use {} to install Python.",
+                        "No Python versions are installed. Use `{}` to install Python.",
                         "uv python install".cyan()
                     )?;
                 } else {
@@ -422,7 +422,7 @@ async fn perform_install(
             PythonUpgrade::Enabled(PythonUpgradeSource::Install) => {
                 writeln!(
                     printer.stderr(),
-                    "No Python versions specified for upgrade; did you mean {}?",
+                    "No Python versions specified for upgrade; did you mean `{}`?",
                     "uv python upgrade".cyan()
                 )?;
             }

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -106,7 +106,7 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    No Python versions are installed. Use uv python install to install Python.
+    No Python versions are installed. Use `uv python install` to install Python.
     ");
 
     // Install earlier patch versions for different minor versions


### PR DESCRIPTION
Fixes #16783

## Summary

- Improves the clarity of the uv python upgrade output message
- Now differentiates between no Python installed and all versions are up to date

## Changes

Now the message is context-aware:

- If no Python versions are installed: suggests using uv python install
- If all installed versions are already on the latest patch release: informs the user