### PR TITLE
Contributing: Require a human in the loop for LLM contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ and make up smart sounding but ultimately wrong claims. Instead, phrase issue an
 comments in your own words. It's not important to sound perfect, but that we can follow what problem
 you're trying to solve and why the pull request uses a correct approach.
 
-When using LLMs, there must always be a human in the loop who fully understands the code. You need
-to be able to explain all changes and how they interact with the rest of the codebase without LLM
-assistance, as LLMs cannot (yet) correctly reason about complex codebases. Generally, this requires
-designing the change yourself and understanding all involved data structures, formats, and
-algorithms, while only using the LLM for directed coding. Autonomous contributions from AI agents
-are not allowed.
+When using LLMs, there must always be a human in the loop who fully understands the work the LLM is
+doing. Since LLMs cannot (yet) correctly reason about complex codebases, you need to be able to
+explain all changes and how they interact with the rest of the codebase in your own words, without
+relying on the LLM to do so. Generally, this requires designing the change yourself and
+understanding all involved data structures, formats, and algorithms, while only using the LLM to aid
+in rather than drive these tasks. Autonomous contributions from AI agents are not allowed.
 
 ## Setup
 


### PR DESCRIPTION
This policy is derived from https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md: We have the problem that there are autonomous contributions, or users trying to get the LLM to solve the hard problems, where it usually fails.

I've kept the section intentionally concise without laying out all the branches of valid and invalid LLM usage. For example, it's totally possible to first have the LLM write the change, review that, then develop a design from that and iterate on it and in the end have a fully human-understood PR. What I want to discourage is that contributors think they can outsource e.g. the hard algorithmic parts to the LLM, without understanding the existing structure, where the LLM currently inevitably fails.