### PR TITLE
Native pyx Trusted Access support

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -823,6 +823,39 @@ jobs:
           # Check that we don't fail on `pyenv-win` shims
           ./uv python list -v
 
+  integration-test-pyx-trusted-access:
+    name: "pyx-trusted-access"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
+
+    permissions:
+      contents: read
+      id-token: write # for Trusted Access
+
+    env:
+      PYTHON_VERSION: 3.12
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: uv-linux-libc-${{ inputs.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Run pyx Trusted Access tests"
+        run: ./uv run -p "${PYTHON_VERSION}" --script scripts/test-pyx-trusted-access.py --uv ./uv
+
   integration-test-registries:
     name: "registries"
     timeout-minutes: 10

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -830,7 +830,6 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.fork != true }}
 
     permissions:
-      contents: read
       id-token: write # for Trusted Access
 
     env:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -930,6 +930,9 @@ jobs:
           UV_TEST_GITLAB_TOKEN: ${{ secrets.UV_TEST_GITLAB_TOKEN }}
           UV_TEST_GITLAB_URL: ${{ secrets.UV_TEST_GITLAB_URL }}
           UV_TEST_GITLAB_USERNAME: token
+          UV_TEST_PYX_TOKEN: ${{ secrets.UV_TEST_PYX_TOKEN }}
+          UV_TEST_PYX_URL: ${{ secrets.UV_TEST_PYX_URL }}
+          UV_TEST_PYX_PKG: ${{ secrets.UV_TEST_PYX_PKG }}
 
       - name: "Run registry tests with text store backend"
         run: ./uv run --no-project -p "${PYTHON_VERSION}" scripts/registries-test.py --uv ./uv --color always --all --auth-method text-store

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -840,10 +840,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
-
       - name: "Download binary"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -868,10 +864,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: "Download binary"
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5829,6 +5829,7 @@ dependencies = [
 name = "uv-auth"
 version = "0.0.29"
 dependencies = [
+ "ambient-id",
  "anyhow",
  "arcstr",
  "astral-reqwest-middleware",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 doc-valid-idents = [
+  "IdP",
   "PyPI",
   "PubGrub",
   "PyPy",

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -18,7 +18,11 @@ workspace = true
 [dependencies]
 uv-cache-key = { workspace = true }
 uv-fs = { workspace = true }
-uv-keyring = { workspace = true, features = ["apple-native", "secret-service", "windows-native"] }
+uv-keyring = { workspace = true, features = [
+  "apple-native",
+  "secret-service",
+  "windows-native",
+] }
 uv-once-map = { workspace = true }
 uv-preview = { workspace = true }
 uv-redacted = { workspace = true }
@@ -27,6 +31,7 @@ uv-state = { workspace = true }
 uv-static = { workspace = true }
 uv-warnings = { workspace = true }
 
+ambient-id = { workspace = true }
 anyhow = { workspace = true }
 arcstr = { workspace = true }
 async-trait = { workspace = true }
@@ -39,7 +44,7 @@ jiff = { workspace = true }
 percent-encoding = { workspace = true }
 reqsign = { workspace = true }
 reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
+reqwest-middleware = { workspace = true, features = ["json"] }
 rust-netrc = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/uv-auth/src/index.rs
+++ b/crates/uv-auth/src/index.rs
@@ -107,6 +107,11 @@ impl Indexes {
             .unwrap_or(AuthPolicy::Auto)
     }
 
+    /// Iterate over all indexes.
+    pub fn iter(&self) -> impl Iterator<Item = &Index> {
+        self.0.iter()
+    }
+
     fn find_prefix_index(&self, url: &Url) -> Option<&Index> {
         self.0.iter().find(|&index| index.is_prefix_for(url))
     }

--- a/crates/uv-auth/src/index.rs
+++ b/crates/uv-auth/src/index.rs
@@ -107,11 +107,6 @@ impl Indexes {
             .unwrap_or(AuthPolicy::Auto)
     }
 
-    /// Iterate over all indexes.
-    pub fn iter(&self) -> impl Iterator<Item = &Index> {
-        self.0.iter()
-    }
-
     fn find_prefix_index(&self, url: &Url) -> Option<&Index> {
         self.0.iter().find(|&index| index.is_prefix_for(url))
     }

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -6,8 +6,7 @@ pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;
 pub use pyx::{
     DEFAULT_TOLERANCE_SECS, PyxAccessToken, PyxJwt, PyxOAuthTokens, PyxTokenStore, PyxTokens,
-    TokenStoreError,
-    is_default_pyx_domain,
+    TokenStoreError, is_default_pyx_domain,
 };
 pub use realm::{Realm, RealmRef};
 pub use service::{Service, ServiceParseError};

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -5,7 +5,8 @@ pub use index::{AuthPolicy, Index, Indexes};
 pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;
 pub use pyx::{
-    DEFAULT_TOLERANCE_SECS, PyxJwt, PyxOAuthTokens, PyxTokenStore, PyxTokens, TokenStoreError,
+    DEFAULT_TOLERANCE_SECS, PyxAccessToken, PyxJwt, PyxOAuthTokens, PyxTokenStore, PyxTokens,
+    TokenStoreError,
     is_default_pyx_domain,
 };
 pub use realm::{Realm, RealmRef};

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -16,7 +16,7 @@ use uv_warnings::owo_colors::OwoColorize;
 
 use crate::credentials::Authentication;
 use crate::providers::{GcsEndpointProvider, HuggingFaceProvider, S3EndpointProvider};
-use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxTokenStore};
+use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxTokenStore, PyxTokens};
 use crate::{
     AccessToken, CredentialsCache, KeyringProvider,
     cache::FetchUrl,
@@ -139,6 +139,23 @@ enum GcsCredentialState {
     Initialized(Option<Arc<Authentication>>),
 }
 
+/// Cached pyx authentication state for an [`AuthMiddleware`] instance.
+///
+/// Transitions from `Uninitialized` on the first request to either `Global` or `Workspace`
+/// depending on which credential type the store returns.
+enum PyxTokenState {
+    /// No fetch has been attempted yet.
+    Uninitialized,
+    /// The store returned a global credential (API key, OAuth token, or `PYX_AUTH_TOKEN`
+    /// env var) that applies to every workspace. A single access token (or `None` if the user
+    /// has no credentials) is cached here; we never perform more than one exchange.
+    Global(Option<AccessToken>),
+    /// The store returned Trusted Access tokens, which are minted per-workspace via an OIDC
+    /// exchange. Each entry is fetched and cached independently; a missing key means the token
+    /// has not yet been fetched for that workspace.
+    Workspace(FxHashMap<String, Option<AccessToken>>),
+}
+
 /// A middleware that adds basic authentication to requests.
 ///
 /// Uses a cache to propagate credentials from previously seen requests and
@@ -158,13 +175,13 @@ pub struct AuthMiddleware {
     base_client: Option<ClientWithMiddleware>,
     /// The pyx token store to use for persistent credentials.
     pyx_token_store: Option<PyxTokenStore>,
-    /// Per-workspace token state.
+    /// Cached pyx token state.
     ///
-    /// Keyed by workspace name (e.g., `"acme"`). All known pyx URL shapes encode the workspace
-    /// so the key is always present. Each workspace gets its own entry so that Trusted Access
-    /// tokens — which are minted per-workspace — are cached and refreshed independently. A
-    /// missing entry means the token has not yet been fetched for that workspace.
-    pyx_token_state: Mutex<FxHashMap<String, Option<AccessToken>>>,
+    /// Once initialized, the state is either `Global` — meaning an API key, OAuth token, or
+    /// `PYX_AUTH_TOKEN` env var applies to every workspace — or `Workspace`, meaning the store
+    /// is using Trusted Access tokens that are minted per-workspace and must be fetched and
+    /// cached independently.
+    pyx_token_state: Mutex<PyxTokenState>,
     /// Cached S3 credentials to avoid running the credential helper multiple times.
     s3_credential_state: Mutex<S3CredentialState>,
     /// Cached GCS credentials to avoid running the credential helper multiple times.
@@ -190,7 +207,7 @@ impl AuthMiddleware {
             only_authenticated: false,
             base_client: None,
             pyx_token_store: None,
-            pyx_token_state: Mutex::new(FxHashMap::default()),
+            pyx_token_state: Mutex::new(PyxTokenState::Uninitialized),
             s3_credential_state: Mutex::new(S3CredentialState::Uninitialized),
             gcs_credential_state: Mutex::new(GcsCredentialState::Uninitialized),
             preview: Preview::default(),
@@ -762,26 +779,85 @@ impl AuthMiddleware {
                     // NOTE: new scope here to avoid holding the token state lock
                     // for the entire function body.
                     let token = {
-                        let mut token_state_map = self.pyx_token_state.lock().await;
+                        let mut token_state = self.pyx_token_state.lock().await;
 
-                        if let Some(token) = token_state_map.get(&workspace) {
-                            token.clone()
+                        // Fast path: return a cached token without fetching.
+                        match &*token_state {
+                            PyxTokenState::Global(token) => {
+                                return {
+                                    let credentials = token.clone().map(|token| {
+                                        trace!("Using credentials from token store for {url}");
+                                        Arc::new(Authentication::from(Credentials::from(token)))
+                                    });
+                                    self.cache().fetches.done(key.clone(), credentials.clone());
+                                    credentials
+                                };
+                            }
+                            PyxTokenState::Workspace(map) if map.contains_key(&workspace) => {
+                                return {
+                                    let credentials =
+                                        map.get(&workspace).unwrap().clone().map(|token| {
+                                            trace!("Using credentials from token store for {url}");
+                                            Arc::new(Authentication::from(Credentials::from(token)))
+                                        });
+                                    self.cache().fetches.done(key.clone(), credentials.clone());
+                                    credentials
+                                };
+                            }
+                            _ => {}
+                        }
+
+                        trace!("Initializing token store for {url}");
+
+                        // Remember whether we're in Workspace mode before the async call,
+                        // so we know how to update the state afterward.
+                        let in_workspace_mode = matches!(*token_state, PyxTokenState::Workspace(_));
+
+                        // Determine the access token and whether it is global (one token
+                        // shared across all workspaces) or workspace-specific (Trusted Access).
+                        let (token, is_global) = if let Some(env_token) =
+                            token_store.auth_token_from_env()
+                        {
+                            // Environment variable tokens are always global.
+                            (Some(env_token), true)
                         } else {
-                            trace!("Initializing token store for {url}");
-                            let generated = match token_store
-                                .access_token(base_client, DEFAULT_TOLERANCE_SECS, Some(&workspace))
+                            let tokens = match token_store
+                                .init(
+                                    base_client,
+                                    DEFAULT_TOLERANCE_SECS,
+                                    Some(workspace.as_str()),
+                                )
                                 .await
                             {
-                                Ok(Some(token)) => Some(token),
-                                Ok(None) => None,
+                                Ok(tokens) => tokens,
                                 Err(err) => {
-                                    warn!("Failed to generate access tokens: {err}");
+                                    warn!("Failed to initialize token store: {err}");
                                     None
                                 }
                             };
-                            token_state_map.insert(workspace, generated.clone());
-                            generated
+                            // Trusted Access tokens are workspace-specific;
+                            // everything else (OAuth, API key, or no credentials)
+                            // is treated as global so we only exchange once.
+                            let is_global = !matches!(tokens, Some(PyxTokens::TrustedAccess(_)));
+                            let token = tokens.map(AccessToken::from);
+                            (token, is_global)
+                        };
+
+                        if in_workspace_mode {
+                            // Already in Workspace mode: fill in this new workspace's entry.
+                            if let PyxTokenState::Workspace(map) = &mut *token_state {
+                                map.insert(workspace.clone(), token.clone());
+                            }
+                        } else if is_global {
+                            *token_state = PyxTokenState::Global(token.clone());
+                        } else {
+                            // First Trusted Access token: switch to Workspace mode.
+                            let mut map = FxHashMap::default();
+                            map.insert(workspace, token.clone());
+                            *token_state = PyxTokenState::Workspace(map);
                         }
+
+                        token
                     };
 
                     let credentials = token.map(|token| {

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -759,25 +759,29 @@ impl AuthMiddleware {
                         return None;
                     };
 
-                    let mut token_state_map = self.pyx_token_state.lock().await;
+                    // NOTE: new scope here to avoid holding the token state lock
+                    // for the entire function body.
+                    let token = {
+                        let mut token_state_map = self.pyx_token_state.lock().await;
 
-                    let token = if let Some(token) = token_state_map.get(&workspace) {
-                        token.clone()
-                    } else {
-                        trace!("Initializing token store for {url}");
-                        let generated = match token_store
-                            .access_token(base_client, DEFAULT_TOLERANCE_SECS, Some(&workspace))
-                            .await
-                        {
-                            Ok(Some(token)) => Some(token),
-                            Ok(None) => None,
-                            Err(err) => {
-                                warn!("Failed to generate access tokens: {err}");
-                                None
-                            }
-                        };
-                        token_state_map.insert(workspace, generated.clone());
-                        generated
+                        if let Some(token) = token_state_map.get(&workspace) {
+                            token.clone()
+                        } else {
+                            trace!("Initializing token store for {url}");
+                            let generated = match token_store
+                                .access_token(base_client, DEFAULT_TOLERANCE_SECS, Some(&workspace))
+                                .await
+                            {
+                                Ok(Some(token)) => Some(token),
+                                Ok(None) => None,
+                                Err(err) => {
+                                    warn!("Failed to generate access tokens: {err}");
+                                    None
+                                }
+                            };
+                            token_state_map.insert(workspace, generated.clone());
+                            generated
+                        }
                     };
 
                     let credentials = token.map(|token| {

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -751,8 +751,7 @@ impl AuthMiddleware {
                 if token_store.is_known_url(url) {
                     // Derive the workspace from the URL. All known pyx URL shapes — Simple API
                     // (`/simple/{workspace}/{view}`) and CDN — encode the workspace name.
-                    let Some(workspace) = token_store.workspace_for_url(url).map(str::to_owned)
-                    else {
+                    let Some(workspace) = token_store.workspace_for_url(url) else {
                         // URL is recognized as pyx but workspace isn't extractable (shouldn't
                         // happen in practice); fall through to other auth methods.
                         debug!("Could not extract workspace from pyx URL {url}");

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -5,6 +5,7 @@ use http::{Extensions, StatusCode};
 use netrc::Netrc;
 use reqwest::{Request, Response};
 use reqwest_middleware::{ClientWithMiddleware, Error, Middleware, Next};
+use rustc_hash::FxHashMap;
 use tokio::sync::Mutex;
 use tracing::{debug, trace, warn};
 
@@ -120,15 +121,6 @@ impl TextStoreMode {
     }
 }
 
-#[derive(Debug, Clone)]
-enum TokenState {
-    /// The token state has not yet been initialized from the store.
-    Uninitialized,
-    /// The token state has been initialized, and the store either returned tokens or `None` if
-    /// the user has not yet authenticated.
-    Initialized(Option<AccessToken>),
-}
-
 #[derive(Clone)]
 enum S3CredentialState {
     /// The S3 credential state has not yet been initialized.
@@ -166,8 +158,13 @@ pub struct AuthMiddleware {
     base_client: Option<ClientWithMiddleware>,
     /// The pyx token store to use for persistent credentials.
     pyx_token_store: Option<PyxTokenStore>,
-    /// Tokens to use for persistent credentials.
-    pyx_token_state: Mutex<TokenState>,
+    /// Per-workspace token state.
+    ///
+    /// Keyed by workspace name (e.g., `"acme"`). All known pyx URL shapes encode the workspace
+    /// so the key is always present. Each workspace gets its own entry so that Trusted Access
+    /// tokens — which are minted per-workspace — are cached and refreshed independently. A
+    /// missing entry means the token has not yet been fetched for that workspace.
+    pyx_token_state: Mutex<FxHashMap<String, Option<AccessToken>>>,
     /// Cached S3 credentials to avoid running the credential helper multiple times.
     s3_credential_state: Mutex<S3CredentialState>,
     /// Cached GCS credentials to avoid running the credential helper multiple times.
@@ -193,7 +190,7 @@ impl AuthMiddleware {
             only_authenticated: false,
             base_client: None,
             pyx_token_store: None,
-            pyx_token_state: Mutex::new(TokenState::Uninitialized),
+            pyx_token_state: Mutex::new(FxHashMap::default()),
             s3_credential_state: Mutex::new(S3CredentialState::Uninitialized),
             gcs_credential_state: Mutex::new(GcsCredentialState::Uninitialized),
             preview: Preview::default(),
@@ -752,27 +749,36 @@ impl AuthMiddleware {
         if let Some(base_client) = self.base_client.as_ref() {
             if let Some(token_store) = self.pyx_token_store.as_ref() {
                 if token_store.is_known_url(url) {
-                    let mut token_state = self.pyx_token_state.lock().await;
+                    // Derive the workspace from the URL. All known pyx URL shapes — Simple API
+                    // (`/simple/{workspace}/{view}`) and CDN — encode the workspace name.
+                    let Some(workspace) = token_store.workspace_for_url(url).map(str::to_owned)
+                    else {
+                        // URL is recognized as pyx but workspace isn't extractable (shouldn't
+                        // happen in practice); fall through to other auth methods.
+                        debug!("Could not extract workspace from pyx URL {url}");
+                        self.cache().fetches.done(key.clone(), None);
+                        return None;
+                    };
 
-                    // If the token store is uninitialized, initialize it.
-                    let token = match *token_state {
-                        TokenState::Uninitialized => {
-                            trace!("Initializing token store for {url}");
-                            let generated = match token_store
-                                .access_token(base_client, DEFAULT_TOLERANCE_SECS)
-                                .await
-                            {
-                                Ok(Some(token)) => Some(token),
-                                Ok(None) => None,
-                                Err(err) => {
-                                    warn!("Failed to generate access tokens: {err}");
-                                    None
-                                }
-                            };
-                            *token_state = TokenState::Initialized(generated.clone());
-                            generated
-                        }
-                        TokenState::Initialized(ref tokens) => tokens.clone(),
+                    let mut token_state_map = self.pyx_token_state.lock().await;
+
+                    let token = if let Some(token) = token_state_map.get(&workspace) {
+                        token.clone()
+                    } else {
+                        trace!("Initializing token store for {url}");
+                        let generated = match token_store
+                            .access_token(base_client, DEFAULT_TOLERANCE_SECS, Some(&workspace))
+                            .await
+                        {
+                            Ok(Some(token)) => Some(token),
+                            Ok(None) => None,
+                            Err(err) => {
+                                warn!("Failed to generate access tokens: {err}");
+                                None
+                            }
+                        };
+                        token_state_map.insert(workspace, generated.clone());
+                        generated
                     };
 
                     let credentials = token.map(|token| {

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -16,7 +16,7 @@ use uv_warnings::owo_colors::OwoColorize;
 
 use crate::credentials::Authentication;
 use crate::providers::{GcsEndpointProvider, HuggingFaceProvider, S3EndpointProvider};
-use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxTokenStore, PyxTokens};
+use crate::pyx::{DEFAULT_TOLERANCE_SECS, PyxAccessToken, PyxTokenStore};
 use crate::{
     AccessToken, CredentialsCache, KeyringProvider,
     cache::FetchUrl,
@@ -813,34 +813,27 @@ impl AuthMiddleware {
                         // so we know how to update the state afterward.
                         let in_workspace_mode = matches!(*token_state, PyxTokenState::Workspace(_));
 
-                        // Determine the access token and whether it is global (one token
-                        // shared across all workspaces) or workspace-specific (Trusted Access).
-                        let (token, is_global) = if let Some(env_token) =
-                            token_store.auth_token_from_env()
+                        let pyx_token = match token_store
+                            .access_token(
+                                base_client,
+                                DEFAULT_TOLERANCE_SECS,
+                                Some(workspace.as_str()),
+                            )
+                            .await
                         {
-                            // Environment variable tokens are always global.
-                            (Some(env_token), true)
-                        } else {
-                            let tokens = match token_store
-                                .init(
-                                    base_client,
-                                    DEFAULT_TOLERANCE_SECS,
-                                    Some(workspace.as_str()),
-                                )
-                                .await
-                            {
-                                Ok(tokens) => tokens,
-                                Err(err) => {
-                                    warn!("Failed to initialize token store: {err}");
-                                    None
-                                }
-                            };
-                            // Trusted Access tokens are workspace-specific;
-                            // everything else (OAuth, API key, or no credentials)
-                            // is treated as global so we only exchange once.
-                            let is_global = !matches!(tokens, Some(PyxTokens::TrustedAccess(_)));
-                            let token = tokens.map(AccessToken::from);
-                            (token, is_global)
+                            Ok(token) => token,
+                            Err(err) => {
+                                warn!("Failed to initialize token store: {err}");
+                                None
+                            }
+                        };
+
+                        // `Global` tokens (API key, OAuth, env var) apply to every workspace;
+                        // `Workspace` tokens (Trusted Access) are minted per-workspace.
+                        let (token, is_global) = match pyx_token {
+                            Some(PyxAccessToken::Global(token)) => (Some(token), true),
+                            Some(PyxAccessToken::Workspace(token)) => (Some(token), false),
+                            None => (None, true),
                         };
 
                         if in_workspace_mode {

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -1046,170 +1046,96 @@ mod tests {
     fn test_workspace_from_cdn_url() {
         let cdn = "astralhosted.com";
 
-        // views CDN URL.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse(
-                    "https://views.astralhosted.com/v1/abc123/acme/main/sig/pkg-1.0-py3-none-any.whl"
-                )
-                .unwrap(),
-                cdn
+        let cases: &[(&str, &str, Option<&str>)] = &[
+            // views CDN URL.
+            (
+                "https://views.astralhosted.com/v1/abc123/acme/main/sig/pkg-1.0-py3-none-any.whl",
+                cdn,
+                Some("acme"),
             ),
-            Some("acme")
-        );
+            // files CDN URL.
+            (
+                "https://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl",
+                cdn,
+                Some("acme"),
+            ),
+            // views CDN URL must have enough path segments (missing view).
+            ("https://views.astralhosted.com/v1/abc123/acme", cdn, None),
+            // files CDN URL must have a path after the workspace.
+            ("https://files.astralhosted.com/acme", cdn, None),
+            // views CDN must start with /v1/.
+            (
+                "https://views.astralhosted.com/v2/abc123/acme/main/sig/file",
+                cdn,
+                None,
+            ),
+            // HTTP is rejected.
+            (
+                "http://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl",
+                cdn,
+                None,
+            ),
+            // Unknown CDN subdomain returns None.
+            (
+                "https://other.astralhosted.com/acme/pkg-1.0-py3-none-any.whl",
+                cdn,
+                None,
+            ),
+            // Wrong CDN domain entirely.
+            (
+                "https://files.other.com/acme/pkg-1.0-py3-none-any.whl",
+                cdn,
+                None,
+            ),
+            // Custom CDN domain works the same way.
+            (
+                "https://files.example-cdn.com/myorg/file.whl",
+                "example-cdn.com",
+                Some("myorg"),
+            ),
+        ];
 
-        // files CDN URL.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse(
-                    "https://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
-                )
-                .unwrap(),
-                cdn
-            ),
-            Some("acme")
-        );
-
-        // views CDN URL must have enough path segments.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse("https://views.astralhosted.com/v1/abc123/acme").unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // files CDN URL must have a path after workspace.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse("https://files.astralhosted.com/acme").unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // views CDN must start with /v1/.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse(
-                    "https://views.astralhosted.com/v2/abc123/acme/main/sig/file"
-                )
-                .unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // HTTP is rejected.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse(
-                    "http://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
-                )
-                .unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // Unknown CDN subdomain returns None.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse(
-                    "https://other.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
-                )
-                .unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // Wrong CDN domain entirely.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse("https://files.other.com/acme/pkg-1.0-py3-none-any.whl")
-                    .unwrap(),
-                cdn
-            ),
-            None
-        );
-
-        // Custom CDN domain works the same way.
-        assert_eq!(
-            workspace_from_cdn_url(
-                &DisplaySafeUrl::parse("https://files.example-cdn.com/myorg/file.whl").unwrap(),
-                "example-cdn.com"
-            ),
-            Some("myorg")
-        );
+        for (url, cdn, expected) in cases {
+            assert_eq!(
+                workspace_from_cdn_url(&DisplaySafeUrl::parse(url).unwrap(), cdn),
+                *expected,
+                "url={url}"
+            );
+        }
     }
 
     #[test]
     fn test_workspace_from_simple_url() {
         let api = DisplaySafeUrl::parse("https://api.pyx.dev").unwrap();
-
-        // Standard pyx simple index URL.
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme/main").unwrap(),
-                &api
-            ),
-            Some("acme")
-        );
-
-        // Trailing slash is fine.
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme/main/").unwrap(),
-                &api
-            ),
-            Some("acme")
-        );
-
-        // Must have a view segment after the workspace (bare /simple/acme is not a full index URL).
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme").unwrap(),
-                &api
-            ),
-            None
-        );
-
-        // Non-simple path returns None.
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://api.pyx.dev/v1/upload/acme/main").unwrap(),
-                &api
-            ),
-            None
-        );
-
-        // Different host returns None.
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://other.pyx.dev/simple/acme/main").unwrap(),
-                &api
-            ),
-            None
-        );
-
-        // Different scheme returns None.
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("http://api.pyx.dev/simple/acme/main").unwrap(),
-                &api
-            ),
-            None
-        );
-
-        // Custom API URL works the same way.
         let custom_api = DisplaySafeUrl::parse("https://staging.example.com").unwrap();
-        assert_eq!(
-            workspace_from_simple_url(
-                &DisplaySafeUrl::parse("https://staging.example.com/simple/myorg/prod").unwrap(),
-                &custom_api
+
+        let cases: &[(&DisplaySafeUrl, &str, Option<&str>)] = &[
+            // Standard pyx simple index URL.
+            (&api, "https://api.pyx.dev/simple/acme/main", Some("acme")),
+            // Trailing slash is fine.
+            (&api, "https://api.pyx.dev/simple/acme/main/", Some("acme")),
+            // Must have a view segment after the workspace (bare /simple/acme is not a full index URL).
+            (&api, "https://api.pyx.dev/simple/acme", None),
+            // Non-simple path returns None.
+            (&api, "https://api.pyx.dev/v1/upload/acme/main", None),
+            // Different host returns None.
+            (&api, "https://other.pyx.dev/simple/acme/main", None),
+            // Different scheme returns None.
+            (&api, "http://api.pyx.dev/simple/acme/main", None),
+            // Custom API URL works the same way.
+            (
+                &custom_api,
+                "https://staging.example.com/simple/myorg/prod",
+                Some("myorg"),
             ),
-            Some("myorg")
-        );
+        ];
+
+        for (api, url, expected) in cases {
+            assert_eq!(
+                workspace_from_simple_url(&DisplaySafeUrl::parse(url).unwrap(), api),
+                *expected,
+                "url={url}"
+            );
+        }
     }
 }

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -104,6 +104,35 @@ impl From<AccessToken> for Credentials {
     }
 }
 
+/// A pyx access token annotated with its caching scope.
+///
+/// - [`Global`](Self::Global) tokens (API key, OAuth, or `PYX_AUTH_TOKEN`) apply to all
+///   workspaces; once fetched, they are reused for every subsequent request.
+/// - [`Workspace`](Self::Workspace) tokens (Trusted Access) are minted per-workspace via an
+///   OIDC exchange and must be fetched and cached independently per workspace.
+#[derive(Debug, Clone)]
+pub enum PyxAccessToken {
+    /// A token obtained from a global credential (API key, OAuth, or `PYX_AUTH_TOKEN` env var).
+    Global(AccessToken),
+    /// A Trusted Access token minted for a specific pyx workspace.
+    Workspace(AccessToken),
+}
+
+impl PyxAccessToken {
+    /// Unwrap into the inner [`AccessToken`].
+    pub fn into_access_token(self) -> AccessToken {
+        match self {
+            Self::Global(token) | Self::Workspace(token) => token,
+        }
+    }
+}
+
+impl From<PyxAccessToken> for AccessToken {
+    fn from(token: PyxAccessToken) -> Self {
+        token.into_access_token()
+    }
+}
+
 /// Reason why a token is considered expired and needs refresh.
 #[derive(Debug, Clone)]
 enum ExpiredTokenReason {
@@ -276,20 +305,13 @@ impl PyxTokenStore {
         &self.api
     }
 
-    /// Retrieve the access token set via the `PYX_AUTH_TOKEN` (or `UV_AUTH_TOKEN`) environment
-    /// variable, if any.
-    pub fn auth_token_from_env(&self) -> Option<AccessToken> {
-        read_pyx_auth_token()
-    }
-
-    /// Get or initialize an [`AccessToken`] from the store.
+    /// Get or initialize a [`PyxAccessToken`] from the store.
     ///
-    /// If an access token is set in the environment, it will be returned as-is.
+    /// If an access token is set in the environment, it will be returned as [`PyxAccessToken::Global`].
     ///
     /// If an access token is present on-disk, it will be returned (and refreshed, if necessary).
-    ///
-    /// If no access token is found, but an API key is present, the API key will be used to
-    /// bootstrap an access token.
+    /// OAuth and API-key tokens are returned as [`PyxAccessToken::Global`]; Trusted Access tokens
+    /// are returned as [`PyxAccessToken::Workspace`].
     ///
     /// `workspace` is the pyx workspace name, required to bootstrap a Trusted Access token. If
     /// `None`, Trusted Access bootstrapping is skipped.
@@ -298,17 +320,20 @@ impl PyxTokenStore {
         client: &ClientWithMiddleware,
         tolerance_secs: u64,
         workspace: Option<&str>,
-    ) -> Result<Option<AccessToken>, TokenStoreError> {
-        // If the access token is already set in the environment, return it.
+    ) -> Result<Option<PyxAccessToken>, TokenStoreError> {
+        // If the access token is already set in the environment, return it as global.
         if let Some(access_token) = read_pyx_auth_token() {
-            return Ok(Some(access_token));
+            return Ok(Some(PyxAccessToken::Global(access_token)));
         }
 
         // Initialize the tokens from the store.
         let tokens = self.init(client, tolerance_secs, workspace).await?;
 
-        // Extract the access token from the OAuth tokens or API key.
-        Ok(tokens.map(AccessToken::from))
+        // Annotate with scope: Trusted Access tokens are workspace-scoped, everything else is global.
+        Ok(tokens.map(|tokens| match tokens {
+            PyxTokens::TrustedAccess(_) => PyxAccessToken::Workspace(AccessToken::from(tokens)),
+            _ => PyxAccessToken::Global(AccessToken::from(tokens)),
+        }))
     }
 
     /// Initialize the [`PyxTokens`] from the store.

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -68,6 +68,11 @@ pub enum PyxTokens {
     ///
     /// API keys are long-lived tokens that can be exchanged for an access token.
     ApiKey(PyxApiKeyTokens),
+    /// A Trusted Access token.
+    ///
+    /// Trusted Access tokens are obtained through an OIDC exchange flow between
+    /// pyx and an OIDC IdP, like GitHub Actions.
+    TrustedAccess(AccessToken),
 }
 
 impl From<PyxTokens> for AccessToken {
@@ -75,6 +80,7 @@ impl From<PyxTokens> for AccessToken {
         match tokens {
             PyxTokens::OAuth(PyxOAuthTokens { access_token, .. }) => access_token,
             PyxTokens::ApiKey(PyxApiKeyTokens { access_token, .. }) => access_token,
+            PyxTokens::TrustedAccess(access_token) => access_token,
         }
     }
 }
@@ -84,6 +90,7 @@ impl From<PyxTokens> for Credentials {
         let access_token = match tokens {
             PyxTokens::OAuth(PyxOAuthTokens { access_token, .. }) => access_token,
             PyxTokens::ApiKey(PyxApiKeyTokens { access_token, .. }) => access_token,
+            PyxTokens::TrustedAccess(access_token) => access_token,
         };
         Self::from(access_token)
     }
@@ -127,6 +134,7 @@ impl PyxTokens {
         match self {
             Self::OAuth(PyxOAuthTokens { access_token, .. }) => access_token,
             Self::ApiKey(PyxApiKeyTokens { access_token, .. }) => access_token,
+            Self::TrustedAccess(access_token) => access_token,
         }
     }
 
@@ -325,6 +333,8 @@ impl PyxTokenStore {
                 )
                 .await?;
             }
+            // Trusted Access tokens are not written to disk.
+            PyxTokens::TrustedAccess(_) => (),
         }
         Ok(())
     }
@@ -395,23 +405,75 @@ impl PyxTokenStore {
                 let digest = uv_cache_key::cache_digest(api_key);
                 self.subdirectory.join(format!("{digest}.lock"))
             }
+            // NOTE: Trusted Access tokens are not stored on disk; this lockfile
+            // synchronizes the in-memory token refresh.
+            PyxTokens::TrustedAccess(_) => self.subdirectory.join("trusted-access.lock"),
         }
     }
 
