### PR TITLE
make missing files warning debug

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1416,14 +1416,14 @@ impl SimpleDetailMetadata {
         for file in files {
             let Some(filename) = DistFilename::try_from_filename(&file.filename, package_name)
             else {
-                warn!("Skipping file for {package_name}: {}", file.filename);
+                debug!("Skipping file for {package_name}: {}", file.filename);
                 continue;
             };
             let file = match File::try_from_pypi(file, &base) {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
-                    warn!("Skipping file for {package_name}: {err}");
+                    debug!("Skipping file for {package_name}: {err}");
                     continue;
                 }
             };
@@ -1470,13 +1470,13 @@ impl SimpleDetailMetadata {
                 Ok(file) => file,
                 Err(err) => {
                     // Ignore files with unparsable version specifiers.
-                    warn!("Skipping file for {package_name}: {err}");
+                    debug!("Skipping file for {package_name}: {err}");
                     continue;
                 }
             };
             let Some(filename) = DistFilename::try_from_filename(&file.filename, package_name)
             else {
-                warn!("Skipping file for {package_name}: {}", file.filename);
+                debug!("Skipping file for {package_name}: {}", file.filename);
                 continue;
             };
             match version_map.entry(filename.version().clone()) {


### PR DESCRIPTION
make missing files warning debug

Currently, there are a lot of spurious warning messages about missing files for some packages. This
results in output like this, with dozens or more of the same message:

```
❯ : uv tool install audible-cli --upgrade
WARN Skipping file for beautifulsoup4: beautifulsoup4-4.6.1-py2.7.egg
WARN Skipping file for beautifulsoup4: beautifulsoup4-4.6.1-py3.5.egg
WARN Skipping file for pyasn1: pyasn1-0.0.11a-py2.3.egg
WARN Skipping file for pyasn1: pyasn1-0.0.11a-py2.4.egg
WARN Skipping file for pyasn1: pyasn1-0.0.11a-py2.5.egg
WARN Skipping file for pyasn1: pyasn1-0.0.11a-py2.6.egg
WARN Skipping file for pyasn1: pyasn1-0.0.11a-py2.7.egg
WARN Skipping file for pyasn1: pyasn1-0.0.12a-py2.3.egg
WARN Skipping file for pyasn1: pyasn1-0.0.12a-py2.4.egg
WARN Skipping file for pyasn1: pyasn1-0.0.12a-py2.5.egg
WARN Skipping file for pyasn1: pyasn1-0.0.12a-py2.6.egg
WARN Skipping file for pyasn1: pyasn1-0.0.12a-py2.7.egg
WARN Skipping file for pyasn1: pyasn1-0.0.13-py2.3.egg
WARN Skipping file for pyasn1: pyasn1-0.0.13-py2.4.egg
WARN Skipping file for pyasn1: pyasn1-0.0.13-py2.5.egg
WARN Skipping file for pyasn1: pyasn1-0.0.13-py2.6.egg
WARN Skipping file for pyasn1: pyasn1-0.0.13-py2.7.egg
```

This change makes them debug messages instead to avoid all these unhelpful messages.
