### PR TITLE
Make the `uv_build` build backend produce `wheel` and `sdist` files with `0o666 & !umask` permissions on `unix` platforms again

### DIFF
--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -12,7 +12,6 @@ use std::io;
 use std::io::{BufReader, Cursor, Write};
 use std::path::{Component, Path, PathBuf};
 use tar::{EntryType, Header};
-use tempfile::NamedTempFile;
 use tracing::{debug, trace};
 use uv_distribution_filename::{SourceDistExtension, SourceDistFilename};
 use uv_fs::Simplified;
@@ -39,7 +38,7 @@ pub fn build_source_dist(
         fs_err::remove_file(&source_dist_path)?;
     }
 
-    let temp_file = NamedTempFile::new_in(source_dist_directory)?;
+    let temp_file = uv_fs::tempfile_in(source_dist_directory)?;
     let writer = TarGzWriter::new(temp_file.as_file(), &source_dist_path);
     write_source_dist(source_tree, writer, uv_version, show_warnings)?;
     temp_file

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -7,7 +7,6 @@ use std::fmt::{Display, Formatter};
 use std::io::{BufReader, Read, Seek, Write};
 use std::path::{Component, Path, PathBuf};
 use std::{io, mem};
-use tempfile::NamedTempFile;
 use tracing::{debug, trace};
 use walkdir::WalkDir;
 use zip::{CompressionMethod, ZipWriter};
@@ -58,7 +57,7 @@ pub fn build_wheel(
         fs_err::remove_file(&wheel_path)?;
     }
 
-    let temp_file = NamedTempFile::new_in(wheel_dir)?;
+    let temp_file = uv_fs::tempfile_in(wheel_dir)?;
     let wheel_writer = ZipDirectoryWriter::new_wheel(temp_file.as_file());
 
     write_wheel(
@@ -319,7 +318,7 @@ pub fn build_editable(
         fs_err::remove_file(&wheel_path)?;
     }
 
-    let temp_file = NamedTempFile::new_in(wheel_dir)?;
+    let temp_file = uv_fs::tempfile_in(wheel_dir)?;
     let mut wheel_writer = ZipDirectoryWriter::new_wheel(temp_file.as_file());
 
     debug!("Adding pth file to {}", wheel_path.user_display());


### PR DESCRIPTION
## Summary

Fix #18004.

#17276 introduced a regression since `NamedTempFile::new_in` defaults to `0o600` permissions. Fortunately `uv_fs` already has a wrapper for a `new_in` with "normal" permissions this so this PR uses that.

## Test Plan

Reliable testing would require us to support setting a umask for a test context process which we currently don't have support for and implementing it is not trivial so for now I just tested this manually.

To test, you can just use:

```bash
#!/usr/bin/env bash

set -e

tempdir=$(mktemp -d)
trap 'rm -rf "$tempdir"' EXIT
uv init --lib "$tempdir"
cd "$tempdir"
uv build
umask
ls -al dist/
```