### PR TITLE
Add code signing of release binaries via `cargo-code-sign`

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -100,6 +100,46 @@ jobs:
       - name: "Install cargo extensions"
         shell: bash
         run: scripts/install-cargo-extensions.sh
+      - name: "Prepare macOS signing certificate"
+        run: |
+          set -euo pipefail
+
+          CERT_NAME="uv-codesign-ci"
+          CERT_DIR="$RUNNER_TEMP/codesign-cert"
+          mkdir -p "$CERT_DIR"
+
+          openssl req -x509 -newkey rsa:2048 -sha256 -days 7 -nodes \
+            -keyout "$CERT_DIR/key.pem" \
+            -out "$CERT_DIR/cert.pem" \
+            -subj "/CN=$CERT_NAME" \
+            -addext "extendedKeyUsage=codeSigning" \
+            -addext "keyUsage=digitalSignature"
+
+          P12_PASSWORD="$(uuidgen | tr -d '-')"
+
+          # LibreSSL (shipped with macOS) doesn't support -legacy; OpenSSL 3.x
+          # requires it for macOS keychain compatibility.
+          LEGACY_FLAG=""
+          if openssl version 2>&1 | grep -q "^OpenSSL 3"; then
+            LEGACY_FLAG="-legacy"
+          fi
+
+          openssl pkcs12 -export $LEGACY_FLAG \
+            -inkey "$CERT_DIR/key.pem" \
+            -in "$CERT_DIR/cert.pem" \
+            -name "$CERT_NAME" \
+            -out "$CERT_DIR/cert.p12" \
+            -passout pass:"$P12_PASSWORD"
+
+          CERT_B64="$(base64 < "$CERT_DIR/cert.p12" | tr -d '\n')"
+          CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')"
+
+          {
+            echo "CODESIGN_IDENTITY=$CERT_SHA1"
+            echo "CODESIGN_CERTIFICATE=$CERT_B64"
+            echo "CODESIGN_CERTIFICATE_PASSWORD=$P12_PASSWORD"
+            echo "CODESIGN_ALLOW_UNTRUSTED=1"
+          } >> "$GITHUB_ENV"
 
       # uv
       - name: "Build wheels - x86_64"
@@ -166,6 +206,46 @@ jobs:
       - name: "Install cargo extensions"
         shell: bash
         run: scripts/install-cargo-extensions.sh
+      - name: "Prepare macOS signing certificate"
+        run: |
+          set -euo pipefail
+
+          CERT_NAME="uv-codesign-ci"
+          CERT_DIR="$RUNNER_TEMP/codesign-cert"
+          mkdir -p "$CERT_DIR"
+
+          openssl req -x509 -newkey rsa:2048 -sha256 -days 7 -nodes \
+            -keyout "$CERT_DIR/key.pem" \
+            -out "$CERT_DIR/cert.pem" \
+            -subj "/CN=$CERT_NAME" \
+            -addext "extendedKeyUsage=codeSigning" \
+            -addext "keyUsage=digitalSignature"
+
+          P12_PASSWORD="$(uuidgen | tr -d '-')"
+
+          # LibreSSL (shipped with macOS) doesn't support -legacy; OpenSSL 3.x
+          # requires it for macOS keychain compatibility.
+          LEGACY_FLAG=""
+          if openssl version 2>&1 | grep -q "^OpenSSL 3"; then
+            LEGACY_FLAG="-legacy"
+          fi
+
+          openssl pkcs12 -export $LEGACY_FLAG \
+            -inkey "$CERT_DIR/key.pem" \
+            -in "$CERT_DIR/cert.pem" \
+            -name "$CERT_NAME" \
+            -out "$CERT_DIR/cert.p12" \
+            -passout pass:"$P12_PASSWORD"
+
+          CERT_B64="$(base64 < "$CERT_DIR/cert.p12" | tr -d '\n')"
+          CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')"
+
+          {
+            echo "CODESIGN_IDENTITY=$CERT_SHA1"
+            echo "CODESIGN_CERTIFICATE=$CERT_B64"
+            echo "CODESIGN_CERTIFICATE_PASSWORD=$P12_PASSWORD"
+            echo "CODESIGN_ALLOW_UNTRUSTED=1"
+          } >> "$GITHUB_ENV"
 
       # uv
       - name: "Build wheels - aarch64"
@@ -256,6 +336,35 @@ jobs:
       - name: "Install cargo extensions"
         shell: bash
         run: scripts/install-cargo-extensions.sh
