### PR TITLE
Switch to free runners when on a fork

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -55,6 +55,14 @@ filter = 'test(/^python_install::/) + test(/^python_update::/) + test(/^python_f
 test-group = 'io-bound'
 priority = 1 # Start earlier so these can complete before the end
 
+# Per-test overrides are not inherited from parent profiles, so keep this in sync with the
+# `ci-windows` override above.
+[[profile.ci-windows-free.overrides]]
+platform = 'cfg(target_os = "windows")'
+filter = 'test(/^python_install::/) + test(/^python_update::/) + test(/^python_find::/)'
+test-group = 'io-bound'
+priority = 1 # Start earlier so these can complete before the end
+
 [scripts.setup.setup-hook-unix]
 command = "scripts/nextest-setup-hook-unix.sh"
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,12 +18,24 @@ path = "junit.xml"
 [profile.ci-linux]
 inherits = "ci"
 
+[profile.ci-linux-free]
+inherits = "ci-linux"
+slow-timeout = { period = "30s", terminate-after = 12 }
+
 [profile.ci-macos]
 inherits = "ci"
 test-threads = 12
 
+[profile.ci-macos-free]
+inherits = "ci-macos"
+slow-timeout = { period = "30s", terminate-after = 12 }
+
 [profile.ci-windows]
 inherits = "ci"
+
+[profile.ci-windows-free]
+inherits = "ci-windows"
+slow-timeout = { period = "30s", terminate-after = 12 }
 
 [test-groups]
 serial = { max-threads = 1 }

--- a/.github/runners.json
+++ b/.github/runners.json
@@ -1,0 +1,51 @@
+{
+  "ubuntu-x86_64-1": [{ "label": "ubuntu-slim", "free": true }],
+  "ubuntu-x86_64-4-github": [{ "label": "ubuntu-latest", "free": true }],
+  "ubuntu-x86_64-4": [
+    { "label": "depot-ubuntu-24.04-4", "free": false },
+    { "label": "ubuntu-latest", "free": true }
+  ],
+  "ubuntu-x86_64-8": [
+    { "label": "depot-ubuntu-24.04-8", "free": false },
+    { "label": "ubuntu-latest", "free": true }
+  ],
+  "ubuntu-x86_64-16": [
+    { "label": "depot-ubuntu-24.04-16", "free": false },
+    { "label": "ubuntu-latest", "free": true }
+  ],
+  "ubuntu-aarch64-2": [
+    { "label": "github-ubuntu-24.04-aarch64-2", "free": false },
+    { "label": "ubuntu-24.04-arm", "free": true }
+  ],
+  "ubuntu-aarch64-4": [
+    { "label": "github-ubuntu-24.04-aarch64-4", "free": false },
+    { "label": "ubuntu-24.04-arm", "free": true }
+  ],
+  "ubuntu-22-04-aarch64-4": [
+    { "label": "depot-ubuntu-22.04-arm-4", "free": false }
+  ],
+  "macos-aarch64": [{ "label": "macos-14", "free": true }],
+  "macos-aarch64-8": [
+    { "label": "depot-macos-15", "free": false },
+    { "label": "macos-14", "free": true }
+  ],
+  "macos-x86_64": [{ "label": "macos-15-intel", "free": true }],
+  "macos-x86_64-12": [
+    { "label": "macos-latest-large", "free": false },
+    { "label": "macos-15-intel", "free": true }
+  ],
+  "windows-x86_64": [{ "label": "windows-latest", "free": true }],
+  "windows-x86_64-8": [
+    { "label": "github-windows-2025-x86_64-8", "free": false },
+    { "label": "windows-latest", "free": true }
+  ],
+  "windows-x86_64-16": [
+    { "label": "namespace-profile-windows-2022-x86-64-16", "free": false },
+    { "label": "windows-latest", "free": true }
+  ],
+  "windows-aarch64": [{ "label": "windows-11-arm", "free": true }],
+  "windows-aarch64-8": [
+    { "label": "github-windows-11-aarch64-8", "free": false },
+    { "label": "windows-11-arm", "free": true }
+  ]
+}

--- a/.github/runners.json
+++ b/.github/runners.json
@@ -35,6 +35,10 @@
     { "label": "macos-15-intel", "free": true }
   ],
   "windows-x86_64": [{ "label": "windows-latest", "free": true }],
