### PR TITLE
Add spans for toml reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7078,6 +7078,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
  "url",
  "uv-configuration",
  "uv-distribution-types",

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -109,17 +109,19 @@ pub fn check_direct_build(
         build_system: BuildSystem,
     }
 
-    let pyproject_toml: PyProjectToml =
-        match fs_err::read_to_string(source_tree.join("pyproject.toml"))
-            .map_err(|err| err.to_string())
-            .and_then(|pyproject_toml| {
-                toml::from_str(&pyproject_toml).map_err(|err| err.to_string())
-            }) {
-            Ok(pyproject_toml) => pyproject_toml,
-            Err(err) => {
-                return Err(DirectBuildIncompatibility::PyprojectToml(err));
-            }
-        };
+    let path = source_tree.join("pyproject.toml");
+    let pyproject_toml: PyProjectToml = match fs_err::read_to_string(&path)
+        .map_err(|err| err.to_string())
+        .and_then(|pyproject_toml| {
+            tracing::info_span!("toml::from_str check direct build", path = %path.display())
+                .in_scope(|| toml::from_str(&pyproject_toml))
+                .map_err(|err| err.to_string())
+        }) {
+        Ok(pyproject_toml) => pyproject_toml,
+        Err(err) => {
+            return Err(DirectBuildIncompatibility::PyprojectToml(err));
+        }
+    };
 
     if pyproject_toml.build_system.build_backend.as_deref() != Some("uv_build") {
         return Err(DirectBuildIncompatibility::WrongBackend(
@@ -229,7 +231,9 @@ impl PyProjectToml {
     pub(crate) fn parse(path: &Path) -> Result<Self, Error> {
         let contents = fs_err::read_to_string(path)?;
         let pyproject_toml =
-            toml::from_str(&contents).map_err(|err| Error::Toml(path.to_path_buf(), err))?;
+            tracing::info_span!("toml::from_str uv build backend", path = %path.display())
+                .in_scope(|| toml::from_str(&contents))
+                .map_err(|err| Error::Toml(path.to_path_buf(), err))?;
         Ok(pyproject_toml)
     }
 

--- a/crates/uv-cache-info/src/cache_info.rs
+++ b/crates/uv-cache-info/src/cache_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
-use tracing::{debug, warn};
+use tracing::{debug, info_span, warn};
 
 use uv_fs::Simplified;
 
@@ -69,19 +69,21 @@ impl CacheInfo {
         let mut env = BTreeMap::new();
 
         // Read the cache keys.
-        let cache_keys =
-            if let Ok(contents) = fs_err::read_to_string(directory.join("pyproject.toml")) {
-                if let Ok(pyproject_toml) = toml::from_str::<PyProjectToml>(&contents) {
-                    pyproject_toml
-                        .tool
-                        .and_then(|tool| tool.uv)
-                        .and_then(|tool_uv| tool_uv.cache_keys)
-                } else {
-                    None
-                }
+        let pyproject_path = directory.join("pyproject.toml");
+        let cache_keys = if let Ok(contents) = fs_err::read_to_string(&pyproject_path) {
+            let result = info_span!("toml::from_str cache keys", path = %pyproject_path.display())
+                .in_scope(|| toml::from_str::<PyProjectToml>(&contents));
+            if let Ok(pyproject_toml) = result {
+                pyproject_toml
+                    .tool
+                    .and_then(|tool| tool.uv)
+                    .and_then(|tool_uv| tool_uv.cache_keys)
             } else {
                 None
-            };
+            }
+        } else {
+            None
+        };
 
         // If no cache keys were defined, use the defaults.
         let cache_keys = cache_keys.unwrap_or_else(|| {

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -790,7 +790,7 @@ fn path_source(
                 let pyproject_path = install_path.join("pyproject.toml");
                 fs_err::read_to_string(&pyproject_path)
                     .ok()
-                    .and_then(|contents| PyProjectToml::from_string(contents).ok())
+                    .and_then(|contents| PyProjectToml::from_string(contents, pyproject_path).ok())
                     // We don't require a build system for path dependencies
                     .map(|pyproject_toml| pyproject_toml.is_package(false))
                     .unwrap_or(true)

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -469,7 +469,7 @@ mod test {
             &WorkspaceCache::default(),
         )
         .await?;
-        let pyproject_toml = uv_pypi_types::PyProjectToml::from_toml(contents)?;
+        let pyproject_toml = uv_pypi_types::PyProjectToml::from_toml(contents, "pyproject.toml")?;
         let requires_dist = uv_pypi_types::RequiresDist::from_pyproject_toml(pyproject_toml)?;
         Ok(RequiresDist::from_project_workspace(
             requires_dist,

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -36,7 +36,7 @@ use uv_distribution_types::{
     SourceUrl,
 };
 use uv_extract::hash::Hasher;
-use uv_fs::{rename_with_retry, write_atomic};
+use uv_fs::{Simplified, rename_with_retry, write_atomic};
 use uv_git::{GIT_LFS, GitError};
 use uv_git_types::{GitHubRepository, GitOid};
 use uv_metadata::read_archive_metadata;
@@ -2123,7 +2123,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         };
 
         // Parse the `pyproject.toml`.
-        let pyproject_toml = match PyProjectToml::from_toml(&content) {
+        let pyproject_toml = match PyProjectToml::from_toml(&content, source) {
             Ok(metadata) => metadata,
             Err(
                 uv_pypi_types::MetadataError::InvalidPyprojectTomlSyntax(..)
@@ -2908,8 +2908,9 @@ fn has_sources(content: &str) -> Result<bool, toml::de::Error> {
         sources: Option<ToolUvSources>,
     }
 
-    let PyProjectToml { tool } = toml::from_str(content)?;
-    if let Some(tool) = tool {
+    let pyproject_toml =
+        info_span!("toml::from_str has sources").in_scope(|| toml::from_str(content))?;
+    if let PyProjectToml { tool: Some(tool) } = pyproject_toml {
         if let Some(uv) = tool.uv {
             if let Some(sources) = uv.sources {
                 if !sources.inner().is_empty() {
@@ -3077,7 +3078,7 @@ async fn read_pyproject_toml(
         Some(subdirectory) => source_tree.join(subdirectory).join("pyproject.toml"),
         None => source_tree.join("pyproject.toml"),
     };
-    let content = match fs::read_to_string(pyproject_toml).await {
+    let content = match fs::read_to_string(&pyproject_toml).await {
         Ok(content) => content,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             return Err(Error::MissingPyprojectToml);
@@ -3085,7 +3086,7 @@ async fn read_pyproject_toml(
         Err(err) => return Err(Error::CacheRead(err)),
     };
 
-    let pyproject_toml = PyProjectToml::from_toml(&content)?;
+    let pyproject_toml = PyProjectToml::from_toml(&content, pyproject_toml.simplified_display())?;
 
     Ok(pyproject_toml)
 }

--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -347,7 +347,7 @@ mod tests {
         [project]
         name = "asdf"
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None);
         assert!(matches!(meta, Err(MetadataError::FieldNotFound("version"))));
 
@@ -356,7 +356,7 @@ mod tests {
         name = "asdf"
         dynamic = ["version"]
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None);
         assert!(matches!(meta, Err(MetadataError::DynamicField("version"))));
 
@@ -365,7 +365,7 @@ mod tests {
         name = "asdf"
         version = "1.0"
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None).unwrap();
         assert_eq!(meta.name, PackageName::from_str("asdf").unwrap());
         assert_eq!(meta.version, Version::new([1, 0]));
@@ -379,7 +379,7 @@ mod tests {
         version = "1.0"
         requires-python = ">=3.6"
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None).unwrap();
         assert_eq!(meta.name, PackageName::from_str("asdf").unwrap());
         assert_eq!(meta.version, Version::new([1, 0]));
@@ -394,7 +394,7 @@ mod tests {
         requires-python = ">=3.6"
         dependencies = ["foo"]
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None).unwrap();
         assert_eq!(meta.name, PackageName::from_str("asdf").unwrap());
         assert_eq!(meta.version, Version::new([1, 0]));
@@ -412,7 +412,7 @@ mod tests {
         [project.optional-dependencies]
         dotenv = ["bar"]
     "#;
-        let pyproject = PyProjectToml::from_toml(s).unwrap();
+        let pyproject = PyProjectToml::from_toml(s, "pyproject.toml").unwrap();
         let meta = ResolutionMetadata::parse_pyproject_toml(pyproject, None).unwrap();
         assert_eq!(meta.name, PackageName::from_str("asdf").unwrap());
         assert_eq!(meta.version, Version::new([1, 0]));

--- a/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
+++ b/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
@@ -1,8 +1,10 @@
+use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
 use indexmap::IndexMap;
 use serde::Deserialize;
 use serde::de::IntoDeserializer;
+use tracing::instrument;
 
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::Version;
@@ -18,7 +20,8 @@ pub struct PyProjectToml {
 }
 
 impl PyProjectToml {
-    pub fn from_toml(toml: &str) -> Result<Self, MetadataError> {
+    #[instrument(name = "toml::from_str uv pypi types", skip_all, fields(source = % _source))]
+    pub fn from_toml(toml: &str, _source: impl Display) -> Result<Self, MetadataError> {
         let pyproject_toml = toml_edit::Document::from_str(toml)
             .map_err(MetadataError::InvalidPyprojectTomlSyntax)?;
         let pyproject_toml = Self::deserialize(pyproject_toml.into_deserializer())

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -284,7 +284,7 @@ impl RequirementsSpecification {
                         ));
                     }
                 };
-                let pyproject_toml = PyProjectToml::from_toml(&content)
+                let pyproject_toml = PyProjectToml::from_toml(&content, path.user_display())
                     .with_context(|| format!("Failed to parse: `{}`", path.user_display()))?;
 
                 Self {

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -14,6 +14,7 @@ use uv_distribution_types::{
     BuildableSource, DirectSourceUrl, DirectorySourceUrl, GitSourceUrl, PathSourceUrl,
     RemoteSource, Requirement, SourceUrl, VersionId,
 };
+use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep508::{UnnamedRequirement, VersionOrUrl};
 use uv_pypi_types::{Metadata10, ParsedUrl, PyProjectToml, VerbatimParsedUrl};
@@ -164,9 +165,12 @@ impl<'a, Context: BuildContext> NamedRequirementsResolver<'a, Context> {
 
                 // Attempt to read a `pyproject.toml` file.
                 let project_path = parsed_directory_url.install_path.join("pyproject.toml");
-                if let Some(pyproject) = fs_err::read_to_string(project_path)
-                    .ok()
-                    .and_then(|contents| PyProjectToml::from_toml(&contents).ok())
+                if let Some(pyproject) =
+                    fs_err::read_to_string(&project_path)
+                        .ok()
+                        .and_then(|contents| {
+                            PyProjectToml::from_toml(&contents, project_path.user_display()).ok()
+                        })
                 {
                     // Read PEP 621 metadata from the `pyproject.toml`.
                     if let Some(project) = pyproject.project {

--- a/crates/uv-requirements/src/upgrade.rs
+++ b/crates/uv-requirements/src/upgrade.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use tracing::info_span;
 
 use uv_configuration::Upgrade;
 use uv_fs::CWD;
@@ -106,7 +107,8 @@ pub async fn read_pylock_toml_requirements(
 
     // Read the `pylock.toml` from disk, and deserialize it from TOML.
     let content = fs_err::tokio::read_to_string(&output_file).await?;
-    let lock = toml::from_str::<PylockToml>(&content)?;
+    let lock = info_span!("toml::from_str upgrade", path = %output_file.display())
+        .in_scope(|| toml::from_str::<PylockToml>(&content))?;
 
     let mut preferences = Vec::new();
     let mut git = Vec::new();

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -15,7 +15,7 @@ use petgraph::visit::EdgeRef;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serializer;
 use toml_edit::{Array, ArrayOfTables, InlineTable, Item, Table, Value, value};
-use tracing::debug;
+use tracing::{debug, instrument};
 use url::Url;
 
 use uv_cache_key::RepositoryUrl;
@@ -31,7 +31,7 @@ use uv_distribution_types::{
     RegistrySourceDist, RemoteSource, Requirement, RequirementSource, RequiresPython, ResolvedDist,
     SimplifiedMarkerTree, StaticMetadata, ToUrlError, UrlString,
 };
-use uv_fs::{PortablePath, PortablePathBuf, relative_to};
+use uv_fs::{PortablePath, PortablePathBuf, Simplified, relative_to};
 use uv_git::{RepositoryReference, ResolvedRepositoryReference};
 use uv_git_types::{GitLfs, GitOid, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -1406,6 +1406,7 @@ impl Lock {
     }
 
     /// Check whether the lock matches the project structure, requirements and configuration.
+    #[instrument(skip_all)]
     pub async fn satisfies<Context: BuildContext>(
         &self,
         root: &Path,
@@ -1796,12 +1797,12 @@ impl Lock {
                 let metadata = match fs_err::tokio::read_to_string(&path).await {
                     Ok(contents) => {
                         let pyproject_toml =
-                            PyProjectToml::from_toml(&contents).map_err(|err| {
-                                LockErrorKind::InvalidPyprojectToml {
+                            PyProjectToml::from_toml(&contents, path.user_display()).map_err(
+                                |err| LockErrorKind::InvalidPyprojectToml {
                                     path: path.clone(),
                                     err,
-                                }
-                            })?;
+                                },
+                            )?;
                         database
                             .requires_dist(&parent, &pyproject_toml)
                             .await

--- a/crates/uv-scripts/Cargo.toml
+++ b/crates/uv-scripts/Cargo.toml
@@ -35,4 +35,5 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 toml = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::LazyLock;
 use memchr::memmem::Finder;
 use serde::Deserialize;
 use thiserror::Error;
+use tracing::instrument;
 use url::Url;
 
 use uv_configuration::NoSources;
@@ -406,6 +407,7 @@ impl FromStr for Pep723Metadata {
     type Err = toml::de::Error;
 
     /// Parse `Pep723Metadata` from a raw TOML string.
+    #[instrument(name = "toml::from_str PEP 723 metadata", skip_all)]
     fn from_str(raw: &str) -> Result<Self, Self::Err> {
         let metadata = toml::from_str(raw)?;
         Ok(Self {

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tracing::info_span;
 use uv_client::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT_UPLOAD};
 use uv_dirs::{system_config_file, user_config_dir};
 use uv_distribution_types::Origin;
@@ -119,20 +120,22 @@ impl FilesystemOptions {
         let path = dir.join("uv.toml");
         match fs_err::read_to_string(&path) {
             Ok(content) => {
-                let options = toml::from_str::<Options>(&content)
-                    .map_err(|err| Error::UvToml(path.clone(), Box::new(err)))?
-                    .relative_to(&std::path::absolute(dir)?)?;
+                let options =
+                    info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
+                        .in_scope(|| toml::from_str::<Options>(&content))
+                        .map_err(|err| Error::UvToml(path.clone(), Box::new(err)))?
+                        .relative_to(&std::path::absolute(dir)?)?;
 
                 // If the directory also contains a `[tool.uv]` table in a `pyproject.toml` file,
                 // warn.
                 let pyproject = dir.join("pyproject.toml");
-                if let Some(pyproject) = fs_err::read_to_string(pyproject)
-                    .ok()
-                    .and_then(|content| toml::from_str::<PyProjectToml>(&content).ok())
-                {
-                    if let Some(options) = pyproject.tool.as_ref().and_then(|tool| tool.uv.as_ref())
+                if let Ok(content) = fs_err::read_to_string(&pyproject) {
+                    let result = info_span!("toml::from_str filesystem options pyproject.toml", path = %pyproject.display())
+                        .in_scope(|| toml::from_str::<PyProjectToml>(&content)).ok();
+                    if let Some(options) =
+                        result.and_then(|pyproject| pyproject.tool.and_then(|tool| tool.uv))
                     {
-                        warn_uv_toml_masked_fields(options);
+                        warn_uv_toml_masked_fields(&options);
                     }
                 }
 
@@ -149,8 +152,10 @@ impl FilesystemOptions {
         match fs_err::read_to_string(&path) {
             Ok(content) => {
                 // Parse, but skip any `pyproject.toml` that doesn't have a `[tool.uv]` section.
-                let pyproject: PyProjectToml = toml::from_str(&content)
-                    .map_err(|err| Error::PyprojectToml(path.clone(), Box::new(err)))?;
+                let pyproject =
+                    info_span!("toml::from_str filesystem options pyproject.toml", path = %path.display())
+                        .in_scope(|| toml::from_str::<PyProjectToml>(&content))
+                        .map_err(|err| Error::PyprojectToml(path.clone(), Box::new(err)))?;
                 let Some(tool) = pyproject.tool else {
                     tracing::debug!(
                         "Skipping `pyproject.toml` in `{}` (no `[tool]` section)",
@@ -198,7 +203,8 @@ impl From<Options> for FilesystemOptions {
 /// Load [`Options`] from a `uv.toml` file.
 fn read_file(path: &Path) -> Result<Options, Error> {
     let content = fs_err::read_to_string(path)?;
-    let options = toml::from_str::<Options>(&content)
+    let options = info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
+        .in_scope(|| toml::from_str::<Options>(&content))
         .map_err(|err| Error::UvToml(path.to_path_buf(), Box::new(err)))?;
     let options = if let Some(parent) = std::path::absolute(path)?.parent() {
         options.relative_to(parent)?

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -20,7 +20,7 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use serde::de::{IntoDeserializer, SeqAccess};
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
-
+use tracing::instrument;
 use uv_build_backend::BuildBackendSettings;
 use uv_configuration::GitLfsSetting;
 use uv_distribution_types::{Index, IndexName, RequirementSource};
@@ -123,7 +123,8 @@ pub struct PyProjectToml {
 
 impl PyProjectToml {
     /// Parse a `PyProjectToml` from a raw TOML string.
-    pub fn from_string(raw: String) -> Result<Self, PyprojectTomlError> {
+    #[instrument("toml::from_str workspace", skip_all, fields(path = %_path.as_ref().display()))]
+    pub fn from_string(raw: String, _path: impl AsRef<Path>) -> Result<Self, PyprojectTomlError> {
         let pyproject =
             toml_edit::Document::from_str(&raw).map_err(PyprojectTomlError::TomlSyntax)?;
         let pyproject = Self::deserialize(pyproject.into_deserializer())

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -202,7 +202,7 @@ impl Workspace {
 
         let pyproject_path = project_path.join("pyproject.toml");
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
-        let pyproject_toml = PyProjectToml::from_string(contents)
+        let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
         // Check if the project is explicitly marked as unmanaged.
@@ -953,7 +953,7 @@ impl Workspace {
         if let Some(project) = &workspace_pyproject_toml.project {
             let pyproject_path = workspace_root.join("pyproject.toml");
             let contents = fs_err::read_to_string(&pyproject_path)?;
-            let pyproject_toml = PyProjectToml::from_string(contents)
+            let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
                 .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
             debug!(
@@ -1069,7 +1069,7 @@ impl Workspace {
                         return Err(err.into());
                     }
                 };
-                let pyproject_toml = PyProjectToml::from_string(contents)
+                let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
                     .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
                 // Check if the current project is explicitly marked as unmanaged.
@@ -1299,7 +1299,7 @@ impl ProjectWorkspace {
         // Read the current `pyproject.toml`.
         let pyproject_path = project_root.join("pyproject.toml");
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
-        let pyproject_toml = PyProjectToml::from_string(contents)
+        let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
         // It must have a `[project]` table.
@@ -1324,7 +1324,7 @@ impl ProjectWorkspace {
             // No `pyproject.toml`, but there may still be a `setup.py` or `setup.cfg`.
             return Ok(None);
         };
-        let pyproject_toml = PyProjectToml::from_string(contents)
+        let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
         // Extract the `[project]` metadata.
@@ -1517,7 +1517,7 @@ async fn find_workspace(
 
         // Read the `pyproject.toml`.
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
-        let pyproject_toml = PyProjectToml::from_string(contents)
+        let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
         return if let Some(workspace) = pyproject_toml
@@ -1714,7 +1714,7 @@ impl VirtualProject {
         // Read the current `pyproject.toml`.
         let pyproject_path = project_root.join("pyproject.toml");
         let contents = fs_err::tokio::read_to_string(&pyproject_path).await?;
-        let pyproject_toml = PyProjectToml::from_string(contents)
+        let pyproject_toml = PyProjectToml::from_string(contents, &pyproject_path)
             .map_err(|err| WorkspaceError::Toml(pyproject_path.clone(), Box::new(err)))?;
 
         if let Some(project) = pyproject_toml.project.as_ref() {
@@ -2782,8 +2782,8 @@ foo = ["a", {include-group = "bar"}]
 bar = ["b"]
 "#;
 
-        let result =
-            PyProjectToml::from_string(toml.to_string()).expect("Deserialization should succeed");
+        let result = PyProjectToml::from_string(toml.to_string(), "pyproject.toml")
+            .expect("Deserialization should succeed");
 
         let groups = result
             .dependency_groups

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use anyhow::Context;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::{Level, debug, enabled, warn};
+use tracing::{Level, debug, enabled, info_span, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -513,9 +513,11 @@ pub(crate) async fn pip_install(
                 let content = fs_err::tokio::read_to_string(&pylock).await?;
                 (install_path, content)
             };
-        let lock = toml::from_str::<PylockToml>(&content).with_context(|| {
-            format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
-        })?;
+        let lock = info_span!("toml::from_str pip install", path = %pylock.display())
+            .in_scope(|| toml::from_str::<PylockToml>(&content))
+            .with_context(|| {
+                format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
+            })?;
 
         // Verify that the Python version is compatible with the lock file.
         if let Some(requires_python) = lock.requires_python.as_ref() {

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
-use tracing::{debug, warn};
+use tracing::{debug, info_span, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -405,9 +405,11 @@ pub(crate) async fn pip_sync(
         let install_path = std::path::absolute(&pylock)?;
         let install_path = install_path.parent().unwrap();
         let content = fs_err::tokio::read_to_string(&pylock).await?;
-        let lock = toml::from_str::<PylockToml>(&content).with_context(|| {
-            format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
-        })?;
+        let lock = info_span!("toml::from_str pip sync", path = %pylock.display())
+            .in_scope(|| toml::from_str::<PylockToml>(&content))
+            .with_context(|| {
+                format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
+            })?;
 
         // Verify that the Python version is compatible with the lock file.
         if let Some(requires_python) = lock.requires_python.as_ref() {

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -1,7 +1,7 @@
+use itertools::Either;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-
-use itertools::Either;
+use tracing::info_span;
 
 use uv_auth::CredentialsCache;
 use uv_configuration::{DependencyGroupsWithDefaults, NoSources};
@@ -288,9 +288,12 @@ impl<'lock> LockTarget<'lock> {
     ///
     /// Returns `Ok(None)` if the lockfile does not exist.
     pub(crate) async fn read(self) -> Result<Option<Lock>, ProjectError> {
-        match fs_err::tokio::read_to_string(self.lock_path()).await {
+        let lock_path = self.lock_path();
+        match fs_err::tokio::read_to_string(&lock_path).await {
             Ok(encoded) => {
-                match toml::from_str::<Lock>(&encoded) {
+                let result = info_span!("toml::from_str lock", path = %lock_path.display())
+                    .in_scope(|| toml::from_str::<Lock>(&encoded));
+                match result {
                     Ok(lock) => {
                         // If the lockfile uses an unsupported version, raise an error.
                         if lock.version() != VERSION {


### PR DESCRIPTION
In a warm cache situation, e.g. with `uv run`, toml parsing is by far our slowest operation. These kinda hacky spans help debugging that. It would be better if `toml::from_str` would be instrumented itself, but this way we can add paths in the relevant places.