+      - name: "Prepare Windows signing certificate"
+        shell: pwsh
+        run: |
+          $cert = New-SelfSignedCertificate `
+            -Type CodeSigningCert `
+            -Subject "CN=uv-codesign-ci" `
+            -CertStoreLocation "Cert:\CurrentUser\My" `
+            -NotAfter (Get-Date).AddDays(7)
+          $passwordPlain = [Guid]::NewGuid().ToString("N")
+          $password = ConvertTo-SecureString -String $passwordPlain -Force -AsPlainText
+          $pfxPath = Join-Path $env:RUNNER_TEMP "uv-codesign-ci.pfx"
+
+          Export-PfxCertificate `
+            -Cert "Cert:\CurrentUser\My\$($cert.Thumbprint)" `
+            -FilePath $pfxPath `
+            -Password $password | Out-Null
+
+          # Find signtool.exe — it's not on PATH on GitHub Actions runners.
+          $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+
+          if (-not $signtool) {
+            throw "signtool.exe not found in Windows SDK"
+          }
+
+          "SIGNTOOL_PATH=$signtool" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "SIGNTOOL_CERTIFICATE_PATH=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "SIGNTOOL_CERTIFICATE_PASSWORD=$passwordPlain" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       # uv
       - name: "Build wheels"

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -115,10 +115,10 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
-          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
+          CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
+          CODE_SIGN_CERTIFICATE: ${{ secrets.CODE_SIGN_CERTIFICATE }}
+          CODE_SIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
+          CODE_SIGN_ALLOW_UNTRUSTED: ${{ vars.CODE_SIGN_ALLOW_UNTRUSTED }}
       - name: "Upload wheels"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -152,10 +152,10 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
-          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
+          CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
+          CODE_SIGN_CERTIFICATE: ${{ secrets.CODE_SIGN_CERTIFICATE }}
+          CODE_SIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
+          CODE_SIGN_ALLOW_UNTRUSTED: ${{ vars.CODE_SIGN_ALLOW_UNTRUSTED }}
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -191,10 +191,10 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
-          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
+          CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
+          CODE_SIGN_CERTIFICATE: ${{ secrets.CODE_SIGN_CERTIFICATE }}
+          CODE_SIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
+          CODE_SIGN_ALLOW_UNTRUSTED: ${{ vars.CODE_SIGN_ALLOW_UNTRUSTED }}
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -234,10 +234,10 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
-          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
+          CODE_SIGN_IDENTITY: ${{ secrets.CODE_SIGN_IDENTITY }}
+          CODE_SIGN_CERTIFICATE: ${{ secrets.CODE_SIGN_CERTIFICATE }}
+          CODE_SIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
+          CODE_SIGN_ALLOW_UNTRUSTED: ${{ vars.CODE_SIGN_ALLOW_UNTRUSTED }}
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -282,12 +282,12 @@ jobs:
       - name: "Prepare Windows signing certificate"
         shell: pwsh
         run: |
-          if (-not $env:CODESIGN_CERTIFICATE_WINDOWS) {
+          if (-not $env:CODE_SIGN_CERTIFICATE_BASE64) {
             Write-Host "No signing certificate configured, skipping."
             return
           }
 
-          $certBytes = [Convert]::FromBase64String($env:CODESIGN_CERTIFICATE_WINDOWS)
+          $certBytes = [Convert]::FromBase64String($env:CODE_SIGN_CERTIFICATE_BASE64)
           $pfxPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"
           [IO.File]::WriteAllBytes($pfxPath, $certBytes)
 
@@ -300,12 +300,12 @@ jobs:
             throw "signtool.exe not found in Windows SDK"
           }
 
-          "CODESIGN_TOOL_PATH_WINDOWS=$signtool" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "CODESIGN_CERTIFICATE_PATH_WINDOWS=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "CODESIGN_CERTIFICATE_PASSWORD=$($env:CODESIGN_CERTIFICATE_PASSWORD)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODE_SIGN_TOOL_PATH=$signtool" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODE_SIGN_CERTIFICATE_PATH=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODE_SIGN_CERTIFICATE_PASSWORD=$($env:CODE_SIGN_CERTIFICATE_PASSWORD)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
         env:
-          CODESIGN_CERTIFICATE_WINDOWS: ${{ secrets.CODESIGN_CERTIFICATE_WINDOWS }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODE_SIGN_CERTIFICATE_BASE64: ${{ secrets.CODE_SIGN_CERTIFICATE_BASE64 }}
+          CODE_SIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_CERTIFICATE_PASSWORD }}
 
       # uv
       - name: "Build wheels"

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -13,6 +13,10 @@ on:
       plan:
         required: false
         type: string
+      environment:
+        description: "GitHub environment for secrets (e.g., code signing certificates)"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -86,6 +90,7 @@ jobs:
   macos-x86_64:
     name: x86_64-apple-darwin
     runs-on: depot-macos-14
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -100,46 +105,6 @@ jobs:
       - name: "Install cargo extensions"
         shell: bash
         run: scripts/install-cargo-extensions.sh
-      - name: "Prepare macOS signing certificate"
-        run: |
-          set -euo pipefail
-
-          CERT_NAME="uv-codesign-ci"
-          CERT_DIR="$RUNNER_TEMP/codesign-cert"
-          mkdir -p "$CERT_DIR"
-
-          openssl req -x509 -newkey rsa:2048 -sha256 -days 7 -nodes \
-            -keyout "$CERT_DIR/key.pem" \
-            -out "$CERT_DIR/cert.pem" \
-            -subj "/CN=$CERT_NAME" \
-            -addext "extendedKeyUsage=codeSigning" \
-            -addext "keyUsage=digitalSignature"
-
-          P12_PASSWORD="$(uuidgen | tr -d '-')"
-
-          # LibreSSL (shipped with macOS) doesn't support -legacy; OpenSSL 3.x
-          # requires it for macOS keychain compatibility.
-          LEGACY_FLAG=""
-          if openssl version 2>&1 | grep -q "^OpenSSL 3"; then
-            LEGACY_FLAG="-legacy"
-          fi
-
-          openssl pkcs12 -export $LEGACY_FLAG \
-            -inkey "$CERT_DIR/key.pem" \
-            -in "$CERT_DIR/cert.pem" \
-            -name "$CERT_NAME" \
-            -out "$CERT_DIR/cert.p12" \
-            -passout pass:"$P12_PASSWORD"
-
-          CERT_B64="$(base64 < "$CERT_DIR/cert.p12" | tr -d '\n')"
-          CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')"
-
-          {
-            echo "CODESIGN_IDENTITY=$CERT_SHA1"
-            echo "CODESIGN_CERTIFICATE=$CERT_B64"
-            echo "CODESIGN_CERTIFICATE_PASSWORD=$P12_PASSWORD"
-            echo "CODESIGN_ALLOW_UNTRUSTED=1"
-          } >> "$GITHUB_ENV"
 
       # uv
       - name: "Build wheels - x86_64"
@@ -150,6 +115,10 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
+          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
       - name: "Upload wheels"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -183,6 +152,10 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
+          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -192,6 +165,7 @@ jobs:
   macos-aarch64:
     name: aarch64-apple-darwin
     runs-on: depot-macos-14
+    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -206,46 +180,6 @@ jobs:
       - name: "Install cargo extensions"
         shell: bash
         run: scripts/install-cargo-extensions.sh
-      - name: "Prepare macOS signing certificate"
-        run: |
-          set -euo pipefail
-
-          CERT_NAME="uv-codesign-ci"
-          CERT_DIR="$RUNNER_TEMP/codesign-cert"
-          mkdir -p "$CERT_DIR"
-
-          openssl req -x509 -newkey rsa:2048 -sha256 -days 7 -nodes \
-            -keyout "$CERT_DIR/key.pem" \
-            -out "$CERT_DIR/cert.pem" \
-            -subj "/CN=$CERT_NAME" \
-            -addext "extendedKeyUsage=codeSigning" \
-            -addext "keyUsage=digitalSignature"
-
-          P12_PASSWORD="$(uuidgen | tr -d '-')"
-
-          # LibreSSL (shipped with macOS) doesn't support -legacy; OpenSSL 3.x
-          # requires it for macOS keychain compatibility.
-          LEGACY_FLAG=""
-          if openssl version 2>&1 | grep -q "^OpenSSL 3"; then
-            LEGACY_FLAG="-legacy"
-          fi
-
-          openssl pkcs12 -export $LEGACY_FLAG \
-            -inkey "$CERT_DIR/key.pem" \
-            -in "$CERT_DIR/cert.pem" \
-            -name "$CERT_NAME" \
-            -out "$CERT_DIR/cert.p12" \
-            -passout pass:"$P12_PASSWORD"
-
-          CERT_B64="$(base64 < "$CERT_DIR/cert.p12" | tr -d '\n')"
-          CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 | cut -d= -f2 | tr -d ':')"
-
-          {
-            echo "CODESIGN_IDENTITY=$CERT_SHA1"
-            echo "CODESIGN_CERTIFICATE=$CERT_B64"
-            echo "CODESIGN_CERTIFICATE_PASSWORD=$P12_PASSWORD"
-            echo "CODESIGN_ALLOW_UNTRUSTED=1"
-          } >> "$GITHUB_ENV"
 
       # uv
       - name: "Build wheels - aarch64"
@@ -257,6 +191,10 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
+          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -296,6 +234,10 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          CODESIGN_IDENTITY_MACOS: ${{ secrets.CODESIGN_IDENTITY_MACOS }}
+          CODESIGN_CERTIFICATE_MACOS: ${{ secrets.CODESIGN_CERTIFICATE_MACOS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_ALLOW_UNTRUSTED_MACOS: ${{ vars.CODESIGN_ALLOW_UNTRUSTED_MACOS }}
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -310,6 +252,7 @@ jobs:
   windows:
     name: ${{ matrix.platform.target }}
     runs-on: ${{ matrix.platform.runner }}
+    environment: ${{ inputs.environment }}
     strategy:
       matrix:
         platform:
@@ -339,19 +282,14 @@ jobs:
       - name: "Prepare Windows signing certificate"
         shell: pwsh
         run: |
-          $cert = New-SelfSignedCertificate `
-            -Type CodeSigningCert `
-            -Subject "CN=uv-codesign-ci" `
-            -CertStoreLocation "Cert:\CurrentUser\My" `
-            -NotAfter (Get-Date).AddDays(7)
-          $passwordPlain = [Guid]::NewGuid().ToString("N")
-          $password = ConvertTo-SecureString -String $passwordPlain -Force -AsPlainText
-          $pfxPath = Join-Path $env:RUNNER_TEMP "uv-codesign-ci.pfx"
+          if (-not $env:CODESIGN_CERTIFICATE_WINDOWS) {
+            Write-Host "No signing certificate configured, skipping."
+            return
+          }
 
-          Export-PfxCertificate `
-            -Cert "Cert:\CurrentUser\My\$($cert.Thumbprint)" `
-            -FilePath $pfxPath `
-            -Password $password | Out-Null
+          $certBytes = [Convert]::FromBase64String($env:CODESIGN_CERTIFICATE_WINDOWS)
+          $pfxPath = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [IO.File]::WriteAllBytes($pfxPath, $certBytes)
 
           # Find signtool.exe — it's not on PATH on GitHub Actions runners.
           $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
