### PR TITLE
Use a single global workspace cache

### DIFF
--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -123,6 +123,7 @@ pub(crate) async fn build_frontend(
     python_downloads: PythonDownloads,
     concurrency: Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -150,6 +151,7 @@ pub(crate) async fn build_frontend(
         python_downloads,
         &concurrency,
         cache,
+        workspace_cache,
         printer,
         preview,
     )
@@ -197,6 +199,7 @@ async fn build_impl(
     python_downloads: PythonDownloads,
     concurrency: &Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<BuildResult> {
@@ -245,11 +248,10 @@ async fn build_impl(
     };
 
     // Attempt to discover the workspace; on failure, save the error for later.
-    let workspace_cache = WorkspaceCache::default();
     let workspace = Workspace::discover(
         src.directory(),
         &DiscoveryOptions::default(),
-        &workspace_cache,
+        workspace_cache,
     )
     .await;
 
@@ -346,6 +348,7 @@ async fn build_impl(
             python_preference,
             python_downloads,
             cache,
+            workspace_cache,
             printer,
             index_locations,
             client_builder.clone(),
@@ -455,6 +458,7 @@ async fn build_package(
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     index_locations: &IndexLocations,
     client_builder: BaseClientBuilder<'_>,
@@ -604,7 +608,6 @@ async fn build_package(
 
     // Initialize any shared state.
     let state = SharedState::default();
-    let workspace_cache = WorkspaceCache::default();
 
     let extra_build_requires =
         LoweredExtraBuildDependencies::from_non_lowered(extra_build_dependencies.clone())
@@ -631,7 +634,7 @@ async fn build_package(
         &hasher,
         exclude_newer,
         sources.clone(),
-        workspace_cache,
+        workspace_cache.clone(),
         concurrency.clone(),
         preview,
     );

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -120,6 +120,7 @@ pub(crate) async fn pip_compile(
     concurrency: Concurrency,
     quiet: bool,
     cache: Cache,
+    workspace_cache: WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -539,7 +540,7 @@ pub(crate) async fn pip_compile(
         &build_hashes,
         exclude_newer.clone(),
         sources,
-        WorkspaceCache::default(),
+        workspace_cache,
         concurrency.clone(),
         preview,
     );

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -100,6 +100,7 @@ pub(crate) async fn pip_install(
     python_preference: PythonPreference,
     concurrency: Concurrency,
     cache: Cache,
+    workspace_cache: WorkspaceCache,
     dry_run: DryRun,
     printer: Printer,
     preview: Preview,
@@ -485,7 +486,7 @@ pub(crate) async fn pip_install(
         &build_hasher,
         exclude_newer.clone(),
         sources.clone(),
-        WorkspaceCache::default(),
+        workspace_cache.clone(),
         concurrency.clone(),
         preview,
     );
@@ -639,7 +640,7 @@ pub(crate) async fn pip_install(
         &build_hasher,
         exclude_newer.clone(),
         sources,
-        WorkspaceCache::default(),
+        workspace_cache,
         concurrency.clone(),
         preview,
     );

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -89,6 +89,7 @@ pub(crate) async fn pip_sync(
     python_preference: PythonPreference,
     concurrency: Concurrency,
     cache: Cache,
+    workspace_cache: WorkspaceCache,
     dry_run: DryRun,
     printer: Printer,
     preview: Preview,
@@ -392,7 +393,7 @@ pub(crate) async fn pip_sync(
         &build_hasher,
         exclude_newer.clone(),
         sources.clone(),
-        WorkspaceCache::default(),
+        workspace_cache.clone(),
         concurrency.clone(),
         preview,
     );
@@ -530,7 +531,7 @@ pub(crate) async fn pip_sync(
         &build_hasher,
         exclude_newer.clone(),
         sources,
-        WorkspaceCache::default(),
+        workspace_cache,
         concurrency.clone(),
         preview,
     );

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -1200,7 +1200,7 @@ async fn lock_and_sync(
         installer_metadata,
         concurrency,
         cache,
-        WorkspaceCache::default(),
+        &WorkspaceCache::default(),
         DryRun::Disabled,
         printer,
         preview,

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -18,6 +18,7 @@ use uv_distribution_types::{Name, Resolution};
 use uv_fs::PythonExt;
 use uv_preview::Preview;
 use uv_python::{Interpreter, PythonEnvironment, canonicalize_executable};
+use uv_workspace::WorkspaceCache;
 
 /// An ephemeral [`PythonEnvironment`] for running an individual command.
 #[derive(Debug)]
@@ -121,6 +122,7 @@ impl CachedEnvironment {
         installer_metadata: bool,
         concurrency: &Concurrency,
         cache: &Cache,
+        workspace_cache: &WorkspaceCache,
         printer: Printer,
         preview: Preview,
     ) -> Result<Self, ProjectError> {
@@ -139,6 +141,7 @@ impl CachedEnvironment {
                 resolve,
                 concurrency,
                 cache,
+                workspace_cache,
                 printer,
                 preview,
             )

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -94,6 +94,7 @@ pub(crate) async fn lock(
     concurrency: Concurrency,
     no_config: bool,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> anyhow::Result<ExitStatus> {
@@ -122,14 +123,12 @@ pub(crate) async fn lock(
     };
 
     // Find the project requirements.
-    let workspace_cache = WorkspaceCache::default();
     let workspace;
     let target = if let Some(script) = script.as_ref() {
         LockTarget::Script(script)
     } else {
         workspace =
-            Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
-                .await?;
+            Workspace::discover(project_dir, &DiscoveryOptions::default(), workspace_cache).await?;
         LockTarget::Workspace(&workspace)
     };
 
@@ -198,7 +197,7 @@ pub(crate) async fn lock(
             Box::new(DefaultResolveLogger),
             &concurrency,
             cache,
-            &workspace_cache,
+            workspace_cache,
             printer,
             preview,
         )

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2004,6 +2004,7 @@ pub(crate) async fn resolve_environment(
     logger: Box<dyn ResolveLogger>,
     concurrency: &Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ResolverOutput, ProjectError> {
@@ -2141,8 +2142,6 @@ pub(crate) async fn resolve_environment(
         FlatIndex::from_entries(entries, Some(&tags), &hasher, build_options)
     };
 
-    let workspace_cache = WorkspaceCache::default();
-
     // Lower the extra build dependencies, if any.
     let extra_build_requires =
         LoweredExtraBuildDependencies::from_non_lowered(extra_build_dependencies.clone())
@@ -2169,7 +2168,7 @@ pub(crate) async fn resolve_environment(
         &build_hasher,
         exclude_newer.clone(),
         sources.clone(),
-        workspace_cache,
+        workspace_cache.clone(),
         concurrency.clone(),
         preview,
     );
@@ -2377,7 +2376,7 @@ pub(crate) async fn update_environment(
     installer_metadata: bool,
     concurrency: &Concurrency,
     cache: &Cache,
-    workspace_cache: WorkspaceCache,
+    workspace_cache: &WorkspaceCache,
     dry_run: DryRun,
     printer: Printer,
     preview: Preview,
@@ -2564,7 +2563,7 @@ pub(crate) async fn update_environment(
         &build_hasher,
         exclude_newer.clone(),
         sources.clone(),
-        workspace_cache,
+        workspace_cache.clone(),
         concurrency.clone(),
         preview,
     );

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -367,7 +367,7 @@ pub(crate) async fn remove(
         installer_metadata,
         &concurrency,
         cache,
-        WorkspaceCache::default(),
+        &WorkspaceCache::default(),
         DryRun::Disabled,
         printer,
         preview,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -106,6 +106,7 @@ pub(crate) async fn run(
     installer_metadata: bool,
     concurrency: Concurrency,
     cache: Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     env_file: EnvFile,
     preview: Preview,
@@ -161,7 +162,6 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
     // Initialize any shared state.
     let lock_state = UniversalState::default();
     let sync_state = lock_state.fork();
-    let workspace_cache = WorkspaceCache::default();
 
     // Read from the `.env` file, if necessary.
     for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
@@ -284,7 +284,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     },
                     &concurrency,
                     &cache,
-                    &workspace_cache,
+                    workspace_cache,
                     printer,
                     preview,
                 )
@@ -332,7 +332,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 installer_metadata,
                 &concurrency,
                 &cache,
-                workspace_cache.clone(),
+                workspace_cache,
                 DryRun::Disabled,
                 printer,
                 preview,
@@ -449,7 +449,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     installer_metadata,
                     &concurrency,
                     &cache,
-                    workspace_cache.clone(),
+                    workspace_cache,
                     DryRun::Disabled,
                     printer,
                     preview,
@@ -565,7 +565,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 Workspace::discover(
                     &discovery_dir,
                     &DiscoveryOptions::default(),
-                    &workspace_cache,
+                    workspace_cache,
                 )
                 .await?
                 .with_current_project(package.clone())
@@ -575,7 +575,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             match VirtualProject::discover(
                 &discovery_dir,
                 &DiscoveryOptions::default(),
-                &workspace_cache,
+                workspace_cache,
             )
             .await
             {
@@ -786,7 +786,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                         },
                         &concurrency,
                         &cache,
-                        &workspace_cache,
+                        workspace_cache,
                         printer,
                         preview,
                     )
@@ -875,7 +875,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     installer_metadata,
                     &concurrency,
                     &cache,
-                    workspace_cache.clone(),
+                    workspace_cache,
                     DryRun::Disabled,
                     printer,
                     preview,
@@ -1030,6 +1030,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                 installer_metadata,
                 &concurrency,
                 &cache,
+                workspace_cache,
                 printer,
                 preview,
             )

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -81,6 +81,7 @@ pub(crate) async fn sync(
     concurrency: Concurrency,
     no_config: bool,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
     output_format: SyncFormat,
@@ -93,7 +94,6 @@ pub(crate) async fn sync(
     }
 
     // Identify the target.
-    let workspace_cache = WorkspaceCache::default();
     let target = if let Some(script) = script {
         SyncTarget::Script(script)
     } else {
@@ -105,12 +105,12 @@ pub(crate) async fn sync(
                     members: MemberDiscovery::None,
                     ..DiscoveryOptions::default()
                 },
-                &workspace_cache,
+                workspace_cache,
             )
             .await?
         } else if let [name] = package.as_slice() {
             VirtualProject::Project(
-                Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+                Workspace::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
                     .await?
                     .with_current_project(name.clone())
                     .with_context(|| format!("Package `{name}` not found in workspace"))?,
@@ -119,7 +119,7 @@ pub(crate) async fn sync(
             let project = VirtualProject::discover(
                 project_dir,
                 &DiscoveryOptions::default(),
-                &workspace_cache,
+                workspace_cache,
             )
             .await?;
 
@@ -285,7 +285,7 @@ pub(crate) async fn sync(
                 installer_metadata,
                 &concurrency,
                 cache,
-                workspace_cache.clone(),
+                workspace_cache,
                 dry_run,
                 printer,
                 preview,
@@ -352,7 +352,7 @@ pub(crate) async fn sync(
             Box::new(DefaultResolveLogger),
             &concurrency,
             cache,
-            &workspace_cache,
+            workspace_cache,
             printer,
             preview,
         )
@@ -615,7 +615,7 @@ pub(super) async fn do_sync(
     installer_metadata: bool,
     concurrency: &Concurrency,
     cache: &Cache,
-    workspace_cache: WorkspaceCache,
+    workspace_cache: &WorkspaceCache,
     dry_run: DryRun,
     printer: Printer,
     preview: Preview,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -148,7 +148,7 @@ pub(crate) async fn tree(
             Box::new(DefaultResolveLogger),
             &concurrency,
             cache,
-            &WorkspaceCache::default(),
+            &workspace_cache,
             printer,
             preview,
         )

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -77,11 +77,18 @@ pub(crate) async fn project_version(
     concurrency: Concurrency,
     no_config: bool,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
     // Read the metadata
-    let project = find_target(project_dir, package.as_ref(), explicit_project).await?;
+    let project = find_target(
+        project_dir,
+        package.as_ref(),
+        explicit_project,
+        workspace_cache,
+    )
+    .await?;
 
     let pyproject_path = project.root().join("pyproject.toml");
     let Some(name) = project.project_name().cloned() else {
@@ -110,6 +117,7 @@ pub(crate) async fn project_version(
                 &concurrency,
                 no_config,
                 cache,
+                workspace_cache,
                 short,
                 output_format,
                 printer,
@@ -371,6 +379,7 @@ async fn find_target(
     project_dir: &Path,
     package: Option<&PackageName>,
     explicit_project: bool,
+    workspace_cache: &WorkspaceCache,
 ) -> Result<VirtualProject> {
     // Find the project in the workspace.
     // No workspace caching since `uv version` changes the workspace definition.
@@ -382,7 +391,7 @@ async fn find_target(
                     project: uv_workspace::ProjectDiscovery::Required,
                     ..DiscoveryOptions::default()
                 },
-                &WorkspaceCache::default(),
+                workspace_cache,
             )
             .await
             .map_err(|err| hint_uv_self_version(err, explicit_project))?
@@ -396,7 +405,7 @@ async fn find_target(
                 project: uv_workspace::ProjectDiscovery::Required,
                 ..DiscoveryOptions::default()
             },
-            &WorkspaceCache::default(),
+            workspace_cache,
         )
         .await
         .map_err(|err| hint_uv_self_version(err, explicit_project))?
@@ -440,6 +449,7 @@ async fn print_frozen_version(
     concurrency: &Concurrency,
     no_config: bool,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     short: bool,
     output_format: VersionFormat,
     printer: Printer,
@@ -480,7 +490,7 @@ async fn print_frozen_version(
             Box::new(DefaultResolveLogger),
             concurrency,
             cache,
-            &WorkspaceCache::default(),
+            workspace_cache,
             printer,
             preview,
         )
@@ -681,7 +691,7 @@ async fn lock_and_sync(
         installer_metadata,
         concurrency,
         cache,
-        workspace_cache,
+        &workspace_cache,
         DryRun::Disabled,
         printer,
         preview,

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -36,6 +36,7 @@ pub(crate) async fn find(
     python_downloads_json_url: Option<&str>,
     client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -45,11 +46,10 @@ pub(crate) async fn find(
         EnvironmentPreference::Any
     };
 
-    let workspace_cache = WorkspaceCache::default();
     let project = if no_project {
         None
     } else {
-        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
             .await
         {
             Ok(project) => Some(project),

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -38,14 +38,14 @@ pub(crate) async fn pin(
     install_mirrors: PythonInstallMirrors,
     client_builder: BaseClientBuilder<'_>,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    let workspace_cache = WorkspaceCache::default();
     let virtual_project = if no_project {
         None
     } else {
-        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
             .await
         {
             Ok(virtual_project) => Some(virtual_project),

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -75,6 +75,7 @@ pub(crate) async fn install(
     concurrency: Concurrency,
     no_config: bool,
     cache: Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -125,7 +126,6 @@ pub(crate) async fn install(
 
     // Initialize any shared state.
     let state = PlatformState::default();
-    let workspace_cache = WorkspaceCache::default();
 
     // Parse the input requirement.
     let request = ToolRequest::parse(&package, from.as_deref())?;
@@ -175,7 +175,7 @@ pub(crate) async fn install(
                 &state,
                 &concurrency,
                 &cache,
-                &workspace_cache,
+                workspace_cache,
                 printer,
                 preview,
                 lfs,
@@ -363,7 +363,7 @@ pub(crate) async fn install(
                 &state,
                 &concurrency,
                 &cache,
-                &workspace_cache,
+                workspace_cache,
                 printer,
                 preview,
                 lfs,
@@ -389,7 +389,7 @@ pub(crate) async fn install(
         &state,
         &concurrency,
         &cache,
-        &workspace_cache,
+        workspace_cache,
         printer,
         preview,
         lfs,
@@ -623,6 +623,7 @@ pub(crate) async fn install(
             Box::new(DefaultResolveLogger),
             &concurrency,
             &cache,
+            workspace_cache,
             printer,
             preview,
         )
@@ -678,6 +679,7 @@ pub(crate) async fn install(
                         Box::new(DefaultResolveLogger),
                         &concurrency,
                         &cache,
+                        workspace_cache,
                         printer,
                         preview,
                     )

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -120,6 +120,7 @@ pub(crate) async fn run(
     installer_metadata: bool,
     concurrency: Concurrency,
     cache: Cache,
+    workspace_cache: WorkspaceCache,
     printer: Printer,
     env_file: Vec<PathBuf>,
     no_env_file: bool,
@@ -305,6 +306,7 @@ pub(crate) async fn run(
         installer_metadata,
         &concurrency,
         &cache,
+        &workspace_cache,
         printer,
         preview,
     ))
@@ -737,6 +739,7 @@ async fn get_or_create_environment(
     installer_metadata: bool,
     concurrency: &Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<(ToolRequirement, PythonEnvironment), ProjectError> {
@@ -795,7 +798,6 @@ async fn get_or_create_environment(
 
     // Initialize any shared state.
     let state = PlatformState::default();
-    let workspace_cache = WorkspaceCache::default();
 
     let from = match request {
         ToolRequest::Python {
@@ -836,7 +838,7 @@ async fn get_or_create_environment(
                         &state,
                         concurrency,
                         cache,
-                        &workspace_cache,
+                        workspace_cache,
                         printer,
                         preview,
                         lfs,
@@ -995,7 +997,7 @@ async fn get_or_create_environment(
                 &state,
                 concurrency,
                 cache,
-                &workspace_cache,
+                workspace_cache,
                 printer,
                 preview,
                 lfs,
@@ -1022,7 +1024,7 @@ async fn get_or_create_environment(
         &state,
         concurrency,
         cache,
-        &workspace_cache,
+        workspace_cache,
         printer,
         preview,
         lfs,
@@ -1149,6 +1151,7 @@ async fn get_or_create_environment(
         installer_metadata,
         concurrency,
         cache,
+        workspace_cache,
         printer,
         preview,
     )
@@ -1209,6 +1212,7 @@ async fn get_or_create_environment(
                     installer_metadata,
                     concurrency,
                     cache,
+                    workspace_cache,
                     printer,
                     preview,
                 )

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -51,6 +51,7 @@ pub(crate) async fn upgrade(
     installer_metadata: bool,
     concurrency: Concurrency,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -131,6 +132,7 @@ pub(crate) async fn upgrade(
             &args,
             &client_builder,
             cache,
+            workspace_cache,
             &filesystem,
             installer_metadata,
             &concurrency,
@@ -266,6 +268,7 @@ async fn upgrade_tool(
     args: &ResolverInstallerOptions,
     client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     filesystem: &ResolverInstallerOptions,
     installer_metadata: bool,
     concurrency: &Concurrency,
@@ -337,7 +340,6 @@ async fn upgrade_tool(
 
     // Initialize any shared state.
     let state = PlatformState::default();
-    let workspace_cache = WorkspaceCache::default();
 
     // Check if we need to create a new environment — if so, resolve it first, then
     // install the requested tool
@@ -356,6 +358,7 @@ async fn upgrade_tool(
             Box::new(SummaryResolveLogger),
             concurrency,
             cache,
+            workspace_cache,
             printer,
             preview,
         )

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -81,15 +81,15 @@ pub(crate) async fn venv(
     no_config: bool,
     no_project: bool,
     cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
     relocatable: bool,
     preview: Preview,
 ) -> Result<ExitStatus> {
-    let workspace_cache = WorkspaceCache::default();
     let project = if no_project {
         None
     } else {
-        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
             .await
         {
             Ok(project) => Some(project),
@@ -239,7 +239,6 @@ pub(crate) async fn venv(
 
         // Initialize any shared state.
         let state = SharedState::default();
-        let workspace_cache = WorkspaceCache::default();
 
         // For seed packages, assume a bunch of default settings are sufficient.
         let build_constraints = Constraints::default();
@@ -273,7 +272,7 @@ pub(crate) async fn venv(
             &build_hasher,
             exclude_newer,
             sources,
-            workspace_cache,
+            workspace_cache.clone(),
             concurrency,
             preview,
         );

--- a/crates/uv/src/commands/workspace/dir.rs
+++ b/crates/uv/src/commands/workspace/dir.rs
@@ -15,11 +15,11 @@ use crate::printer::Printer;
 pub(crate) async fn dir(
     package_name: Option<PackageName>,
     project_dir: &Path,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let workspace_cache = WorkspaceCache::default();
     let workspace =
-        Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache).await?;
+        Workspace::discover(project_dir, &DiscoveryOptions::default(), workspace_cache).await?;
 
     let dir = match package_name {
         None => workspace.install_path(),

--- a/crates/uv/src/commands/workspace/list.rs
+++ b/crates/uv/src/commands/workspace/list.rs
@@ -11,10 +11,14 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// List workspace members
-pub(crate) async fn list(project_dir: &Path, paths: bool, printer: Printer) -> Result<ExitStatus> {
-    let workspace_cache = WorkspaceCache::default();
+pub(crate) async fn list(
+    project_dir: &Path,
+    paths: bool,
+    workspace_cache: &WorkspaceCache,
+    printer: Printer,
+) -> Result<ExitStatus> {
     let workspace =
-        Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache).await?;
+        Workspace::discover(project_dir, &DiscoveryOptions::default(), workspace_cache).await?;
 
     for (name, member) in workspace.packages() {
         if paths {

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -53,6 +53,7 @@ struct MetadataReport {
 pub(crate) async fn metadata(
     project_dir: &Path,
     preview: Preview,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     if !preview.is_enabled(PreviewFeature::WorkspaceMetadata) {
@@ -62,9 +63,8 @@ pub(crate) async fn metadata(
         );
     }
 
-    let workspace_cache = WorkspaceCache::default();
     let workspace =
-        Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache).await?;
+        Workspace::discover(project_dir, &DiscoveryOptions::default(), workspace_cache).await?;
 
     let members = workspace
         .packages()

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -689,6 +689,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.concurrency,
                 globals.quiet > 0,
                 cache,
+                workspace_cache,
                 printer,
                 globals.preview,
             )
@@ -774,6 +775,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.python_preference,
                 globals.concurrency,
                 cache,
+                workspace_cache,
                 args.dry_run,
                 printer,
                 globals.preview,
@@ -932,6 +934,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.python_preference,
                 globals.concurrency,
                 cache,
+                workspace_cache,
                 args.dry_run,
                 printer,
                 globals.preview,
@@ -1180,6 +1183,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.python_downloads,
                 globals.concurrency,
                 &cache,
+                &workspace_cache,
                 printer,
                 globals.preview,
             )
@@ -1256,6 +1260,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 cli.top_level.no_config,
                 args.no_project,
                 &cache,
+                &workspace_cache,
                 printer,
                 args.relocatable
                     || (globals
@@ -1278,6 +1283,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 client_builder,
                 filesystem,
                 cache,
+                &workspace_cache,
                 printer,
             ))
             .await
@@ -1452,6 +1458,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.installer_metadata,
                 globals.concurrency,
                 cache,
+                workspace_cache,
                 printer,
                 args.env_file,
                 args.no_env_file,
@@ -1553,6 +1560,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.concurrency,
                 cli.top_level.no_config,
                 cache,
+                &workspace_cache,
                 printer,
                 globals.preview,
             ))
@@ -1605,6 +1613,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 globals.installer_metadata,
                 globals.concurrency,
                 &cache,
+                &workspace_cache,
                 printer,
                 globals.preview,
             ))
@@ -1780,6 +1789,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     args.python_downloads_json_url.as_deref(),
                     &client_builder.subcommand(vec!["python".to_owned(), "find".to_owned()]),
                     &cache,
+                    &workspace_cache,
                     printer,
                     globals.preview,
                 )
@@ -1807,6 +1817,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.install_mirrors,
                 client_builder.subcommand(vec!["python".to_owned(), "pin".to_owned()]),
                 &cache,
+                &workspace_cache,
                 printer,
                 globals.preview,
             )
@@ -1880,10 +1891,14 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }
         Commands::Workspace(WorkspaceNamespace { command }) => match command {
             WorkspaceCommand::Metadata(_args) => {
-                commands::metadata(&project_dir, globals.preview, printer).await
+                commands::metadata(&project_dir, globals.preview, &workspace_cache, printer).await
             }
-            WorkspaceCommand::Dir(args) => commands::dir(args.package, &project_dir, printer).await,
-            WorkspaceCommand::List(args) => commands::list(&project_dir, args.paths, printer).await,
+            WorkspaceCommand::Dir(args) => {
+                commands::dir(args.package, &project_dir, &workspace_cache, printer).await
+            }
+            WorkspaceCommand::List(args) => {
+                commands::list(&project_dir, args.paths, &workspace_cache, printer).await
+            }
         },
         Commands::BuildBackend { command } => spawn_blocking(move || match command {
             BuildBackendCommand::BuildSdist { sdist_directory } => {
@@ -1945,6 +1960,7 @@ async fn run_project(
     client_builder: BaseClientBuilder<'_>,
     filesystem: Option<FilesystemOptions>,
     cache: Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Write out any resolved settings.
@@ -2081,6 +2097,7 @@ async fn run_project(
                 globals.installer_metadata,
                 globals.concurrency,
                 cache,
+                workspace_cache,
                 printer,
                 args.env_file,
                 globals.preview,
@@ -2137,6 +2154,7 @@ async fn run_project(
                 globals.concurrency,
                 no_config,
                 &cache,
+                workspace_cache,
                 printer,
                 globals.preview,
                 args.output_format,
@@ -2189,6 +2207,7 @@ async fn run_project(
                 globals.concurrency,
                 no_config,
                 &cache,
+                workspace_cache,
                 printer,
                 globals.preview,
             ))
@@ -2417,6 +2436,7 @@ async fn run_project(
                 globals.concurrency,
                 no_config,
                 &cache,
+                workspace_cache,
                 printer,
                 globals.preview,
             ))

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -18927,7 +18927,6 @@ fn lock_explicit_default_index() -> Result<()> {
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Found workspace root: `[TEMP_DIR]/`
-    DEBUG Adding root workspace member: `[TEMP_DIR]/`
     DEBUG No Python version file found in workspace: [TEMP_DIR]/
     DEBUG Using Python request `>=3.12` from `requires-python` metadata
     DEBUG Checking for Python environment at: `.venv`


### PR DESCRIPTION
Currently, uv parses each workspace member 's `pyproject.toml` in airflow 4 times, this reduces it to 3 times.