### PR TITLE
Upload extra release artifacts to mirror

### DIFF
--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -37,7 +37,9 @@ jobs:
         run: |
           aws s3 cp --recursive --output table --color on \
             --exclude '*' \
-            --include '*.zip' --include '*.tar.gz' \
+            --include '*.zip' --include '*.zip.sha256' \
+            --include '*.tar.gz' --include '*.tar.gz.sha256' \
+            --include sha256.sum --include '*.ps1' --include '*.sh' \
             --cache-control "public, max-age=31536000, immutable" \
             artifacts/ \
             s3://${R2_BUCKET}/github/$PROJECT/releases/download/$VERSION/


### PR DESCRIPTION
@Gankra pointed out that the installer scripts and sha256 checksums are helpful to also preserve on the mirror.

This is a followup to #18159.
