### PR TITLE
feat: optimize uvx startup with receipt-based fast path and parallel discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3403,6 +3418,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +3466,12 @@ dependencies = [
  "percent-encoding",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -3591,6 +3631,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4127,6 +4176,18 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -5438,6 +5499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5644,6 +5711,7 @@ dependencies = [
  "owo-colors",
  "petgraph",
  "predicates",
+ "proptest",
  "regex",
  "reqwest",
  "rkyv",
@@ -7102,7 +7170,9 @@ dependencies = [
  "fs-err",
  "pathdiff",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "toml",
  "toml_edit 0.24.0+spec-1.1.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ temp-env = { version = "0.3.6" }
 test-case = { version = "3.3.1" }
 test-log = { version = "0.2.16", features = ["trace"], default-features = false }
 tokio-rustls = { version = "0.26.2", default-features = false }
+proptest = { version = "1.6.0" }
 whoami = { version = "2.0.0" }
 
 [workspace.lints.rust]

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -39,3 +39,7 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -143,6 +143,7 @@ hyper-util = { workspace = true }
 indoc = { workspace = true }
 insta = { workspace = true }
 predicates = { workspace = true }
+proptest = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"], default-features = false }
 sha2 = { workspace = true }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1739,6 +1739,10 @@ impl std::ops::Deref for ScriptEnvironment {
 }
 
 /// Resolve any [`UnresolvedRequirementSpecification`] into a fully-qualified [`Requirement`].
+///
+/// The returned requirements preserve the input order: all named requirements appear first
+/// (in their original order), followed by all unnamed requirements (in their original order,
+/// resolved concurrently via [`FuturesOrdered`]). Callers may rely on this ordering guarantee.
 pub(crate) async fn resolve_names(
     requirements: Vec<UnresolvedRequirementSpecification>,
     interpreter: &Interpreter,


### PR DESCRIPTION
### Summary

This PR optimizes the `uvx` (`uv tool run`) hot path for the most common scenario: re-running a tool that's already installed with no extra flags. The key insight is that `get_or_create_environment()` currently performs Python discovery, name resolution, and requirement resolution *before* checking whether the tool is already installed. For repeat invocations — particularly MCP servers launched via `uvx` — this adds avoidable latency.

### Benchmarks

Measured with `hyperfine --warmup 5 --min-runs 50` on macOS (Apple Silicon), comparing `main` against this branch.

**Simple invocation (fast path applies): `uvx ruff --version`**

| Command | Mean [ms] | Min [ms] | Max [ms] |
|:---|---:|---:|---:|
| baseline (main) | 75.4 ± 7.0 | 64.0 | 106.3 |
| optimized (fast path) | 33.9 ± 4.2 | 23.8 | 44.0 |

**2.2x faster** — the fast path skips Python discovery and name resolution entirely.

### Approach

Three tiers of optimization, each independent and backward-compatible:

**Tier 1 — Receipt-based fast path** (largest win)

For "simple" invocations (bare `uvx <package>` with no `--with`, `--from`, `--python`, `--isolated`, `@version`, `@latest`, or build constraints), a new `try_installed_fast_path()` checks the tool receipt and validates the environment *before* any Python discovery or name resolution. If the receipt matches and the interpreter exists, the installed environment is returned immediately.

- `is_simple_invocation()` gates entry to the fast path
- `receipt_matches_request()` encapsulates the pure matching logic (extracted for testability)
- `try_installed_fast_path()` orchestrates the check: parse package name → shared lock → read receipt → match options → validate environment

**Tier 2 — Shared file locking for read-only checks**

Adds `InstalledTools::lock_shared()` using `LockedFileMode::Shared`, replacing the exclusive lock for all read-only installed tool checks. This allows concurrent `uvx` processes to check tool status without blocking each other. Write operations (environment creation) continue to use the exclusive lock.

**Tier 3 — Batched name resolution and parallel discovery**

- `resolve_names` calls for `--with` requirements and overrides are batched into a single call (the main requirement's resolution stays separate since it happens during target parsing)
- Python discovery and the installed tool pre-check run concurrently via `tokio::join!` for non-simple invocations, reducing wall-clock time when the fast path can't be used

### Testing

**Unit tests** (5 tests in `uv-tool`):
- Shared lock acquisition, multiple concurrent shared locks, exclusive lock still works

**Property-based tests** (8 tests in `uv`, 100 iterations each via `proptest`):
- Property 1: Fast path equivalence — receipt match produces the same `ToolRequirement` as the full path
- Property 2: Fast path fallback completeness — all failure conditions (mismatched options, constraints, overrides, build constraints, empty requirements) return `None`
- Property 3: Receipt match implies success — valid matching receipts always succeed
- Property 4: Non-simple invocations bypass fast path — any non-simple flag causes `is_simple_invocation` to return `false`
- Property 5: Error propagation in parallel operations — first error (Python discovery) takes precedence when both concurrent operations fail

### Changed files

- `crates/uv-tool/src/lib.rs` — `lock_shared()` method + unit tests
- `crates/uv/src/commands/tool/run.rs` — fast path, `is_simple_invocation`, batched resolution, parallel discovery, property tests
- `crates/uv/src/commands/project/mod.rs` — doc comment on `resolve_names` order guarantee
- `Cargo.toml`, `crates/uv/Cargo.toml`, `crates/uv-tool/Cargo.toml` — `proptest` + dev-dependency additions
