### PR TITLE
Fix `UV_NO_DEFAULT_GROUPS` rejecting truthy values like `1`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3531,7 +3531,7 @@ pub struct RunArgs {
     ///
     /// uv includes the groups defined in `tool.uv.default-groups` by default.
     /// This disables that option, however, specific groups can still be included with `--group`.
-    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS)]
+    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_default_groups: bool,
 
     /// Only include dependencies from the specified dependency group.
@@ -3869,7 +3869,7 @@ pub struct SyncArgs {
     ///
     /// uv includes the groups defined in `tool.uv.default-groups` by default.
     /// This disables that option, however, specific groups can still be included with `--group`.
-    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS)]
+    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_default_groups: bool,
 
     /// Only include dependencies from the specified dependency group.
@@ -4684,7 +4684,7 @@ pub struct TreeArgs {
     ///
     /// uv includes the groups defined in `tool.uv.default-groups` by default.
     /// This disables that option, however, specific groups can still be included with `--group`.
-    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS)]
+    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_default_groups: bool,
 
     /// Only include dependencies from the specified dependency group.
@@ -4861,7 +4861,7 @@ pub struct ExportArgs {
     ///
     /// uv includes the groups defined in `tool.uv.default-groups` by default.
     /// This disables that option, however, specific groups can still be included with `--group`.
-    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS)]
+    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_default_groups: bool,
 
     /// Only include dependencies from the specified dependency group.


### PR DESCRIPTION
## Summary

Fixes #18002.

`UV_NO_DEFAULT_GROUPS=1 uv sync` currently fails with:

```
error: invalid value '1' for '--no-default-groups'
  [possible values: true, false]
```

This is because `--no-default-groups` uses clap's default bool parser, which only accepts `true`/`false`. Meanwhile, `--no-dev` (and `UV_NO_DEV`) already uses `BoolishValueParser`, which accepts `1`, `yes`, `on`, `true` (and their negatives).

## Fix

Add `value_parser = clap::builder::BoolishValueParser::new()` to all four `--no-default-groups` argument definitions (`SyncArgs`, `RunArgs`, `ExportArgs`, `TreeArgs`), matching the existing pattern used by `--no-dev`.

## Test Plan

`UV_NO_DEFAULT_GROUPS=1 uv sync` should now succeed instead of erroring.