### PR TITLE
docs(gitlab): move cache prune to `after_script`

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -53,6 +53,7 @@ uv-install:
         - $UV_CACHE_DIR
   script:
     # Your `uv` commands
+  after_script:
     - uv cache prune --ci
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

IMO the cache prune should be moved to [`after_script`](https://docs.gitlab.com/ci/yaml/#after_script)

<!-- What's the purpose of the change? What does it do, and why? -->
