### PR TITLE
Fix Python version selection for scripts with a `requires-python` conflicting with `.python-version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6806,6 +6806,7 @@ dependencies = [
  "uv-client",
  "uv-dirs",
  "uv-distribution-filename",
+ "uv-distribution-types",
  "uv-extract",
  "uv-fs",
  "uv-install-wheel",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -22,6 +22,7 @@ uv-cache-key = { workspace = true }
 uv-client = { workspace = true }
 uv-dirs = { workspace = true }
 uv-distribution-filename = { workspace = true }
+uv-distribution-types = { workspace = true }
 uv-extract = { workspace = true }
 uv-fs = { workspace = true }
 uv-install-wheel = { workspace = true }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use uv_cache::Cache;
 use uv_client::BaseClient;
+use uv_distribution_types::RequiresPython;
 use uv_fs::Simplified;
 use uv_fs::which::is_executable;
 use uv_pep440::{
@@ -2241,8 +2242,53 @@ impl PythonRequest {
             Self::Key(download_request) => download_request
                 .version()
                 .and_then(VersionRequest::as_pep440_version),
-            _ => None,
+            Self::Default
+            | Self::Any
+            | Self::Directory(_)
+            | Self::File(_)
+            | Self::ExecutableName(_)
+            | Self::Implementation(_) => None,
         }
+    }
+
+    /// Convert an interpreter request into [`VersionSpecifiers`] representing the range of
+    /// compatible versions.
+    ///
+    /// Returns `None` if the request doesn't carry version constraints (e.g., a path or
+    /// executable name).
+    pub fn as_version_specifiers(&self) -> Option<VersionSpecifiers> {
+        match self {
+            Self::Version(version) | Self::ImplementationVersion(_, version) => {
+                version.as_version_specifiers()
+            }
+            Self::Key(download_request) => download_request
+                .version()
+                .and_then(VersionRequest::as_version_specifiers),
+            Self::Default
+            | Self::Any
+            | Self::Directory(_)
+            | Self::File(_)
+            | Self::ExecutableName(_)
+            | Self::Implementation(_) => None,
+        }
+    }
+
+    /// Returns `true` when this request is compatible with the given `requires-python` specifier.
+    ///
+    /// Requests without version constraints (e.g., paths, executable names) are always considered
+    /// compatible. For versioned requests, compatibility means the request's version range has a
+    /// non-empty intersection with the `requires-python` range.
+    pub fn intersects_requires_python(&self, requires_python: &RequiresPython) -> bool {
+        let Some(specifiers) = self.as_version_specifiers() else {
+            return true;
+        };
+
+        let request_range = release_specifiers_to_ranges(specifiers);
+        let requires_python_range =
+            release_specifiers_to_ranges(requires_python.specifiers().clone());
+        !request_range
+            .intersection(&requires_python_range)
+            .is_empty()
     }
 }
 
@@ -3101,6 +3147,38 @@ impl VersionRequest {
             ),
         }
     }
+
+    /// Convert this request into [`VersionSpecifiers`] representing the range of compatible
+    /// versions.
+    ///
+    /// Returns `None` for requests without version constraints (e.g., [`VersionRequest::Default`]
+    /// and [`VersionRequest::Any`]).
+    pub fn as_version_specifiers(&self) -> Option<VersionSpecifiers> {
+        match self {
+            Self::Default | Self::Any => None,
+            Self::Major(major, _) => Some(VersionSpecifiers::from(
+                VersionSpecifier::equals_star_version(Version::new([u64::from(*major)])),
+            )),
+            Self::MajorMinor(major, minor, _) => Some(VersionSpecifiers::from(
+                VersionSpecifier::equals_star_version(Version::new([
+                    u64::from(*major),
+                    u64::from(*minor),
+                ])),
+            )),
+            Self::MajorMinorPatch(major, minor, patch, _) => {
+                Some(VersionSpecifiers::from(VersionSpecifier::equals_version(
+                    Version::new([u64::from(*major), u64::from(*minor), u64::from(*patch)]),
+                )))
+            }
+            Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
+                Some(VersionSpecifiers::from(VersionSpecifier::equals_version(
+                    Version::new([u64::from(*major), u64::from(*minor), 0])
+                        .with_pre(Some(*prerelease)),
+                )))
+            }
+            Self::Range(specifiers, _) => Some(specifiers.clone()),
+        }
+    }
 }
 
 impl FromStr for VersionRequest {
@@ -3498,6 +3576,7 @@ mod tests {
     use assert_fs::{TempDir, prelude::*};
     use target_lexicon::{Aarch64Architecture, Architecture};
     use test_log::test;
+    use uv_distribution_types::RequiresPython;
     use uv_pep440::{Prerelease, PrereleaseKind, Version, VersionSpecifiers};
 
     use crate::{
@@ -4292,6 +4371,64 @@ mod tests {
         assert_eq!(
             PythonRequest::Version(VersionRequest::from_str(">=3.10").unwrap()).as_pep440_version(),
             None
+        );
+    }
+
+    #[test]
+    fn intersects_requires_python_exact() {
+        let requires_python =
+            RequiresPython::from_specifiers(&VersionSpecifiers::from_str(">=3.12").unwrap());
+
+        assert!(PythonRequest::parse("3.12").intersects_requires_python(&requires_python));
+        assert!(!PythonRequest::parse("3.11").intersects_requires_python(&requires_python));
+    }
+
+    #[test]
+    fn intersects_requires_python_major() {
+        let requires_python =
+            RequiresPython::from_specifiers(&VersionSpecifiers::from_str(">=3.12").unwrap());
+
+        // `3` overlaps with `>=3.12` (e.g., 3.12, 3.13, ... are all Python 3)
+        assert!(PythonRequest::parse("3").intersects_requires_python(&requires_python));
+        // `2` does not overlap with `>=3.12`
+        assert!(!PythonRequest::parse("2").intersects_requires_python(&requires_python));
+    }
+
+    #[test]
+    fn intersects_requires_python_range() {
+        let requires_python =
+            RequiresPython::from_specifiers(&VersionSpecifiers::from_str(">=3.12").unwrap());
+
+        assert!(PythonRequest::parse(">=3.12,<3.13").intersects_requires_python(&requires_python));
+        assert!(!PythonRequest::parse(">=3.10,<3.12").intersects_requires_python(&requires_python));
+    }
+
+    #[test]
+    fn intersects_requires_python_implementation_range() {
+        let requires_python =
+            RequiresPython::from_specifiers(&VersionSpecifiers::from_str(">=3.12").unwrap());
+
+        assert!(
+            PythonRequest::parse("cpython@>=3.12,<3.13")
+                .intersects_requires_python(&requires_python)
+        );
+        assert!(
+            !PythonRequest::parse("cpython@>=3.10,<3.12")
+                .intersects_requires_python(&requires_python)
+        );
+    }
+
+    #[test]
+    fn intersects_requires_python_no_version() {
+        let requires_python =
+            RequiresPython::from_specifiers(&VersionSpecifiers::from_str(">=3.12").unwrap());
+
+        // Requests without version constraints are always compatible
+        assert!(PythonRequest::Any.intersects_requires_python(&requires_python));
+        assert!(PythonRequest::Default.intersects_requires_python(&requires_python));
+        assert!(
+            PythonRequest::Implementation(ImplementationName::CPython)
+                .intersects_requires_python(&requires_python)
         );
     }
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -475,59 +475,111 @@ fn run_pep723_script() -> Result<()> {
 
 #[test]
 fn run_pep723_script_requires_python() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&["3.9", "3.11"]);
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
 
-    // If we have a `.python-version` that's incompatible with the script, we should error.
+    // If we have a `.python-version` that's incompatible with the script, we should use the
+    // script's `requires-python` for Python discovery instead.
     let python_version = context.temp_dir.child(PYTHON_VERSION_FILENAME);
-    python_version.write_str("3.9")?;
+    python_version.write_str("3.11")?;
 
-    // If the script contains a PEP 723 tag, we should install its requirements.
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # ///
+
+        import platform
+        print(platform.python_version())
+       "#
+    })?;
+
+    // The `.python-version` (3.11) is incompatible with the script's `requires-python` (>=3.12),
+    // so uv should ignore it and discover a compatible Python (3.12) instead.
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.[X]
+
+    ----- stderr -----
+    ");
+
+    // Deleting the `.python-version` file should not change the behavior.
+    fs_err::remove_file(&python_version)?;
+
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.[X]
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+/// When a `.python-version` is compatible with a script's `requires-python`, the `.python-version`
+/// should be used.
+#[test]
+fn run_pep723_script_requires_python_compatible() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
+
+    let python_version = context.temp_dir.child(PYTHON_VERSION_FILENAME);
+    python_version.write_str("3.11")?;
+
     let test_script = context.temp_dir.child("main.py");
     test_script.write_str(indoc! { r#"
         # /// script
         # requires-python = ">=3.11"
-        # dependencies = [
-        #   "iniconfig",
-        # ]
         # ///
 
-        import iniconfig
-
-        x: str | int = "hello"
-        print(x)
+        import platform
+        print(platform.python_version())
        "#
     })?;
 
-    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r#"
-    success: false
-    exit_code: 1
-    ----- stdout -----
-
-    ----- stderr -----
-    warning: The Python request from `.python-version` resolved to Python 3.9.[X], which is incompatible with the script's Python requirement: `>=3.11`
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + iniconfig==2.0.0
-    Traceback (most recent call last):
-      File "[TEMP_DIR]/main.py", line 10, in <module>
-        x: str | int = "hello"
-    TypeError: unsupported operand type(s) for |: 'type' and 'type'
-    "#);
-
-    // Delete the `.python-version` file to allow the script to run.
-    fs_err::remove_file(&python_version)?;
-
-    uv_snapshot!(context.filters(), context.run().arg("main.py"), @"
+    // The `.python-version` (3.11) is compatible with the script's `requires-python` (>=3.11),
+    // so it should be used.
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r"
     success: true
     exit_code: 0
     ----- stdout -----
-    hello
+    3.11.[X]
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + iniconfig==2.0.0
+    ");
+
+    Ok(())
+}
+
+/// When `.python-version` specifies an incompatible range, script `requires-python` should be used
+/// for discovery.
+#[test]
+fn run_pep723_script_requires_python_incompatible_range() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
+
+    let python_version = context.temp_dir.child(PYTHON_VERSION_FILENAME);
+    python_version.write_str(">3.8,<3.12")?;
+
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # ///
+
+        import platform
+        print(platform.python_version())
+       "#
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.[X]
+
+    ----- stderr -----
     ");
 
     Ok(())


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/17717#issuecomment-3886377795

Updates `ScriptPython::from_request` to match the implementation of `WorkspacePython::from_request` and adds filtering such that if the `.python-version` conflicts with the `requires-python`, we prefer the latter.