### PR TITLE
Include current platform tag in platform incompatibility hint

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -829,6 +829,7 @@ impl PubGrubReportFormatter<'_> {
                 // So, instead, we only show the platforms that are linked to otherwise-compatible
                 // wheels (e.g., `manylinux2014` in `cp313-cp313-manylinux2014`). In other words,
                 // we only show platforms for ABI-compatible wheels.
+                let best = tags.and_then(Tags::platform_tag).cloned();
                 let tags = prioritized
                     .platform_tags(self.tags?)
                     .cloned()
@@ -840,6 +841,7 @@ impl PubGrubReportFormatter<'_> {
                         package: name.clone(),
                         version: candidate.version().clone(),
                         tags,
+                        best,
                     })
                 }
             }
@@ -1244,6 +1246,8 @@ pub(crate) enum PubGrubHint {
         version: Version,
         // excluded from `PartialEq` and `Hash`
         tags: BTreeSet<PlatformTag>,
+        // excluded from `PartialEq` and `Hash`
+        best: Option<PlatformTag>,
     },
     /// All versions of a package were excluded by `exclude-newer`.
     ExcludeNewer {
@@ -1833,19 +1837,41 @@ impl std::fmt::Display for PubGrubHint {
                 package,
                 version,
                 tags,
+                best,
             } => {
-                let s = if tags.len() == 1 { "" } else { "s" };
-                write!(
-                    f,
-                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    package.cyan(),
-                    format!("v{version}").cyan(),
-                    tags.iter()
-                        .map(|tag| format!("`{}`", tag.cyan()))
-                        .join(", "),
-                )
+                if let Some(best) = best {
+                    let s = if tags.len() == 1 { "" } else { "s" };
+                    let best = if let Some(pretty) = best.pretty() {
+                        format!("{} (`{}`)", pretty.cyan(), best.cyan())
+                    } else {
+                        format!("`{}`", best.cyan())
+                    };
+                    write!(
+                        f,
+                        "{}{} You require {}, but we only found wheels for `{}` ({}) on the following platform{s}: {}",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        best,
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                    )
+                } else {
+                    let s = if tags.len() == 1 { "" } else { "s" };
+                    write!(
+                        f,
+                        "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
+                        "hint".bold().cyan(),
+                        ":".bold(),
+                        package.cyan(),
+                        format!("v{version}").cyan(),
+                        tags.iter()
+                            .map(|tag| format!("`{}`", tag.cyan()))
+                            .join(", "),
+                    )
+                }
             }
             Self::ExcludeNewer {
                 package,

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -15150,7 +15150,7 @@ fn invalid_platform() -> Result<()> {
 
           hint: You require CPython 3.10 (`cp310`), but we only found wheels for `open3d` (v0.15.2) with the following Python ABI tags: `cp36m`, `cp37m`, `cp38`, `cp39`
 
-          hint: Wheels are available for `open3d` (v0.18.0) on the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `win_amd64`
+          hint: You require Linux (`manylinux_2_17_x86_64`), but we only found wheels for `open3d` (v0.18.0) on the following platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `macosx_11_0_x86_64`, `macosx_13_0_arm64`, `win_amd64`
     ");
 
     Ok(())

--- a/crates/uv/tests/it/pip_install_scenarios.rs
+++ b/crates/uv/tests/it/pip_install_scenarios.rs
@@ -3797,7 +3797,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 has no wheels with a matching platform tag (e.g., `manylinux_2_17_x86_64`), we can conclude that all versions of package-a cannot be used.
           And because you require package-a, we can conclude that your requirements are unsatisfiable.
 
-          hint: Wheels are available for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
+          hint: You require Linux (`manylinux_2_17_x86_64`), but we only found wheels for `package-a` (v1.0.0) on the following platform: `macosx_10_0_ppc64`
     ");
 
     context.assert_not_installed("no_sdist_no_wheels_with_matching_platform_a");


### PR DESCRIPTION
Closes #18169

When a wheel has no matching platform tag, the hint now includes the best platform tag for the current environment, following the same pattern used by `LanguageTags` and `AbiTags` hints.

This is especially helpful on musl-based systems (e.g., Alpine Linux) where users see `manylinux` tags listed but need `musllinux` wheels — the hint now clearly shows what platform the resolver expects.

Before:
```
hint: Wheels are available for `vtk` (v9.6.0) on the following platforms: `manylinux_2_17_x86_64`, `manylinux_2_28_aarch64`
```

After:
```
hint: You require Linux (`musllinux_1_2_aarch64`), but we only found wheels for `vtk` (v9.6.0) on the following platforms: `manylinux_2_17_x86_64`, `manylinux_2_28_aarch64`
```

## Test plan
- Updated snapshots for `invalid_platform` and `no_sdist_no_wheels_with_matching_platform`
- All 16 platform-related integration tests pass