### PR TITLE
Add debian community repository

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,6 +96,16 @@ uv is available in the core Homebrew packages.
 $ brew install uv
 ```
 
+### Debian and Ubuntu
+
+uv is available via Community package [debian.griffo.io](https://debian.griffo.io).
+
+```console
+$ curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
+$ echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
+$ sudo apt update && apt sudo apt install uv
+```
+
 ### MacPorts
 
 uv is available via [MacPorts](https://ports.macports.org/port/uv/).


### PR DESCRIPTION
## Summary

Added a debian community repository for Debian and Ubuntu.
My reposiroty is referenced by zed and ghostty
https://zed.dev/docs/linux#debian
https://ghostty.org/docs/install/binary#debian

And currently uv is the undefeated most download package from my repo, this is just February downloads
<img width="643" height="642" alt="image" src="https://github.com/user-attachments/assets/54cd4f62-ceed-4ba8-8e8f-8f5c66b8b294" />
