### PR TITLE
Add `UV_INIT_BARE` environment variable for `uv init`

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -657,6 +657,7 @@ pub struct EnvironmentOptions {
     pub no_env_file: EnvFlag,
     pub venv_seed: EnvFlag,
     pub venv_clear: EnvFlag,
+    pub init_bare: EnvFlag,
 }
 
 impl EnvironmentOptions {
@@ -749,6 +750,7 @@ impl EnvironmentOptions {
             no_env_file: EnvFlag::new(EnvVars::UV_NO_ENV_FILE)?,
             venv_seed: EnvFlag::new(EnvVars::UV_VENV_SEED)?,
             venv_clear: EnvFlag::new(EnvVars::UV_VENV_CLEAR)?,
+            init_bare: EnvFlag::new(EnvVars::UV_INIT_BARE)?,
         })
     }
 }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -380,6 +380,11 @@ impl EnvVars {
     #[attr_added_in("0.3.0")]
     pub const UV_TOOL_BIN_DIR: &'static str = "UV_TOOL_BIN_DIR";
 
+    /// Equivalent to the `--bare` argument for `uv init`. If set, uv will only create a
+    /// `pyproject.toml`.
+    #[attr_added_in("0.10.7")]
+    pub const UV_INIT_BARE: &'static str = "UV_INIT_BARE";
+
     /// Equivalent to the `--build-backend` argument for `uv init`. Determines the default backend
     /// to use when creating a new project.
     #[attr_added_in("0.8.2")]

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -431,6 +431,8 @@ impl InitSettings {
         )
         .unwrap_or(kind.packaged_by_default());
 
+        let bare = resolve_flag(bare, "bare", environment.init_bare).is_enabled();
+
         let filesystem_install_mirrors = filesystem
             .map(|fs| fs.install_mirrors.clone())
             .unwrap_or_default();


### PR DESCRIPTION
Resolves https://github.com/astral-sh/uv/issues/18202

This diff adds a `UV_INIT_BARE` environment variable that makes `--bare` the default behavior for `uv init`. The command-line flag takes precedence over the environment variable, following the same pattern used by `UV_FROZEN`, `UV_LOCKED`, and other boolean environment variables.