### PR TITLE
Use `uv build` for macOS release builds instead of maturin-action

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -97,6 +97,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install cross-compilation target"
+        run: rustup target add x86_64-apple-darwin
       - name: "Prep README.md"
         run: python scripts/transform_readme.py --target pypi
 


### PR DESCRIPTION
In preparation for adding code-signing via `uv build`. 