@@ -362,9 +300,12 @@ jobs:
             throw "signtool.exe not found in Windows SDK"
           }
 
-          "SIGNTOOL_PATH=$signtool" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "SIGNTOOL_CERTIFICATE_PATH=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "SIGNTOOL_CERTIFICATE_PASSWORD=$passwordPlain" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODESIGN_TOOL_PATH_WINDOWS=$signtool" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODESIGN_CERTIFICATE_PATH_WINDOWS=$pfxPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "CODESIGN_CERTIFICATE_PASSWORD=$($env:CODESIGN_CERTIFICATE_PASSWORD)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        env:
+          CODESIGN_CERTIFICATE_WINDOWS: ${{ secrets.CODESIGN_CERTIFICATE_WINDOWS }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
 
       # uv
       - name: "Build wheels"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,8 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.build-release-binaries == 'true' }}
     uses: ./.github/workflows/build-release-binaries.yml
+    with:
+      environment: release-test
     secrets: inherit
 
   build-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
     uses: ./.github/workflows/build-release-binaries.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
+      environment: release
     secrets: inherit
 
   custom-build-docker:

--- a/scripts/cargo-auditable.cmd
+++ b/scripts/cargo-auditable.cmd
@@ -1,0 +1,5 @@
+@echo off
+REM Cargo wrapper that runs `cargo auditable` to embed SBOM metadata.
+REM See cargo-auditable.sh for the full explanation.
+
+cargo.exe auditable %*

