### PR TITLE
Fix combinatorial explosion in conflicted marker expressions

### DIFF
--- a/crates/uv-pep508/src/marker/algebra.rs
+++ b/crates/uv-pep508/src/marker/algebra.rs
@@ -622,10 +622,25 @@ impl InternerGuard<'_> {
         py_lower: Bound<&Version>,
         py_upper: Bound<&Version>,
     ) -> NodeId {
+        let mut cache = FxHashMap::default();
+        self.simplify_python_versions_cached(i, py_lower, py_upper, &mut cache)
+    }
+
+    fn simplify_python_versions_cached(
+        &mut self,
+        i: NodeId,
+        py_lower: Bound<&Version>,
+        py_upper: Bound<&Version>,
+        cache: &mut FxHashMap<NodeId, NodeId>,
+    ) -> NodeId {
         if matches!(i, NodeId::TRUE | NodeId::FALSE)
             || matches!((py_lower, py_upper), (Bound::Unbounded, Bound::Unbounded))
         {
             return i;
+        }
+
+        if let Some(&cached) = cache.get(&i) {
+            return cached;
         }
 
         let node = self.shared.node(i);
@@ -638,14 +653,17 @@ impl InternerGuard<'_> {
         else {
             // Simplify all nodes recursively.
             let children = node.children.map(i, |node_id| {
-                self.simplify_python_versions(node_id, py_lower, py_upper)
+                self.simplify_python_versions_cached(node_id, py_lower, py_upper, cache)
             });
-            return self.create_node(node.var.clone(), children);
+            let result = self.create_node(node.var.clone(), children);
+            cache.insert(i, result);
+            return result;
         };
         let py_range = Ranges::from_range_bounds((py_lower.cloned(), py_upper.cloned()));
         if py_range.is_empty() {
             // Oops, the bounds imply there is nothing that can match,
             // so we always evaluate to false.
+            cache.insert(i, NodeId::FALSE);
             return NodeId::FALSE;
         }
         let mut new = SmallVec::new();
@@ -675,8 +693,11 @@ impl InternerGuard<'_> {
         let clipped = Ranges::from_range_bounds((last_lower.cloned(), Bound::Unbounded));
         *new.last_mut().unwrap() = (clipped, last_node_id);
 
-        self.create_node(node.var.clone(), Edges::Version { edges: new })
-            .negate(i)
+        let result = self
+            .create_node(node.var.clone(), Edges::Version { edges: new })
+            .negate(i);
+        cache.insert(i, result);
+        result
     }
 
     /// Complexify this tree by requiring the given Python version
@@ -697,100 +718,16 @@ impl InternerGuard<'_> {
         {
             return i;
         }
-
         let py_range = Ranges::from_range_bounds((py_lower.cloned(), py_upper.cloned()));
         if py_range.is_empty() {
-            // Oops, the bounds imply there is nothing that can match,
-            // so we always evaluate to false.
             return NodeId::FALSE;
         }