+  "windows-x86_64-4": [
+    { "label": "namespace-profile-windows-2022-x86-64-4", "free": false },
+    { "label": "windows-latest", "free": true }
+  ],
   "windows-x86_64-8": [
     { "label": "github-windows-2025-x86_64-8", "free": false },
     { "label": "windows-latest", "free": true }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,6 +5,9 @@ on:
         required: false
         type: string
         default: "true"
+      runner-ubuntu-22-04-aarch64-4:
+        required: false
+        type: string
 
 permissions: {}
 
@@ -18,8 +21,8 @@ jobs:
   benchmarks-walltime-build:
     name: "walltime build"
     # codspeed-macro doesn't support Ubuntu 24.04 yet
-    runs-on: depot-ubuntu-22.04-arm-4
-    if: ${{ github.repository == 'astral-sh/uv' }}
+    runs-on: ${{ inputs.runner-ubuntu-22-04-aarch64-4 }}
+    if: ${{ inputs.runner-ubuntu-22-04-aarch64-4 != '' }}
     timeout-minutes: 30
     steps:
       - name: "Checkout Branch"

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -94,8 +94,8 @@ jobs:
 
   build-binary-linux-armv7-gnueabihf:
     name: "linux armv7 gnueabihf"
-    timeout-minutes: 15
-    runs-on: github-ubuntu-24.04-x86_64-8
+    timeout-minutes: ${{ inputs.is-fork && 30 || 15 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -5,6 +5,27 @@ on:
         required: false
         type: string
         default: "true"
+      runner-ubuntu-x86_64-8:
+        required: true
+        type: string
+      runner-ubuntu-aarch64-4:
+        required: true
+        type: string
+      runner-macos-aarch64:
+        required: true
+        type: string
+      runner-macos-x86_64-12:
+        required: true
+        type: string
+      runner-windows-x86_64:
+        required: true
+        type: string
+      runner-windows-aarch64:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 permissions: {}
 
@@ -17,8 +38,8 @@ env:
 jobs:
   build-binary-linux-libc:
     name: "linux libc"
-    timeout-minutes: 10
-    runs-on: github-ubuntu-24.04-x86_64-8
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -45,8 +66,8 @@ jobs:
 
   build-binary-linux-aarch64:
     name: "linux aarch64"
-    timeout-minutes: 10
-    runs-on: github-ubuntu-24.04-aarch64-4
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-aarch64-4 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -109,8 +130,8 @@ jobs:
 
   build-binary-linux-musl:
     name: "linux musl"
-    timeout-minutes: 10
-    runs-on: github-ubuntu-24.04-x86_64-8
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -142,8 +163,8 @@ jobs:
 
   build-binary-macos-aarch64:
     name: "macos aarch64"
-    timeout-minutes: 10
-    runs-on: macos-14 # github-macos-14-aarch64-3
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-macos-aarch64 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -167,8 +188,8 @@ jobs:
 
   build-binary-macos-x86_64:
     name: "macos x86_64"
-    timeout-minutes: 10
-    runs-on: macos-latest-large # github-macos-14-x86_64-12
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-macos-x86_64-12 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -192,8 +213,8 @@ jobs:
 
   build-binary-windows-x86_64:
     name: "windows x86_64"
-    timeout-minutes: 10
-    runs-on: windows-latest
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-windows-x86_64 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -227,8 +248,8 @@ jobs:
 
   build-binary-windows-aarch64:
     name: "windows aarch64"
-    timeout-minutes: 10
-    runs-on: windows-11-arm
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-windows-aarch64 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -262,8 +283,8 @@ jobs:
 
   build-binary-msrv:
     name: "msrv"
-    runs-on: github-ubuntu-24.04-x86_64-8
-    timeout-minutes: 10
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -289,8 +310,8 @@ jobs:
 
   build-binary-android-aarch64:
     name: "android aarch64"
-    timeout-minutes: 10
-    runs-on: github-ubuntu-24.04-x86_64-8
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -339,7 +360,7 @@ jobs:
 
   build-binary-freebsd:
     name: "freebsd"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -13,6 +13,27 @@ on:
       plan:
         required: false
         type: string
+      runner-ubuntu-x86_64-1:
+        required: true
+        type: string
+      runner-ubuntu-x86_64-4:
+        required: true
+        type: string
+      runner-ubuntu-x86_64-8:
+        required: true
+        type: string
+      runner-macos-aarch64-8:
+        required: true
+        type: string
+      runner-windows-x86_64-8:
+        required: true
+        type: string
+      runner-windows-aarch64-8:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,7 +53,7 @@ permissions: {}
 jobs:
   sdist:
     name: sdist
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -87,7 +108,7 @@ jobs:
 
   macos-x86_64:
     name: x86_64-apple-darwin
-    runs-on: depot-macos-15
+    runs-on: ${{ inputs.runner-macos-aarch64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -159,7 +180,7 @@ jobs:
 
   macos-aarch64:
     name: aarch64-apple-darwin
-    runs-on: depot-macos-15
+    runs-on: ${{ inputs.runner-macos-aarch64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -249,13 +270,13 @@ jobs:
         platform:
           - target: x86_64-pc-windows-msvc
             arch: x64
-            runner: github-windows-2025-x86_64-8
+            runner: ${{ inputs.runner-windows-x86_64-8 }}
           - target: i686-pc-windows-msvc
             arch: x86
-            runner: github-windows-2025-x86_64-8
+            runner: ${{ inputs.runner-windows-x86_64-8 }}
           - target: aarch64-pc-windows-msvc
             arch: arm64
-            runner: github-windows-11-aarch64-8
+            runner: ${{ inputs.runner-windows-aarch64-8 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -343,7 +364,7 @@ jobs:
 
   linux:
     name: ${{ matrix.target }}
-    runs-on: depot-ubuntu-latest-4
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     strategy:
       matrix:
         include:
@@ -459,8 +480,8 @@ jobs:
 
   linux-arm:
     name: ${{ matrix.platform.target }}
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 30
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
+    timeout-minutes: ${{ inputs.is-fork && 60 || 30 }}
     strategy:
       matrix:
         platform:
@@ -589,8 +610,8 @@ jobs:
   # Like `linux-arm`.
   linux-s390x:
     name: ${{ matrix.platform.target }}
-    timeout-minutes: 30
-    runs-on: depot-ubuntu-latest-4
+    timeout-minutes: ${{ inputs.is-fork && 60 || 30 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     strategy:
       matrix:
         platform:
@@ -711,7 +732,7 @@ jobs:
   # Like `linux-arm`, but install the `gcc-powerpc64-linux-gnu` package.
   linux-powerpc:
     name: ${{ matrix.platform.target }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     strategy:
       matrix:
         platform:
@@ -821,8 +842,8 @@ jobs:
   # Like `linux-arm`.
   linux-riscv64:
     name: ${{ matrix.platform.target }}
-    timeout-minutes: 30
-    runs-on: depot-ubuntu-latest-4
+    timeout-minutes: ${{ inputs.is-fork && 60 || 30 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     strategy:
       matrix:
         platform:
@@ -939,7 +960,7 @@ jobs:
 
   musllinux:
     name: ${{ matrix.target }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-4 }}
     strategy:
       matrix:
         target:
@@ -1042,7 +1063,7 @@ jobs:
 
   musllinux-cross:
     name: ${{ matrix.platform.target }}
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     env:
       CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static"
     strategy:
@@ -1206,7 +1227,7 @@ jobs:
 
   check-wheels:
     name: "check wheel contents"
-    runs-on: ubuntu-slim
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     needs:
       - macos-x86_64
       - macos-aarch64

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -11,6 +11,9 @@ on:
       runner-ubuntu-x86_64-1:
         required: true
         type: string
+      runner-windows-x86_64-4:
+        required: true
+        type: string
       is-fork:
         required: true
         type: boolean
@@ -36,6 +39,8 @@ jobs:
         with:
           version: "0.11.23"
       - run: uvx ruff check .
+      - name: "Validate runner configuration"
+        run: python3 -m unittest scripts.ci.test_resolve_runners
 
   ty:
     timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
@@ -122,7 +127,7 @@ jobs:
     name: "clippy on windows"
     timeout-minutes: ${{ inputs.is-fork && 30 || 15 }}
     if: ${{ inputs.code-changed == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: namespace-profile-windows-2022-x86-64-4
+    runs-on: ${{ inputs.runner-windows-x86_64-4 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -8,6 +8,12 @@ on:
         required: false
         type: string
         default: "true"
+      runner-ubuntu-x86_64-1:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 permissions: {}
 
@@ -19,8 +25,8 @@ env:
 
 jobs:
   ruff:
-    timeout-minutes: 10
-    runs-on: ubuntu-slim
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -32,8 +38,8 @@ jobs:
       - run: uvx ruff check .
 
   ty:
-    timeout-minutes: 10
-    runs-on: ubuntu-slim
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -50,8 +56,8 @@ jobs:
             ty check --python-version 3.13 fetch-download-metadata.py
 
   shellcheck:
-    timeout-minutes: 10
-    runs-on: ubuntu-slim
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -66,8 +72,8 @@ jobs:
         run: find . -name '*.sh' -type f | xargs shellcheck --shell bash --severity style
 
   validate-pyproject:
-    timeout-minutes: 10
-    runs-on: ubuntu-slim
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -79,8 +85,8 @@ jobs:
       - run: uvx --from 'validate-pyproject[all,store]' validate-pyproject pyproject.toml
 
   readme:
-    timeout-minutes: 10
-    runs-on: ubuntu-slim
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -92,7 +98,7 @@ jobs:
 
   clippy-ubuntu:
     name: "clippy on linux"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     if: ${{ inputs.code-changed == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -114,7 +120,7 @@ jobs:
 
   clippy-windows:
     name: "clippy on windows"
-    timeout-minutes: 15
+    timeout-minutes: ${{ inputs.is-fork && 30 || 15 }}
     if: ${{ inputs.code-changed == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: namespace-profile-windows-2022-x86-64-4
     steps:
@@ -144,7 +150,7 @@ jobs:
 
   shear:
     name: "cargo shear"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -157,7 +163,7 @@ jobs:
       - run: cargo shear --deny-warnings
 
   typos:
-    runs-on: ubuntu-slim
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-1 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    inputs:
+      runner-ubuntu-x86_64-8:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 permissions: {}
 
@@ -11,8 +18,8 @@ env:
 
 jobs:
   cargo-publish-dry-run:
-    timeout-minutes: 20
-    runs-on: depot-ubuntu-24.04-8
+    timeout-minutes: ${{ inputs.is-fork && 40 || 20 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-8 }}
     name: "cargo publish dry-run"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       runner-macos-x86_64: ${{ steps.runners.outputs.runner_macos_x86_64 }}
       runner-macos-x86_64-12: ${{ steps.runners.outputs.runner_macos_x86_64_12 }}
       runner-windows-x86_64: ${{ steps.runners.outputs.runner_windows_x86_64 }}
+      runner-windows-x86_64-4: ${{ steps.runners.outputs.runner_windows_x86_64_4 }}
       runner-windows-x86_64-16: ${{ steps.runners.outputs.runner_windows_x86_64_16 }}
       runner-windows-aarch64: ${{ steps.runners.outputs.runner_windows_aarch64 }}
       runner-windows-x86_64-8: ${{ steps.runners.outputs.runner_windows_x86_64_8 }}
@@ -177,27 +178,11 @@ jobs:
 
       - name: "Determine runners"
         id: runners
-        shell: bash
-        env:
-          GH_REPOSITORY: ${{ github.repository }}
         run: |
-          if [[ "$GH_REPOSITORY" == "astral-sh/uv" ]]; then
-            # Use the first runner for each role
-            jq -r '
-              to_entries[] |
-              .key as $role |
-              .value[0].label as $label |
-              "runner_\($role | gsub("-";"_"))=\($label)"
-            ' .github/runners.json >> "$GITHUB_OUTPUT"
-          else
-            # Use the first free runner for each role
-            jq -r '
-              to_entries[] |
-              .key as $role |
-              (.value | map(select(.free)) | .[0].label) as $label |
-              "runner_\($role | gsub("-";"_"))=\($label)"
-            ' .github/runners.json >> "$GITHUB_OUTPUT"
-          fi
+          python3 scripts/ci/resolve-ci-runners.py \
+            --free-only="${{ github.repository != 'astral-sh/uv' }}" \
+            .github/runners.json \
+            >> "$GITHUB_OUTPUT"
 
   check-fmt:
     uses: ./.github/workflows/check-fmt.yml
@@ -209,6 +194,7 @@ jobs:
       code-changed: ${{ needs.plan.outputs.test-code }}
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
       runner-ubuntu-x86_64-1: ${{ needs.plan.outputs.runner-ubuntu-x86_64-1 }}
+      runner-windows-x86_64-4: ${{ needs.plan.outputs.runner-windows-x86_64-4 }}
       is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   check-docs:
@@ -360,7 +346,6 @@ jobs:
     secrets: inherit
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
-      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
       runner-ubuntu-22-04-aarch64-4: ${{ needs.plan.outputs.runner-ubuntu-22-04-aarch64-4 }}
 
   # This job cannot be moved into a reusable workflow because it includes coverage for uploading

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   plan:
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-slim
     outputs:
       test-code: ${{ steps.plan.outputs.test_code }}
       check-schema: ${{ steps.plan.outputs.check_schema }}
@@ -32,6 +32,25 @@ jobs:
       test-macos: ${{ steps.plan.outputs.test_macos }}
       build-docker: ${{ steps.plan.outputs.build_docker }}
       push-docker: ${{ steps.plan.outputs.push_docker }}
+      is-fork: ${{ steps.plan.outputs.is_fork }}
+      is-external-pr: ${{ steps.plan.outputs.is_external_pr }}
+      runner-ubuntu-x86_64-1: ${{ steps.runners.outputs.runner_ubuntu_x86_64_1 }}
+      runner-ubuntu-x86_64-4-github: ${{ steps.runners.outputs.runner_ubuntu_x86_64_4_github }}
+      runner-ubuntu-x86_64-4: ${{ steps.runners.outputs.runner_ubuntu_x86_64_4 }}
+      runner-ubuntu-x86_64-8: ${{ steps.runners.outputs.runner_ubuntu_x86_64_8 }}
+      runner-ubuntu-x86_64-16: ${{ steps.runners.outputs.runner_ubuntu_x86_64_16 }}
+      runner-ubuntu-aarch64-2: ${{ steps.runners.outputs.runner_ubuntu_aarch64_2 }}
+      runner-ubuntu-aarch64-4: ${{ steps.runners.outputs.runner_ubuntu_aarch64_4 }}
+      runner-macos-aarch64: ${{ steps.runners.outputs.runner_macos_aarch64 }}
+      runner-macos-aarch64-8: ${{ steps.runners.outputs.runner_macos_aarch64_8 }}
+      runner-macos-x86_64: ${{ steps.runners.outputs.runner_macos_x86_64 }}
+      runner-macos-x86_64-12: ${{ steps.runners.outputs.runner_macos_x86_64_12 }}
+      runner-windows-x86_64: ${{ steps.runners.outputs.runner_windows_x86_64 }}
+      runner-windows-x86_64-16: ${{ steps.runners.outputs.runner_windows_x86_64_16 }}
+      runner-windows-aarch64: ${{ steps.runners.outputs.runner_windows_aarch64 }}
+      runner-windows-x86_64-8: ${{ steps.runners.outputs.runner_windows_x86_64_8 }}
+      runner-windows-aarch64-8: ${{ steps.runners.outputs.runner_windows_aarch64_8 }}
+      runner-ubuntu-22-04-aarch64-4: ${{ steps.runners.outputs.runner_ubuntu_22_04_aarch64_4 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -42,6 +61,8 @@ jobs:
         id: plan
         shell: bash
         env:
+          GH_REPOSITORY: ${{ github.repository }}
+          IS_EXTERNAL_PR: ${{ github.event.pull_request.head.repo.fork == true }}
           GH_REF: ${{ github.ref }}
           HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:skip') }}
           HAS_INTEGRATION_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'test:integration') }}
@@ -146,6 +167,38 @@ jobs:
             out push_docker             "$push_docker"
           } >> "$GITHUB_OUTPUT"
 
+          # Fork detection
+          if [[ "$GH_REPOSITORY" == "astral-sh/uv" ]]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "is_external_pr=$IS_EXTERNAL_PR" >> "$GITHUB_OUTPUT"
+
+      - name: "Determine runners"
+        id: runners
+        shell: bash
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [[ "$GH_REPOSITORY" == "astral-sh/uv" ]]; then
+            # Use the first runner for each role
+            jq -r '
+              to_entries[] |
+              .key as $role |
+              .value[0].label as $label |
+              "runner_\($role | gsub("-";"_"))=\($label)"
+            ' .github/runners.json >> "$GITHUB_OUTPUT"
+          else
+            # Use the first free runner for each role
+            jq -r '
+              to_entries[] |
+              .key as $role |
+              (.value | map(select(.free)) | .[0].label) as $label |
+              "runner_\($role | gsub("-";"_"))=\($label)"
+            ' .github/runners.json >> "$GITHUB_OUTPUT"
+          fi
+
   check-fmt:
     uses: ./.github/workflows/check-fmt.yml
 
@@ -155,6 +208,8 @@ jobs:
     with:
       code-changed: ${{ needs.plan.outputs.test-code }}
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
+      runner-ubuntu-x86_64-1: ${{ needs.plan.outputs.runner-ubuntu-x86_64-1 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   check-docs:
     needs: plan
@@ -174,6 +229,9 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.test-code == 'true' }}
     uses: ./.github/workflows/check-publish.yml
+    with:
+      runner-ubuntu-x86_64-8: ${{ needs.plan.outputs.runner-ubuntu-x86_64-8 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   check-release:
     needs: plan
@@ -200,6 +258,10 @@ jobs:
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
       test-macos: ${{ needs.plan.outputs.test-macos }}
+      runner-ubuntu-x86_64-16: ${{ needs.plan.outputs.runner-ubuntu-x86_64-16 }}
+      runner-macos-aarch64-8: ${{ needs.plan.outputs.runner-macos-aarch64-8 }}
+      runner-windows-x86_64-16: ${{ needs.plan.outputs.runner-windows-x86_64-16 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   test-windows-trampolines:
     needs: plan
@@ -214,6 +276,13 @@ jobs:
     uses: ./.github/workflows/build-dev-binaries.yml
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
+      runner-ubuntu-x86_64-8: ${{ needs.plan.outputs.runner-ubuntu-x86_64-8 }}
+      runner-ubuntu-aarch64-4: ${{ needs.plan.outputs.runner-ubuntu-aarch64-4 }}
+      runner-macos-aarch64: ${{ needs.plan.outputs.runner-macos-aarch64 }}
+      runner-macos-x86_64-12: ${{ needs.plan.outputs.runner-macos-x86_64-12 }}
+      runner-windows-x86_64: ${{ needs.plan.outputs.runner-windows-x86_64 }}
+      runner-windows-aarch64: ${{ needs.plan.outputs.runner-windows-aarch64 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   test-smoke:
     needs:
@@ -223,6 +292,9 @@ jobs:
     uses: ./.github/workflows/test-smoke.yml
     with:
       sha: ${{ github.sha }}
+      runner-ubuntu-aarch64-2: ${{ needs.plan.outputs.runner-ubuntu-aarch64-2 }}
+      runner-windows-aarch64: ${{ needs.plan.outputs.runner-windows-aarch64 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   test-integration:
     needs:
@@ -259,6 +331,14 @@ jobs:
     if: ${{ needs.plan.outputs.build-release-binaries == 'true' }}
     uses: ./.github/workflows/build-release-binaries.yml
     secrets: inherit
+    with:
+      runner-ubuntu-x86_64-1: ${{ needs.plan.outputs.runner-ubuntu-x86_64-1 }}
+      runner-ubuntu-x86_64-4: ${{ needs.plan.outputs.runner-ubuntu-x86_64-4 }}
+      runner-ubuntu-x86_64-8: ${{ needs.plan.outputs.runner-ubuntu-x86_64-8 }}
+      runner-macos-aarch64-8: ${{ needs.plan.outputs.runner-macos-aarch64-8 }}
+      runner-windows-x86_64-8: ${{ needs.plan.outputs.runner-windows-x86_64-8 }}
+      runner-windows-aarch64-8: ${{ needs.plan.outputs.runner-windows-aarch64-8 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
 
   build-docker:
     needs: plan
@@ -280,18 +360,20 @@ jobs:
     secrets: inherit
     with:
       save-rust-cache: ${{ needs.plan.outputs.save-rust-cache }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
+      runner-ubuntu-22-04-aarch64-4: ${{ needs.plan.outputs.runner-ubuntu-22-04-aarch64-4 }}
 
   # This job cannot be moved into a reusable workflow because it includes coverage for uploading
   # attestations and PyPI does not support attestations in reusable workflows.
   test-publish:
     name: "test uv publish"
-    timeout-minutes: 20
+    timeout-minutes: ${{ needs.plan.outputs.is-fork == 'true' && 40 || 20 }}
     needs:
       - plan
       - build-dev-binaries
     runs-on: ubuntu-latest
     # Only the main repository is a trusted publisher
-    if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true && needs.plan.outputs.test-publish == 'true' }}
+    if: ${{ needs.plan.outputs.is-fork != 'true' && needs.plan.outputs.is-external-pr != 'true' && needs.plan.outputs.test-publish == 'true' }}
     environment:
       name: uv-test-publish
       deployment: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,13 @@ jobs:
       tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
       tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
       publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
+      runner-ubuntu-x86_64-1: ${{ steps.runners.outputs.runner_ubuntu_x86_64_1 }}
+      runner-ubuntu-x86_64-4: ${{ steps.runners.outputs.runner_ubuntu_x86_64_4 }}
+      runner-ubuntu-x86_64-8: ${{ steps.runners.outputs.runner_ubuntu_x86_64_8 }}
+      runner-macos-aarch64-8: ${{ steps.runners.outputs.runner_macos_aarch64_8 }}
+      runner-windows-x86_64-8: ${{ steps.runners.outputs.runner_windows_x86_64_8 }}
+      runner-windows-aarch64-8: ${{ steps.runners.outputs.runner_windows_aarch64_8 }}
+      is-fork: ${{ steps.fork-detect.outputs.is_fork }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -82,6 +89,25 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: "Determine runners"
+        id: runners
+        shell: bash
+        run: |
+          jq -r '
+            to_entries[] |
+            .key as $role |
+            .value[0].label as $label |
+            "runner_\($role | gsub("-";"_"))=\($label)"
+          ' .github/runners.json >> "$GITHUB_OUTPUT"
+      - name: "Detect fork"
+        id: fork-detect
+        shell: bash
+        run: |
+          if [[ "${{ github.repository }}" == "astral-sh/uv" ]]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install dist
         shell: bash
         run: |
@@ -120,6 +146,13 @@ jobs:
     uses: ./.github/workflows/build-release-binaries.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
+      runner-ubuntu-x86_64-1: ${{ needs.plan.outputs.runner-ubuntu-x86_64-1 }}
+      runner-ubuntu-x86_64-4: ${{ needs.plan.outputs.runner-ubuntu-x86_64-4 }}
+      runner-ubuntu-x86_64-8: ${{ needs.plan.outputs.runner-ubuntu-x86_64-8 }}
+      runner-macos-aarch64-8: ${{ needs.plan.outputs.runner-macos-aarch64-8 }}
+      runner-windows-x86_64-8: ${{ needs.plan.outputs.runner-windows-x86_64-8 }}
+      runner-windows-aarch64-8: ${{ needs.plan.outputs.runner-windows-aarch64-8 }}
+      is-fork: ${{ needs.plan.outputs.is-fork == 'true' }}
     secrets: inherit
 
   custom-build-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,14 +91,8 @@ jobs:
           submodules: recursive
       - name: "Determine runners"
         id: runners
-        shell: bash
         run: |
-          jq -r '
-            to_entries[] |
-            .key as $role |
-            .value[0].label as $label |
-            "runner_\($role | gsub("-";"_"))=\($label)"
-          ' .github/runners.json >> "$GITHUB_OUTPUT"
+          python3 scripts/ci/resolve-ci-runners.py .github/runners.json >> "$GITHUB_OUTPUT"
       - name: "Detect fork"
         id: fork-detect
         shell: bash

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -5,6 +5,15 @@ on:
         description: "The commit SHA to use for artifact names"
         required: true
         type: string
+      runner-ubuntu-aarch64-2:
+        required: true
+        type: string
+      runner-windows-aarch64:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 permissions: {}
 
@@ -17,7 +26,7 @@ env:
 jobs:
   smoke-test-linux:
     name: "linux"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -45,8 +54,8 @@ jobs:
 
   smoke-test-linux-aarch64:
     name: "linux aarch64"
-    timeout-minutes: 10
-    runs-on: github-ubuntu-24.04-aarch64-2
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-aarch64-2 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -73,7 +82,7 @@ jobs:
 
   smoke-test-linux-musl:
     name: "linux musl"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: ubuntu-latest
     container: alpine:latest
     steps:
@@ -97,7 +106,7 @@ jobs:
 
   smoke-test-macos:
     name: "macos"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -125,7 +134,7 @@ jobs:
 
   smoke-test-windows-x86_64:
     name: "windows x86_64"
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -154,8 +163,8 @@ jobs:
 
   smoke-test-windows-aarch64:
     name: "windows aarch64"
-    timeout-minutes: 10
-    runs-on: windows-11-arm
+    timeout-minutes: ${{ inputs.is-fork && 20 || 10 }}
+    runs-on: ${{ inputs.runner-windows-aarch64 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,18 @@ on:
         required: false
         type: string
         default: "false"
+      runner-ubuntu-x86_64-16:
+        required: true
+        type: string
+      runner-macos-aarch64-8:
+        required: true
+        type: string
+      runner-windows-x86_64-16:
+        required: true
+        type: string
+      is-fork:
+        required: true
+        type: boolean
 
 permissions: {}
 
@@ -25,8 +37,8 @@ jobs:
   # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-ubuntu-and-windows-larger-runners
 
   cargo-test-linux:
-    timeout-minutes: 10
-    runs-on: depot-ubuntu-24.04-16
+    timeout-minutes: ${{ inputs.is-fork && 40 || 10 }}
+    runs-on: ${{ inputs.runner-ubuntu-x86_64-16 }}
     name: "cargo test on linux"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -77,7 +89,11 @@ jobs:
           sudo chown "$(id -u):$(id -g)" /tmpfs
 
       - name: "Create minix filesystem (low hardlink limit)"
+        id: minix
+        # The minix kernel module is not available on GitHub runners
+        continue-on-error: ${{ inputs.is-fork }}
         run: |
+          sudo modprobe minix
           truncate -s 16M /tmp/minix.img
           mkfs.minix /tmp/minix.img
           sudo mkdir /minix
@@ -97,7 +113,7 @@ jobs:
           UV_INTERNAL__TEST_COW_FS: /btrfs
           UV_INTERNAL__TEST_NOCOW_FS: /tmpfs
           UV_INTERNAL__TEST_ALT_FS: /tmpfs
-          UV_INTERNAL__TEST_LOWLINKS_FS: /minix
+          UV_INTERNAL__TEST_LOWLINKS_FS: ${{ steps.minix.outcome == 'success' && '/minix' || '' }}
           # Write pending snapshots to a separate directory for artifact upload
           INSTA_UPDATE: new
           INSTA_PENDING_DIR: ${{ github.workspace }}/pending-snapshots
@@ -106,7 +122,7 @@ jobs:
             --cargo-profile fast-build \
             --features test-python-patch,native-auth,secret-service \
             --workspace \
-            --profile ci-linux
+            --profile ${{ inputs.is-fork && 'ci-linux-free' || 'ci-linux' }}
 
       - name: "Upload pending snapshots"
         if: ${{ failure() }}
@@ -128,10 +144,10 @@ jobs:
           retention-days: 14
 
   cargo-test-macos:
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.is-fork && 60 || 20 }}
     # Only run macOS tests on main without opt-in
     if: ${{ inputs.test-macos == 'true' }}
-    runs-on: depot-macos-15
+    runs-on: ${{ inputs.runner-macos-aarch64-8 }}
     name: "cargo test on macos"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -182,7 +198,7 @@ jobs:
             --no-default-features \
             --features test-python,test-python-managed,test-pypi,test-git,test-git-lfs,performance,test-crates-io,native-auth,apple-native \
             --workspace \
-            --profile ci-macos
+            --profile ${{ inputs.is-fork && 'ci-macos-free' || 'ci-macos' }}
 
       - name: "Upload pending snapshots"
         if: ${{ failure() }}
@@ -204,8 +220,8 @@ jobs:
           retention-days: 14
 
   cargo-test-windows:
-    timeout-minutes: 15
-    runs-on: namespace-profile-windows-2022-x86-64-16
+    timeout-minutes: ${{ inputs.is-fork && 60 || 15 }}
+    runs-on: ${{ inputs.runner-windows-x86_64-16 }}
     name: "cargo test on windows ${{ matrix.partition }} of 3"
     strategy:
       fail-fast: false
@@ -277,7 +293,7 @@ jobs:
             --no-default-features \
             --features test-python,test-pypi,test-python-managed,test-windows-registry,native-auth,windows-native \
             --workspace \
-            --profile ci-windows \
+            --profile ${{ inputs.is-fork && 'ci-windows-free' || 'ci-windows' }} \
             --partition hash:${{ matrix.partition }}/3
 
       - name: "Upload pending snapshots"

--- a/scripts/ci/resolve-ci-runners.py
+++ b/scripts/ci/resolve-ci-runners.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import TypedDict
+
+
+class Runner(TypedDict):
+    label: str
+    free: bool
+
+
+class ConfigError(ValueError):
+    pass
+
+
+ROLE_PATTERN = re.compile(r"^[a-z0-9_]+(?:-[a-z0-9_]+)*$")
+
+
+def load_config(path: Path) -> dict[str, list[Runner]]:
+    try:
+        with path.open(encoding="utf-8") as file:
+            config = json.load(file)
+    except OSError as error:
+        raise ConfigError(f"Failed to read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ConfigError(f"Failed to parse {path}: {error}") from error
+
+    return validate_config(config)
+
+
+def validate_config(config: object) -> dict[str, list[Runner]]:
+    if not isinstance(config, dict) or not config:
+        raise ConfigError("Runner configuration must be a non-empty object")
+
+    validated: dict[str, list[Runner]] = {}
+    output_names: set[str] = set()
+    for role, candidates in config.items():
+        if not isinstance(role, str) or not ROLE_PATTERN.fullmatch(role):
+            raise ConfigError(f"Invalid runner role: {role!r}")
+        if not isinstance(candidates, list) or not candidates:
+            raise ConfigError(f"Runner role {role!r} must have at least one candidate")
+
+        output_name = role.replace("-", "_")
+        if output_name in output_names:
+            raise ConfigError(f"Runner role {role!r} has a duplicate output name")
+        output_names.add(output_name)
+
+        validated_candidates: list[Runner] = []
+        labels: set[str] = set()
+        for index, candidate in enumerate(candidates):
+            if not isinstance(candidate, dict):
+                raise ConfigError(
+                    f"Runner candidate {index} for {role!r} must be an object"
+                )
+
+            missing = {"label", "free"} - candidate.keys()
+            unknown = candidate.keys() - {"label", "free"}
+            if missing:
+                raise ConfigError(
+                    f"Runner candidate {index} for {role!r} is missing: {', '.join(sorted(missing))}"
+                )
+            if unknown:
+                raise ConfigError(
+                    f"Runner candidate {index} for {role!r} has unknown fields: "
+                    f"{', '.join(sorted(unknown))}"
+                )
+
+            label = candidate["label"]
+            free = candidate["free"]
+            if (
+                not isinstance(label, str)
+                or not label
+                or "\n" in label
+                or "\r" in label
+            ):
+                raise ConfigError(
+                    f"Runner candidate {index} for {role!r} has an invalid label"
+                )
+            if not isinstance(free, bool):
+                raise ConfigError(
+                    f"Runner candidate {index} for {role!r} has a non-boolean free field"
+                )
+            if label in labels:
+                raise ConfigError(f"Runner role {role!r} repeats label {label!r}")
+            labels.add(label)
+            validated_candidates.append({"label": label, "free": free})
+
+        validated[role] = validated_candidates
+
+    return validated
+
+
+def resolve_runners(
+    config: dict[str, list[Runner]], *, free_only: bool
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for role, candidates in config.items():
+        candidate = next(
+            (
+                candidate
+                for candidate in candidates
+                if not free_only or candidate["free"]
+            ),
+            None,
+        )
+        if candidate is not None:
+            resolved[role] = candidate["label"]
+    return resolved
+
+
+def parse_bool(value: str) -> bool:
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", type=Path)
+    parser.add_argument(
+        "--free-only", type=parse_bool, default=False, metavar="{true,false}"
+    )
+    arguments = parser.parse_args(argv)
+
+    try:
+        config = load_config(arguments.config)
+    except ConfigError as error:
+        parser.error(str(error))
+
+    for role, label in resolve_runners(config, free_only=arguments.free_only).items():
+        print(f"runner_{role.replace('-', '_')}={label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_resolve_runners.py
+++ b/scripts/ci/test_resolve_runners.py
@@ -64,6 +64,27 @@ class ResolveRunnersTest(unittest.TestCase):
             resolve_runners(config, free_only=True),
         )
 
+    def test_build_dev_workflow_has_no_hardcoded_private_runners(self) -> None:
+        root = Path(__file__).parents[2]
+        config = load_config(root / ".github" / "runners.json")
+        private_labels = {
+            candidate["label"]
+            for candidates in config.values()
+            for candidate in candidates
+            if not candidate["free"]
+        }
+        workflow = (
+            root / ".github" / "workflows" / "build-dev-binaries.yml"
+        ).read_text()
+        hardcoded = [
+            line.strip().removeprefix("runs-on: ")
+            for line in workflow.splitlines()
+            if line.strip().startswith("runs-on: ")
+            and line.strip().removeprefix("runs-on: ") in private_labels
+        ]
+
+        self.assertEqual(hardcoded, [])
+
     def test_rejects_missing_fields(self) -> None:
         with self.assertRaisesRegex(ConfigError, "missing: free"):
             validate_config({"linux": [{"label": "runner"}]})

--- a/scripts/ci/test_resolve_runners.py
+++ b/scripts/ci/test_resolve_runners.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+
+def load_resolver() -> ModuleType:
+    path = Path(__file__).with_name("resolve-ci-runners.py")
+    spec = importlib.util.spec_from_file_location("resolve_ci_runners", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+resolver = load_resolver()
+ConfigError = resolver.ConfigError
+load_config = resolver.load_config
+resolve_runners = resolver.resolve_runners
+validate_config = resolver.validate_config
+
+
+class ResolveRunnersTest(unittest.TestCase):
+    def test_uses_first_candidate(self) -> None:
+        config = validate_config(
+            {
+                "linux-x86_64": [
+                    {"label": "fast-runner", "free": False},
+                    {"label": "free-runner", "free": True},
+                ]
+            }
+        )
+
+        self.assertEqual(
+            resolve_runners(config, free_only=False),
+            {"linux-x86_64": "fast-runner"},
+        )
+
+    def test_omits_roles_without_a_free_candidate(self) -> None:
+        config = validate_config(
+            {
+                "available": [
+                    {"label": "paid-runner", "free": False},
+                    {"label": "free-runner", "free": True},
+                ],
+                "unavailable": [{"label": "paid-only-runner", "free": False}],
+            }
+        )
+
+        self.assertEqual(
+            resolve_runners(config, free_only=True),
+            {"available": "free-runner"},
+        )
+
+    def test_validates_repository_config(self) -> None:
+        root = Path(__file__).parents[2]
+        config = load_config(root / ".github" / "runners.json")
+
+        self.assertNotIn(
+            "ubuntu-22-04-aarch64-4",
+            resolve_runners(config, free_only=True),
+        )
+
+    def test_rejects_missing_fields(self) -> None:
+        with self.assertRaisesRegex(ConfigError, "missing: free"):
+            validate_config({"linux": [{"label": "runner"}]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Testing here and at https://github.com/zanieb/uv/pull/13

This generates the runners to use during plan following a scheme similar to python-build-standalone where we can select a runner based on whether it is marked as free or not. This means uv's CI can run in near totality on a fork. We need to skip the Codspeed walltime benchmarks since those require custom runners. We also need to increase the timeouts for some things. This has the benefit of abstracting the underlying runner labels so we no longer need to mix Depot and GitHub naming schemes.