--- a/scripts/cargo-auditable.sh
+++ b/scripts/cargo-auditable.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+## Cargo wrapper that runs `cargo auditable` to embed SBOM metadata.
+##
+## Used as the inner build command for `cargo-code-sign`.
+##
+## Usage:
+##
+##   CARGO_CODE_SIGN_CARGO="$PWD/scripts/cargo-auditable.sh" cargo-code-sign code-sign ...
+
+set -eu
+
+exec cargo auditable "$@"

--- a/scripts/cargo-code-sign.cmd
+++ b/scripts/cargo-code-sign.cmd
@@ -1,0 +1,5 @@
+@echo off
+REM Cargo wrapper that signs binaries after building via `cargo-code-sign`.
+REM See cargo-code-sign.sh for the full explanation.
+
+cargo-code-sign.exe code-sign %*

--- a/scripts/cargo-code-sign.sh
+++ b/scripts/cargo-code-sign.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+## Cargo wrapper that signs binaries after building via `cargo-code-sign`.
+##
+## Uses `CARGO_CODE_SIGN_CARGO` to determine the inner cargo command.
+## If unset, falls back to plain `cargo`.
+##
+## Usage:
+##
+##   CARGO_CODE_SIGN_CARGO="$PWD/scripts/cargo-auditable.sh" \
+##     scripts/cargo-code-sign.sh build --release
+
+set -eu
+
+exec cargo-code-sign code-sign "$@"

