### PR TITLE
Open locked files for writing but only when they are being opened to take an exclusive lock

### DIFF
--- a/crates/uv-fs/src/locked_file.rs
+++ b/crates/uv-fs/src/locked_file.rs
@@ -257,7 +257,8 @@ impl LockedFile {
 
         // While `flock` itself does not need write permissions to take an exclusive lock, on Linux
         // it can be silently translated to a POSIX byte-range lock (`fcntl`/`lockf`) on the whole
-        // file when NFS is involved. POSIX locks require the file to be opened for writing.
+        // file when NFS is involved. Exclusive POSIX locks require the file to be opened for
+        // writing.
         //
         // To accommodate this, we conditionally open for writing when taking exclusive locks.
         //


### PR DESCRIPTION
## Summary

Fix #18061.

#17956 has introduced a regression causing locking locked files to fail when the locked file is on an NFS mountpoint. This is because nfs doesn't support `flock` and on linux `flock` will get silently turned into an `fcntl` (aka POSIX) advisory record locking call. These locks _do_ require the file to be open for writing when trying to take the lock.

Since we should only be taking exclusive locks when we intend to modify the resource which is being locked, it should be okay to open the file for writing as well as reading whenever we are taking an exclusive lock, since if we cannot open the locked file for writing, it's likely we'll fail shortly afterwards even if we could open it for reading only.

## Test Plan

I set up an NFSv4 mount on Linux 6.12.67 and verified that the EBADF errors were gone.