### PR TITLE
Include earliest available date in `exclude-newer` resolver hint

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -30,7 +30,8 @@ use crate::resolver::{
     UnavailableVersion,
 };
 use crate::{
-    ExcludeNewerValue, Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionsResponse,
+    ExcludeNewerValue, Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionMap,
+    VersionsResponse,
 };
 
 #[derive(Debug)]
@@ -648,10 +649,16 @@ impl PubGrubReportFormatter<'_> {
                             .is_some_and(BTreeSet::is_empty)
                             && Self::has_versions_in_index(name, index, fork_indexes)
                         {
+                            let earliest_upload_time = Self::earliest_upload_time_in_index(
+                                name,
+                                index,
+                                fork_indexes,
+                            );
                             output_hints.insert(PubGrubHint::ExcludeNewer {
                                 package: name.clone(),
                                 per_package: options.exclude_newer.package.contains_key(name),
                                 exclude_newer,
+                                earliest_upload_time,
                             });
                         }
                     }
@@ -1077,6 +1084,31 @@ impl PubGrubReportFormatter<'_> {
             .iter()
             .any(|vm| vm.iter(&Ranges::full()).next().is_some())
     }
+
+    /// Return the earliest upload timestamp (in milliseconds) across all versions in the index
+    /// for a given package.
+    fn earliest_upload_time_in_index(
+        name: &PackageName,
+        index: &InMemoryIndex,
+        fork_indexes: &ForkIndexes,
+    ) -> Option<i64> {
+        let response = if let Some(url) = fork_indexes.get(name).map(IndexMetadata::url) {
+            index.explicit().get(&(name.clone(), url.clone()))
+        } else {
+            index.implicit().get(name)
+        };
+
+        let response = response?;
+
+        let VersionsResponse::Found(ref version_maps) = *response else {
+            return None;
+        };
+
+        version_maps
+            .iter()
+            .filter_map(VersionMap::earliest_upload_time)
+            .min()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1251,6 +1283,8 @@ pub(crate) enum PubGrubHint {
         per_package: bool,
         // excluded from `PartialEq` and `Hash`
         exclude_newer: ExcludeNewerValue,
+        // excluded from `PartialEq` and `Hash`
+        earliest_upload_time: Option<i64>,
     },
     /// The resolution failed for a Python version that is different from the current Python version.
     DisjointPythonVersion {
@@ -1851,12 +1885,22 @@ impl std::fmt::Display for PubGrubHint {
                 package,
                 per_package,
                 exclude_newer,
+                earliest_upload_time,
             } => {
+                let earliest_date_hint = earliest_upload_time
+                    .and_then(|ms| jiff::Timestamp::from_millisecond(ms).ok())
+                    .map(|ts| {
+                        format!(
+                            " The earliest available version was published on {}.",
+                            ts.strftime("%Y-%m-%dT%H:%M:%SZ").cyan(),
+                        )
+                    })
+                    .unwrap_or_default();
                 if *per_package {
                     write!(
                         f,
                         "{}{} `{}` was filtered by `{}` to only include packages uploaded \
-                        before {}. Consider removing the setting or updating it to a later date.",
+                        before {}.{earliest_date_hint} Consider removing the setting or updating it to a later date.",
                         "hint".bold().cyan(),
                         ":".bold(),
                         package.cyan(),
@@ -1867,7 +1911,7 @@ impl std::fmt::Display for PubGrubHint {
                     write!(
                         f,
                         "{}{} `{}` was filtered by `{}` to only include packages uploaded \
-                        before {}. Consider using `{}` to override the cutoff for this package.",
+                        before {}.{earliest_date_hint} Consider using `{}` to override the cutoff for this package.",
                         "hint".bold().cyan(),
                         ":".bold(),
                         package.cyan(),

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -188,6 +188,30 @@ impl VersionMap {
         }
     }
 
+    /// Return the earliest upload timestamp (in milliseconds) across all files in this map.
+    pub(crate) fn earliest_upload_time(&self) -> Option<i64> {
+        match &self.inner {
+            VersionMapInner::Eager(_) => None,
+            VersionMapInner::Lazy(lazy) => {
+                let mut earliest: Option<i64> = None;
+                for datum in lazy.simple_metadata.iter() {
+                    let files =
+                        rkyv::deserialize::<VersionFiles, rkyv::rancor::Error>(&datum.files)
+                            .expect("archived version files always deserializes");
+                    for (_filename, file) in files.all() {
+                        if let Some(upload_time) = file.upload_time_utc_ms {
+                            earliest = Some(match earliest {
+                                Some(current) => current.min(upload_time),
+                                None => upload_time,
+                            });
+                        }
+                    }
+                }
+                earliest
+            }
+        }
+    }
+
     /// Return an iterator over the versions and distributions.
     ///
     /// Note that the value returned in this iterator is a [`VersionMapDist`],

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -32516,7 +32516,7 @@ fn lock_exclude_newer_hint() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because there are no versions of iniconfig and your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2000-01-01T00:00:00Z. Consider using `exclude-newer-package` to override the cutoff for this package.
+          hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2000-01-01T00:00:00Z. The earliest available version was published on 2010-10-12T17:42:07Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
 
     Ok(())

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1136,7 +1136,7 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
       ╰─▶ Because there are no versions of iniconfig and iniconfig==2.0.0 was published after the exclude newer time, we can conclude that all versions of iniconfig cannot be used.
           And because your project depends on iniconfig, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2006-12-02T02:07:43Z. Consider using `exclude-newer-package` to override the cutoff for this package.
+          hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2006-12-02T02:07:43Z. The earliest available version was published on 2010-10-12T17:42:07Z. Consider using `exclude-newer-package` to override the cutoff for this package.
     ");
 
     uv_snapshot!(context.filters(), context


### PR DESCRIPTION
Closes #18220

When `exclude-newer` filters out all versions of a package, the resolver hint now includes the earliest upload date from the index. This helps users quickly determine what date to set.

Before:
```
hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2000-01-01T00:00:00Z. Consider using `exclude-newer-package` to override the cutoff for this package.
```

After:
```
hint: `iniconfig` was filtered by `exclude-newer` to only include packages uploaded before 2000-01-01T00:00:00Z. The earliest available version was published on 2010-10-12T17:42:07Z. Consider using `exclude-newer-package` to override the cutoff for this package.
```

## Test plan
- Updated existing `lock_exclude_newer_hint` and `lock_exclude_newer_relative_values` snapshot tests
- All 19 `exclude_newer` integration tests pass