-    /// Bootstrap the tokens from the store.
+    /// Bootstrap the tokens from an API key or from Trusted Access.
     async fn bootstrap(
         &self,
         client: &ClientWithMiddleware,
     ) -> Result<Option<PyxTokens>, TokenStoreError> {
+        if let Some(api_key) = read_pyx_api_key() {
+            // If an API key is present, use it to bootstrap the tokens.
+            self.bootstrap_from_api_key(api_key, client).await.map(Some)
+        } else {
+            // Otherwise, attempt to bootstrap from Trusted Access.
+            self.bootstrap_from_trusted_access(client).await
+        }
+    }
+
+    /// Bootstrap a [`PyxTokens`] from Trusted Access.
+    async fn bootstrap_from_trusted_access(
+        &self,
+        client: &ClientWithMiddleware,
+    ) -> Result<Option<PyxTokens>, TokenStoreError> {
+        #[derive(Debug, Clone, serde::Serialize)]
+        struct RequestBody<'a> {
+            token: &'a str,
+        }
+
+        #[derive(Debug, Clone, serde::Deserialize)]
+        struct ResponseBody {
+            token: AccessToken,
+        }
+
+        // Get an OIDC token from the ambient environment (e.g., GitHub Actions).
+        let detector = ambient_id::Detector::new_with_client(client.clone());
+        let Some(id_token) = detector.detect("pyx:trusted-access").await? else {
+            debug!("No ambient OIDC credentials detected for Trusted Access");
+            return Ok(None);
+        };
+
+        // Exchange the OIDC token for a Trusted Access token from pyx.
+        let mut url = self.api.clone();
+        url.set_path("v1/trusted-access/TODO/mint-token");
+
+        let request = client
+            .request(reqwest::Method::POST, Url::from(url))
+            .json(&RequestBody {
+                token: id_token.reveal(),
+            })
+            .build()?;
+
+        let response = client.execute(request).await?;
+        let ResponseBody { token } = response.error_for_status()?.json::<ResponseBody>().await?;
+
+        Ok(Some(PyxTokens::TrustedAccess(token)))
+    }
+
+    /// Bootstrap a [`PyxTokens`] from an API key.
+    async fn bootstrap_from_api_key(
+        &self,
+        api_key: String,
+        client: &ClientWithMiddleware,
+    ) -> Result<PyxTokens, TokenStoreError> {
         #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
         struct Payload {
             access_token: AccessToken,
         }
-
-        // Retrieve the API key from the environment variable, if set.
-        let Some(api_key) = read_pyx_api_key() else {
-            return Ok(None);
-        };
 
         debug!("Bootstrapping access token from an API key");
 
@@ -435,7 +497,7 @@ impl PyxTokenStore {
         // Write the tokens to disk.
         self.write(&tokens).await?;
 
-        Ok(Some(tokens))
+        Ok(tokens)
     }
 
     /// Refresh the tokens in the store, if they are expired.
@@ -525,6 +587,18 @@ impl PyxTokenStore {
                     api_key,
                 })
             }
