### PR TITLE
Show when --config-file overrides discovered config in verbose logs

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -147,8 +147,10 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     //    If found, this file is combined with the user configuration file.
     // 3. The nearest configuration file (`uv.toml` or `pyproject.toml`) in the directory tree,
     //    starting from the current directory.
+    let config_file = cli.top_level.config_file.clone();
+
     let workspace_cache = WorkspaceCache::default();
-    let filesystem = if let Some(config_file) = cli.top_level.config_file.as_ref() {
+    let filesystem = if let Some(config_file) = config_file.as_ref() {
         if config_file
             .file_name()
             .is_some_and(|file_name| file_name == "pyproject.toml")
@@ -362,6 +364,12 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     )?;
 
     debug!("uv {}", uv_cli::version::uv_self_version());
+    if let Some(config_file) = config_file.as_ref() {
+        debug!(
+            "Using `--config-file` / `UV_CONFIG_FILE` at `{}`, ignoring discovered project, user, and system configuration files",
+            config_file.user_display()
+        );
+    }
     if globals.preview.all_enabled() {
         debug!("All preview features are enabled");
     } else if globals.preview.any_enabled() {

--- a/crates/uv/tests/it/cache_clean.rs
+++ b/crates/uv/tests/it/cache_clean.rs
@@ -36,6 +36,31 @@ fn clean_all() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn clean_all_with_config_file_logs_override() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+
+    let config = context.temp_dir.child("uv.toml");
+    config.write_str("")?;
+
+    uv_snapshot!(context.filters(), context.clean()
+        .arg("--verbose")
+        .arg("--config-file")
+        .arg(config.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    DEBUG uv [VERSION] ([COMMIT] DATE)
+    DEBUG Using `--config-file` / `UV_CONFIG_FILE` at `uv.toml`, ignoring discovered project, user, and system configuration files
+    Clearing cache at: [CACHE_DIR]/
+    Removed [N] files ([SIZE])
+    ");
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn clean_force() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_counts();


### PR DESCRIPTION
## Summary

When `--config-file` (or `UV_CONFIG_FILE`) is set, uv skips discovered project/user/system configuration files, but this wasn't visible in verbose output. That made debugging config behavior confusing, especially when the file came from an environment variable.

This PR adds a debug log line that makes the override explicit.

## What changed

- Added a `DEBUG` message during startup when `--config-file` / `UV_CONFIG_FILE` is active.
- Message includes the resolved config file path and states that discovered project/user/system config files are ignored.
- Added an integration test to cover this behavior.

## Example log

```text
DEBUG Using `--config-file` / `UV_CONFIG_FILE` at `uv.toml`, ignoring discovered project, user, and system configuration files
```

## Validation

- `cargo test -p uv --test it cache_clean::clean_all_with_config_file_logs_override -- --exact`
- `cargo test -p uv --test it cache_clean::clean_`

Fixes #17182.
