### PR TITLE
docs: clarify that uv lock uses universal resolution (fixes #18029)

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -64,11 +64,11 @@ explicitly created or updated using `uv lock`:
 $ uv lock
 ```
 
-uv uses [universal resolution](../resolution/#universal-resolution) when creating the lockfile,
+uv uses [universal resolution](../resolution.md#universal-resolution) when creating the lockfile,
 meaning all dependency groups and supported platforms are resolved simultaneously into a single
 lockfile. If any dependency groups have mutually incompatible requirements, they must be declared
-explicitly using [`tool.uv.conflicts`](config/#conflicting-dependencies). See the
-[resolution concepts](../resolution/) page for more details.
+explicitly using [`tool.uv.conflicts`](config.md#conflicting-dependencies). See the
+[resolution concepts](../resolution.md) page for more details.
 
 ## Syncing the environment
 

--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -64,6 +64,13 @@ explicitly created or updated using `uv lock`:
 $ uv lock
 ```
 
+uv uses [universal resolution](../../resolution/#universal-resolution) when creating the
+lockfile, meaning all dependency groups and supported platforms are resolved simultaneously
+into a single lockfile. If any dependency groups have mutually incompatible requirements,
+they must be declared explicitly using
+[`tool.uv.conflicts`](../config/#conflicting-dependencies). See the
+[resolution concepts](../../resolution/) page for more details.
+
 ## Syncing the environment
 
 While the environment is synced [automatically](#automatic-lock-and-sync), it may also be explicitly

--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -64,12 +64,11 @@ explicitly created or updated using `uv lock`:
 $ uv lock
 ```
 
-uv uses [universal resolution](../../resolution/#universal-resolution) when creating the
-lockfile, meaning all dependency groups and supported platforms are resolved simultaneously
-into a single lockfile. If any dependency groups have mutually incompatible requirements,
-they must be declared explicitly using
-[`tool.uv.conflicts`](../config/#conflicting-dependencies). See the
-[resolution concepts](../../resolution/) page for more details.
+uv uses [universal resolution](../resolution/#universal-resolution) when creating the lockfile,
+meaning all dependency groups and supported platforms are resolved simultaneously into a single
+lockfile. If any dependency groups have mutually incompatible requirements, they must be declared
+explicitly using [`tool.uv.conflicts`](config/#conflicting-dependencies). See the
+[resolution concepts](../resolution/) page for more details.
 
 ## Syncing the environment
 


### PR DESCRIPTION
## Summary
The "Locking and syncing" page had no mention of how resolution 
works, making it impossible for users to understand why `uv lock` 
and `uv sync` behave the way they do.

## Changes
Added one paragraph to the "Creating the lockfile" section explaining:
- uv uses universal resolution (all groups + platforms at once)
- Conflicting groups require explicit `tool.uv.conflicts` declaration
- Link to the Resolution concepts page

## Related
Fixes #18029