### PR TITLE
Trim trailing whitespace in help output

### DIFF
--- a/crates/uv/src/commands/help.rs
+++ b/crates/uv/src/commands/help.rs
@@ -82,6 +82,10 @@ pub(crate) fn help(query: &[String], printer: Printer, no_pager: bool) -> Result
         reformat_env_annotations(&help.ansi().to_string())
     };
 
+    // Trim trailing whitespace from each line (https://github.com/clap-rs/clap/issues/5074).
+    let help_plain = help_plain.lines().map(str::trim_end).join("\n");
+    let help_ansi = help_ansi.lines().map(str::trim_end).join("\n");
+
     let want_color = match anstream::Stdout::choice(&std::io::stdout()) {
         ColorChoice::Always | ColorChoice::AlwaysAnsi => true,
         ColorChoice::Never => false,

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -81,7 +81,6 @@ fn help() {
 
     Use `uv help <command>` for more information on a specific command.
 
-
     ----- stderr -----
     "#);
 }
@@ -314,23 +313,23 @@ fn help_subcommand() {
       -n, --no-cache
               Avoid reading from or writing to the cache, instead using a temporary directory for the
               duration of the operation
-              
+
               [env: UV_NO_CACHE=]
 
           --cache-dir [CACHE_DIR]
               Path to the cache directory.
-              
+
               Defaults to `$XDG_CACHE_HOME/uv` or `$HOME/.cache/uv` on macOS and Linux, and
               `%LOCALAPPDATA%/uv/cache` on Windows.
-              
+
               To view the location of the cache directory, run `uv cache dir`.
-              
+
               [env: UV_CACHE_DIR=]
 
     Python options:
           --managed-python
               Require use of uv-managed Python versions.
-              
+
               By default, uv prefers using Python versions it manages. However, it will use system
               Python versions if a uv-managed Python is not installed. This option disables use of
               system Python versions.
@@ -339,7 +338,7 @@ fn help_subcommand() {
 
           --no-managed-python
               Disable use of uv-managed Python versions.
-              
+
               Instead, uv will search for a suitable Python version on the system.
 
               [env: UV_NO_MANAGED_PYTHON=]
@@ -350,19 +349,19 @@ fn help_subcommand() {
     Global options:
       -q, --quiet...
               Use quiet output.
-              
+
               Repeating this option, e.g., `-qq`, will enable a silent mode in which uv will write no
               output to stdout.
 
       -v, --verbose...
               Use verbose output.
-              
+
               You can configure fine-grained logging using the `RUST_LOG` environment variable.
               (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
 
           --color <COLOR_CHOICE>
               Control the use of color in output.
-              
+
               By default, uv will automatically detect support for colors when writing to a terminal.
 
               Possible values:
@@ -374,81 +373,81 @@ fn help_subcommand() {
           --system-certs
               Whether to load TLS certificates from the platform's native certificate store [env:
               UV_SYSTEM_CERTS=]
-              
+
               By default, uv uses bundled Mozilla root certificates, which improves portability and
               performance (especially on macOS).
-              
+
               However, in some cases, you may want to use the platform's native certificate store,
               especially if you're relying on a corporate trust root (e.g., for a mandatory proxy)
               that's included in your system's certificate store.
 
           --offline
               Disable network access.
-              
+
               When disabled, uv will only use locally cached data and locally available files.
 
               [env: UV_OFFLINE=]
 
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host.
-              
+
               Can be provided multiple times.
-              
+
               Expects to receive either a hostname (e.g., `localhost`), a host-port pair (e.g.,
               `localhost:8080`), or a URL (e.g., `https://localhost`).
-              
+
               WARNING: Hosts included in this list will not be verified against the system's certificate
               store. Only use `--allow-insecure-host` in a secure network with verified sources, as it
               bypasses SSL verification and could expose you to MITM attacks.
-              
+
               [env: UV_INSECURE_HOST=]
 
           --no-progress
               Hide all progress outputs.
-              
+
               For example, spinners or progress bars.
 
               [env: UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
-              
+
               Relative paths are resolved with the given directory as the base.
-              
+
               See `--project` to only change the project root directory.
-              
+
               [env: UV_WORKING_DIR=]
 
           --project <PROJECT>
               Discover a project in the given directory.
-              
+
               All `pyproject.toml`, `uv.toml`, and `.python-version` files will be discovered by walking
               up the directory tree from the project root, as will the project's virtual environment
               (`.venv`).
-              
+
               Other command-line arguments (such as relative paths) will be resolved relative to the
               current working directory.
-              
+
               See `--directory` to change the working directory entirely.
-              
+
               This setting has no effect when used in the `uv pip` interface.
-              
+
               [env: UV_PROJECT=]
 
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration.
-              
+
               While uv configuration can be included in a `pyproject.toml` file, it is not allowed in
               this context.
-              
+
               [env: UV_CONFIG_FILE=]
 
           --no-config
               Avoid discovering configuration files (`pyproject.toml`, `uv.toml`).
-              
+
               Normally, configuration files are discovered in the current directory, parent directories,
               or user configuration directories.
-              
+
               [env: UV_NO_CONFIG=]
 
       -h, --help
@@ -491,53 +490,53 @@ fn help_subsubcommand() {
     Arguments:
       [TARGETS]...
               The Python version(s) to install.
-              
+
               If not provided, the requested Python version(s) will be read from the `UV_PYTHON`
               environment variable then `.python-versions` or `.python-version` files. If none of the
               above are present, uv will check if it has installed any Python versions. If not, it will
               install the latest stable version of Python.
-              
+
               See `uv help python` to view supported request formats.
-              
+
               [env: UV_PYTHON=]
 
     Options:
       -i, --install-dir <INSTALL_DIR>
               The directory to store the Python installation in.
-              
+
               If provided, `UV_PYTHON_INSTALL_DIR` will need to be set for subsequent operations for uv
               to discover the Python installation.
-              
+
               See `uv python dir` to view the current Python installation directory. Defaults to
               `~/.local/share/uv/python`.
-              
+
               [env: UV_PYTHON_INSTALL_DIR=]
 
           --no-bin
               Do not install a Python executable into the `bin` directory.
-              
+
               This can also be set with `UV_PYTHON_INSTALL_BIN=0`.
 
           --no-registry
               Do not register the Python installation in the Windows registry.
-              
+
               This can also be set with `UV_PYTHON_INSTALL_REGISTRY=0`.
 
           --mirror <MIRROR>
               Set the URL to use as the source for downloading Python installations.
-              
+
               The provided URL will replace
               `https://github.com/astral-sh/python-build-standalone/releases/download` in, e.g.,
               `https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
-              
+
               Distributions can be read from a local directory by using the `file://` URL scheme.
 
           --pypy-mirror <PYPY_MIRROR>
               Set the URL to use as the source for downloading PyPy installations.
-              
+
               The provided URL will replace `https://downloads.python.org/pypy` in, e.g.,
               `https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2`.
-              
+
               Distributions can be read from a local directory by using the `file://` URL scheme.
 
           --python-downloads-json-url <PYTHON_DOWNLOADS_JSON_URL>
@@ -545,76 +544,76 @@ fn help_subsubcommand() {
 
       -r, --reinstall
               Reinstall the requested Python version, if it's already installed.
-              
+
               By default, uv will exit successfully if the version is already installed.
 
       -f, --force
               Replace existing Python executables during installation.
-              
+
               By default, uv will refuse to replace executables that it does not manage.
-              
+
               Implies `--reinstall`.
 
       -U, --upgrade
               Upgrade existing Python installations to the latest patch version.
-              
+
               By default, uv will not upgrade already-installed Python versions to newer patch releases.
               With `--upgrade`, uv will upgrade to the latest available patch version for the specified
               minor version(s).
-              
+
               If the requested versions are not yet installed, uv will install them.
-              
+
               This option is only supported for minor version requests, e.g., `3.12`; uv will exit with
               an error if a patch version, e.g., `3.12.2`, is requested.
 
           --default
               Use as the default Python version.
-              
+
               By default, only a `python{major}.{minor}` executable is installed, e.g., `python3.10`.
               When the `--default` flag is used, `python{major}`, e.g., `python3`, and `python`
               executables are also installed.
-              
+
               Alternative Python variants will still include their tag. For example, installing
               3.13+freethreaded with `--default` will include `python3t` and `pythont` instead of
               `python3` and `python`.
-              
+
               If multiple Python versions are requested, uv will exit with an error.
 
           --compile-bytecode
               Compile Python's standard library to bytecode after installation.
-              
+
               By default, uv does not compile Python (`.py`) files to bytecode (`__pycache__/*.pyc`);
               instead, compilation is performed lazily the first time a module is imported. For
               use-cases in which start time is important, such as CLI applications and Docker
               containers, this option can be enabled to trade longer installation times and some
               additional disk space for faster start times.
-              
+
               When enabled, uv will process the Python version's `stdlib` directory. It will ignore any
               compilation errors.
-              
+
               [env: UV_COMPILE_BYTECODE=]
 
     Cache options:
       -n, --no-cache
               Avoid reading from or writing to the cache, instead using a temporary directory for the
               duration of the operation
-              
+
               [env: UV_NO_CACHE=]
 
           --cache-dir [CACHE_DIR]
               Path to the cache directory.
-              
+
               Defaults to `$XDG_CACHE_HOME/uv` or `$HOME/.cache/uv` on macOS and Linux, and
               `%LOCALAPPDATA%/uv/cache` on Windows.
-              
+
               To view the location of the cache directory, run `uv cache dir`.
-              
+
               [env: UV_CACHE_DIR=]
 
     Python options:
           --managed-python
               Require use of uv-managed Python versions.
-              
+
               By default, uv prefers using Python versions it manages. However, it will use system
               Python versions if a uv-managed Python is not installed. This option disables use of
               system Python versions.
@@ -623,7 +622,7 @@ fn help_subsubcommand() {
 
           --no-managed-python
               Disable use of uv-managed Python versions.
-              
+
               Instead, uv will search for a suitable Python version on the system.
 
               [env: UV_NO_MANAGED_PYTHON=]
@@ -634,19 +633,19 @@ fn help_subsubcommand() {
     Global options:
       -q, --quiet...
               Use quiet output.
-              
+
               Repeating this option, e.g., `-qq`, will enable a silent mode in which uv will write no
               output to stdout.
 
       -v, --verbose...
               Use verbose output.
-              
+
               You can configure fine-grained logging using the `RUST_LOG` environment variable.
               (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
 
           --color <COLOR_CHOICE>
               Control the use of color in output.
-              
+
               By default, uv will automatically detect support for colors when writing to a terminal.
 
               Possible values:
@@ -658,81 +657,81 @@ fn help_subsubcommand() {
           --system-certs
               Whether to load TLS certificates from the platform's native certificate store [env:
               UV_SYSTEM_CERTS=]
-              
+
               By default, uv uses bundled Mozilla root certificates, which improves portability and
               performance (especially on macOS).
-              
+
               However, in some cases, you may want to use the platform's native certificate store,
               especially if you're relying on a corporate trust root (e.g., for a mandatory proxy)
               that's included in your system's certificate store.
 
           --offline
               Disable network access.
-              
+
               When disabled, uv will only use locally cached data and locally available files.
 
               [env: UV_OFFLINE=]
 
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host.
-              
+
               Can be provided multiple times.
-              
+
               Expects to receive either a hostname (e.g., `localhost`), a host-port pair (e.g.,
               `localhost:8080`), or a URL (e.g., `https://localhost`).
-              
+
               WARNING: Hosts included in this list will not be verified against the system's certificate
               store. Only use `--allow-insecure-host` in a secure network with verified sources, as it
               bypasses SSL verification and could expose you to MITM attacks.
-              
+
               [env: UV_INSECURE_HOST=]
 
           --no-progress
               Hide all progress outputs.
-              
+
               For example, spinners or progress bars.
 
               [env: UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
-              
+
               Relative paths are resolved with the given directory as the base.
-              
+
               See `--project` to only change the project root directory.
-              
+
               [env: UV_WORKING_DIR=]
 
           --project <PROJECT>
               Discover a project in the given directory.
-              
+
               All `pyproject.toml`, `uv.toml`, and `.python-version` files will be discovered by walking
               up the directory tree from the project root, as will the project's virtual environment
               (`.venv`).
-              
+
               Other command-line arguments (such as relative paths) will be resolved relative to the
               current working directory.
-              
+
               See `--directory` to change the working directory entirely.
-              
+
               This setting has no effect when used in the `uv pip` interface.
-              
+
               [env: UV_PROJECT=]
 
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration.
-              
+
               While uv configuration can be included in a `pyproject.toml` file, it is not allowed in
               this context.
-              
+
               [env: UV_CONFIG_FILE=]
 
           --no-config
               Avoid discovering configuration files (`pyproject.toml`, `uv.toml`).
-              
+
               Normally, configuration files are discovered in the current directory, parent directories,
               or user configuration directories.
-              
+
               [env: UV_NO_CONFIG=]
 
       -h, --help
@@ -1055,7 +1054,6 @@ fn help_with_global_option() {
 
     Use `uv help <command>` for more information on a specific command.
 
-
     ----- stderr -----
     "#);
 }
@@ -1178,7 +1176,6 @@ fn help_with_no_pager() {
               Display the uv version
 
     Use `uv help <command>` for more information on a specific command.
-
 
     ----- stderr -----
     "#);


### PR DESCRIPTION
Many formatters trim trailing whitespace, while some clap help outputs trailing whitespace. This causes churn regularly, latest example: https://github.com/astral-sh/uv/pull/18124/changes#diff-97a69f02448134717881c6ce094acacd9f49df54534d457066f95f3d838a1ae7. This PR trims trailing whitespace from each line after rendering clap help text, working around https://github.com/clap-rs/clap/issues/5074.