### PR TITLE
Fix `astral-test-pypa-gh-action` publish test bug in patch version retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
           cd astral-test-pypa-gh-action
           ../uv init --package
           # Get the latest patch version
-          patch_version=$(curl https://test.pypi.org/simple/astral-test-pypa-gh-action/?format=application/vnd.pypi.simple.v1+json | jq --raw-output '.files[-1].filename' | sed 's/astral_test_pypa_gh_action-0\.1\.\([0-9]\+\)\.tar\.gz/\1/')
+          patch_version=$(curl https://test.pypi.org/simple/astral-test-pypa-gh-action/?format=application/vnd.pypi.simple.v1+json | jq --raw-output '[.files[].filename | select(endswith(".tar.gz"))] | last' | sed 's/astral_test_pypa_gh_action-0\.1\.\([0-9]\+\)\.tar\.gz/\1/')
           # Set the current version to one higher (which should be unused)
           sed -i "s/0.1.0/0.1.$((patch_version + 1))/g" pyproject.toml
           ../uv build


### PR DESCRIPTION
The jq filter used `.files[-1].filename` to get the latest published version then uses sed to extract the version from a sdist filename, but the last file in the list can be a wheel rather than an sdist in the middle of an upload. When it's a wheel, the filename passes through unchanged and bash complains trying to evaluate it as arithmetic. 

e.g.:

> astral_test_pypa_gh_action-0.1.1650-py3-none-any.whl: syntax error: invalid arithmetic operator (error token is ".1.1650-py3-none-any.whl")                                                                       

Surprisingly, this does not fail the job — `sed -i "s/0.1.0/0.1.$((patch_version + 1))/g` fails silently in its subshell, leaving the version as 0.1.0, `test.pypi.org` returns 400 File already exists, and the test succeeds because we use `skip-existing: true`.