### PR TITLE
Avoid toml `Document` overhead

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use glob::Pattern;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxBuildHasher, FxHashSet};
-use serde::de::{IntoDeserializer, SeqAccess};
+use serde::de::SeqAccess;
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use tracing::instrument;
@@ -39,9 +39,7 @@ use uv_redacted::DisplaySafeUrl;
 #[derive(Error, Debug)]
 pub enum PyprojectTomlError {
     #[error(transparent)]
-    TomlSyntax(#[from] toml_edit::TomlError),
-    #[error(transparent)]
-    TomlSchema(#[from] toml_edit::de::Error),
+    Toml(#[from] toml::de::Error),
     #[error(
         "`pyproject.toml` is using the `[project]` table, but the required `project.name` field is not set"
     )]
@@ -125,10 +123,7 @@ impl PyProjectToml {
     /// Parse a `PyProjectToml` from a raw TOML string.
     #[instrument("toml::from_str workspace", skip_all, fields(path = %_path.as_ref().display()))]
     pub fn from_string(raw: String, _path: impl AsRef<Path>) -> Result<Self, PyprojectTomlError> {
-        let pyproject =
-            toml_edit::Document::from_str(&raw).map_err(PyprojectTomlError::TomlSyntax)?;
-        let pyproject = Self::deserialize(pyproject.into_deserializer())
-            .map_err(PyprojectTomlError::TomlSchema)?;
+        let pyproject = toml::from_str(&raw).map_err(PyprojectTomlError::Toml)?;
         Ok(Self { raw, ..pyproject })
     }
 


### PR DESCRIPTION
The difference is below the noise threshold, but it showed up in the profiled. The code originally existed for error handling that has since been removed.
