### PR TITLE
fix: use `remove_virtualenv` in `InstalledTools::create_environment`

### DIFF
--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -314,15 +314,12 @@ impl InstalledTools {
         let environment_path = self.tool_dir(name);
 
         // Remove any existing environment.
-        match fs_err::remove_dir_all(&environment_path) {
-            Ok(()) => {
-                debug!(
-                    "Removed existing environment for tool `{name}`: {}",
-                    environment_path.user_display()
-                );
-            }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => (),
-            Err(err) => return Err(err.into()),
+        if environment_path.try_exists()? {
+            remove_virtualenv(&environment_path)?;
+            debug!(
+                "Removed existing environment for tool `{name}`: {}",
+                environment_path.user_display()
+            );
         }
 
         debug!(


### PR DESCRIPTION
## Summary

Closes #14985.

- `InstalledTools::create_environment` was using `fs_err::remove_dir_all` directly to remove existing tool environments before recreating them
- Replaced with the `remove_virtualenv` helper, which provides safe removal behavior:
  - Defers `pyvenv.cfg` deletion so uv can still identify the directory as a virtual environment if removal fails partway
  - Handles Windows self-deletion of running executables
  - Gracefully handles `ResourceBusy` errors (e.g., Docker-mounted filesystems)

## AI Assistance Disclosure

This PR was written with the assistance of Claude Code (Claude Opus). The change was identified, implemented, and tested with AI assistance.

## Test plan

- [x] `cargo check -p uv-tool` passes
- [x] `cargo clippy -p uv-tool -- -D warnings` passes with zero warnings
- [x] `cargo test -p uv-tool` passes (no unit tests in this crate; behavior is covered by integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)