### PR TITLE
Add a development build of `aarch64-linux-android` to CI

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -249,6 +249,54 @@ jobs:
           MSRV: ${{ steps.msrv.outputs.value }}
       - run: ./target/no-debug/uv --version
 
+  build-binary-android-aarch64:
+    name: "android aarch64"
+    timeout-minutes: 10
+    runs-on: github-ubuntu-24.04-x86_64-8
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Setup Android NDK"
+        run: |
+          # Use ANDROID_NDK_ROOT if set, otherwise find the latest installed NDK
+          if [ -z "${ANDROID_NDK_ROOT}" ]; then
+            NDK_ROOT=$(ls -d "${ANDROID_HOME}/ndk/"* 2>/dev/null | sort -V | tail -n1)
+          else
+            NDK_ROOT="${ANDROID_NDK_ROOT}"
+          fi
+          TOOLCHAIN="${NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64"
+
+          echo "CC_aarch64_linux_android=${TOOLCHAIN}/bin/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
+          echo "CXX_aarch64_linux_android=${TOOLCHAIN}/bin/aarch64-linux-android24-clang++" >> "$GITHUB_ENV"
+          echo "AR_aarch64_linux_android=${TOOLCHAIN}/bin/llvm-ar" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/bin/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
+
+          # NDK 23+ removed libgcc, provide a stub that redirects to libunwind
+          LIBDIR=$(echo "${TOOLCHAIN}"/lib/clang/*/lib/linux/aarch64)
+          if [ ! -f "${LIBDIR}/libgcc.a" ]; then
+            echo 'INPUT(-lunwind)' | sudo tee "${LIBDIR}/libgcc.a" > /dev/null
+          fi
+
+          rustup target add aarch64-linux-android
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          save-if: ${{ inputs.save-rust-cache == 'true' }}
+
+      - name: "Build"
+        run: cargo build --profile no-debug --target aarch64-linux-android --bin uv --bin uvx
+
+      - name: "Upload binary"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: uv-android-aarch64-${{ github.sha }}
+          path: |
+            ./target/aarch64-linux-android/no-debug/uv
+            ./target/aarch64-linux-android/no-debug/uvx
+          retention-days: 1
+
   build-binary-freebsd:
     name: "freebsd"
     timeout-minutes: 10


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/14574

Adds a cross-compiled build for the `aarch64-linux-android` target using the Android NDK available on the runner.

Requires #18324