### PR TITLE
Conditionalize two new tests on the test-pypi feature

### DIFF
--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1449,6 +1449,7 @@ fn build_with_all_metadata() -> Result<()> {
 /// Warn for cases where `tool.uv.build-backend` is used without the corresponding build backend
 /// entry.
 #[test]
+#[cfg(feature = "test-pypi")]
 fn tool_uv_build_backend_without_build_backend() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
@@ -1512,6 +1513,7 @@ fn tool_uv_build_backend_without_build_backend() -> Result<()> {
 /// Warn for cases where `tool.uv.build-backend` is used without the corresponding build backend
 /// entry.
 #[test]
+#[cfg(feature = "test-pypi")]
 fn tool_uv_build_backend_wrong_build_backend() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Both `build_backend::tool_uv_build_backend_without_build_backend` and `build_backend::tool_uv_build_backend_wrong_build_backend` fail in offline environments because they try to download a build backend from PyPI.

This PR conditionalizes both tests on the existing `test-pypi` feature.

## Test Plan

<!-- How was it tested? -->
Applied as a downstream patch to Fedora’s `uv` package.