### PR TITLE
Use latest Python version filtering in more places

### DIFF
--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -13829,7 +13829,8 @@ fn install_with_system_interpreter() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_python_download_cache()
         .with_managed_python_dirs()
-        .with_filtered_python_keys();
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
 
     // We use a managed Python version here to ensure consistent output across systems
     context.python_install().arg("3.12").assert().success();
@@ -13842,8 +13843,8 @@ fn install_with_system_interpreter() {
     ----- stdout -----
 
     ----- stderr -----
-    Using Python 3.12.13 environment at: managed/cpython-3.12.13-[PLATFORM]
-    error: The interpreter at managed/cpython-3.12.13-[PLATFORM] is externally managed, and indicates the following:
+    Using Python 3.12.[LATEST] environment at: managed/cpython-3.12.[LATEST]-[PLATFORM]
+    error: The interpreter at managed/cpython-3.12.[LATEST]-[PLATFORM] is externally managed, and indicates the following:
 
       This Python installation is managed by uv and should not be modified.
 
@@ -13912,7 +13913,8 @@ fn install_missing_python_version_with_target() {
     // Create a context that only has Python 3.11 available.
     let context = uv_test::test_context!("3.11")
         .with_python_download_cache()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     let target_dir = context.temp_dir.child("target-dir");
 
@@ -13926,7 +13928,7 @@ fn install_missing_python_version_with_target() {
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.12.13
+    Using CPython 3.12.[LATEST]
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -6189,7 +6189,8 @@ fn sync_with_target_installs_missing_python() -> Result<()> {
     // Create a context that only has Python 3.11 available.
     let context = uv_test::test_context!("3.11")
         .with_python_download_cache()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     let target_dir = context.temp_dir.child("target-dir");
     let requirements = context.temp_dir.child("requirements.txt");
@@ -6205,7 +6206,7 @@ fn sync_with_target_installs_missing_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.12.13
+    Using CPython 3.12.[LATEST]
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -12,7 +12,7 @@ use assert_fs::{
 use indoc::indoc;
 use predicates::prelude::predicate;
 use tracing::debug;
-use uv_test::uv_snapshot;
+use uv_test::{LATEST_PYTHON_3_12, uv_snapshot};
 
 use uv_fs::Simplified;
 use uv_python::managed::platform_key_from_env;
@@ -207,7 +207,8 @@ fn python_reinstall_patch() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_python_download_cache();
+        .with_python_download_cache()
+        .with_filtered_latest_python_versions();
 
     // Install a couple patch versions
     uv_snapshot!(context.filters(), context.python_install().arg("3.12.6").arg("3.12.7"), @"
@@ -230,8 +231,8 @@ fn python_reinstall_patch() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     ");
 }
 
@@ -4220,7 +4221,8 @@ fn python_install_upgrade_build_version() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install Python 3.12
     uv_snapshot!(context.filters(), context.python_install().arg("3.12"), @"
@@ -4229,8 +4231,8 @@ fn python_install_upgrade_build_version() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     ");
 
     // Should be a no-op when already installed at latest version
@@ -4245,7 +4247,8 @@ fn python_install_upgrade_build_version() {
 
     // Overwrite the BUILD file with an older build version
     let installation_dir = context.temp_dir.child("managed").child(format!(
-        "cpython-3.12.13-{}",
+        "cpython-{}-{}",
+        LATEST_PYTHON_3_12,
         platform_key_from_env().unwrap()
     ));
     let build_file = installation_dir.join("BUILD");
@@ -4258,8 +4261,8 @@ fn python_install_upgrade_build_version() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     ~ cpython-3.12.13-[PLATFORM]
+    Installed Python 3.12.[LATEST] in [TIME]
+     ~ cpython-3.12.[LATEST]-[PLATFORM]
     ");
 
     // Should be a no-op again after upgrade

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -360,17 +360,19 @@ fn python_list_duplicate_path_entries() {
 
 #[test]
 fn python_list_downloads() {
-    let context = uv_test::test_context_with_versions!(&[]).with_filtered_python_keys();
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
 
     // We do not test showing all interpreters — as it differs per platform
-    // Instead, we choose a Python version where our available distributions are stable
+    // Instead, we choose a Python version where our available distributions are stable
 
     // Test the default display, which requires reverting the test context disabling Python downloads
     uv_snapshot!(context.filters(), context.python_list().arg("3.10").env_remove(EnvVars::UV_PYTHON_DOWNLOADS), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM]    <download available>
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
     pypy-3.10.16-[PLATFORM]       <download available>
     graalpy-3.10.0-[PLATFORM]     <download available>
 
@@ -382,7 +384,7 @@ fn python_list_downloads() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM]    <download available>
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
     cpython-3.10.19-[PLATFORM]    <download available>
     cpython-3.10.18-[PLATFORM]    <download available>
     cpython-3.10.17-[PLATFORM]    <download available>
@@ -420,17 +422,18 @@ fn python_list_downloads_installed() {
         .with_filtered_python_keys()
         .with_filtered_python_install_bin()
         .with_filtered_python_names()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
-    // We do not test showing all interpreters — as it differs per platform
-    // Instead, we choose a Python version where our available distributions are stable
+    // We do not test showing all interpreters - as it differs per platform
+    // Instead, we choose a Python version where our available distributions are stable
 
     // First, the download is shown as available
     uv_snapshot!(context.filters(), context.python_list().arg("3.10").env_remove(EnvVars::UV_PYTHON_DOWNLOADS), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM]    <download available>
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
     pypy-3.10.16-[PLATFORM]       <download available>
     graalpy-3.10.0-[PLATFORM]     <download available>
 
@@ -457,7 +460,7 @@ fn python_list_downloads_installed() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM]    managed/cpython-3.10-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.10.[LATEST]-[PLATFORM]    managed/cpython-3.10-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
     pypy-3.10.16-[PLATFORM]       <download available>
     graalpy-3.10.0-[PLATFORM]     <download available>
 
@@ -469,7 +472,7 @@ fn python_list_downloads_installed() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM]    <download available>
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
     pypy-3.10.16-[PLATFORM]       <download available>
     graalpy-3.10.0-[PLATFORM]     <download available>
 
@@ -596,6 +599,7 @@ fn python_list_with_mirrors() {
     let context = uv_test::test_context_with_versions!(&[])
         .with_filtered_python_keys()
         .with_collapsed_whitespace()
+        .with_filtered_latest_python_versions()
         // Add filters to normalize file paths in URLs
         .with_filter((
             r"(https://mirror\.example\.com/).*".to_string(),
@@ -666,7 +670,7 @@ fn python_list_with_mirrors() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM] https://python-mirror.example.com/[FILE-PATH]
+    cpython-3.10.[LATEST]-[PLATFORM] https://python-mirror.example.com/[FILE-PATH]
     pypy-3.10.16-[PLATFORM] https://pypy-mirror.example.com/[FILE-PATH]
     graalpy-3.10.0-[PLATFORM] https://github.com/oracle/graalpython/releases/download/[FILE-PATH]
 
@@ -681,7 +685,7 @@ fn python_list_with_mirrors() {
     success: true
     exit_code: 0
     ----- stdout -----
-    cpython-3.10.20-[PLATFORM] https://releases.astral.sh/github/python-build-standalone/releases/download/[FILE-PATH]
+    cpython-3.10.[LATEST]-[PLATFORM] https://releases.astral.sh/github/python-build-standalone/releases/download/[FILE-PATH]
     pypy-3.10.16-[PLATFORM] https://downloads.python.org/pypy/[FILE-PATH]
     graalpy-3.10.0-[PLATFORM] https://github.com/oracle/graalpython/releases/download/[FILE-PATH]
 

--- a/crates/uv/tests/it/python_upgrade.rs
+++ b/crates/uv/tests/it/python_upgrade.rs
@@ -4,7 +4,7 @@ use assert_fs::fixture::FileTouch;
 use assert_fs::prelude::PathChild;
 use uv_python::managed::platform_key_from_env;
 use uv_static::EnvVars;
-use uv_test::uv_snapshot;
+use uv_test::{LATEST_PYTHON_3_12, uv_snapshot};
 
 #[test]
 fn python_upgrade() {
@@ -97,7 +97,8 @@ fn python_upgrade_without_version() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Should be a no-op when no versions have been installed
     uv_snapshot!(context.filters(), context.python_upgrade(), @"
@@ -122,8 +123,6 @@ fn python_upgrade_without_version() {
      + cpython-3.13.1-[PLATFORM] (python3.13)
     ");
 
-    let context = context.with_filter((r"3.13.\d+", "3.13.[X]"));
-
     // Upgrade one patch version
     uv_snapshot!(context.filters(), context.python_upgrade().arg("3.13"), @"
     success: true
@@ -131,8 +130,8 @@ fn python_upgrade_without_version() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.13.[X] in [TIME]
-     + cpython-3.13.[X]-[PLATFORM] (python3.13)
+    Installed Python 3.13.[LATEST] in [TIME]
+     + cpython-3.13.[LATEST]-[PLATFORM] (python3.13)
     ");
 
     // Providing no minor version to `uv python upgrade` should upgrade the rest
@@ -144,8 +143,8 @@ fn python_upgrade_without_version() {
 
     ----- stderr -----
     Installed 2 versions in [TIME]
-     + cpython-3.11.15-[PLATFORM] (python3.11)
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+     + cpython-3.11.[LATEST]-[PLATFORM] (python3.11)
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     ");
 
     // Should be a no-op when every version is already upgraded
@@ -165,7 +164,8 @@ fn python_upgrade_transparent_from_venv() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install an earlier patch version
     uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
@@ -232,8 +232,8 @@ fn python_upgrade_transparent_from_venv() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // First virtual environment should reflect upgraded patch
@@ -241,7 +241,7 @@ fn python_upgrade_transparent_from_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.10.20
+    Python 3.10.[LATEST]
 
     ----- stderr -----
     "
@@ -253,7 +253,7 @@ fn python_upgrade_transparent_from_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.10.20
+    Python 3.10.[LATEST]
 
     ----- stderr -----
     "
@@ -268,7 +268,8 @@ fn python_upgrade_transparent_from_venv_preview() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install an earlier patch version
     uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
@@ -310,8 +311,8 @@ fn python_upgrade_transparent_from_venv_preview() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // Virtual environment should reflect upgraded patch
@@ -319,7 +320,7 @@ fn python_upgrade_transparent_from_venv_preview() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.10.20
+    Python 3.10.[LATEST]
 
     ----- stderr -----
     "
@@ -332,7 +333,8 @@ fn python_upgrade_ignored_with_python_pin() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install an earlier patch version
     uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
@@ -374,8 +376,8 @@ fn python_upgrade_ignored_with_python_pin() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // Virtual environment should continue to respect pinned patch version
@@ -398,7 +400,8 @@ fn python_no_transparent_upgrade_with_venv_patch_specification() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install an earlier patch version
     uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
@@ -440,8 +443,8 @@ fn python_no_transparent_upgrade_with_venv_patch_specification() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // The virtual environment Python version remains the same.
@@ -465,7 +468,8 @@ fn python_transparent_upgrade_venv_venv() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_filtered_virtualenv_bin()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install an earlier patch version
     uv_snapshot!(context.filters(), context.python_install().arg("3.10.17"), @"
@@ -532,8 +536,8 @@ fn python_transparent_upgrade_venv_venv() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     ");
 
     // Should have transparently upgraded in second virtual environment
@@ -543,7 +547,7 @@ fn python_transparent_upgrade_venv_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.10.20
+    Python 3.10.[LATEST]
 
     ----- stderr -----
     "
@@ -559,7 +563,8 @@ fn python_upgrade_transparent_from_venv_module() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_filtered_python_install_bin();
+        .with_filtered_python_install_bin()
+        .with_filtered_latest_python_versions();
 
     let bin_dir = context.temp_dir.child("bin");
 
@@ -601,8 +606,8 @@ fn python_upgrade_transparent_from_venv_module() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     "
     );
 
@@ -611,7 +616,7 @@ fn python_upgrade_transparent_from_venv_module() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.12.13
+    Python 3.12.[LATEST]
 
     ----- stderr -----
     "
@@ -627,7 +632,8 @@ fn python_upgrade_transparent_from_venv_module_in_venv() {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_managed_python_dirs()
-        .with_filtered_python_install_bin();
+        .with_filtered_python_install_bin()
+        .with_filtered_latest_python_versions();
 
     let bin_dir = context.temp_dir.child("bin");
 
@@ -687,8 +693,8 @@ fn python_upgrade_transparent_from_venv_module_in_venv() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.10.20 in [TIME]
-     + cpython-3.10.20-[PLATFORM] (python3.10)
+    Installed Python 3.10.[LATEST] in [TIME]
+     + cpython-3.10.[LATEST]-[PLATFORM] (python3.10)
     "
     );
 
@@ -699,7 +705,7 @@ fn python_upgrade_transparent_from_venv_module_in_venv() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Python 3.10.20
+    Python 3.10.[LATEST]
 
     ----- stderr -----
     "
@@ -715,7 +721,8 @@ fn python_upgrade_force_install() -> Result<()> {
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
         .with_empty_python_install_mirror()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     context
         .bin_dir
@@ -730,8 +737,8 @@ fn python_upgrade_force_install() -> Result<()> {
 
     ----- stderr -----
     warning: Executable already exists at `[BIN]/python3.12` but is not managed by uv; use `uv python install 3.12 --force` to replace it
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM]
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM]
     ");
 
     // Force the `bin` install.
@@ -741,8 +748,8 @@ fn python_upgrade_force_install() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     ");
 
     Ok(())
@@ -777,7 +784,8 @@ fn python_upgrade_build_version() {
         .with_python_download_cache()
         .with_filtered_python_keys()
         .with_filtered_exe_suffix()
-        .with_managed_python_dirs();
+        .with_managed_python_dirs()
+        .with_filtered_latest_python_versions();
 
     // Install Python 3.12
     uv_snapshot!(context.filters(), context.python_install().arg("3.12"), @"
@@ -786,8 +794,8 @@ fn python_upgrade_build_version() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     + cpython-3.12.13-[PLATFORM] (python3.12)
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]-[PLATFORM] (python3.12)
     ");
 
     // Should be a no-op when already installed at latest version
@@ -802,7 +810,8 @@ fn python_upgrade_build_version() {
 
     // Overwrite the BUILD file with an older build version
     let installation_dir = context.temp_dir.child("managed").child(format!(
-        "cpython-3.12.13-{}",
+        "cpython-{}-{}",
+        LATEST_PYTHON_3_12,
         platform_key_from_env().unwrap()
     ));
     let build_file = installation_dir.join("BUILD");
@@ -815,8 +824,8 @@ fn python_upgrade_build_version() {
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.12.13 in [TIME]
-     ~ cpython-3.12.13-[PLATFORM]
+    Installed Python 3.12.[LATEST] in [TIME]
+     ~ cpython-3.12.[LATEST]-[PLATFORM]
     ");
 
     // Should be a no-op again after upgrade


### PR DESCRIPTION
Add `with_filtered_latest_python_versions()` to tests that were using
hardcoded patch versions for latest Python releases. This makes the
tests resilient to Python version bumps by using `[LATEST]` placeholders
instead of specific version numbers like `3.12.12` or `3.10.19`.

Also use `LATEST_PYTHON_3_12` constant for constructing directory paths
in the build version upgrade tests.