--- a/scripts/cargo.cmd
+++ b/scripts/cargo.cmd
@@ -1,15 +1,8 @@
 @echo off
-REM Wrapper script that invokes `cargo auditable` instead of plain `cargo`.
+REM Top-level cargo wrapper for release builds.
 REM
-REM Use `scripts/install-cargo-extensions.sh` to install the dependencies.
-REM
-REM Usage:
-REM
-REM   set CARGO=%CD%\scripts\cargo.cmd
-REM   cargo build --release
+REM Chains `cargo-code-sign` (post-build binary signing) with `cargo-auditable`
+REM (SBOM embedding). See cargo.sh for the full explanation.
 
-if defined REAL_CARGO (
-    "%REAL_CARGO%" auditable %*
-) else (
-    cargo.exe auditable %*
-)
+set CARGO_CODE_SIGN_CARGO=%~dp0cargo-auditable.cmd
+%~dp0cargo-code-sign.cmd %*

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env sh
-## Wrapper script that invokes `cargo auditable` instead of plain `cargo`.
+## Top-level cargo wrapper for release builds.
+##
+## Chains `cargo-code-sign` (post-build binary signing) with `cargo-auditable`
+## (SBOM embedding):
+##
+##   maturin -> cargo.sh -> cargo-code-sign -> cargo-auditable -> cargo
 ##
 ## Use `scripts/install-cargo-extensions.sh` to install the dependencies.
 ##
 ## Usage:
 ##
-##   CARGO="$PWD/scripts/cargo.sh" cargo build --release
+##   CARGO="$PWD/scripts/cargo.sh" maturin build --release
 
 set -eu
 
-if [ -n "${REAL_CARGO:-}" ]; then
-    exec "$REAL_CARGO" auditable "$@"
-else
-    exec cargo auditable "$@"
-fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Tell cargo-code-sign to use cargo-auditable as the inner build command.
+export CARGO_CODE_SIGN_CARGO="${SCRIPT_DIR}/cargo-auditable.sh"
+
+exec "${SCRIPT_DIR}/cargo-code-sign.sh" "$@"

