### PR TITLE
Add uname -m to the interpreter cache key

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1036,7 +1036,7 @@ jobs:
         run: ./uv python install ${{ matrix.alt-python }}
 
       - name: "Create venv with alternate-arch Python"
-        run: ./uv venv --python ${{ matrix.alt-python }} test-venv
+        run: ./uv venv -v --python ${{ matrix.alt-python }} test-venv
 
       - name: "Write requirements file"
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1004,3 +1004,53 @@ jobs:
 
       - name: "Check cache compatibility"
         run: python scripts/check_cache_compat.py --uv-current ./uv --uv-previous ./uv-aarch64-apple-darwin/uv
+
+  integration-test-setarch:
+    name: "setarch ${{ matrix.setarch }} on ${{ matrix.native-arch }}"
+    timeout-minutes: 10
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            artifact: uv-linux-libc
+            setarch: linux32
+            native-arch: x86_64
+            alt-python: "3.11-i686"
+          - runner: ubuntu-24.04-arm
+            artifact: uv-linux-aarch64
+            setarch: armv7l
+            native-arch: aarch64
+            alt-python: "3.11-armv7-gnueabihf"
+    steps:
+      - name: "Download binary"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ matrix.artifact }}-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Install alternate-arch Python"
+        run: ./uv python install ${{ matrix.alt-python }}
+
+      - name: "Create venv with alternate-arch Python"
+        run: ./uv venv --python ${{ matrix.alt-python }} test-venv
+
+      - name: "Write requirements file"
+        run: |
+          cat > requirements.txt <<'EOF'
+          idna==3.10; platform_machine == '${{ matrix.native-arch }}'
+          idna==3.9; platform_machine != '${{ matrix.native-arch }}'
+          EOF
+
+      - name: "Resolve with native arch (populates cache)"
+        run: |
+          ./uv pip install --python test-venv --dry-run -r requirements.txt 2>&1 | tee native-output.txt
+          grep 'idna==3.10' native-output.txt
+
+      - name: "Resolve under setarch (expect cache invalidation)"
+        run: |
+          setarch ${{ matrix.setarch }} ./uv pip install --python test-venv --dry-run -r requirements.txt 2>&1 | tee setarch-output.txt
+          grep 'idna==3.9' setarch-output.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,6 +6857,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "junction",
+ "nix 0.30.1",
  "owo-colors",
  "ref-cast",
  "regex",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -73,6 +73,9 @@ junction = { workspace = true }
 windows-registry = { workspace = true }
 windows = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["feature"] }  # "feature" gates `nix::sys::utsname`
+
 [dev-dependencies]
 anyhow = { workspace = true }
 assert_fs = { workspace = true }

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -1077,10 +1077,9 @@ impl InterpreterInfo {
 
     #[cfg(unix)]
     fn uname_machine() -> Option<String> {
-        match uname() {
-            Ok(uts) => uts.machine().to_str().map(str::to_string),
-            Err(_) => None,
-        }
+        uname()
+            .ok()
+            .and_then(|uts| uts.machine().to_str().map(str::to_string))
     }
 
     #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

On multi-arch systems, the value of platform_machine can change if the user runs `python` under setarch. This affects dependency resolution. This PR adds the host's effective `uname` to the interpreter cache key 

Fixes #18163 

## Test Plan

I tested this manually on an AArch64/armv8l Raspberry Pi. Open to suggestions for more tests!