-        if matches!(i, NodeId::TRUE) {
-            let var = Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion);
-            let edges = Edges::Version {
-                edges: Edges::from_range(&py_range),
-            };
-            return self.create_node(var, edges).negate(i);
-        }
-
-        let node = self.shared.node(i);
-        let Node {
-            var: Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion),
-            children: Edges::Version { edges },
-        } = node
-        else {
-            // Complexify all nodes recursively.
-            let children = node.children.map(i, |node_id| {
-                self.complexify_python_versions(node_id, py_lower, py_upper)
-            });
-            return self.create_node(node.var.clone(), children);
+        let var = Variable::Version(CanonicalMarkerValueVersion::PythonFullVersion);
+        let edges = Edges::Version {
+            edges: Edges::from_range(&py_range),
         };
-        // The approach we take here is to filter out any range that
-        // has no intersection with our Python lower/upper bounds.
-        // These ranges will now always be false, so we can dismiss
-        // them entirely.
-        //
-        // Then, depending on whether we have finite lower/upper bound,
-        // we "fix up" the edges by clipping the existing ranges and
-        // adding an additional range that covers the Python versions
-        // outside of our bounds by always mapping them to false.
-        let mut new: SmallVec<_> = edges
-            .iter()
-            .filter(|(range, _)| !py_range.intersection(range).is_empty())
-            .cloned()
-            .collect();
-        // Below, we assume `new` has at least one element. It's
-        // subtle, but since 1) edges is a disjoint covering of the
-        // universe and 2) our `py_range` is non-empty at this point,
-        // it must intersect with at least one range.
-        assert!(
-            !new.is_empty(),
-            "expected at least one non-empty intersection"
-        );
-        // This is the NodeId we map to anything that should
-        // always be false. We have to "negate" it in case the
-        // parent is negated.
-        let exclude_node_id = NodeId::FALSE.negate(i);
-        if !matches!(py_lower, Bound::Unbounded) {
-            let &(ref first_range, first_node_id) = new.first().unwrap();
-            let first_upper = first_range.bounding_range().unwrap().1;
-            // When the first range is always false, then we can just
-            // "expand" it out to negative infinity to reflect that
-            // anything less than our lower bound should evaluate to
-            // false. If we don't do this, then we could have two
-            // adjacent ranges map to the same node, which would not be
-            // a canonical representation.
-            if exclude_node_id == first_node_id {
-                let clipped = Ranges::from_range_bounds((Bound::Unbounded, first_upper.cloned()));
-                *new.first_mut().unwrap() = (clipped, first_node_id);
-            } else {
-                let clipped = Ranges::from_range_bounds((py_lower.cloned(), first_upper.cloned()));
-                *new.first_mut().unwrap() = (clipped, first_node_id);
-
-                let py_range_lower =
-                    Ranges::from_range_bounds((py_lower.cloned(), Bound::Unbounded));
-                new.insert(0, (py_range_lower.complement(), NodeId::FALSE.negate(i)));
-            }
-        }
-        if !matches!(py_upper, Bound::Unbounded) {
-            let &(ref last_range, last_node_id) = new.last().unwrap();
-            let last_lower = last_range.bounding_range().unwrap().0;
-            // See lower bound case above for why we do this. The
-            // same reasoning applies here: to maintain a canonical
-            // representation.
-            if exclude_node_id == last_node_id {
-                let clipped = Ranges::from_range_bounds((last_lower.cloned(), Bound::Unbounded));
-                *new.last_mut().unwrap() = (clipped, last_node_id);
-            } else {
-                let clipped = Ranges::from_range_bounds((last_lower.cloned(), py_upper.cloned()));
-                *new.last_mut().unwrap() = (clipped, last_node_id);
-
-                let py_range_upper =
-                    Ranges::from_range_bounds((Bound::Unbounded, py_upper.cloned()));
-                new.push((py_range_upper.complement(), exclude_node_id));
-            }
-        }
-        self.create_node(node.var.clone(), Edges::Version { edges: new })
-            .negate(i)
+        let py_node = self.create_node(var, edges);
+        self.and(i, py_node)
     }
 
     /// The disjunction of known incompatible conditions.

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -2113,6 +2113,157 @@ mod test {
         );
     }
 
