### PR TITLE
Mention cooldown and tweak inline script metadata in dependency bots documentation

### DIFF
--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -40,9 +40,9 @@ option:
 ### Inline script metadata
 
 Renovate supports updating dependencies defined using
-[script inline metadata](../scripts.md/#declaring-script-dependencies).
+[inline script metadata](../scripts.md/#declaring-script-dependencies).
 
-Since it cannot automatically detect which Python files use script inline metadata, their locations
+Since it cannot automatically detect which Python files use inline script metadata, their locations
 need to be explicitly defined using
 [`managerFilePatterns`](https://docs.renovatebot.com/configuration-options/#managerfilepatterns),
 like so:


### PR DESCRIPTION
## Summary

Update [Dependency bots](https://docs.astral.sh/uv/guides/integration/dependency-bots/) documentation to mention how to set up dependency cooldown on Renovate/Dependabot, to match what could be set in `exclude-newer`.

Also:
- updating configuration example for inline script metadata, as per [this documentation](https://docs.renovatebot.com/configuration-options/#managerfilepatterns), `fileMatch` is deprecated, and `managerFilePatterns` should be used instead -- the option supports both globs and regexes, so I've updated the examples to highlight that globs can be used
- adding a note about Renovate not supporting lock files for inline script metadata yet

## Test Plan

Rendered the documentation locally.

For all Renovate changes, tested locally using:
```shell
pnpx renovate --platform local
```

For Dependabot, I did not test it as I don't use it, so I've followed the [documentation](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-).