### PR TITLE
Strip trailing whitespace from tool_install_uninstallable

### DIFF
--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1813,6 +1813,10 @@ fn tool_install_uninstallable() {
             (r"bdist\.[^/\\\s]+(-[^/\\\s]+)?", "bdist.linux-x86_64"),
             (r"\\\.", ""),
             (r"#+", "#"),
+            (
+                "Please read the installation instructions at:\n ",
+                "Please read the installation instructions at:\n",
+            ),
         ])
         .collect::<Vec<_>>();
     uv_snapshot!(filters, context.tool_install()
@@ -1841,7 +1845,7 @@ fn tool_install_uninstallable() {
           We are sorry, but this package is not installable with pip.
 
           Please read the installation instructions at:
-     
+
           https://github.com/pyenv/pyenv#installation
           #
 


### PR DESCRIPTION
Avoid churn in this file when IDEs remove the trailing whitespace while the snapshot contains. This single space looks like a typo in the pyenv placeholder package.

Alternative to https://github.com/astral-sh/uv/pull/18182.