### PR TITLE
Add resolver hint when `--exclude-newer` filters out all versions of a package

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -324,6 +324,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             "Solving with target Python version: {}",
             self.python_requirement.target()
         );
+        if !self.options.exclude_newer.is_empty() {
+            debug!("Solving with exclude-newer: {}", self.options.exclude_newer);
+        }
 
         let mut visited = FxHashSet::default();
 

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 
 use pubgrub::Ranges;
 use rustc_hash::FxHashMap;
-use tracing::instrument;
+use tracing::{instrument, trace};
 
 use uv_client::{FlatIndexEntry, OwnedArchive, SimpleDetailMetadata, VersionFiles};
 use uv_configuration::BuildOptions;
@@ -448,6 +448,10 @@ impl VersionMapLazy {
                 let (excluded, upload_time) = if let Some(exclude_newer) = &self.exclude_newer {
                     match file.upload_time_utc_ms.as_ref() {
                         Some(&upload_time) if upload_time >= exclude_newer.timestamp_millis() => {
+                            trace!(
+                                "Excluding `{}` (uploaded {upload_time}) due to exclude-newer ({exclude_newer})",
+                                file.filename
+                            );
                             (true, Some(upload_time))
                         }
                         None => {

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1125,7 +1125,7 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
     uv_snapshot!(context.filters(), context
         .lock()
         .arg("--exclude-newer")
-        .arg("2006-12-02T02:07:43"), @"
+        .arg("2006-12-02T02:07:43Z"), @"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -1135,6 +1135,8 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because there are no versions of iniconfig and iniconfig==2.0.0 was published after the exclude newer time, we can conclude that all versions of iniconfig cannot be used.
           And because your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
+
+          hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2006-12-02T02:07:43Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
 
     uv_snapshot!(context.filters(), context


### PR DESCRIPTION
Resolves #18014 (also related to https://github.com/astral-sh/uv/issues/18010)

When `--exclude-newer` is active and all versions of a required package were uploaded after the cutoff, resolution fails with no indication that the setting is the cause. This diff adds a resolver hint that surfaces the relationship.

The diff also includes debug-level logging of the exclude-newer configuration at resolver start (happy to get this in separately, if needed), and trace-level logging each time an individual file is excluded by the timestamp cutoff. These help diagnose resolution behavior without requiring the hint to fire.