### PR TITLE
Allow pushing Docker images in pull requests for testing

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,14 +24,14 @@ on:
         required: false
         type: string
         default: ""
-      push-sha:
+      push-dev:
         required: false
         type: boolean
         default: false
 
 env:
-  UV_GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.push-sha && 'uv-dev' || 'uv' }}
-  UV_DOCKERHUB_IMAGE: ${{ !inputs.push-sha && 'docker.io/astral/uv' || '' }}
+  UV_GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ inputs.push-dev && 'uv-dev' || 'uv' }}
+  UV_DOCKERHUB_IMAGE: ${{ !inputs.push-dev && 'docker.io/astral/uv' || '' }}
 
 permissions: {}
 
@@ -51,16 +51,16 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.plan == '' || fromJson(inputs.plan).announcement_tag_is_implicit }}
           TAG: ${{ inputs.plan != '' && fromJson(inputs.plan).announcement_tag }}
-          PUSH_SHA: ${{ inputs.push-sha }}
+          PUSH_DEV: ${{ inputs.push-dev }}
           IS_LOCAL_PR: ${{ github.event.pull_request.head.repo.full_name == 'astral-sh/uv' }}
         id: plan
         run: |
-          if [ "${PUSH_SHA}" == "true" ] && [ "${IS_LOCAL_PR}" == "true" ]; then
+          if [ "${PUSH_DEV}" == "true" ] && [ "${IS_LOCAL_PR}" == "true" ]; then
             echo "login=true" >> "$GITHUB_OUTPUT"
             echo "push=true" >> "$GITHUB_OUTPUT"
             echo "push-version=false" >> "$GITHUB_OUTPUT"
             echo "tag=sha" >> "$GITHUB_OUTPUT"
-            echo "action=build and publish (sha)" >> "$GITHUB_OUTPUT"
+            echo "action=build and publish to uv-dev" >> "$GITHUB_OUTPUT"
           elif [ "${DRY_RUN}" == "false" ]; then
             echo "login=true" >> "$GITHUB_OUTPUT"
             echo "push=true" >> "$GITHUB_OUTPUT"
@@ -118,7 +118,7 @@ jobs:
       - name: Check tag consistency
         if: ${{ needs.docker-plan.outputs.push == 'true' }}
         run: |
-          if [ "${PUSH_SHA}" == "true" ]; then
+          if [ "${PUSH_DEV}" == "true" ]; then
             echo "Building at $(git rev-parse HEAD)"
             exit 0
           fi
@@ -133,7 +133,7 @@ jobs:
           echo "Releasing ${version}"
         env:
           TAG: ${{ needs.docker-plan.outputs.tag }}
-          PUSH_SHA: ${{ inputs.push-sha }}
+          PUSH_DEV: ${{ inputs.push-dev }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -149,7 +149,7 @@ jobs:
             type=raw,value=dry-run,enable=${{ needs.docker-plan.outputs.push == 'false' }}
             type=pep440,pattern={{ version }},value=${{ needs.docker-plan.outputs.tag }},enable=${{ needs.docker-plan.outputs.push-version == 'true' }}
             type=pep440,pattern={{ major }}.{{ minor }},value=${{ needs.docker-plan.outputs.tag }},enable=${{ needs.docker-plan.outputs.push-version == 'true' }}
-            type=sha,enable=${{ inputs.push-sha }}
+            type=sha,enable=${{ inputs.push-dev }}
 
       - name: Build and push by digest
         id: build
@@ -251,7 +251,7 @@ jobs:
           # Loop through all base tags and append its docker metadata pattern to the list
           # Order is on purpose such that the label org.opencontainers.image.version has the first pattern with the full version
           IFS=','; for TAG in ${BASE_TAGS}; do
-            if [ "${PUSH_SHA}" == "true" ]; then
+            if [ "${PUSH_DEV}" == "true" ]; then
               TAG_PATTERNS="${TAG_PATTERNS}type=sha,suffix=-${TAG}\n"
             else
               TAG_PATTERNS="${TAG_PATTERNS}type=pep440,pattern={{ version }},suffix=-${TAG},value=${VERSION}\n"
@@ -271,7 +271,7 @@ jobs:
           } >> $GITHUB_ENV
         env:
           VERSION: ${{ needs.docker-plan.outputs.tag }}
-          PUSH_SHA: ${{ inputs.push-sha }}
+          PUSH_DEV: ${{ inputs.push-dev }}
           UV_BASE_TAG: ${{ needs.docker-publish-base.outputs.image-version }}
 
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
     if: ${{ needs.plan.outputs.build-docker == 'true' }}
     uses: ./.github/workflows/build-docker.yml
     with:
-      push-sha: ${{ needs.plan.outputs.push-docker == 'true' }}
+      push-dev: ${{ needs.plan.outputs.push-docker == 'true' }}
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
I need to test features that require push to a registry, e.g., #18252, and want to do so without releasing. This adds publish to a `uv-dev` namespace and uses the sha instead of the version. It requires the `release-test` environment, which is allowed from non-main but requires approval from me to run. It is trigged by the `build:push-docker` label.

See https://github.com/astral-sh/uv/pkgs/container/uv-dev