### PR TITLE
Recreate Python environments under `uv tool install --force`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5704,7 +5704,8 @@ pub struct ToolInstallArgs {
 
     /// Force installation of the tool.
     ///
-    /// Will replace any existing entry points with the same name in the executable directory.
+    /// Will recreate any existing environment for the tool and replace any existing entry points
+    /// with the same name in the executable directory.
     #[arg(long)]
     pub force: bool,
 

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -329,7 +329,7 @@ pub(crate) async fn install(
         settings
     };
 
-    // If the user passed `--force`, it implies `--reinstall-package <from>`
+    // If the user passed `--force`, it implies `--reinstall-package <from>`.
     let settings = if force {
         ResolverInstallerSettings {
             reinstall: Reinstall::package(package_name.clone()).combine(settings.reinstall),
@@ -446,20 +446,23 @@ pub(crate) async fn install(
             }
         };
 
-    let existing_environment = installed_tools
-        .get_environment(package_name, &cache)?
-        .filter(|environment| {
-            existing_environment_usable(
-                environment.environment(),
-                &interpreter,
-                package_name,
-                python_request.as_ref(),
-                explicit_python_request,
-                &settings,
-                existing_tool_receipt.as_ref(),
-                printer,
-            )
-        });
+    let existing_environment = if force {
+        None
+    } else {
+        installed_tools
+            .get_environment(package_name, &cache)?
+            .filter(|environment| {
+                existing_environment_usable(
+                    environment.environment(),
+                    &interpreter,
+                    package_name,
+                    explicit_python_request,
+                    &settings,
+                    existing_tool_receipt.as_ref(),
+                    printer,
+                )
+            })
+    };
 
     // If the requested and receipt requirements are the same...
     if let Some(environment) = existing_environment.as_ref().filter(|_| {
@@ -770,7 +773,6 @@ fn existing_environment_usable(
     environment: &PythonEnvironment,
     interpreter: &Interpreter,
     package_name: &PackageName,
-    python_request: Option<&PythonRequest>,
     explicit_python_request: bool,
     settings: &ResolverInstallerSettings,
     existing_tool_receipt: Option<&uv_tool::Tool>,
@@ -797,14 +799,12 @@ fn existing_environment_usable(
         return false;
     }
 
-    // Otherwise, we'll invalidate the environment if all of the following are true:
-    // - The user requested a reinstall
-    // - The tool was not previously pinned to a Python version
-    // - There is _some_ alternative Python request
+    // Otherwise, invalidate the environment when this tool is being reinstalled and its
+    // previous receipt did not pin a Python request. In that case, the reinstall should
+    // follow the newly selected interpreter instead of reusing the old environment.
     if let Some(tool_receipt) = existing_tool_receipt
-        && settings.reinstall.is_all()
+        && settings.reinstall.contains_package(package_name)
         && tool_receipt.python().is_none()
-        && python_request.is_some()
     {
         let _ = writeln!(
             printer.stderr(),

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -411,6 +411,98 @@ fn tool_install_python_from_global_version_file() {
 }
 
 #[test]
+fn tool_install_force_respects_global_python_change() {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12", "3.13"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .python_pin()
+        .arg("3.12")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("flask")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==3.0.2
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
+     + werkzeug==3.0.1
+    Installed 1 executable: flask
+    ");
+
+    uv_snapshot!(context.filters(), Command::new("flask").arg("--version").env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+    Flask 3.0.2
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    ");
+
+    context
+        .python_pin()
+        .arg("3.13")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("flask")
+        .arg("--force")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==3.0.2
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
+     + werkzeug==3.0.1
+    Installed 1 executable: flask
+    ");
+
+    uv_snapshot!(context.filters(), Command::new("flask").arg("--version").env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.13.[X]
+    Flask 3.0.2
+    Werkzeug 3.0.1
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn tool_install_with_editable() -> Result<()> {
     let context = uv_test::test_context!("3.12")
         .with_exclude_newer("2025-01-18T00:00:00Z")
@@ -1483,6 +1575,10 @@ fn tool_install_force() {
 
     tool_dir.child("black").assert(predicate::path::is_dir());
 
+    let marker = tool_dir.child("black").child("marker");
+    fs_err::write(&marker, b"marker").unwrap();
+    marker.assert(predicate::path::is_file());
+
     // Re-install `black` with `--force`
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("black")
@@ -1496,13 +1592,18 @@ fn tool_install_force() {
 
     ----- stderr -----
     Resolved [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     ~ black==24.3.0
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     ");
 
     tool_dir.child("black").assert(predicate::path::is_dir());
+    marker.assert(predicate::path::missing());
 
     // Re-install `black` without `--force`
     uv_snapshot!(context.filters(), context.tool_install()


### PR DESCRIPTION
## Summary

`uv tool install --force` will now always recreate the environment, which I find more intuitive (and makes it a more reliable escape hatch).

Closes https://github.com/astral-sh/uv/issues/17907.
