### PR TITLE
feat: Log when using custom configuration file (fixes #17182)

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -157,6 +157,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 "The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--project` argument instead."
             );
         }
+        tracing::info!("Using configuration file at: `{}`", config_file.display());
         Some(FilesystemOptions::from_file(config_file)?)
     } else if deprecated_isolated || cli.top_level.no_config {
         None


### PR DESCRIPTION
## Summary

Adds visibility for when a custom configuration file is used via `--config-file` or `UV_CONFIG_FILE` environment variable.

## Problem

When using `--config-file` or `UV_CONFIG_FILE`, users have no way to verify which configuration file is actually being used. This can lead to confusion when debugging configuration issues.

## Solution

Add a `tracing::info!` log when a custom configuration file is loaded:

```
$ uv --config-file /path/to/uv.toml pip list -v
DEBUG uv::settings Using configuration file at: `/path/to/uv.toml`
```

## Changes

- Added info log in `crates/uv/src/lib.rs` when `config_file` is specified

## Testing

- Manually verified the log appears with `-v` flag
- The log level is `info`, so it appears with `-v` but not in normal operation

Fixes #17182