### PR TITLE
Add a `uv-code-sign` crate for macOS code signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6173,6 +6173,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-code-sign"
+version = "0.0.17"
+dependencies = [
+ "base64 0.22.1",
+ "csv",
+ "fs-err",
+ "goblin",
+ "owo-colors",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "uv-extract",
+ "uv-install-wheel",
+ "walkdir",
+ "zip",
+]
+
+[[package]]
 name = "uv-configuration"
 version = "0.0.27"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,12 +152,7 @@ futures = { version = "0.3.30" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.15" }
 globwalk = { version = "0.9.1" }
-goblin = { version = "0.10.0", default-features = false, features = [
-  "std",
-  "elf32",
-  "elf64",
-  "endian_fd",
-] }
+goblin = { version = "0.10.0", default-features = false, features = ["std", "elf32", "elf64", "mach64", "endian_fd"] }
 h2 = { version = "0.4.7" }
 hashbrown = { version = "0.16.0" }
 hex = { version = "0.4.3" }

--- a/crates/uv-code-sign/Cargo.toml
+++ b/crates/uv-code-sign/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "uv-code-sign"
+version = "0.0.17"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+uv-extract = { workspace = true }
+uv-install-wheel = { workspace = true }
+
+base64 = { workspace = true }
+csv = { workspace = true }
+fs-err = { workspace = true }
+goblin = { workspace = true }
+owo-colors = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+walkdir = { workspace = true }
+zip = { workspace = true }

--- a/crates/uv-code-sign/src/codesign.rs
+++ b/crates/uv-code-sign/src/codesign.rs
@@ -1,0 +1,150 @@
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+
+use owo_colors::OwoColorize;
+use thiserror::Error;
+
+/// Options for the `codesign` invocation.
+pub struct SignOptions {
+    /// Signing identity. Defaults to `"-"` (ad-hoc).
+    pub identity: String,
+    /// Path to the `codesign` binary. Defaults to `"codesign"`.
+    pub codesign_path: PathBuf,
+}
+
+impl Default for SignOptions {
+    fn default() -> Self {
+        Self {
+            identity: "-".to_string(),
+            codesign_path: PathBuf::from("codesign"),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CodeSignError {
+    #[error("Failed to run `codesign`")]
+    Command(#[source] std::io::Error),
+    #[error(transparent)]
+    Failed(#[from] CodeSignFailed),
+}
+
+/// `codesign` exited with a non-zero status.
+#[derive(Debug, Error)]
+pub struct CodeSignFailed {
+    pub path: PathBuf,
+    pub code: ExitStatus,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl Display for CodeSignFailed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Signing `{}` failed with exit status {}",
+            self.path.display(),
+            self.code
+        )?;
+
+        let mut non_empty = false;
+
+        if !self.stdout.trim().is_empty() {
+            write!(f, "\n\n{}\n{}", "[stdout]".red(), self.stdout)?;
+            non_empty = true;
+        }
+
+        if !self.stderr.trim().is_empty() {
+            write!(f, "\n\n{}\n{}", "[stderr]".red(), self.stderr)?;
+            non_empty = true;
+        }
+
+        if non_empty {
+            writeln!(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Run `codesign --force --sign <identity> <path>` on a single file.
+pub fn codesign_file(path: &Path, options: &SignOptions) -> Result<(), CodeSignError> {
+    let output = Command::new(&options.codesign_path)
+        .args(["--force", "--sign", &options.identity])
+        .arg(path)
+        .output()
+        .map_err(CodeSignError::Command)?;
+
+    if !output.status.success() {
+        return Err(CodeSignFailed {
+            path: path.to_path_buf(),
+            code: output.status,
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }
+        .into());
+    }
+
+    tracing::debug!("signed {}", path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sign_options_default() {
+        let opts = SignOptions::default();
+        assert_eq!(opts.identity, "-");
+        assert_eq!(opts.codesign_path, PathBuf::from("codesign"));
+    }
+
+    #[test]
+    fn test_codesign_missing_binary() {
+        let opts = SignOptions {
+            codesign_path: PathBuf::from("/nonexistent/codesign"),
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("dummy");
+        fs_err::write(&path, "not a binary").unwrap();
+
+        let result = codesign_file(&path, &opts);
+        assert!(
+            matches!(result, Err(CodeSignError::Command(_))),
+            "expected Command error, got: {result:?}"
+        );
+    }
+
+    /// On macOS, codesign on a nonexistent path should fail.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_codesign_nonexistent_path_fails() {
+        let opts = SignOptions::default();
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does_not_exist");
+
+        let result = codesign_file(&path, &opts);
+        assert!(
+            matches!(result, Err(CodeSignError::Failed(_))),
+            "expected Failed error, got: {result:?}"
+        );
+    }
+
+    /// On macOS, signing a real Mach-O binary with ad-hoc identity should succeed.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_codesign_real_binary() {
+        let opts = SignOptions::default();
+
+        // Copy /usr/bin/true to a temp location so we can sign it.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("true_copy");
+        fs_err::copy("/usr/bin/true", &path).unwrap();
+
+        let result = codesign_file(&path, &opts);
+        assert!(result.is_ok(), "expected signing to succeed: {result:?}");
+    }
+}

--- a/crates/uv-code-sign/src/lib.rs
+++ b/crates/uv-code-sign/src/lib.rs
@@ -1,0 +1,230 @@
+mod codesign;
+mod macho;
+mod record;
+mod wheel;
+
+pub use codesign::{CodeSignError, SignOptions};
+
+use std::path::Path;
+
+use fs_err as fs;
+use thiserror::Error;
+use walkdir::WalkDir;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    CodeSign(#[from] CodeSignError),
+    #[error("Failed to create temporary directory")]
+    TempDir(#[source] std::io::Error),
+    #[error("Failed to unpack wheel `{}`", path.display())]
+    Unpack {
+        path: std::path::PathBuf,
+        #[source]
+        source: uv_extract::Error,
+    },
+    #[error("Failed to repack wheel to `{}`", path.display())]
+    Repack {
+        path: std::path::PathBuf,
+        #[source]
+        source: wheel::WheelError,
+    },
+    #[error(transparent)]
+    Record(#[from] record::RecordError),
+    #[error(transparent)]
+    Walk(#[from] walkdir::Error),
+    #[error("No `.dist-info/RECORD` found in wheel")]
+    MissingRecord,
+    #[error("Non-UTF-8 path in wheel")]
+    NonUtf8Path,
+    #[error(transparent)]
+    StripPrefix(#[from] std::path::StripPrefixError),
+    #[error("Failed to copy wheel from `{from}` to `{to}`")]
+    Copy {
+        from: std::path::PathBuf,
+        to: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Sign all Mach-O binaries inside a `.whl` file.
+///
+/// 1. Unpacks the wheel into a temporary directory.
+/// 2. Finds all Mach-O binaries (`.so`, `.dylib`, executables) via header inspection.
+/// 3. Signs each with `codesign`.
+/// 4. Recomputes the `RECORD` file.
+/// 5. Repacks into a new wheel at `output`.
+pub fn sign_wheel(input: &Path, output: &Path, options: &SignOptions) -> Result<(), Error> {
+    let tmp = tempfile::tempdir().map_err(Error::TempDir)?;
+    let unpack_dir = tmp.path();
+
+    tracing::info!("unpacking {}", input.display());
+    let file = fs::File::open(input).map_err(|source| Error::Unpack {
+        path: input.to_path_buf(),
+        source: uv_extract::Error::Io(source),
+    })?;
+    uv_extract::unzip(file, unpack_dir).map_err(|source| Error::Unpack {
+        path: input.to_path_buf(),
+        source,
+    })?;
+
+    // Find and sign Mach-O binaries.
+    let mut signed = 0usize;
+    for entry in WalkDir::new(unpack_dir) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if macho::is_macho(entry.path()) {
+            codesign::codesign_file(entry.path(), options)?;
+            signed += 1;
+        }
+    }
+    if signed == 0 {
+        tracing::warn!("no Mach-O binaries found in wheel, copying as-is");
+        fs::copy(input, output).map_err(|source| Error::Copy {
+            from: input.to_path_buf(),
+            to: output.to_path_buf(),
+            source,
+        })?;
+        return Ok(());
+    }
+    tracing::info!("signed {signed} Mach-O binaries");
+
+    // Find the RECORD file (e.g., "package-1.0.dist-info/RECORD").
+    let record_rel = find_record(unpack_dir)?;
+    record::write_record(unpack_dir, &record_rel)?;
+
+    tracing::info!("repacking to {}", output.display());
+    wheel::repack(unpack_dir, output).map_err(|source| Error::Repack {
+        path: output.to_path_buf(),
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// Locate the `*.dist-info/RECORD` file relative to the wheel root.
+fn find_record(wheel_dir: &Path) -> Result<String, Error> {
+    for entry in WalkDir::new(wheel_dir).min_depth(1).max_depth(2) {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel = entry.path().strip_prefix(wheel_dir)?;
+        let rel_str = rel.to_str().ok_or(Error::NonUtf8Path)?;
+        // Normalize to forward slashes for wheel spec compliance.
+        let rel_str = rel_str.replace('\\', "/");
+        if rel_str.ends_with(".dist-info/RECORD") {
+            return Ok(rel_str);
+        }
+    }
+    Err(Error::MissingRecord)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fs_err as fs;
+
+    #[test]
+    fn test_find_record_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_dir = tmp.path();
+        let dist_info = wheel_dir.join("mypackage-1.0.dist-info");
+        fs::create_dir_all(&dist_info).unwrap();
+        fs::write(dist_info.join("RECORD"), "").unwrap();
+        fs::write(dist_info.join("METADATA"), "Name: mypackage\n").unwrap();
+
+        let result = find_record(wheel_dir).unwrap();
+        assert_eq!(result, "mypackage-1.0.dist-info/RECORD");
+    }
+
+    #[test]
+    fn test_find_record_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_dir = tmp.path();
+        // No dist-info directory at all.
+        fs::create_dir_all(wheel_dir.join("pkg")).unwrap();
+        fs::write(wheel_dir.join("pkg/__init__.py"), "").unwrap();
+
+        let result = find_record(wheel_dir);
+        assert!(
+            matches!(result, Err(Error::MissingRecord)),
+            "expected MissingRecord, got: {result:?}"
+        );
+    }
+
+    /// Build a synthetic wheel with a Mach-O binary (copied from the system),
+    /// sign it, and verify the output wheel is valid.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_sign_wheel_roundtrip() {
+        use std::io::Write;
+        use zip::write::FileOptions;
+        use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+        // Read a real Mach-O binary to embed in the test wheel.
+        let macho_bytes = fs::read("/usr/bin/true").unwrap();
+
+        // Build a synthetic wheel zip.
+        let tmp = tempfile::tempdir().unwrap();
+        let input_path = tmp.path().join("pkg-1.0-cp310-cp310-macosx_11_0_arm64.whl");
+        {
+            let file = fs::File::create(&input_path).unwrap();
+            let mut writer = ZipWriter::new(file);
+            let options =
+                FileOptions::<()>::default().compression_method(CompressionMethod::Deflated);
+
+            writer.start_file("pkg/__init__.py", options).unwrap();
+            writer.write_all(b"# init").unwrap();
+
+            writer.start_file("pkg/native.so", options).unwrap();
+            writer.write_all(&macho_bytes).unwrap();
+
+            writer
+                .start_file("pkg-1.0.dist-info/METADATA", options)
+                .unwrap();
+            writer.write_all(b"Name: pkg\nVersion: 1.0\n").unwrap();
+
+            writer
+                .start_file("pkg-1.0.dist-info/RECORD", options)
+                .unwrap();
+            writer.write_all(b"").unwrap();
+
+            writer.finish().unwrap();
+        }
+
+        let output_path = tmp.path().join("pkg-1.0-signed.whl");
+        let opts = SignOptions::default();
+        sign_wheel(&input_path, &output_path, &opts).unwrap();
+
+        // Verify the output wheel exists and is a valid zip.
+        assert!(output_path.exists());
+        let file = fs::File::open(&output_path).unwrap();
+        let mut archive = ZipArchive::new(file).unwrap();
+
+        // Collect file names.
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        assert!(names.contains(&"pkg/__init__.py".to_string()));
+        assert!(names.contains(&"pkg/native.so".to_string()));
+        assert!(names.contains(&"pkg-1.0.dist-info/RECORD".to_string()));
+
+        // Verify the RECORD file has proper entries.
+        let mut record_entry = archive.by_name("pkg-1.0.dist-info/RECORD").unwrap();
+        let mut record_content = String::new();
+        std::io::Read::read_to_string(&mut record_entry, &mut record_content).unwrap();
+        assert!(
+            record_content.contains("pkg/native.so,sha256="),
+            "RECORD should have hash for native.so"
+        );
+        assert!(
+            record_content.contains("pkg-1.0.dist-info/RECORD,,"),
+            "RECORD should have self-entry"
+        );
+    }
+}

--- a/crates/uv-code-sign/src/macho.rs
+++ b/crates/uv-code-sign/src/macho.rs
@@ -1,0 +1,101 @@
+use std::io::Read;
+use std::path::Path;
+
+use fs_err as fs;
+use goblin::mach::fat::{FAT_CIGAM, FAT_MAGIC};
+use goblin::mach::header::{MH_CIGAM, MH_CIGAM_64, MH_MAGIC, MH_MAGIC_64};
+use goblin::mach::peek;
+
+/// Returns `true` if the file at `path` starts with a Mach-O magic number.
+///
+/// Only reads the first 4 bytes of the file rather than loading it entirely.
+pub fn is_macho(path: &Path) -> bool {
+    let Ok(mut file) = fs::File::open(path).inspect_err(|err| {
+        tracing::debug!("failed to open `{}`: {err}", path.display());
+    }) else {
+        return false;
+    };
+    let mut buf = [0u8; 4];
+    if let Err(err) = file.read_exact(&mut buf) {
+        tracing::debug!("failed to read `{}`: {err}", path.display());
+        return false;
+    }
+    let Ok(magic) = peek(&buf, 0) else {
+        return false;
+    };
+    matches!(
+        magic,
+        MH_MAGIC | MH_CIGAM | MH_MAGIC_64 | MH_CIGAM_64 | FAT_MAGIC | FAT_CIGAM
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_macho_plain_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("hello.py");
+        fs::write(&path, "print('hello')").unwrap();
+        assert!(!is_macho(&path));
+    }
+
+    #[test]
+    fn test_is_macho_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("empty");
+        fs::write(&path, "").unwrap();
+        assert!(!is_macho(&path));
+    }
+
+    #[test]
+    fn test_is_macho_nonexistent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nope");
+        assert!(!is_macho(&path));
+    }
+
+    #[test]
+    fn test_is_macho_random_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("random");
+        fs::write(&path, [0x00, 0x01, 0x02, 0x03, 0x04]).unwrap();
+        assert!(!is_macho(&path));
+    }
+
+    #[test]
+    fn test_is_macho_synthetic_magic() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // MH_MAGIC_64
+        let path = tmp.path().join("macho64");
+        fs::write(&path, MH_MAGIC_64.to_be_bytes()).unwrap();
+        assert!(is_macho(&path));
+
+        // FAT_MAGIC (universal)
+        let path = tmp.path().join("fat");
+        fs::write(&path, FAT_MAGIC.to_be_bytes()).unwrap();
+        assert!(is_macho(&path));
+    }
+
+    #[test]
+    fn test_is_macho_too_short() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("short");
+        fs::write(&path, [0xFE, 0xED]).unwrap();
+        assert!(!is_macho(&path));
+    }
+
+    /// Verify that a real Mach-O binary on the system is detected.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_is_macho_real_binary() {
+        use std::path::PathBuf;
+        // /usr/bin/true is a Mach-O binary on macOS.
+        let path = PathBuf::from("/usr/bin/true");
+        if path.exists() {
+            assert!(is_macho(&path), "/usr/bin/true should be Mach-O");
+        }
+    }
+}

--- a/crates/uv-code-sign/src/record.rs
+++ b/crates/uv-code-sign/src/record.rs
@@ -1,0 +1,192 @@
+use std::path::Path;
+
+use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD as base64;
+use fs_err as fs;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uv_install_wheel::RecordEntry;
+use walkdir::WalkDir;
+
+#[derive(Debug, Error)]
+pub enum RecordError {
+    #[error(transparent)]
+    Walk(#[from] walkdir::Error),
+    #[error(transparent)]
+    StripPrefix(#[from] std::path::StripPrefixError),
+    #[error("Non-UTF-8 path in wheel")]
+    NonUtf8Path,
+    #[error("Failed to read `{}`", path.display())]
+    Read {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to write RECORD file")]
+    Write(#[source] std::io::Error),
+    #[error("Failed to write CSV record")]
+    Csv(#[source] csv::Error),
+}
+
+/// Recompute and write the `RECORD` file for a wheel directory.
+///
+/// Every file gets a `sha256=<base64url_nopad>` hash and byte size.
+/// The RECORD file's own entry is written as `<path>,,` (no hash, no size).
+pub fn write_record(wheel_dir: &Path, record_rel_path: &str) -> Result<(), RecordError> {
+    let record_path = wheel_dir.join(record_rel_path);
+    let f = fs::File::create(&record_path).map_err(RecordError::Write)?;
+    let mut csv_writer = csv::WriterBuilder::new()
+        .has_headers(false)
+        .escape(b'"')
+        .from_writer(f);
+
+    let mut entries: Vec<RecordEntry> = Vec::new();
+
+    for entry in WalkDir::new(wheel_dir).sort_by_file_name() {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let abs = entry.path();
+        let rel = abs.strip_prefix(wheel_dir)?;
+        let rel_str = rel.to_str().ok_or(RecordError::NonUtf8Path)?;
+        // Wheel RECORD paths must use forward slashes.
+        let rel_str = rel_str.replace('\\', "/");
+
+        // RECORD's own entry has no hash/size.
+        if rel_str == record_rel_path {
+            continue;
+        }
+
+        let contents = fs::read(abs).map_err(|source| RecordError::Read {
+            path: abs.to_path_buf(),
+            source,
+        })?;
+        let hash = base64.encode(Sha256::digest(&contents));
+        let size = contents.len();
+
+        entries.push(RecordEntry {
+            path: rel_str,
+            hash: Some(format!("sha256={hash}")),
+            size: Some(size as u64),
+        });
+    }
+
+    // Sort for deterministic output.
+    entries.sort();
+
+    for entry in &entries {
+        csv_writer.serialize(entry).map_err(RecordError::Csv)?;
+    }
+
+    // Add the RECORD's own entry last (no hash, no size).
+    csv_writer
+        .serialize(RecordEntry {
+            path: record_rel_path.to_string(),
+            hash: None,
+            size: None,
+        })
+        .map_err(RecordError::Csv)?;
+
+    csv_writer.flush().map_err(RecordError::Write)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base64::Engine;
+    use base64::prelude::BASE64_URL_SAFE_NO_PAD as base64;
+    use sha2::{Digest, Sha256};
+
+    /// Create a wheel directory with some files and verify that `write_record`
+    /// produces a valid RECORD with correct hashes, sizes, and the self-entry.
+    #[test]
+    fn test_write_record_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_dir = tmp.path();
+
+        // Create a dist-info directory and an initial (empty) RECORD file.
+        let dist_info = wheel_dir.join("pkg-1.0.dist-info");
+        fs::create_dir_all(&dist_info).unwrap();
+        fs::write(dist_info.join("RECORD"), "").unwrap();
+        fs::write(dist_info.join("METADATA"), "Name: pkg\nVersion: 1.0\n").unwrap();
+
+        // Create a package file.
+        let pkg_dir = wheel_dir.join("pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        let init_content = b"print('hello')";
+        fs::write(pkg_dir.join("__init__.py"), init_content).unwrap();
+
+        let record_rel = "pkg-1.0.dist-info/RECORD";
+        write_record(wheel_dir, record_rel).unwrap();
+
+        let record_content = fs::read_to_string(dist_info.join("RECORD")).unwrap();
+        let lines: Vec<&str> = record_content.lines().collect();
+
+        // Expect 3 entries: METADATA, __init__.py, and the RECORD self-entry.
+        assert_eq!(
+            lines.len(),
+            3,
+            "unexpected RECORD content:\n{record_content}"
+        );
+
+        // The RECORD self-entry must have no hash or size.
+        assert!(
+            lines.contains(&"pkg-1.0.dist-info/RECORD,,"),
+            "missing RECORD self-entry in:\n{record_content}"
+        );
+
+        // Verify hash for __init__.py.
+        let expected_hash = base64.encode(Sha256::digest(init_content));
+        let expected_line = format!(
+            "pkg/__init__.py,sha256={expected_hash},{size}",
+            size = init_content.len()
+        );
+        assert!(
+            lines.contains(&expected_line.as_str()),
+            "missing or incorrect __init__.py entry.\nExpected: {expected_line}\nGot:\n{record_content}"
+        );
+    }
+
+    /// Verify that entries are sorted by file name for deterministic output.
+    #[test]
+    fn test_write_record_sorted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_dir = tmp.path();
+
+        let dist_info = wheel_dir.join("pkg-1.0.dist-info");
+        fs::create_dir_all(&dist_info).unwrap();
+        fs::write(dist_info.join("RECORD"), "").unwrap();
+
+        let pkg_dir = wheel_dir.join("pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        // Create files in reverse alphabetical order.
+        fs::write(pkg_dir.join("z.py"), "z").unwrap();
+        fs::write(pkg_dir.join("a.py"), "a").unwrap();
+        fs::write(pkg_dir.join("m.py"), "m").unwrap();
+
+        let record_rel = "pkg-1.0.dist-info/RECORD";
+        write_record(wheel_dir, record_rel).unwrap();
+
+        let record_content = fs::read_to_string(dist_info.join("RECORD")).unwrap();
+        let file_names: Vec<&str> = record_content
+            .lines()
+            .map(|l| l.split(',').next().unwrap())
+            .collect();
+
+        // Entries should be sorted (RECORD self-entry comes last by convention).
+        let len = file_names.len();
+        let data_entries: Vec<&str> = file_names[..len - 1].to_vec();
+        let record_entry = file_names[len - 1];
+        let mut sorted_entries = data_entries.clone();
+        sorted_entries.sort();
+        assert_eq!(record_entry, "pkg-1.0.dist-info/RECORD");
+        assert_eq!(
+            data_entries, sorted_entries,
+            "RECORD entries are not sorted"
+        );
+    }
+}

--- a/crates/uv-code-sign/src/wheel.rs
+++ b/crates/uv-code-sign/src/wheel.rs
@@ -1,0 +1,199 @@
+use std::io::{Read, Write};
+use std::path::Path;
+
+use fs_err as fs;
+use thiserror::Error;
+use walkdir::WalkDir;
+use zip::write::FileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+#[derive(Debug, Error)]
+pub enum WheelError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Walk(#[from] walkdir::Error),
+    #[error(transparent)]
+    StripPrefix(#[from] std::path::StripPrefixError),
+    #[error("Non-UTF-8 path in wheel")]
+    NonUtf8Path,
+    #[error("Failed to extract zip entry")]
+    Extract(#[source] std::io::Error),
+    #[error("Failed to write zip entry")]
+    ZipWrite(#[source] zip::result::ZipError),
+}
+
+/// Repack a directory into a wheel zip at `output_path`.
+///
+/// Entries are sorted for deterministic output.
+pub fn repack(source_dir: &Path, output_path: &Path) -> Result<(), WheelError> {
+    let out_file = fs::File::create(output_path)?;
+    let mut writer = ZipWriter::new(out_file);
+
+    let options = FileOptions::<()>::default()
+        .compression_method(CompressionMethod::Deflated)
+        .system(zip::System::Unix);
+
+    let mut entries: Vec<_> = Vec::new();
+    for entry in WalkDir::new(source_dir).sort_by_file_name() {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let abs = entry.path().to_path_buf();
+        let rel = abs
+            .strip_prefix(source_dir)?
+            .to_str()
+            .ok_or(WheelError::NonUtf8Path)?
+            // Zip entry names must use forward slashes.
+            .replace('\\', "/");
+        entries.push((rel, abs));
+    }
+
+    for (rel, abs) in &entries {
+        // Preserve the executable bit, matching the uv build backend convention:
+        // 0o755 (rwxr-xr-x) for executables, 0o644 (rw-r--r--) for regular files.
+        #[cfg(unix)]
+        let entry_options = {
+            use std::os::unix::fs::PermissionsExt;
+            let executable = fs::metadata(abs)?.permissions().mode() & 0o111 != 0;
+            let permissions = if executable { 0o755 } else { 0o644 };
+            options.unix_permissions(permissions)
+        };
+        #[cfg(not(unix))]
+        let entry_options = options;
+
+        writer
+            .start_file(rel, entry_options)
+            .map_err(WheelError::ZipWrite)?;
+        let mut f = fs::File::open(abs)?;
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf).map_err(WheelError::Extract)?;
+        writer.write_all(&buf).map_err(WheelError::Extract)?;
+    }
+
+    writer.finish().map_err(WheelError::ZipWrite)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+    use std::io::Write;
+    use zip::ZipArchive;
+
+    /// Build a minimal wheel zip in memory with the given file entries.
+    fn build_test_wheel(entries: &BTreeMap<&str, &[u8]>) -> Vec<u8> {
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(buf);
+        let options = FileOptions::<()>::default().compression_method(CompressionMethod::Stored);
+        for (name, data) in entries {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(data).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    /// Helper to unpack a wheel file using `uv_extract::unzip`.
+    fn unpack(wheel_path: &Path, dest: &Path) {
+        let file = fs::File::open(wheel_path).unwrap();
+        uv_extract::unzip(file, dest).unwrap();
+    }
+
+    #[test]
+    fn test_unpack_creates_files() {
+        let mut entries = BTreeMap::new();
+        entries.insert("pkg/__init__.py", b"hello" as &[u8]);
+        entries.insert("pkg-1.0.dist-info/METADATA", b"Name: pkg\n" as &[u8]);
+        let wheel_bytes = build_test_wheel(&entries);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_path = tmp.path().join("test.whl");
+        fs::write(&wheel_path, &wheel_bytes).unwrap();
+
+        let dest = tmp.path().join("unpacked");
+        fs::create_dir_all(&dest).unwrap();
+        unpack(&wheel_path, &dest);
+
+        assert_eq!(
+            fs::read_to_string(dest.join("pkg/__init__.py")).unwrap(),
+            "hello"
+        );
+        assert_eq!(
+            fs::read_to_string(dest.join("pkg-1.0.dist-info/METADATA")).unwrap(),
+            "Name: pkg\n"
+        );
+    }
+
+    #[test]
+    fn test_unpack_repack_roundtrip() {
+        let mut entries = BTreeMap::new();
+        entries.insert("pkg/__init__.py", b"content_a" as &[u8]);
+        entries.insert("pkg/mod.py", b"content_b" as &[u8]);
+        entries.insert("pkg-1.0.dist-info/RECORD", b"" as &[u8]);
+        let wheel_bytes = build_test_wheel(&entries);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_path = tmp.path().join("input.whl");
+        fs::write(&wheel_path, &wheel_bytes).unwrap();
+
+        // Unpack.
+        let unpack_dir = tmp.path().join("unpacked");
+        fs::create_dir_all(&unpack_dir).unwrap();
+        unpack(&wheel_path, &unpack_dir);
+
+        // Repack.
+        let output_path = tmp.path().join("output.whl");
+        repack(&unpack_dir, &output_path).unwrap();
+
+        // Verify the repacked wheel contains the same files and content.
+        let file = fs::File::open(&output_path).unwrap();
+        let mut archive = ZipArchive::new(file).unwrap();
+        let mut repacked: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).unwrap();
+            let name = entry.name().to_string();
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).unwrap();
+            repacked.insert(name, data);
+        }
+
+        assert_eq!(repacked.len(), entries.len());
+        for (name, expected) in &entries {
+            let actual = repacked
+                .get(*name)
+                .unwrap_or_else(|| panic!("missing entry: {name}"));
+            assert_eq!(actual, expected, "content mismatch for {name}");
+        }
+    }
+
+    #[test]
+    fn test_unpack_skips_path_traversal() {
+        // Create a zip with a suspicious entry name (path traversal).
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(buf);
+        let options = FileOptions::<()>::default().compression_method(CompressionMethod::Stored);
+        writer.start_file("../escape.txt", options).unwrap();
+        writer.write_all(b"bad").unwrap();
+        // Also add a normal file.
+        writer.start_file("normal.txt", options).unwrap();
+        writer.write_all(b"good").unwrap();
+        let wheel_bytes = writer.finish().unwrap().into_inner();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let wheel_path = tmp.path().join("evil.whl");
+        fs::write(&wheel_path, &wheel_bytes).unwrap();
+
+        let dest = tmp.path().join("unpacked");
+        fs::create_dir_all(&dest).unwrap();
+        unpack(&wheel_path, &dest);
+
+        // The traversal entry should be skipped (enclosed_name returns None).
+        assert!(!dest.join("../escape.txt").exists());
+        assert!(!tmp.path().join("escape.txt").exists());
+        // The normal file should be extracted.
+        assert_eq!(fs::read_to_string(dest.join("normal.txt")).unwrap(), "good");
+    }
+}

--- a/crates/uv-install-wheel/src/lib.rs
+++ b/crates/uv-install-wheel/src/lib.rs
@@ -13,6 +13,7 @@ use uv_pypi_types::Scheme;
 
 pub use install::install_wheel;
 pub use linker::{InstallState, LinkMode, link_wheel_files};
+pub use record::RecordEntry;
 pub use uninstall::{Uninstall, uninstall_egg, uninstall_legacy_editable, uninstall_wheel};
 pub use wheel::{LibKind, WheelFile, read_record_file};
 


### PR DESCRIPTION
This adds support for code signing a wheel by unpacking it, signing all the Maco-O files, updating the RECORD, and repacking it. The intent is to use this in our release process.