### PR TITLE
Remove `ProjectDiscovery`

### DIFF
--- a/crates/uv-distribution/src/metadata/dependency_groups.rs
+++ b/crates/uv-distribution/src/metadata/dependency_groups.rs
@@ -80,7 +80,6 @@ impl SourcedDependencyGroups {
             } else {
                 MemberDiscovery::None
             },
-            ..DiscoveryOptions::default()
         };
 
         // The subsequent API takes an absolute path to the dir the pyproject is in

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -64,7 +64,6 @@ impl RequiresDist {
             } else {
                 MemberDiscovery::None
             },
-            ..DiscoveryOptions::default()
         };
         let Some(project_workspace) =
             ProjectWorkspace::from_maybe_project_root(install_path, &discovery, cache).await?

--- a/crates/uv-workspace/src/lib.rs
+++ b/crates/uv-workspace/src/lib.rs
@@ -1,7 +1,6 @@
 pub use workspace::{
-    DiscoveryOptions, Editability, MemberDiscovery, ProjectDiscovery, ProjectWorkspace,
-    RequiresPythonSources, VirtualProject, Workspace, WorkspaceCache, WorkspaceError,
-    WorkspaceMember,
+    DiscoveryOptions, Editability, MemberDiscovery, ProjectWorkspace, RequiresPythonSources,
+    VirtualProject, Workspace, WorkspaceCache, WorkspaceError, WorkspaceMember,
 };
 
 pub mod dependency_groups;

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -96,39 +96,12 @@ pub enum MemberDiscovery {
     Ignore(BTreeSet<PathBuf>),
 }
 
-/// Whether a "project" must be defined via a `[project]` table.
-#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
-pub enum ProjectDiscovery {
-    /// The `[project]` table is optional; when missing, the target is treated as a virtual
-    /// project with only dependency groups.
-    #[default]
-    Optional,
-    /// A `[project]` table must be defined.
-    ///
-    /// If not defined, discovery will fail.
-    Required,
-}
-
-impl ProjectDiscovery {
-    /// Whether a `[project]` table is required.
-    pub fn allows_implicit_workspace(&self) -> bool {
-        matches!(self, Self::Optional)
-    }
-
-    /// Whether a non-project workspace root is allowed.
-    pub fn allows_non_project_workspace(&self) -> bool {
-        matches!(self, Self::Optional)
-    }
-}
-
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub struct DiscoveryOptions {
     /// The path to stop discovery at.
     pub stop_discovery_at: Option<PathBuf>,
     /// The strategy to use when discovering workspace members.
     pub members: MemberDiscovery,
-    /// The strategy to use when discovering the project.
-    pub project: ProjectDiscovery,
 }
 
 pub type RequiresPythonSources = BTreeMap<(PackageName, Option<GroupName>), VersionSpecifiers>;
@@ -1735,7 +1708,6 @@ impl VirtualProject {
             .as_ref()
             .and_then(|tool| tool.uv.as_ref())
             .and_then(|uv| uv.workspace.as_ref())
-            .filter(|_| options.project.allows_non_project_workspace())
         {
             // Otherwise, if it contains a `tool.uv.workspace` table, it's a non-project workspace
             // root.
@@ -1754,7 +1726,7 @@ impl VirtualProject {
             .await?;
 
             Ok(Self::NonProject(workspace))
-        } else if options.project.allows_implicit_workspace() {
+        } else {
             // Otherwise it's a pyproject.toml that maybe contains dependency-groups
             // that we want to treat like a project/workspace to handle those uniformly
             let project_path = std::path::absolute(project_root)
@@ -1772,8 +1744,6 @@ impl VirtualProject {
             .await?;
 
             Ok(Self::NonProject(workspace))
-        } else {
-            Err(WorkspaceError::MissingProject(pyproject_path))
         }
     }
 
@@ -1785,10 +1755,15 @@ impl VirtualProject {
         package: PackageName,
     ) -> Result<Self, WorkspaceError> {
         let workspace = Workspace::discover(path, options, cache).await?;
-        let project_workspace = Workspace::with_current_project(workspace.clone(), package.clone());
-        Ok(Self::Project(project_workspace.ok_or_else(|| {
-            WorkspaceError::NoSuchMember(package.clone(), workspace.install_path)
-        })?))
+        let Some(project_workspace) =
+            Workspace::with_current_project(workspace.clone(), package.clone())
+        else {
+            return Err(WorkspaceError::NoSuchMember(
+                package,
+                workspace.install_path.clone(),
+            ));
+        };
+        Ok(Self::Project(project_workspace))
     }
 
     /// Update the `pyproject.toml` for the current project.

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use owo_colors::OwoColorize;
 
 use tracing::debug;
@@ -377,26 +377,30 @@ async fn find_target(
     let project = if let Some(package) = package {
         VirtualProject::discover_with_package(
             project_dir,
-            &DiscoveryOptions {
-                project: uv_workspace::ProjectDiscovery::Required,
-                ..DiscoveryOptions::default()
-            },
+            &DiscoveryOptions::default(),
             &WorkspaceCache::default(),
             package.clone(),
         )
         .await
         .map_err(|err| hint_uv_self_version(err, explicit_project))?
     } else {
-        VirtualProject::discover(
+        let project = VirtualProject::discover(
             project_dir,
-            &DiscoveryOptions {
-                project: uv_workspace::ProjectDiscovery::Required,
-                ..DiscoveryOptions::default()
-            },
+            &DiscoveryOptions::default(),
             &WorkspaceCache::default(),
         )
         .await
-        .map_err(|err| hint_uv_self_version(err, explicit_project))?
+        .map_err(|err| hint_uv_self_version(err, explicit_project))?;
+        match &project {
+            VirtualProject::Project(_) => project,
+            VirtualProject::NonProject(workspace) => bail!(
+                "No `project` table found in: {}",
+                workspace
+                    .install_path()
+                    .join("pyproject.toml")
+                    .simplified_display()
+            ),
+        }
     };
     Ok(project)
 }


### PR DESCRIPTION
This doesn't actually change workspace discovery (anymore), so we can error after discovery.
