### PR TITLE
fix(uv-platform): adjust windows ostype to match sys-info-rs, fix windows version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6751,7 +6751,7 @@ dependencies = [
  "uv-fs",
  "uv-platform-tags",
  "uv-static",
- "windows-registry",
+ "windows-version",
 ]
 
 [[package]]
@@ -7851,6 +7851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "700dad7c058606087f6fdc1f88da5841e06da40334413c6cd4367b25ef26d24e"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,7 @@ windows = { version = "0.61.0", features = [
   "Win32_UI_WindowsAndMessaging",
 ] }
 windows-registry = { version = "0.5.0" }
+windows-version = { version = "0.1.6" }
 wiremock = { version = "0.6.4" }
 wmi = { version = "0.16.0", default-features = false }
 xz2 = { version = "0.1.7", features = ["static"] }

--- a/crates/uv-platform/Cargo.toml
+++ b/crates/uv-platform/Cargo.toml
@@ -34,7 +34,7 @@ rustix = { workspace = true }
 procfs = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-registry = { workspace = true }
+windows-version = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/uv-platform/src/host.rs
+++ b/crates/uv-platform/src/host.rs
@@ -11,8 +11,8 @@ pub enum OsType {
     Linux(String),
     /// macOS / Darwin.
     Darwin,
-    /// Windows NT.
-    WindowsNt,
+    /// Windows.
+    Windows,
 }
 
 impl OsType {
@@ -32,7 +32,7 @@ impl OsType {
         }
         #[cfg(target_os = "windows")]
         {
-            Some(Self::WindowsNt)
+            Some(Self::Windows)
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
         {
@@ -46,7 +46,7 @@ impl fmt::Display for OsType {
         match self {
             Self::Linux(os_type) => f.write_str(os_type),
             Self::Darwin => f.write_str("Darwin"),
-            Self::WindowsNt => f.write_str("Windows_NT"),
+            Self::Windows => f.write_str("Windows"),
         }
     }
 }
@@ -56,8 +56,13 @@ impl fmt::Display for OsType {
 pub enum OsRelease {
     /// Unix kernel release from `uname -r` (e.g., `"6.8.0-90-generic"`).
     Unix(String),
-    /// Windows build number from the registry (e.g., `"22631"`).
-    Windows(String),
+    /// Windows version major.minor.build.revision (e.g., `"10.0.26100.6901"`).
+    Windows {
+        major: u32,
+        minor: u32,
+        build: u32,
+        revision: u32,
+    },
 }
 
 impl OsRelease {
@@ -73,10 +78,13 @@ impl OsRelease {
         }
         #[cfg(windows)]
         {
-            let key = windows_registry::LOCAL_MACHINE
-                .open(r"SOFTWARE\Microsoft\Windows NT\CurrentVersion")
-                .ok()?;
-            Some(Self::Windows(key.get_string("CurrentBuildNumber").ok()?))
+            let os_version = windows_version::OsVersion::current();
+            Some(Self::Windows {
+                major: os_version.major,
+                minor: os_version.minor,
+                build: os_version.build,
+                revision: windows_version::revision(),
+            })
         }
         #[cfg(not(any(unix, windows)))]
         {
@@ -89,7 +97,12 @@ impl fmt::Display for OsRelease {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unix(release) => f.write_str(release),
-            Self::Windows(build) => f.write_str(build),
+            Self::Windows {
+                major,
+                minor,
+                build,
+                revision,
+            } => write!(f, "{major}.{minor}.{build}.{revision}"),
         }
     }
 }
@@ -232,7 +245,7 @@ VERSION_ID=40
         #[cfg(target_os = "macos")]
         assert_eq!(os_type, OsType::Darwin);
         #[cfg(target_os = "windows")]
-        assert_eq!(os_type, OsType::WindowsNt);
+        assert_eq!(os_type, OsType::Windows);
     }
 
     #[test]
@@ -242,6 +255,6 @@ VERSION_ID=40
         #[cfg(unix)]
         assert!(matches!(os_release, OsRelease::Unix(_)));
         #[cfg(windows)]
-        assert!(matches!(os_release, OsRelease::Windows(_)));
+        assert!(matches!(os_release, OsRelease::Windows { .. }));
     }
 }


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/uv/pull/18324, sys-info-rs was dropped in favor of a more native reimplementation to provide OsType and OsRelease.

This PR adjusts two areas for windows to match closely previous behavior:

1. OsType should be `Windows` rather than `Windows_NT` https://github.com/astral-sh/uv/pull/18324#discussion_r2902257834 as seen in https://github.com/FillZpp/sys-info-rs/blob/60ecf1470a5b7c90242f429934a3bacb6023ec4d/c/windows.c#L12. This also matches the output of `platform.system()` in CPython.
2. OsRelease previously used `GetVersionEx` in sys-info-rs. Looking closely, this was used primarily in `crates/uv-python/src/interpreter.rs` and not in linehaul as linehaul uses `platform.release()`. The problem with `GetVersionEx` is that it returns often the wrong version due to legacy reasons (e.g. may be stuck returning `6.2.9200`). The current implementation only returns the build number from the registry which is prone to problems across windows older variants. The implementation should use `RtlGetVersion` system call which returns the current major, minor, build in the same way as reported by `sys.getwindowsversion()` in CPython. In order to strike balance, this switches the implementation to use four octects `{major}.{minor}.{build}.{revision}` as recent windows versioning relies on major, build and revision where as older versions rely on major, minor and service pack. A windows-version crate by the same author as windows-rs  was added as it includes the correct system calls for the windows versions.

## Test Plan

Tested manually on both Windows desktop (10, 11) and Windows Server (2016).