### PR TITLE
Update stale comments and downgrade a `warn!`

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -212,7 +212,7 @@ impl<'a> FlatIndexClient<'a> {
                             Ok(file) => Some(file),
                             Err(err) => {
                                 // Ignore files with unparsable version specifiers.
-                                warn!("Skipping file in {}: {err}", &url);
+                                debug!("Skipping file in {}: {err}", &url);
                                 None
                             }
                         }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -6085,7 +6085,7 @@ fn simplified_universal_markers(
 /// For example, a package included under `sys_platform == 'win32'` does not need Linux
 /// wheels.
 ///
-/// Returns `false` if the wheel is definitely unreachable, and `true` if it may be reachable,
+/// Returns `true` if the wheel is definitely unreachable, and `false` if it may be reachable,
 /// including if the wheel tag isn't recognized.
 pub(crate) fn is_wheel_unreachable(
     filename: &WheelFilename,

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -284,9 +284,9 @@ impl ResolverEnvironment {
     /// When a group is excluded from a resolver environment,
     /// `ResolverEnvironment::included_by_group` will return false. The idea
     /// is that a dependency with a corresponding group should be excluded by
-    /// forks in the resolver with this environment. (Include rules have no
-    /// effect in `included_by_group` since, for the purposes of conflicts
-    /// during resolution, we only care about what *isn't* allowed.)
+    /// forks in the resolver with this environment. (Include rules also
+    /// affect `included_by_group`: when a project-level exclusion exists,
+    /// an explicit inclusion for a specific extra overrides it.)
     ///
     /// If calling this routine results in the same conflict item being both
     /// included and excluded, then this returns `None` (since it would


### PR DESCRIPTION
This came out of an experience on whether claude code can find missing updates in from changes in PRs:

#18096 — Propagate project-level conflicts to package extras (zanieb)
**Stale docstring on `filter_by_group`**: In `crates/uv-resolver/src/resolver/environment.rs`, the docstring still says "Include rules have no effect in `included_by_group`". After this PR, include rules DO affect `included_by_group` when a project-level exclusion exists for a package — an explicit inclusion for a specific extra overrides the exclusion.

#18081 — Filter `pylock.toml` wheels by tags and `requires-python` (konstin)
**Inverted docstring on `is_wheel_unreachable`**: At `crates/uv-resolver/src/lock/mod.rs:6088`, the docstring says "Returns `false` if the wheel is definitely unreachable" but the function actually returns `true` when unreachable. The `true`/`false` are swapped.

#18075 — make missing files warning debug (dead10ck)
**Analogous `warn!` not changed in flat_index.rs**: `crates/uv-client/src/flat_index.rs:215` has a similar `warn!("Skipping file in {}: {err}", &url)` that exhibits the same noisy pattern. Arguable whether flat indexes warrant the same change since they're user-configured and less likely to trigger mass warnings.