--- a/scripts/check-release-artifacts-signed.sh
+++ b/scripts/check-release-artifacts-signed.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+## Check that release artifacts from a CI run are code-signed.
+##
+## Downloads macOS and Windows artifacts and wheels from the given GitHub
+## Actions run, extracts binaries, and verifies:
+##   - macOS:   codesign identity signature (not ad-hoc)
+##   - Windows: Authenticode signature present
+##
+## Usage:
+##   scripts/check-release-artifacts-signed.sh <run-id>
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <run-id>" >&2
+    exit 1
+fi
+
+missing=()
+command -v gh >/dev/null 2>&1 || missing+=(gh)
+command -v codesign >/dev/null 2>&1 || missing+=(codesign)
+command -v osslsigncode >/dev/null 2>&1 || missing+=(osslsigncode)
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "error: missing required tools: ${missing[*]}" >&2
+    echo "" >&2
+    echo "Install with:" >&2
+    for tool in "${missing[@]}"; do
+        case "$tool" in
+            gh)            echo "  brew install gh" >&2 ;;
+            codesign)      echo "  (requires macOS)" >&2 ;;
+            osslsigncode)  echo "  brew install osslsigncode" >&2 ;;
+        esac
+    done
+    exit 1
+fi
+
+RUN_ID="$1"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL $1"; FAIL=$((FAIL + 1)); }
+
+check_macos() {
+    local binary="$1"
+    local label="$2"
+    local info
+    info=$(codesign -dv "$binary" 2>&1) || true
+    if echo "$info" | grep -q "Signature=adhoc"; then
+        fail "$label (ad-hoc, not identity-signed)"
+    elif sig_size=$(echo "$info" | grep "Signature size=" | sed 's/.*Signature size=//'); then
+        pass "$label (identity-signed, size=$sig_size)"
+    else
+        fail "$label (not signed)"
+    fi
+}
+
+check_windows() {
+    local binary="$1"
+    local label="$2"
+    local output
+    output=$(osslsigncode verify -in "$binary" 2>&1) || true
+    if echo "$output" | grep -q "Signer's certificate:"; then
+        local subject
+        subject=$(echo "$output" | grep "Subject:" | head -1 | sed 's/.*Subject: //')
+        pass "$label (Authenticode, $subject)"
+    else
+        fail "$label (not Authenticode signed)"
+    fi
+}
+
+echo "Fetching artifacts for run $RUN_ID..."
+ALL_ARTIFACTS=$(gh api "repos/{owner}/{repo}/actions/runs/$RUN_ID/artifacts" \
+    --paginate --jq '.artifacts[].name')
+
+echo ""
+
+for artifact in $ALL_ARTIFACTS; do
+    # Only check macOS and Windows archives and wheels.
+    case "$artifact" in
+        artifacts-*apple-darwin*|artifacts-macos-*)  check=check_macos ;;
+        artifacts-*windows*|artifacts-*win*)         check=check_windows ;;
+        wheels_uv-*apple-darwin*|wheels_uv-macos-*)  check=check_macos ;;
+        wheels_uv-*windows*|wheels_uv-*win*)         check=check_windows ;;
+        *) continue ;;
+    esac
+
+    dest="$WORK_DIR/$artifact"
+    mkdir -p "$dest"
+    if ! gh run download "$RUN_ID" -n "$artifact" -D "$dest"; then
+        fail "$artifact (download failed)"
+        continue
+    fi
+
+    # Extract everything: tar.gz archives, zip archives, and wheels.
+    for tarball in "$dest"/*.tar.gz; do
+        [ -f "$tarball" ] || continue
+        tar xzf "$tarball" -C "$dest"
+    done
+    for zip in "$dest"/*.zip "$dest"/*.whl; do
+        [ -f "$zip" ] || continue
+        unzip -qo "$zip" -d "$dest"
+    done
+
+    # Check each binary. The label shows the archive/wheel filename and binary name,
+    # e.g. "uv-x86_64-apple-darwin.tar.gz uv" or "uv-0.10.8-py3-none-win_amd64.whl uv.exe".
+    while IFS= read -r binary; do
+        bin_name=$(basename "$binary")
+        # Walk up to find the archive or wheel this binary came from.
+        archive=""
+        for f in "$dest"/*.tar.gz "$dest"/*.zip "$dest"/*.whl; do
+            [ -f "$f" ] && archive=$(basename "$f") && break
+        done
+        $check "$binary" "${archive:-$artifact} / $bin_name"
+    done < <(find "$dest" \( -name "uv" -o -name "uvx" -o -name "uv.exe" -o -name "uvx.exe" -o -name "uvw.exe" \) -type f ! -name "*.sha256")
+done
+
+echo ""
+echo "PASS $PASS / FAIL $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/generate-codesign-test-secrets.sh
+++ b/scripts/generate-codesign-test-secrets.sh
@@ -2,9 +2,9 @@
 ## Generate a self-signed code signing certificate and populate a GitHub
 ## environment with the resulting secrets and variables via the `gh` CLI.
 ##
-## Secrets: CODESIGN_CERTIFICATE_PASSWORD, CODESIGN_IDENTITY_MACOS,
-##   CODESIGN_CERTIFICATE_MACOS, CODESIGN_CERTIFICATE_WINDOWS
-## Variables: CODESIGN_ALLOW_UNTRUSTED_MACOS
+## Secrets: CODE_SIGN_CERTIFICATE_PASSWORD, CODE_SIGN_IDENTITY,
+##   CODE_SIGN_CERTIFICATE, CODE_SIGN_CERTIFICATE_BASE64
+## Variables: CODE_SIGN_ALLOW_UNTRUSTED
 ##
 ## Usage:
 ##
@@ -68,25 +68,33 @@ CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 \
 
 echo "Setting secrets and variables in '${ENV_NAME}' environment for ${REPO}..."
 
-gh secret set CODESIGN_CERTIFICATE_PASSWORD \
+# Shared password for the .p12/.pfx certificate.
+gh secret set CODE_SIGN_CERTIFICATE_PASSWORD \
   --repo "$REPO" --env "$ENV_NAME" --body "$P12_PASSWORD"
 
-gh secret set CODESIGN_IDENTITY_MACOS \
+# macOS: identity (SHA1 fingerprint) and base64-encoded .p12 certificate.
+# These are passed directly to cargo-code-sign as CODE_SIGN_IDENTITY and
+# CODE_SIGN_CERTIFICATE.
+gh secret set CODE_SIGN_IDENTITY \
   --repo "$REPO" --env "$ENV_NAME" --body "$CERT_SHA1"
 
-gh secret set CODESIGN_CERTIFICATE_MACOS \
+gh secret set CODE_SIGN_CERTIFICATE \
   --repo "$REPO" --env "$ENV_NAME" --body "$CERT_B64"
 
-gh secret set CODESIGN_CERTIFICATE_WINDOWS \
+# Windows: base64-encoded .pfx certificate. The workflow decodes this to a
+# file and sets CODE_SIGN_CERTIFICATE_PATH for cargo-code-sign.
+gh secret set CODE_SIGN_CERTIFICATE_BASE64 \
   --repo "$REPO" --env "$ENV_NAME" --body "$CERT_B64"
 
-gh variable set CODESIGN_ALLOW_UNTRUSTED_MACOS \
+# Self-signed certs aren't trusted by the macOS keychain, so cargo-code-sign
+# needs this to find the identity.
+gh variable set CODE_SIGN_ALLOW_UNTRUSTED \
   --repo "$REPO" --env "$ENV_NAME" --body "1"
 
 echo ""
 echo "Done. Set in '${ENV_NAME}' environment for ${REPO}:"
-echo "  CODESIGN_CERTIFICATE_PASSWORD"
-echo "  CODESIGN_IDENTITY_MACOS"
-echo "  CODESIGN_CERTIFICATE_MACOS"
-echo "  CODESIGN_CERTIFICATE_WINDOWS"
-echo "  CODESIGN_ALLOW_UNTRUSTED_MACOS"
+echo "  CODE_SIGN_CERTIFICATE_PASSWORD"
+echo "  CODE_SIGN_IDENTITY"
+echo "  CODE_SIGN_CERTIFICATE"
+echo "  CODE_SIGN_CERTIFICATE_BASE64"
+echo "  CODE_SIGN_ALLOW_UNTRUSTED"

--- a/scripts/generate-codesign-test-secrets.sh
+++ b/scripts/generate-codesign-test-secrets.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+## Generate a self-signed code signing certificate and populate a GitHub
+## environment with the resulting secrets and variables via the `gh` CLI.
+##
+## Secrets: CODESIGN_CERTIFICATE_PASSWORD, CODESIGN_IDENTITY_MACOS,
+##   CODESIGN_CERTIFICATE_MACOS, CODESIGN_CERTIFICATE_WINDOWS
+## Variables: CODESIGN_ALLOW_UNTRUSTED_MACOS
+##
+## Usage:
+##
+##   scripts/generate-codesign-test-secrets.sh
+
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+  echo "error: gh CLI is required but not found. Install from https://cli.github.com" >&2
+  exit 1
+fi
+
+REPO="astral-sh/uv"
+ENV_NAME="release-test"
+
+echo "Generating self-signed code signing certificate..."
+
+CERT_DIR="$(mktemp -d)"
+trap 'rm -rf "$CERT_DIR"' EXIT
+
+CERT_NAME="uv-codesign-test"
+P12_PASSWORD="$(uuidgen | tr -d '-')"
+
+# ---------------------------------------------------------------------------
+# Generate a self-signed code-signing certificate as a PKCS#12 / PFX.
+# The same file is used for both macOS (.p12) and Windows (.pfx) — they are
+# the same format.
+# ---------------------------------------------------------------------------
+
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+  -keyout "$CERT_DIR/key.pem" \
+  -out "$CERT_DIR/cert.pem" \
+  -subj "/CN=$CERT_NAME" \
+  -addext "extendedKeyUsage=codeSigning" \
+  -addext "keyUsage=digitalSignature" \
+  2>/dev/null
+
+# Detect whether we need -legacy (OpenSSL 3.x requires it for macOS keychain
+# compatibility; LibreSSL shipped with macOS does not support it).
+LEGACY_FLAG=""
+if openssl version 2>&1 | grep -q "^OpenSSL 3"; then
+  LEGACY_FLAG="-legacy"
+fi
+
+# shellcheck disable=SC2086
+openssl pkcs12 -export $LEGACY_FLAG \
+  -inkey "$CERT_DIR/key.pem" \
+  -in "$CERT_DIR/cert.pem" \
+  -name "$CERT_NAME" \
+  -out "$CERT_DIR/cert.p12" \
+  -passout pass:"$P12_PASSWORD" \
+  2>/dev/null
+
+CERT_B64="$(base64 < "$CERT_DIR/cert.p12" | tr -d '\n')"
+CERT_SHA1="$(openssl x509 -in "$CERT_DIR/cert.pem" -noout -fingerprint -sha1 \
+  | cut -d= -f2 | tr -d ':')"
+
+# ---------------------------------------------------------------------------
+# Populate the GitHub environment.
+# ---------------------------------------------------------------------------
+
+echo "Setting secrets and variables in '${ENV_NAME}' environment for ${REPO}..."
+
+gh secret set CODESIGN_CERTIFICATE_PASSWORD \
+  --repo "$REPO" --env "$ENV_NAME" --body "$P12_PASSWORD"
+
+gh secret set CODESIGN_IDENTITY_MACOS \
+  --repo "$REPO" --env "$ENV_NAME" --body "$CERT_SHA1"
+
+gh secret set CODESIGN_CERTIFICATE_MACOS \
+  --repo "$REPO" --env "$ENV_NAME" --body "$CERT_B64"
+
+gh secret set CODESIGN_CERTIFICATE_WINDOWS \
+  --repo "$REPO" --env "$ENV_NAME" --body "$CERT_B64"
+
+gh variable set CODESIGN_ALLOW_UNTRUSTED_MACOS \
+  --repo "$REPO" --env "$ENV_NAME" --body "1"
+
+echo ""
+echo "Done. Set in '${ENV_NAME}' environment for ${REPO}:"
+echo "  CODESIGN_CERTIFICATE_PASSWORD"
+echo "  CODESIGN_IDENTITY_MACOS"
+echo "  CODESIGN_CERTIFICATE_MACOS"
+echo "  CODESIGN_CERTIFICATE_WINDOWS"
+echo "  CODESIGN_ALLOW_UNTRUSTED_MACOS"

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -19,8 +19,7 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
 
 CARGO_CODE_SIGN_INSTALL="cargo install cargo-code-sign \
     --locked \
-    --git https://github.com/zanieb/cargo-code-sign \
-    --rev 5d3dea1e1f4319a37dfa18d8018703a04050a561"
+    --version 0.2.0"
 
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in
 # musl-based environments (Alpine, etc.).

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -20,7 +20,7 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
 CARGO_CODE_SIGN_INSTALL="cargo install cargo-code-sign \
     --locked \
     --git https://github.com/zanieb/cargo-code-sign \
-    --rev 3448dce9525127604dc65db1dc2a5f4b67f214b6"
+    --rev 5d3dea1e1f4319a37dfa18d8018703a04050a561"
 
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in
 # musl-based environments (Alpine, etc.).

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 ## Install cargo extensions for release builds.
 ##
-## Installs cargo-auditable for SBOM embedding.
+## Installs cargo-auditable for SBOM embedding and cargo-code-sign for binary signing.
 ##
 ## Includes handling for cross-build containers in our release workflow.
 ##
@@ -17,6 +17,11 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
     --locked \
     --version 0.7.4"
 
+CARGO_CODE_SIGN_INSTALL="cargo install cargo-code-sign \
+    --locked \
+    --git https://github.com/zanieb/cargo-code-sign \
+    --rev 3448dce9525127604dc65db1dc2a5f4b67f214b6"
+
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in
 # musl-based environments (Alpine, etc.).
 #
@@ -26,6 +31,8 @@ if [ "$(uname -m 2>/dev/null)" = "x86_64" ] && [ "$(uname -s 2>/dev/null)" = "Li
     MUSL_TARGET="x86_64-unknown-linux-musl"
     rustup target add "$MUSL_TARGET"
     CC=gcc $CARGO_AUDITABLE_INSTALL --target "$MUSL_TARGET"
+    CC=gcc $CARGO_CODE_SIGN_INSTALL --target "$MUSL_TARGET"
 else
     $CARGO_AUDITABLE_INSTALL
+    $CARGO_CODE_SIGN_INSTALL
 fi


### PR DESCRIPTION
Adds code signing of our release binaries on Windows and macOS, using temporary self-signed certificates for testing.

Instead of signing via `uv build` as explored in #18262, we use a cargo extension to sign on build. This allows us to sign both the artifacts inside and outside of wheels without changing maturin. This builds on patterns introduced in #18276.

I built `cargo-code-sign` as a standalone tool, heavily referencing existing code signing techniques in the ecosystem, see https://github.com/zanieb/code-sign-tools

Includes https://github.com/astral-sh/uv/pull/18295
This does not configure secrets for the actual release environment yet.