### PR TITLE
Use the `static` feature for the `xz2` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ windows = { version = "0.61.0", features = ["std", "Win32_Foundation", "Win32_Gl
 windows-registry = { version = "0.5.0" }
 wiremock = { version = "0.6.4" }
 wmi = { version = "0.16.0", default-features = false }
-xz2 = { version = "0.1.7" }
+xz2 = { version = "0.1.7", features = ["static"] }
 zeroize = { version = "1.8.1" }
 zip = { version = "2.2.3", default-features = false, features = ["deflate", "zstd", "bzip2", "lzma", "xz"] }
 zstd = { version = "0.13.3" }


### PR DESCRIPTION
## Summary

Potential fix for CI failures relating to liblzma: https://github.com/astral-sh/uv/actions/runs/21994267967/job/63549829432?pr=18012