### PR TITLE
Fix #18285: Restore `sysconfig.get_platform()` `android` behaving as `linux`

### DIFF
--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -456,7 +456,7 @@ def get_operating_system_and_architecture():
         )
         sys.exit(0)
 
-    if operating_system == "linux":
+    if operating_system in ["linux", "android"]:
         # noinspection PyProtectedMember
         from .packaging._manylinux import _get_glibc_version
 
@@ -487,6 +487,15 @@ def get_operating_system_and_architecture():
                 "minor": glibc_version[1],
             }
         elif hasattr(sys, "getandroidapilevel"):
+            # For Python 3.13+ (for instance Termux)
+            android_abi_to_arch = {
+                "arm64_v8a": "aarch64",
+                "armeabi_v7a": "armv7l",
+                "x86": "i686",
+            }
+
+            architecture = android_abi_to_arch.get(architecture, architecture)
+
             operating_system = {
                 "name": "android",
                 "api_level": sys.getandroidapilevel(),


### PR DESCRIPTION
https://peps.python.org/pep-0738/#sys

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

See #18285.

Personal notes: [Benjamin_Loison/Voice_assistant/issues/9#issuecomment-11198012](https://codeberg.org/Benjamin_Loison/Voice_assistant/issues/9#issuecomment-11198012)

## Test Plan

<!-- How was it tested? -->

I tested successfully this change with Python 3.13 `uv venv` only on current Termux package version being 0.9.15 due to [termux/termux-packages/issues/27547](https://github.com/termux/termux-packages/issues/27547) on Virtual Machine Manager x86-64 LineageOS 23.0 (Android 16) virtual machine and aarch64 Fairphone 4 LineageOS 23.2.