### PR TITLE
Build and test Windows aarch64 binaries natively

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -190,15 +190,14 @@ jobs:
 
   build-binary-windows-aarch64:
     name: "windows aarch64"
-    timeout-minutes: 25
-    runs-on:
-      labels: windows-latest
+    timeout-minutes: 10
+    runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Create Dev Drive using ReFS
+      - name: Setup Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
@@ -211,20 +210,17 @@ jobs:
           workspaces: ${{ env.UV_WORKSPACE }}
           save-if: ${{ inputs.save-rust-cache == 'true' }}
 
-      - name: "Install cross target"
-        run: rustup target add aarch64-pc-windows-msvc
-
       - name: "Build"
         working-directory: ${{ env.UV_WORKSPACE }}
-        run: cargo build --profile no-debug --target aarch64-pc-windows-msvc
+        run: cargo build --profile no-debug --bin uv --bin uvx
 
       - name: "Upload binary"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: uv-windows-aarch64-${{ github.sha }}
           path: |
-            ${{ env.UV_WORKSPACE }}/target/aarch64-pc-windows-msvc/no-debug/uv.exe
-            ${{ env.UV_WORKSPACE }}/target/aarch64-pc-windows-msvc/no-debug/uvx.exe
+            ${{ env.UV_WORKSPACE }}/target/no-debug/uv.exe
+            ${{ env.UV_WORKSPACE }}/target/no-debug/uvx.exe
           retention-days: 1
 
   build-binary-msrv:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -215,16 +215,19 @@ jobs:
 
   windows:
     name: ${{ matrix.platform.target }}
-    runs-on: github-windows-2022-x86_64-8
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         platform:
           - target: x86_64-pc-windows-msvc
             arch: x64
+            runner: github-windows-2022-x86_64-8
           - target: i686-pc-windows-msvc
             arch: x86
+            runner: github-windows-2022-x86_64-8
           - target: aarch64-pc-windows-msvc
-            arch: x64 # not relevant here
+            arch: arm64
+            runner: github-windows-11-aarch64-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -245,7 +248,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist --features self-update,windows-gui-bin --compatibility pypi
       - name: "Test wheel"
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -284,7 +286,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
       - name: "Test wheel uv-build"
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall


### PR DESCRIPTION
Previously, aarch64 Windows binaries were cross-compiled on x86_64 hosts in both build-release-binaries.yml and build-dev-binaries.yml, with the wheel test steps explicitly skipped for aarch64 targets.

> [!NOTE]
> We need to ensure that the `github-windows-11-aarch64-8` runner exists in the astral-sh org before this job can run.

Release binaries are now built on `github-windows-11-aarch64-8`, and tests are enabled.

Dev binaries are now built on `windows-11-arm`, which is a standard 4-core ARM runner, with the timeout reduced from 25 to 10 minutes.