+            PyxTokens::TrustedAccess(_) => {
+                // Refreshing a Trusted Access token is the same as bootstrapping it.
+                self.bootstrap_from_trusted_access(client)
+                    .await?
+                    .ok_or_else(|| {
+                        // This can only happen if we're in an environment that previously
+                        // offered us an OIDC token, but is no longer detected.
+                        // This strongly suggests some kind of runtime meddling by the user.
+                        // TODO: Custom error type here?
+                        TokenStoreError::Io(io::Error::other("could not refresh Trusted Access token: no ambient OIDC credentials detected"))
+                    })?
+            }
         };
 
         // Write the new tokens to disk
@@ -566,6 +640,8 @@ pub enum TokenStoreError {
     Jiff(#[from] jiff::Error),
     #[error(transparent)]
     Jwt(#[from] JwtError),
+    #[error(transparent)]
+    TrustedAccess(#[from] ambient_id::Error),
 }
 
 impl TokenStoreError {

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -633,8 +633,7 @@ impl PyxTokenStore {
                         // This can only happen if we're in an environment that previously
                         // offered us an OIDC token, but is no longer detected.
                         // This strongly suggests some kind of runtime meddling by the user.
-                        // TODO: Custom error type here?
-                        TokenStoreError::Io(io::Error::other("could not refresh Trusted Access token: no ambient OIDC credentials detected"))
+                        TokenStoreError::TrustedAccessRefresh
                     })?
             }
         };
@@ -680,6 +679,10 @@ pub enum TokenStoreError {
     Jwt(#[from] JwtError),
     #[error(transparent)]
     TrustedAccess(#[from] ambient_id::Error),
+    #[error(
+        "Failed to refresh Trusted Access token due to unexpected runtime change (e.g., process environment changed)"
+    )]
+    TrustedAccessRefresh,
 }
 
 impl TokenStoreError {

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -276,6 +276,12 @@ impl PyxTokenStore {
         &self.api
     }
 
+    /// Retrieve the access token set via the `PYX_AUTH_TOKEN` (or `UV_AUTH_TOKEN`) environment
+    /// variable, if any.
+    pub fn auth_token_from_env(&self) -> Option<AccessToken> {
+        read_pyx_auth_token()
+    }
+
     /// Get or initialize an [`AccessToken`] from the store.
     ///
     /// If an access token is set in the environment, it will be returned as-is.

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -813,12 +813,10 @@ fn workspace_from_cdn_url(url: &DisplaySafeUrl, cdn: &str) -> Option<String> {
 /// the URL matches the given `api` base URL.
 fn workspace_from_simple_url(url: &DisplaySafeUrl, api: &DisplaySafeUrl) -> Option<String> {
     // The URL must be on the same host/port as the API.
-    if url.scheme() != api.scheme()
-        || url.host_str() != api.host_str()
-        || url.port_or_known_default() != api.port_or_known_default()
-    {
+    if url.origin() != api.origin() {
         return None;
     }
+
     // Path must be `/simple/{workspace}/{view}[/]`.
     let mut segments = url.path_segments()?;
     if segments.next()? != "simple" {

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -262,7 +262,7 @@ impl PyxTokenStore {
     /// - CDN files: `https://files.{cdn}/{workspace}/{path}`
     ///
     /// Returns `None` if the URL does not match any known shape for this store.
-    pub fn workspace_for_url<'a>(&self, url: &'a DisplaySafeUrl) -> Option<&'a str> {
+    pub fn workspace_for_url(&self, url: &DisplaySafeUrl) -> Option<String> {
         workspace_from_simple_url(url, &self.api).or_else(|| workspace_from_cdn_url(url, &self.cdn))
     }
 
@@ -772,7 +772,7 @@ fn is_known_domain(url: &Url, api: &DisplaySafeUrl, cdn: &str) -> bool {
 /// Pyx CDN URLs come in two forms:
 /// - `https://views.{cdn}/v1/{shard}/{workspace}/{view}/{viewSignature}/{filePath}`
 /// - `https://files.{cdn}/{workspace}/{path}`
-fn workspace_from_cdn_url<'a>(url: &'a DisplaySafeUrl, cdn: &str) -> Option<&'a str> {
+fn workspace_from_cdn_url(url: &DisplaySafeUrl, cdn: &str) -> Option<String> {
     // Must be HTTPS on a known CDN subdomain.
     if url.scheme() != "https" {
         return None;
@@ -789,7 +789,7 @@ fn workspace_from_cdn_url<'a>(url: &'a DisplaySafeUrl, cdn: &str) -> Option<&'a 
         let workspace = segments.next().filter(|s| !s.is_empty())?;
         // Must have at least a view segment after the workspace.
         segments.next().filter(|s| !s.is_empty())?;
-        return Some(workspace);
+        return Some(workspace.to_owned());
     }
 
     // files.{cdn}/{workspace}/{path}
@@ -797,7 +797,7 @@ fn workspace_from_cdn_url<'a>(url: &'a DisplaySafeUrl, cdn: &str) -> Option<&'a 
         let workspace = segments.next().filter(|s| !s.is_empty())?;
         // Must have at least one path segment after the workspace.
         segments.next().filter(|s| !s.is_empty())?;
-        return Some(workspace);
+        return Some(workspace.to_owned());
     }
 
     None
@@ -808,7 +808,7 @@ fn workspace_from_cdn_url<'a>(url: &'a DisplaySafeUrl, cdn: &str) -> Option<&'a 
 /// Pyx Simple API URLs have the form `{api}/simple/{workspace}/{view}` (e.g.,
 /// `https://api.pyx.dev/simple/acme/main`). Returns the workspace segment when
 /// the URL matches the given `api` base URL.
-fn workspace_from_simple_url<'a>(url: &'a DisplaySafeUrl, api: &DisplaySafeUrl) -> Option<&'a str> {
+fn workspace_from_simple_url(url: &DisplaySafeUrl, api: &DisplaySafeUrl) -> Option<String> {
     // The URL must be on the same host/port as the API.
     if url.scheme() != api.scheme()
         || url.host_str() != api.host_str()
@@ -824,7 +824,7 @@ fn workspace_from_simple_url<'a>(url: &'a DisplaySafeUrl, api: &DisplaySafeUrl) 
     let workspace = segments.next().filter(|s| !s.is_empty())?;
     // There must be at least a view segment after the workspace.
     segments.next().filter(|s| !s.is_empty())?;
-    Some(workspace)
+    Some(workspace.to_owned())
 }
 
 /// Returns `true` if the URL is on the default pyx domain.
@@ -1097,7 +1097,7 @@ mod tests {
 
         for (url, cdn, expected) in cases {
             assert_eq!(
-                workspace_from_cdn_url(&DisplaySafeUrl::parse(url).unwrap(), cdn),
+                workspace_from_cdn_url(&DisplaySafeUrl::parse(url).unwrap(), cdn).as_deref(),
                 *expected,
                 "url={url}"
             );
@@ -1132,7 +1132,7 @@ mod tests {
 
         for (api, url, expected) in cases {
             assert_eq!(
-                workspace_from_simple_url(&DisplaySafeUrl::parse(url).unwrap(), api),
+                workspace_from_simple_url(&DisplaySafeUrl::parse(url).unwrap(), api).as_deref(),
                 *expected,
                 "url={url}"
             );

--- a/crates/uv-auth/src/pyx.rs
+++ b/crates/uv-auth/src/pyx.rs
@@ -253,6 +253,19 @@ impl PyxTokenStore {
         })
     }
 
+    /// Extract the workspace name from a pyx URL (Simple API or CDN).
+    ///
+    /// Handles all URL shapes served by pyx:
+    /// - Simple API: `{api}/simple/{workspace}/{view}`
+    ///   e.g. `https://api.pyx.dev/simple/acme/main`
+    /// - CDN views: `https://views.{cdn}/v1/{shard}/{workspace}/{view}/{sig}/{path}`
+    /// - CDN files: `https://files.{cdn}/{workspace}/{path}`
+    ///
+    /// Returns `None` if the URL does not match any known shape for this store.
+    pub fn workspace_for_url<'a>(&self, url: &'a DisplaySafeUrl) -> Option<&'a str> {
+        workspace_from_simple_url(url, &self.api).or_else(|| workspace_from_cdn_url(url, &self.cdn))
+    }
+
     /// Return the root directory for the token store.
     pub fn root(&self) -> &Path {
         &self.root
@@ -271,10 +284,14 @@ impl PyxTokenStore {
     ///
     /// If no access token is found, but an API key is present, the API key will be used to
     /// bootstrap an access token.
+    ///
+    /// `workspace` is the pyx workspace name, required to bootstrap a Trusted Access token. If
+    /// `None`, Trusted Access bootstrapping is skipped.
     pub async fn access_token(
         &self,
         client: &ClientWithMiddleware,
         tolerance_secs: u64,
+        workspace: Option<&str>,
     ) -> Result<Option<AccessToken>, TokenStoreError> {
         // If the access token is already set in the environment, return it.
         if let Some(access_token) = read_pyx_auth_token() {
@@ -282,7 +299,7 @@ impl PyxTokenStore {
         }
 
         // Initialize the tokens from the store.
-        let tokens = self.init(client, tolerance_secs).await?;
+        let tokens = self.init(client, tolerance_secs, workspace).await?;
 
         // Extract the access token from the OAuth tokens or API key.
         Ok(tokens.map(AccessToken::from))
@@ -294,20 +311,26 @@ impl PyxTokenStore {
     ///
     /// If no access token is found, but an API key is present, the API key will be used to
     /// bootstrap an access token.
+    ///
+    /// `workspace` is the pyx workspace name, required to bootstrap a Trusted Access token. If
+    /// `None`, Trusted Access bootstrapping is skipped.
     pub async fn init(
         &self,
         client: &ClientWithMiddleware,
         tolerance_secs: u64,
+        workspace: Option<&str>,
     ) -> Result<Option<PyxTokens>, TokenStoreError> {
         match self.read().await? {
             Some(tokens) => {
                 // Refresh the tokens if they are expired.
-                let tokens = self.refresh(tokens, client, tolerance_secs).await?;
+                let tokens = self
+                    .refresh(tokens, client, tolerance_secs, workspace)
+                    .await?;
                 Ok(Some(tokens))
             }
             None => {
-                // If no tokens are present, bootstrap them from an API key.
-                self.bootstrap(client).await
+                // If no tokens are present, bootstrap them from an API key or Trusted Access.
+                self.bootstrap(client, workspace).await
             }
         }
     }
@@ -412,23 +435,31 @@ impl PyxTokenStore {
     }
 
     /// Bootstrap the tokens from an API key or from Trusted Access.
+    ///
+    /// `workspace` is the pyx workspace name, required to bootstrap a Trusted Access token. If
+    /// `None`, Trusted Access bootstrapping is skipped.
     async fn bootstrap(
         &self,
         client: &ClientWithMiddleware,
+        workspace: Option<&str>,
     ) -> Result<Option<PyxTokens>, TokenStoreError> {
         if let Some(api_key) = read_pyx_api_key() {
             // If an API key is present, use it to bootstrap the tokens.
             self.bootstrap_from_api_key(api_key, client).await.map(Some)
         } else {
             // Otherwise, attempt to bootstrap from Trusted Access.
-            self.bootstrap_from_trusted_access(client).await
+            self.bootstrap_from_trusted_access(client, workspace).await
         }
     }
 
     /// Bootstrap a [`PyxTokens`] from Trusted Access.
+    ///
+    /// `workspace` is the pyx workspace name. If `None`, Trusted Access bootstrapping is skipped,
+    /// since the workspace is required to construct the token endpoint.
     async fn bootstrap_from_trusted_access(
         &self,
         client: &ClientWithMiddleware,
+        workspace: Option<&str>,
     ) -> Result<Option<PyxTokens>, TokenStoreError> {
         #[derive(Debug, Clone, serde::Serialize)]
         struct RequestBody<'a> {
@@ -440,6 +471,12 @@ impl PyxTokenStore {
             token: AccessToken,
         }
 
+        // Trusted Access requires the workspace name to construct the token endpoint.
+        let Some(workspace) = workspace else {
+            debug!("Skipping Trusted Access: pyx workspace name is not known");
+            return Ok(None);
+        };
+
         // Get an OIDC token from the ambient environment (e.g., GitHub Actions).
         let detector = ambient_id::Detector::new_with_client(client.clone());
         let Some(id_token) = detector.detect("pyx:trusted-access").await? else {
@@ -449,7 +486,7 @@ impl PyxTokenStore {
 
         // Exchange the OIDC token for a Trusted Access token from pyx.
         let mut url = self.api.clone();
-        url.set_path("v1/trusted-access/TODO/mint-token");
+        url.set_path(&format!("v1/trusted-access/{workspace}/mint-token"));
 
         let request = client
             .request(reqwest::Method::POST, Url::from(url))
@@ -509,6 +546,7 @@ impl PyxTokenStore {
         tokens: PyxTokens,
         client: &ClientWithMiddleware,
         tolerance_secs: u64,
+        workspace: Option<&str>,
     ) -> Result<PyxTokens, TokenStoreError> {
         let reason = match tokens.check_fresh(tolerance_secs) {
             Ok(exp) => {
@@ -589,7 +627,7 @@ impl PyxTokenStore {
             }
             PyxTokens::TrustedAccess(_) => {
                 // Refreshing a Trusted Access token is the same as bootstrapping it.
-                self.bootstrap_from_trusted_access(client)
+                self.bootstrap_from_trusted_access(client, workspace)
                     .await?
                     .ok_or_else(|| {
                         // This can only happen if we're in an environment that previously
@@ -727,6 +765,66 @@ fn is_known_domain(url: &Url, api: &DisplaySafeUrl, cdn: &str) -> bool {
         }
     }
     is_known_url(url, api, cdn)
+}
+
+/// Extract the workspace name from a pyx CDN URL.
+///
+/// Pyx CDN URLs come in two forms:
+/// - `https://views.{cdn}/v1/{shard}/{workspace}/{view}/{viewSignature}/{filePath}`
+/// - `https://files.{cdn}/{workspace}/{path}`
+fn workspace_from_cdn_url<'a>(url: &'a DisplaySafeUrl, cdn: &str) -> Option<&'a str> {
+    // Must be HTTPS on a known CDN subdomain.
+    if url.scheme() != "https" {
+        return None;
+    }
+    let host = url.host_str()?;
+    let mut segments = url.path_segments()?;
+
+    // views.{cdn}/v1/{shard}/{workspace}/{view}/...
+    if host.strip_prefix("views.") == Some(cdn) {
+        if segments.next()? != "v1" {
+            return None;
+        }
+        let _shard = segments.next().filter(|s| !s.is_empty())?;
+        let workspace = segments.next().filter(|s| !s.is_empty())?;
+        // Must have at least a view segment after the workspace.
+        segments.next().filter(|s| !s.is_empty())?;
+        return Some(workspace);
+    }
+
+    // files.{cdn}/{workspace}/{path}
+    if host.strip_prefix("files.") == Some(cdn) {
+        let workspace = segments.next().filter(|s| !s.is_empty())?;
+        // Must have at least one path segment after the workspace.
+        segments.next().filter(|s| !s.is_empty())?;
+        return Some(workspace);
+    }
+
+    None
+}
+
+/// Extract the workspace name from a pyx Simple API URL.
+///
+/// Pyx Simple API URLs have the form `{api}/simple/{workspace}/{view}` (e.g.,
+/// `https://api.pyx.dev/simple/acme/main`). Returns the workspace segment when
+/// the URL matches the given `api` base URL.
+fn workspace_from_simple_url<'a>(url: &'a DisplaySafeUrl, api: &DisplaySafeUrl) -> Option<&'a str> {
+    // The URL must be on the same host/port as the API.
+    if url.scheme() != api.scheme()
+        || url.host_str() != api.host_str()
+        || url.port_or_known_default() != api.port_or_known_default()
+    {
+        return None;
+    }
+    // Path must be `/simple/{workspace}/{view}[/]`.
+    let mut segments = url.path_segments()?;
+    if segments.next()? != "simple" {
+        return None;
+    }
+    let workspace = segments.next().filter(|s| !s.is_empty())?;
+    // There must be at least a view segment after the workspace.
+    segments.next().filter(|s| !s.is_empty())?;
+    Some(workspace)
 }
 
 /// Returns `true` if the URL is on the default pyx domain.
@@ -942,5 +1040,176 @@ mod tests {
         assert!(!is_default_pyx_domain(
             &Url::parse("https://beta.pyx.dev").unwrap()
         ));
+    }
+
+    #[test]
+    fn test_workspace_from_cdn_url() {
+        let cdn = "astralhosted.com";
+
+        // views CDN URL.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse(
+                    "https://views.astralhosted.com/v1/abc123/acme/main/sig/pkg-1.0-py3-none-any.whl"
+                )
+                .unwrap(),
+                cdn
+            ),
+            Some("acme")
+        );
+
+        // files CDN URL.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse(
+                    "https://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
+                )
+                .unwrap(),
+                cdn
+            ),
+            Some("acme")
+        );
+
+        // views CDN URL must have enough path segments.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse("https://views.astralhosted.com/v1/abc123/acme").unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // files CDN URL must have a path after workspace.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse("https://files.astralhosted.com/acme").unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // views CDN must start with /v1/.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse(
+                    "https://views.astralhosted.com/v2/abc123/acme/main/sig/file"
+                )
+                .unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // HTTP is rejected.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse(
+                    "http://files.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
+                )
+                .unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // Unknown CDN subdomain returns None.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse(
+                    "https://other.astralhosted.com/acme/pkg-1.0-py3-none-any.whl"
+                )
+                .unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // Wrong CDN domain entirely.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse("https://files.other.com/acme/pkg-1.0-py3-none-any.whl")
+                    .unwrap(),
+                cdn
+            ),
+            None
+        );
+
+        // Custom CDN domain works the same way.
+        assert_eq!(
+            workspace_from_cdn_url(
+                &DisplaySafeUrl::parse("https://files.example-cdn.com/myorg/file.whl").unwrap(),
+                "example-cdn.com"
+            ),
+            Some("myorg")
+        );
+    }
+
+    #[test]
+    fn test_workspace_from_simple_url() {
+        let api = DisplaySafeUrl::parse("https://api.pyx.dev").unwrap();
+
+        // Standard pyx simple index URL.
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme/main").unwrap(),
+                &api
+            ),
+            Some("acme")
+        );
+
+        // Trailing slash is fine.
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme/main/").unwrap(),
+                &api
+            ),
+            Some("acme")
+        );
+
+        // Must have a view segment after the workspace (bare /simple/acme is not a full index URL).
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://api.pyx.dev/simple/acme").unwrap(),
+                &api
+            ),
+            None
+        );
+
+        // Non-simple path returns None.
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://api.pyx.dev/v1/upload/acme/main").unwrap(),
+                &api
+            ),
+            None
+        );
+
+        // Different host returns None.
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://other.pyx.dev/simple/acme/main").unwrap(),
+                &api
+            ),
+            None
+        );
+
+        // Different scheme returns None.
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("http://api.pyx.dev/simple/acme/main").unwrap(),
+                &api
+            ),
+            None
+        );
+
+        // Custom API URL works the same way.
+        let custom_api = DisplaySafeUrl::parse("https://staging.example.com").unwrap();
+        assert_eq!(
+            workspace_from_simple_url(
+                &DisplaySafeUrl::parse("https://staging.example.com/simple/myorg/prod").unwrap(),
+                &custom_api
+            ),
+            Some("myorg")
+        );
     }
 }

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -94,6 +94,7 @@ async fn credentials_for_url(
             .access_token(
                 client.for_host(pyx_store.api()).raw_client(),
                 DEFAULT_TOLERANCE_SECS,
+                pyx_store.workspace_for_url(url),
             )
             .await
             .context("Authentication failure")?

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -94,7 +94,7 @@ async fn credentials_for_url(
             .access_token(
                 client.for_host(pyx_store.api()).raw_client(),
                 DEFAULT_TOLERANCE_SECS,
-                pyx_store.workspace_for_url(url),
+                pyx_store.workspace_for_url(url).as_deref(),
             )
             .await
             .context("Authentication failure")?

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -98,7 +98,8 @@ async fn credentials_for_url(
             )
             .await
             .context("Authentication failure")?
-            .context("No access token found")?;
+            .context("No access token found")?
+            .into_access_token();
         return Ok(Some(Credentials::bearer(token.into_bytes())));
     }
     let backend = AuthBackend::from_settings(preview).await?;

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -91,7 +91,7 @@ async fn pyx_refresh(store: &PyxTokenStore, client: &BaseClient, printer: Printe
     // Retrieve the token store.
     // Use zero tolerance to force a refresh.
     let token = match store
-        .access_token(client.for_host(store.api()).raw_client(), 0)
+        .access_token(client.for_host(store.api()).raw_client(), 0, None)
         .await
     {
         // If the tokens were successfully refreshed, return them.

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -95,7 +95,7 @@ async fn pyx_refresh(store: &PyxTokenStore, client: &BaseClient, printer: Printe
         .await
     {
         // If the tokens were successfully refreshed, return them.
-        Ok(Some(token)) => token,
+        Ok(Some(token)) => token.into_access_token(),
 
         // If the token store is empty, prompt for login.
         Ok(None) => {

--- a/scripts/registries-test.py
+++ b/scripts/registries-test.py
@@ -193,8 +193,12 @@ def run_test(
     print(f"\nAttempting to install {package}")
 
     if auth_method == "env":
-        env[f"UV_INDEX_{registry_name.upper()}_USERNAME"] = username
-        env[f"UV_INDEX_{registry_name.upper()}_PASSWORD"] = token
+        if registry_name == "pyx":
+            # Special case: uv takes PYX_API_KEY for pyx.
+            env["PYX_API_KEY"] = token
+        else:
+            env[f"UV_INDEX_{registry_name.upper()}_USERNAME"] = username
+            env[f"UV_INDEX_{registry_name.upper()}_PASSWORD"] = token
     elif auth_method == "text-store":
         # Use uv's text store for authentication
         subprocess.check_call(

--- a/scripts/registries-test.py
+++ b/scripts/registries-test.py
@@ -63,6 +63,7 @@ KNOWN_REGISTRIES = [
     "gcp",
     "gemfury",
     "gitlab",
+    "pyx",
 ]
 
 

--- a/scripts/test-pyx-trusted-access.py
+++ b/scripts/test-pyx-trusted-access.py
@@ -1,0 +1,79 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+import logging
+import os
+import subprocess
+import tempfile
+from argparse import ArgumentParser
+from pathlib import Path
+
+
+def setup_test_project(
+    registry_name: str, registry_url: str, project_dir: str, requires_python: str
+):
+    """Create a temporary project directory with a pyproject.toml"""
+    pyproject_content = f"""[project]
+name = "{registry_name}-test"
+version = "0.1.0"
+description = "Test registry"
+requires-python = ">={requires_python}"
+
+[[tool.uv.index]]
+name = "{registry_name}"
+url = "{registry_url}"
+default = true
+"""
+    pyproject_file = Path(project_dir) / "pyproject.toml"
+    pyproject_file.write_text(pyproject_content)
+
+
+def test_github_trusted_access_view(uv: Path) -> None:
+    """
+    Test that we can authenticate to a pyx view via Trusted Access on GitHub Actions.
+    """
+
+    # Check that we're running on GitHub Actions.
+    if "GITHUB_ACTIONS" not in os.environ:
+        logging.warning("Not running on GitHub Actions, skipping test.")
+        return
+
+    with tempfile.TemporaryDirectory() as project_dir:
+        setup_test_project(
+            registry_name="pyx",
+            registry_url="https://api.pyx.dev/simple/astral-test/uv-e2e-test",
+            project_dir=project_dir,
+            requires_python="3.12",
+        )
+
+        command = [
+            uv,
+            "add",
+            "hyperion",
+            "--directory",
+            project_dir,
+            "--no-cache",
+        ]
+        subprocess.run(command, capture_output=True, text=True, check=True)
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO,
+    )
+
+    parser = ArgumentParser()
+    parser.add_argument("--uv", required=True)
+    args = parser.parse_args()
+
+    uv = Path.cwd().joinpath(args.uv)
+    assert uv.is_file(), f"`uv` not found: {uv}"
+
+    test_github_trusted_access_view(uv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

~~WIP.~~ The idea here is to allow `uv ...` invocations that touch pyx indices to perform a Trusted Access token exchange on the fly, meaning the user doesn't have to bother with `uv auth login` or an API token when on a supported platform.

The wrinkle with Trusted Access is that it's (currently) keyed to a workspace, so a user who has a dependency topology that contains multiple pyx workspaces will need to perform credential exchange against each. This is accommodated internally by turning `pyx_token_state` into a map of workspaces to access tokens. However, I'm not convinced this is a good idea -- it complicates the internal authentication model quite a bit (and makes CDN authentication more confusing), all for a pretty rare topology that also doesn't work with API tokens or other auth forms. I'll discuss some alternatives out-of-band.

## Test Plan

~~Needs unit and integration tests.~~ I've added an initial integration test, will add more.