### PR TITLE
Log explicit config file path in verbose output

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -363,10 +363,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
 
     debug!("uv {}", uv_cli::version::uv_self_version());
     if let Some(config_file) = cli.top_level.config_file.as_ref() {
-        debug!(
-            "Using explicit configuration file at `{}`",
-            config_file.display()
-        );
+        debug!("Using configuration file: {}", config_file.user_display());
     }
     if globals.preview.all_enabled() {
         debug!("All preview features are enabled");


### PR DESCRIPTION
When `--config-file` or `UV_CONFIG_FILE` is used, emit a `DEBUG` message after logging is initialized so users can verify which configuration file is active.

The existing debug log in `FilesystemOptions::from_file()` fires before the tracing subscriber is registered, so it is silently dropped.

Closes #17182