### PR TITLE
Use optimized `rustfmt` step in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,11 @@ repos:
 
   - repo: local
     hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt --
+      - id: rustfmt
+        name: rustfmt
+        entry: rustfmt
         language: system
         types: [rust]
-        pass_filenames: false # This makes it a lot faster
 
   - repo: local
     hooks:


### PR DESCRIPTION
Matches the setup we use in Ruff.