### PR TITLE
Bump zlib-rs to 0.6.2 to fix panic on decompression of large wheels on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8298,9 +8298,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
## Summary

Extracting a wheel on windows which has a larger total uncompressed size than 4GiB leads to panics as seen in <https://github.com/astral-sh/uv/issues/18316#issuecomment-4016534644>.

This is caused by <https://github.com/trifectatechfoundation/zlib-rs/issues/472>.

`zlib-rs` 0.6.2 includes <https://github.com/trifectatechfoundation/zlib-rs/pull/473> which addresses this issue.

## Test Plan

Manually verified via:

```
uv pip install --no-cache-dir https://repo.radeon.com/rocm/windows/rocm-rel-7.2/rocm_sdk_devel-7.2.0.dev0-py3-none-win_amd64.whl
```

On a Windows 11 VM.