### PR TITLE
Remove verbose documentation from optional dependencies help text

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3462,8 +3462,6 @@ pub struct RunArgs {
     ///
     /// May be provided more than once.
     ///
-    /// Optional dependencies are defined via `project.optional-dependencies` in a `pyproject.toml`.
-    ///
     /// This option is only available when running in a project.
     #[arg(
         long,
@@ -3476,8 +3474,6 @@ pub struct RunArgs {
     pub extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.
-    ///
-    /// Optional dependencies are defined via `project.optional-dependencies` in a `pyproject.toml`.
     ///
     /// This option is only available when running in a project.
     #[arg(long, conflicts_with = "extra", conflicts_with = "only_group")]


### PR DESCRIPTION
This seems a bit much