### PR TITLE
Retry on apt downloads in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG RUSTUP_VERSION=1.28.1
 ENV HOME="/root"
 WORKDIR $HOME
 
+# Retry apt downloads to handle transient mirror failures (e.g., 503s from snapshot.ubuntu.com).
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
+
 # Install dependencies using an Ubuntu snapshot for reproducibility.
 # ca-certificates are required for using the snapshot.
 RUN --mount=type=cache,target=/var/lib/apt/lists \


### PR DESCRIPTION
This failed with a 503 flake. I hate flakes.

```
   E: Failed to fetch                              
 https://snapshot.ubuntu.com/.../libcurl4t64_8.5.0 -2ubuntu10.7_arm64.deb  503  Service Unavailable  
```