### PR TITLE
Ensure the `astral-test-pypa-gh-action` test case fails on script bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,13 +294,14 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Build astral-test-pypa-gh-action"
+        shell: bash -eo pipefail {0}
         run: |
           # Build a yet unused version of `astral-test-pypa-gh-action`
           mkdir astral-test-pypa-gh-action
           cd astral-test-pypa-gh-action
           ../uv init --package
           # Get the latest patch version
-          patch_version=$(curl https://test.pypi.org/simple/astral-test-pypa-gh-action/?format=application/vnd.pypi.simple.v1+json | jq --raw-output '[.files[].filename | select(endswith(".tar.gz"))] | last' | sed 's/astral_test_pypa_gh_action-0\.1\.\([0-9]\+\)\.tar\.gz/\1/')
+          patch_version=$(curl https://test.pypi.org/simple/astral-test-pypa-gh-action/?format=application/vnd.pypi.simple.v1+json | jq --raw-output '[.files[].filename | select(endswith(".tar.gz"))] | last' | grep -oP '(?<=astral_test_pypa_gh_action-0\.1\.)\d+(?=\.tar\.gz)')
           # Set the current version to one higher (which should be unused)
           sed -i "s/0.1.0/0.1.$((patch_version + 1))/g" pyproject.toml
           ../uv build


### PR DESCRIPTION
Per https://github.com/astral-sh/uv/pull/18174 this should fail but it depends on hitting the simple API in the middle of a release being uploaded.