### PR TITLE
Downgrade ubuntu runner to align with codspeed

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,8 @@ env:
 jobs:
   benchmarks-walltime-build:
     name: "walltime build"
-    runs-on: depot-ubuntu-24.04-arm-4
+    # codspeed-macro doesn't support Ubuntu 24.04 yet
+    runs-on: depot-ubuntu-22.04-arm-4
     if: ${{ github.repository == 'astral-sh/uv' }}
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/uv/pull/17995 to fix benchmark running, codspeed-macro is based on an older glibc version not compatible with Ubuntu 24.04.