### PR TITLE
Make access to system site packages directory configureable for tools

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6001,6 +6001,10 @@ pub struct ToolInstallArgs {
     )]
     pub build_constraints: Vec<Maybe<PathBuf>>,
 
+    /// Give the tool virtual environment access to the system site packages directory.
+    #[arg(long)]
+    pub system_site_packages: bool,
+
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,
 

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -319,6 +319,7 @@ impl InstalledTools {
         &self,
         name: &PackageName,
         interpreter: Interpreter,
+        system_site_packages: bool,
     ) -> Result<PythonEnvironment, Error> {
         let environment_path = self.tool_dir(name);
 
@@ -344,7 +345,7 @@ impl InstalledTools {
             &environment_path,
             interpreter,
             uv_virtualenv::Prompt::None,
-            false,
+            system_site_packages,
             uv_virtualenv::OnExisting::Remove(uv_virtualenv::RemovalReason::ManagedEnvironment),
             false,
             false,

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -28,6 +28,8 @@ pub struct Tool {
     excludes: Vec<ExcludeDependency>,
     /// The build constraints requested by the user during installation.
     build_constraints: Vec<Requirement>,
+    /// The system site packages access requested by the user during installation.
+    system_site_packages: bool,
     /// The Python requested by the user during installation.
     python: Option<PythonRequest>,
     /// A mapping of entry point names to their metadata.
@@ -49,6 +51,8 @@ struct ToolWire {
     excludes: Vec<ExcludeDependency>,
     #[serde(default)]
     build_constraint_dependencies: Vec<Requirement>,
+    #[serde(default)]
+    system_site_packages: bool,
     python: Option<PythonRequest>,
     entrypoints: Vec<ToolEntrypoint>,
     #[serde(default)]
@@ -77,6 +81,7 @@ impl From<Tool> for ToolWire {
             overrides: tool.overrides,
             excludes: tool.excludes,
             build_constraint_dependencies: tool.build_constraints,
+            system_site_packages: tool.system_site_packages,
             python: tool.python,
             entrypoints: tool.entrypoints,
             options: tool.options.into(),
@@ -101,6 +106,7 @@ impl TryFrom<ToolWire> for Tool {
             overrides: tool.overrides,
             excludes: tool.excludes,
             build_constraints: tool.build_constraint_dependencies,
+            system_site_packages: tool.system_site_packages,
             python: tool.python,
             entrypoints: tool.entrypoints,
             options: tool.options.into(),
@@ -177,6 +183,7 @@ impl Tool {
         overrides: Vec<Requirement>,
         excludes: Vec<ExcludeDependency>,
         build_constraints: Vec<Requirement>,
+        system_site_packages: bool,
         python: Option<PythonRequest>,
         entrypoints: impl IntoIterator<Item = ToolEntrypoint>,
         options: ToolOptions,
@@ -189,6 +196,7 @@ impl Tool {
             overrides,
             excludes,
             build_constraints,
+            system_site_packages,
             python,
             entrypoints,
             options,
@@ -315,6 +323,17 @@ impl Tool {
             });
         }
 
+        if self.system_site_packages {
+            let system_site_packages = self.system_site_packages;
+            table.insert(
+                "system-site-packages",
+                value(serde::Serialize::serialize(
+                    &system_site_packages,
+                    toml_edit::ser::ValueSerializer::new(),
+                )?),
+            );
+        }
+
         if let Some(ref python) = self.python {
             table.insert(
                 "python",
@@ -373,6 +392,10 @@ impl Tool {
 
     pub fn build_constraints(&self) -> &[Requirement] {
         &self.build_constraints
+    }
+
+    pub fn system_site_packages(&self) -> &bool {
+        &self.system_site_packages
     }
 
     pub fn python(&self) -> &Option<PythonRequest> {

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -739,6 +739,7 @@ pub(crate) fn finalize_tool_install(
     overrides: Vec<Requirement>,
     excludes: Vec<ExcludeDependency>,
     build_constraints: Vec<Requirement>,
+    system_site_packages: bool,
     lock: Option<&ToolLock>,
     printer: Printer,
 ) -> anyhow::Result<()> {
@@ -933,6 +934,7 @@ pub(crate) fn finalize_tool_install(
         overrides,
         excludes,
         build_constraints,
+        system_site_packages,
         python,
         installed_entrypoints,
         options.clone(),

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -64,6 +64,7 @@ pub(crate) async fn install(
     overrides: &[RequirementsSource],
     excludes: &[RequirementsSource],
     build_constraints: &[RequirementsSource],
+    system_site_packages: bool,
     entrypoints: &[PackageName],
     lfs: GitLfsSetting,
     python: Option<String>,
@@ -801,6 +802,7 @@ pub(crate) async fn install(
                         receipt_overrides.clone(),
                         receipt_excludes.clone(),
                         receipt_build_constraints.clone(),
+                        system_site_packages,
                         python,
                         existing_tool_receipt.entrypoints().iter().cloned(),
                         options.clone(),
@@ -1021,7 +1023,8 @@ pub(crate) async fn install(
         } else {
             HashStrategy::default()
         };
-        let environment = installed_tools.create_environment(package_name, interpreter)?;
+        let environment =
+            installed_tools.create_environment(package_name, interpreter, system_site_packages)?;
 
         // At this point, we removed any existing environment, so we should remove any of its
         // executables.
@@ -1082,6 +1085,7 @@ pub(crate) async fn install(
         receipt_overrides,
         receipt_excludes,
         receipt_build_constraints,
+        system_site_packages,
         tool_lock.as_ref(),
         printer,
     )?;

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -344,6 +344,8 @@ async fn upgrade_tool(
         &settings.resolver.dependency_metadata,
     );
 
+    let system_site_packages = *existing_tool_receipt.system_site_packages();
+
     // Resolve the requirements.
     let spec = RequirementsSpecification::from_excludes(
         existing_tool_receipt.requirements().to_vec(),
@@ -393,8 +395,11 @@ async fn upgrade_tool(
         let hash_strategy = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
 
         if requested_interpreter.is_some() {
-            let environment =
-                installed_tools.create_environment(name, target_interpreter.clone())?;
+            let environment = installed_tools.create_environment(
+                name,
+                target_interpreter.clone(),
+                system_site_packages,
+            )?;
             let environment = sync_environment(
                 environment,
                 &resolution,
@@ -507,7 +512,8 @@ async fn upgrade_tool(
             preview,
         )
         .await?;
-        let environment = installed_tools.create_environment(name, interpreter.clone())?;
+        let environment =
+            installed_tools.create_environment(name, interpreter.clone(), system_site_packages)?;
         let environment = sync_environment(
             environment,
             &resolution.into(),
@@ -593,6 +599,7 @@ async fn upgrade_tool(
             existing_tool_receipt.overrides().to_vec(),
             existing_tool_receipt.excludes().to_vec(),
             existing_tool_receipt.build_constraints().to_vec(),
+            *existing_tool_receipt.system_site_packages(),
             tool_lock.as_ref(),
             printer,
         )?;

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1658,6 +1658,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &overrides,
                 &excludes,
                 &build_constraints,
+                args.system_site_packages,
                 &entrypoints,
                 args.lfs,
                 args.python,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1028,6 +1028,7 @@ pub(crate) struct ToolInstallSettings {
     pub(crate) overrides: Vec<PathBuf>,
     pub(crate) excludes: Vec<PathBuf>,
     pub(crate) build_constraints: Vec<PathBuf>,
+    pub(crate) system_site_packages: bool,
     pub(crate) lfs: GitLfsSetting,
     pub(crate) python: Option<String>,
     pub(crate) python_platform: Option<TargetTriple>,
@@ -1058,6 +1059,7 @@ impl ToolInstallSettings {
             overrides,
             excludes,
             build_constraints,
+            system_site_packages,
             lfs,
             installer,
             force,
@@ -1126,6 +1128,7 @@ impl ToolInstallSettings {
                 .into_iter()
                 .filter_map(Maybe::into_option)
                 .collect(),
+            system_site_packages,
             lfs,
             python: python.and_then(Maybe::into_option),
             python_platform,

--- a/crates/uv/tests/sync/show_settings.rs
+++ b/crates/uv/tests/sync/show_settings.rs
@@ -716,6 +716,7 @@ fn tool_install_baseline() {
         overrides: [],
         excludes: [],
         build_constraints: [],
+        system_site_packages: false,
         lfs: Disabled,
         python: None,
         python_platform: None,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #18303

Add --system-site-packages cli arg for uv tool install which is used when creating the tool venv.
Store this value in the tool receipt so that when the tool is upgraded the same value can be used.

## Test Plan

<!-- How was it tested? -->

Here is an example of how to use this feature. On a system with pythonWx installed in the system python, e.g by installing the `python3-wxgtk4.0` package with apt, install a tool which uses pythonWx:

```sh
$ cat /tmp/excludes.txt 
wxpython

$ ~/Dev/uv/target/debug/uv tool install --system-site-packages --excludes /tmp/excludes.txt yt-dlg
Resolved 8 packages in 368ms
Installed 8 packages in 115ms
 + altgraph==0.17.5
 + packaging==26.0
 + polib==1.2.0
 + pyinstaller==5.6.2
 + pyinstaller-hooks-contrib==2026.0
 + pypubsub==4.0.7
 + setuptools==82.0.0
 + yt-dlg==1.8.4
Installed 1 executable: yt-dlg

$ cat ~/.local/share/uv/tools/yt-dlg/uv-receipt.toml
[tool]
requirements = [{ name = "yt-dlg" }]
system-site-packages = true
entrypoints = [
    { name = "yt-dlg", install-path = "/home/brad/.local/bin/yt-dlg", from = "yt-dlg" },
]
```

This tool will now run and pythonWx did not need to be built by uv.