### PR TITLE
Use an Ubuntu snapshot to pin some Docker build dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,22 @@
-FROM --platform=$BUILDPLATFORM ubuntu:22.04@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751 AS build
+FROM --platform=$BUILDPLATFORM ubuntu:24.04@sha256:d1e2e92c075e5ca139d51a140fff46f84315c0fdce203eab2807c7e495eff4f9 AS build
 
-ARG BUILD_ESSENTIAL_VERSION=12.9ubuntu3
-ARG CURL_VERSION=7.81.0-1ubuntu1.22
-ARG PYTHON3_VENV_VERSION=3.10.6-1~22.04.1
-ARG CARGO_ZIGBUILD_VERSION=0.22.1
+ARG UBUNTU_SNAPSHOT=20260301T000000Z
 
 ENV HOME="/root"
 WORKDIR $HOME
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential=${BUILD_ESSENTIAL_VERSION} \
-  curl=${CURL_VERSION} \
-  python3-venv=${PYTHON3_VENV_VERSION} \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+# Install dependencies using an Ubuntu snapshot for reproducibility.
+# ca-certificates are required for using the snapshot.
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+  apt install -y --update ca-certificates && \
+  apt install -y --update --snapshot ${UBUNTU_SNAPSHOT} --no-install-recommends \
+  build-essential \
+  curl \
+  python3-venv
 
 # Setup zig as cross compiling linker
 RUN python3 -m venv $HOME/.venv
-RUN .venv/bin/pip install cargo-zigbuild==${CARGO_ZIGBUILD_VERSION}
+RUN .venv/bin/pip install cargo-zigbuild
 ENV PATH="$HOME/.venv/bin:$PATH"
 
 # Install rust


### PR DESCRIPTION
This is an incremental step to harden our Docker build pipeline.