+    /// Test that simplify_python_versions preserves correlations between
+    /// extras and platform markers (i.e., memoization doesn't lose info).
+    #[test]
+    fn simplify_python_versions_preserves_extra_platform_correlation() {
+        // The marker "(sys_platform != 'linux' and extra == 'x1') or (extra == 'x1' and extra == 'x2')"
+        // should NOT simplify to just "extra == 'x1'" — the sys_platform condition matters.
+        let marker =
+            m("(sys_platform != 'linux' and extra == 'x1') or (extra == 'x1' and extra == 'x2')");
+        let simplified = marker.simplify_python_versions(
+            Bound::Included(Version::new([3, 8])).as_ref(),
+            Bound::Unbounded.as_ref(),
+        );
+        // The simplified marker should still contain sys_platform — it shouldn't be lost.
+        assert_eq!(
+            simplified.try_to_string().unwrap(),
+            "(sys_platform != 'linux' and extra == 'x1') or (extra == 'x1' and extra == 'x2')"
+        );
+    }
+
+    /// Test that simplify_python_versions handles deeply shared BDD structures
+    /// efficiently (the memoization case). Many extras sharing the same
+    /// python_version subtree should not cause exponential traversal.
+    #[test]
+    fn simplify_python_versions_many_extras_shared_subtree() {
+        // Build a marker: (extra == 'a' or extra == 'b' or ... or extra == 'j') and python_version >= '3.9'
+        // This creates a BDD where many extra nodes share the same python_version subtree.
+        let marker = m(
+            "(extra == 'a' or extra == 'b' or extra == 'c' or extra == 'd' or extra == 'e' \
+             or extra == 'f' or extra == 'g' or extra == 'h' or extra == 'i' or extra == 'j') \
+             and python_full_version >= '3.9'",
+        );
+        let simplified = marker.simplify_python_versions(
+            Bound::Included(Version::new([3, 8])).as_ref(),
+            Bound::Unbounded.as_ref(),
+        );
+        // After simplification with requires-python >= 3.8, the python >= 3.9
+        // constraint should be preserved, along with all extras.
+        assert_eq!(
+            simplified.try_to_string().unwrap(),
+            "(python_full_version >= '3.9' and extra == 'a') \
+             or (python_full_version >= '3.9' and extra == 'b') \
+             or (python_full_version >= '3.9' and extra == 'c') \
+             or (python_full_version >= '3.9' and extra == 'd') \
+             or (python_full_version >= '3.9' and extra == 'e') \
+             or (python_full_version >= '3.9' and extra == 'f') \
+             or (python_full_version >= '3.9' and extra == 'g') \
+             or (python_full_version >= '3.9' and extra == 'h') \
+             or (python_full_version >= '3.9' and extra == 'i') \
+             or (python_full_version >= '3.9' and extra == 'j')"
+        );
+    }
+
+    /// Test that simplify_python_versions correctly simplifies when
+    /// requires-python subsumes the marker constraint, even with extras present.
+    #[test]
+    fn simplify_python_versions_subsumed_with_extras() {
+        // python_full_version >= '3.8' is always true given requires-python >= 3.8
+        let marker = m("extra == 'foo' and python_full_version >= '3.8'");
+        let simplified = marker.simplify_python_versions(
+            Bound::Included(Version::new([3, 8])).as_ref(),
+            Bound::Unbounded.as_ref(),
+        );
+        // The python constraint should be removed, leaving just the extra.
+        assert_eq!(simplified.try_to_string().unwrap(), "extra == 'foo'");
+    }
+
+    /// Test that complexify_python_versions works correctly with extras,
+    /// including the memoization path.
+    #[test]
+    fn complexify_python_versions_with_extras() {
+        // Start with a simplified marker that has extras and a python constraint.
+        let marker = m("extra == 'foo' and python_full_version < '3.12'");
+        let complexified = marker.complexify_python_versions(
+            Bound::Included(Version::new([3, 8])).as_ref(),
+            Bound::Unbounded.as_ref(),
+        );
+        // Should add the lower bound: python >= 3.8 AND python < 3.12 AND extra == 'foo'
+        assert_eq!(
+            complexified.try_to_string().unwrap(),
+            "python_full_version >= '3.8' and python_full_version < '3.12' and extra == 'foo'"
+        );
+    }
+
+    /// Regression test: the pathological case for complexify/simplify is a
+    /// marker tree with many extras OR'd together, where each conjunction
+    /// shares the same python_version/platform subtrees in the BDD.
+    ///
+    /// This mirrors what happens with cross-cutting conflicts (e.g., sktime):
+    /// many forks produce markers like:
+    ///   (extra == 'task_1' and extra != 'pin_a' and ... and python >= '3.11' and sys_platform != 'win32')
+    ///   OR (extra == 'task_2' and extra != 'pin_a' and ... and python >= '3.11' and sys_platform != 'win32')
+    ///   OR ...
+    ///
+    /// The BDD compresses the shared python/platform subtrees, but old
+    /// complexify_python_versions recursively re-walked them without
+    /// memoization.
+    #[test]
+    fn complexify_simplify_high_sharing_bdd() {
+        // Build marker trees mimicking cross-cutting conflict forks (e.g., sktime).
+        // Each conjunction: ONE task extra included, ALL OTHERS excluded,
+        // all pin extras excluded, plus shared python/platform conditions.
+        // This creates a BDD where many extra paths converge to the same
+        // python_version/platform subtrees — the pathological case for the
+        // old recursive complexify_python_versions.
+        let py_conditions = [
+            "(python_full_version >= '3.10' and python_full_version < '3.11' and sys_platform == 'linux')",
+            "(python_full_version >= '3.11' and python_full_version < '3.12' and sys_platform != 'win32')",
+            "(python_full_version >= '3.12' and sys_platform != 'darwin')",
+        ];
+        let py_clause = py_conditions.join(" or ");
+
+        for n in [10, 15, 20, 25, 30] {
+            let clauses: Vec<String> = (0..n)
+                .map(|i| {
+                    let mut parts = vec![];
+                    parts.push(format!("extra == 'task_{i}'"));
+                    for j in 0..n {
+                        if j != i {
+                            parts.push(format!("extra != 'task_{j}'"));
+                        }
+                    }
+                    for j in 0..5 {
+                        parts.push(format!("extra != 'pin_{j}'"));
+                    }
+                    format!("({} and ({}))", parts.join(" and "), py_clause)
+                })
+                .collect();
+            let marker = m(&clauses.join(" or "));
+
+            let start = std::time::Instant::now();
+            let simplified = marker.simplify_python_versions(
+                Bound::Included(Version::new([3, 10])).as_ref(),
+                Bound::Excluded(Version::new([3, 13])).as_ref(),
+            );
+            let simplify_time = start.elapsed();
+
+            let start = std::time::Instant::now();
+            let _complexified = simplified.complexify_python_versions(
+                Bound::Included(Version::new([3, 10])).as_ref(),
+                Bound::Excluded(Version::new([3, 13])).as_ref(),
+            );
+            let complexify_time = start.elapsed();
+
+            eprintln!("n={n}: simplify={simplify_time:?}, complexify={complexify_time:?}");
+            assert!(
+                complexify_time.as_secs() < 10,
+                "complexify took too long at n={n}: {complexify_time:?}"
+            );
+        }
+    }
+
     #[test]
     fn release_only() {
         assert!(m("python_full_version > '3.10' or python_full_version <= '3.10'").is_true());


### PR DESCRIPTION
Follow-up to #18094. In https://github.com/astral-sh/uv/issues/18026, resolution of projects with many cross-cutting conflict extras (e.g., [sktime](https://github.com/sktime/sktime/pull/8892)) hung during lock file generation, even after #18094 resolved the fork explosion in the resolver itself.
