### PR TITLE
Preserve file permissions when using reflinks on Linux

### DIFF
--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -781,7 +781,10 @@ impl TestContext {
         let tmp = tempfile::TempDir::new_in(dir)?;
         self.temp_dir = ChildPath::new(tmp.path()).child("temp");
         fs_err::create_dir_all(&self.temp_dir)?;
-        self.venv = ChildPath::new(tmp.path().canonicalize()?.join(".venv"));
+        // Place the venv inside temp_dir (matching the default TestContext layout)
+        // so that `context.venv()` creates it at the same path that `VIRTUAL_ENV` points to.
+        let canonical_temp_dir = self.temp_dir.canonicalize()?;
+        self.venv = ChildPath::new(canonical_temp_dir.join(".venv"));
         let temp_replacement = format!("[{name}]/[TEMP_DIR]/");
         self.filters.extend(
             Self::path_patterns(&self.temp_dir)

--- a/test/packages/executable_file/pyproject.toml
+++ b/test/packages/executable_file/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "executable-file"
+version = "1.0.0"
+description = "A test package containing a file with executable permissions"
+requires-python = ">=3.12"
+
+[build-system]
+requires = ["uv_build>=0.8.0,<0.11.0"]
+build-backend = "uv_build"

--- a/test/packages/executable_file/src/executable_file/__init__.py
+++ b/test/packages/executable_file/src/executable_file/__init__.py
@@ -1,0 +1,1 @@
+# A test package with an executable file.

--- a/test/packages/executable_file/src/executable_file/bin/run.sh
+++ b/test/packages/executable_file/src/executable_file/bin/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "hello from executable_file"


### PR DESCRIPTION
Fixes an regression from #18117 where executable permissions were not preserved on reflink. On Linux, the `FICLONE` ioctl only clones data blocks without preserving file metadata, so permissions must be copied separately. On macOS, `clonefile` already preserves permissions.

This appears to be a well known issue:

- https://github.com/pnpm/pnpm/issues/8546
- https://github.com/morelj/reflink/blob/53408edf3bf3c5090b1146923f72066c7f6e9200/cloneflags.go#L6-L22
- https://github.com/python/cpython/issues/81338

Closes https://github.com/astral-sh/uv/issues/18181