### PR TITLE
Preserve absolute/relative paths passed to `uv add`

### DIFF
--- a/crates/uv-pep508/src/unnamed.rs
+++ b/crates/uv-pep508/src/unnamed.rs
@@ -8,6 +8,7 @@ use uv_normalize::ExtraName;
 
 use crate::marker::parse;
 use crate::verbatim_url::strip_host;
+use crate::verbatim_url::were_vars_expanded;
 use crate::{
     Cursor, MarkerEnvironment, MarkerTree, Pep508Error, Pep508ErrorSource, Pep508Url, Reporter,
     RequirementOrigin, Scheme, TracingReporter, VerbatimUrl, VerbatimUrlError, expand_env_vars,
@@ -32,6 +33,12 @@ pub trait UnnamedRequirementUrl: Pep508Url {
     #[must_use]
     fn with_given(self, given: impl AsRef<str>) -> Self;
 
+    /// Set the "given value contained variables which were expanded" flag.
+    #[must_use]
+    fn with_expanded(self, _expanded: bool) -> Self {
+        self
+    }
+
     /// Return the original string as given by the user, if available.
     fn given(&self) -> Option<&str>;
 }
@@ -54,6 +61,10 @@ impl UnnamedRequirementUrl for VerbatimUrl {
 
     fn with_given(self, given: impl AsRef<str>) -> Self {
         self.with_given(given)
+    }
+
+    fn with_expanded(self, expanded: bool) -> Self {
+        self.with_expanded(expanded)
     }
 
     fn given(&self) -> Option<&str> {
@@ -234,6 +245,7 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
 
     // Expand environment variables in the URL.
     let expanded = expand_env_vars(url);
+    let vars_expanded = were_vars_expanded(url, expanded.as_ref());
 
     if let Some((scheme, path)) = split_scheme(&expanded) {
         match Scheme::parse(scheme) {
@@ -254,7 +266,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                             len,
                             input: cursor.to_string(),
                         })?
-                        .with_given(url);
+                        .with_given(url)
+                        .with_expanded(vars_expanded);
                     return Ok((url, extras));
                 }
 
@@ -265,7 +278,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                         len,
                         input: cursor.to_string(),
                     })?
-                    .with_given(url);
+                    .with_given(url)
+                    .with_expanded(vars_expanded);
                 Ok((url, extras))
             }
             // Ex) `https://download.pytorch.org/whl/torch_stable.html`
@@ -278,7 +292,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                         len,
                         input: cursor.to_string(),
                     })?
-                    .with_given(url);
+                    .with_given(url)
+                    .with_expanded(vars_expanded);
                 Ok((url, extras))
             }
 
@@ -292,7 +307,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                             len,
                             input: cursor.to_string(),
                         })?
-                        .with_given(url);
+                        .with_given(url)
+                        .with_expanded(vars_expanded);
                     return Ok((url, extras));
                 }
 
@@ -303,7 +319,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                         len,
                         input: cursor.to_string(),
                     })?
-                    .with_given(url);
+                    .with_given(url)
+                    .with_expanded(vars_expanded);
                 Ok((url, extras))
             }
         }
@@ -317,7 +334,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                     len,
                     input: cursor.to_string(),
                 })?
-                .with_given(url);
+                .with_given(url)
+                .with_expanded(vars_expanded);
             return Ok((url, extras));
         }
 
@@ -328,7 +346,8 @@ fn preprocess_unnamed_url<Url: UnnamedRequirementUrl>(
                 len,
                 input: cursor.to_string(),
             })?
-            .with_given(url);
+            .with_given(url)
+            .with_expanded(vars_expanded);
         Ok((url, extras))
     }
 }

--- a/crates/uv-pep508/src/verbatim_url.rs
+++ b/crates/uv-pep508/src/verbatim_url.rs
@@ -285,9 +285,9 @@ impl VerbatimUrl {
 
     /// Set the "given value contained variables which were expanded" flag.
     ///
-    /// Intended to only be used by the [`Pep508Url`] impl.
+    /// Intended to only be used by the URL parser implementations.
     #[must_use]
-    fn with_expanded(self, expanded: bool) -> Self {
+    pub(crate) fn with_expanded(self, expanded: bool) -> Self {
         Self { expanded, ..self }
     }
 
@@ -399,15 +399,7 @@ impl Pep508Url for VerbatimUrl {
         // Expand environment variables in the URL.
         let expanded = expand_env_vars(url);
 
-        // Since `expand_env_vars` can return `Cow::Owned` even when variables were not expanded,
-        // the check needs to fall back to comparison for that case.
-        //
-        // Note: If a variable named `FOO` expands to `${FOO}` then this will produce a false
-        // negative. This seems like too much of a corner case to justify trying to fix it.
-        let vars_expanded = match &expanded {
-            Cow::Owned(owned) => owned != url,
-            Cow::Borrowed(_) => false,
-        };
+        let vars_expanded = were_vars_expanded(url, expanded.as_ref());
 
         if let Some((scheme, path)) = split_scheme(&expanded) {
             match Scheme::parse(scheme) {
@@ -543,6 +535,14 @@ pub fn expand_env_vars(s: &str) -> Cow<'_, str> {
             _ => caps["var"].to_owned(),
         })
     })
+}
+
+/// Returns `true` if [`expand_env_vars`] changed the given value.
+///
+/// Note: If a variable named `FOO` expands to `${FOO}` then this will produce a false negative.
+/// This seems like too much of a corner case to justify trying to fix it.
+pub(crate) fn were_vars_expanded(given: &str, expanded: &str) -> bool {
+    expanded != given
 }
 
 /// Like [`Url::parse`], but only splits the scheme. Derived from the `url` crate.

--- a/crates/uv-pypi-types/src/parsed_url.rs
+++ b/crates/uv-pypi-types/src/parsed_url.rs
@@ -158,6 +158,16 @@ impl UnnamedRequirementUrl for VerbatimParsedUrl {
         }
     }
 
+    fn with_expanded(self, expanded: bool) -> Self {
+        Self {
+            verbatim: <VerbatimUrl as UnnamedRequirementUrl>::with_expanded(
+                self.verbatim,
+                expanded,
+            ),
+            ..self
+        }
+    }
+
     fn given(&self) -> Option<&str> {
         self.verbatim.given()
     }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -22,7 +22,7 @@ use tracing::instrument;
 use uv_build_backend::BuildBackendSettings;
 use uv_configuration::{ExcludeDependency, GitLfsSetting, Override};
 use uv_distribution_types::{Index, IndexName, RequirementSource};
-use uv_fs::{PortablePathBuf, relative_to};
+use uv_fs::{PortablePathBuf, try_relative_to_if};
 use uv_git_types::GitReference;
 use uv_macros::OptionsMetadata;
 use uv_normalize::{DefaultGroups, ExtraName, GroupName, PackageName};
@@ -1761,12 +1761,13 @@ impl Source {
                 }
             }
             RequirementSource::Registry { index: None, .. } => return Ok(None),
-            RequirementSource::Path { install_path, .. } => Self::Path {
+            RequirementSource::Path {
+                install_path, url, ..
+            } => Self::Path {
                 editable: None,
                 package: None,
                 path: PortablePathBuf::from(
-                    relative_to(&install_path, root)
-                        .or_else(|_| std::path::absolute(&install_path))
+                    try_relative_to_if(&install_path, root, !url.was_given_absolute())
                         .map_err(SourceError::Absolute)?
                         .into_boxed_path(),
                 ),
@@ -1777,13 +1778,13 @@ impl Source {
             RequirementSource::Directory {
                 install_path,
                 editable: is_editable,
+                url,
                 ..
             } => Self::Path {
                 editable: editable.or(is_editable),
                 package: None,
                 path: PortablePathBuf::from(
-                    relative_to(&install_path, root)
-                        .or_else(|_| std::path::absolute(&install_path))
+                    try_relative_to_if(&install_path, root, !url.was_given_absolute())
                         .map_err(SourceError::Absolute)?
                         .into_boxed_path(),
                 ),

--- a/crates/uv/tests/project/edit.rs
+++ b/crates/uv/tests/project/edit.rs
@@ -3070,7 +3070,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         ]
 
         [tool.uv.sources]
-        dependency = { path = "../dependency" }
+        dependency = { path = "[TEMP_DIR]/dependency" }
         "#
         );
     });
@@ -3093,7 +3093,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         [[package]]
         name = "dependency"
         version = "0.1.0"
-        source = { directory = "../dependency" }
+        source = { directory = "[TEMP_DIR]/dependency" }
 
         [[package]]
         name = "project"
@@ -3104,7 +3104,7 @@ fn add_path_adjacent_directory() -> Result<()> {
         ]
 
         [package.metadata]
-        requires-dist = [{ name = "dependency", directory = "../dependency" }]
+        requires-dist = [{ name = "dependency", directory = "[TEMP_DIR]/dependency" }]
         "#
         );
     });
@@ -3114,8 +3114,10 @@ fn add_path_adjacent_directory() -> Result<()> {
 
 /// Check relative and absolute path handling with `uv add`.
 ///
-/// TODO(tk): Currently `uv add` always relativizes paths in `pyproject.toml`,
-/// this is a bug.
+/// When a user provides an absolute path or `file://` URL, it should be preserved as absolute
+/// in pyproject.toml and uv.lock. Relative paths should remain relative.
+///
+/// See: <https://github.com/astral-sh/uv/issues/17307>
 #[test]
 fn add_relative_and_absolute_paths() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -3186,6 +3188,25 @@ fn add_relative_and_absolute_paths() -> Result<()> {
         .child("__init__.py")
         .touch()?;
 
+    // Create a dependency that will be added via a file:// URL containing an expanded variable.
+    let expanded_dep = context.temp_dir.child("expanded_dep");
+    expanded_dep.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "expanded-dep"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    expanded_dep
+        .child("src")
+        .child("expanded_dep")
+        .child("__init__.py")
+        .touch()?;
+
     // Add the relative dependency using a relative path.
     uv_snapshot!(context.filters(), context.add().arg("../relative_dep").current_dir(project.path()), @"
     success: true
@@ -3228,7 +3249,21 @@ fn add_relative_and_absolute_paths() -> Result<()> {
      + file-url-dep==0.1.0 (from file://[TEMP_DIR]/file_url_dep)
     ");
 
-    // Check pyproject.toml.
+    // Expanded variables retain the portability behavior from #18680 and stay relative.
+    uv_snapshot!(context.filters(), context.add().arg("file:///${PROJECT_ROOT}/../expanded_dep").current_dir(project.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + expanded-dep==0.1.0 (from file://[TEMP_DIR]/expanded_dep)
+    ");
+
+    // Check pyproject.toml - relative paths stay relative, absolute paths and file:// URLs
+    // stay absolute.
     let pyproject_toml = fs_err::read_to_string(project.join("pyproject.toml"))?;
 
     insta::with_settings!({
@@ -3242,19 +3277,21 @@ fn add_relative_and_absolute_paths() -> Result<()> {
         requires-python = ">=3.12"
         dependencies = [
             "absolute-dep",
+            "expanded-dep",
             "file-url-dep",
             "relative-dep",
         ]
 
         [tool.uv.sources]
         relative-dep = { path = "../relative_dep" }
-        absolute-dep = { path = "../absolute_dep" }
-        file-url-dep = { path = "../file_url_dep" }
+        absolute-dep = { path = "[TEMP_DIR]/absolute_dep" }
+        file-url-dep = { path = "[TEMP_DIR]/file_url_dep" }
+        expanded-dep = { path = "../expanded_dep" }
         "#
         );
     });
 
-    // Check uv.lock.
+    // Check uv.lock - relative paths stay relative, absolute paths stay absolute.
     let lock = fs_err::read_to_string(project.join("uv.lock"))?;
 
     insta::with_settings!({
@@ -3272,12 +3309,17 @@ fn add_relative_and_absolute_paths() -> Result<()> {
         [[package]]
         name = "absolute-dep"
         version = "0.1.0"
-        source = { directory = "../absolute_dep" }
+        source = { directory = "[TEMP_DIR]/absolute_dep" }
+
+        [[package]]
+        name = "expanded-dep"
+        version = "0.1.0"
+        source = { directory = "../expanded_dep" }
 
         [[package]]
         name = "file-url-dep"
         version = "0.1.0"
-        source = { directory = "../file_url_dep" }
+        source = { directory = "[TEMP_DIR]/file_url_dep" }
 
         [[package]]
         name = "project"
@@ -3285,14 +3327,16 @@ fn add_relative_and_absolute_paths() -> Result<()> {
         source = { virtual = "." }
         dependencies = [
             { name = "absolute-dep" },
+            { name = "expanded-dep" },
             { name = "file-url-dep" },
             { name = "relative-dep" },
         ]
 
         [package.metadata]
         requires-dist = [
-            { name = "absolute-dep", directory = "../absolute_dep" },
-            { name = "file-url-dep", directory = "../file_url_dep" },
+            { name = "absolute-dep", directory = "[TEMP_DIR]/absolute_dep" },
+            { name = "expanded-dep", directory = "../expanded_dep" },
+            { name = "file-url-dep", directory = "[TEMP_DIR]/file_url_dep" },
             { name = "relative-dep", directory = "../relative_dep" },
         ]
 
@@ -3300,6 +3344,86 @@ fn add_relative_and_absolute_paths() -> Result<()> {
         name = "relative-dep"
         version = "0.1.0"
         source = { directory = "../relative_dep" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Check relative and absolute archive path handling with `uv add`.
+#[test]
+fn add_relative_and_absolute_archives() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let relative_archives = context.temp_dir.child("relative_archives");
+    relative_archives.create_dir_all()?;
+    let relative_archive = relative_archives.child("ok-1.0.0-py3-none-any.whl");
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+        relative_archive.path(),
+    )?;
+
+    let absolute_archives = context.temp_dir.child("absolute_archives");
+    absolute_archives.create_dir_all()?;
+    let absolute_archive = absolute_archives.child("tqdm-1000.0.0-py3-none-any.whl");
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/tqdm-1000.0.0-py3-none-any.whl"),
+        absolute_archive.path(),
+    )?;
+
+    uv_snapshot!(context.filters(), context.add().arg("../relative_archives/ok-1.0.0-py3-none-any.whl").arg("--no-sync").current_dir(project.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    ");
+
+    uv_snapshot!(context.filters(), context.add().arg(absolute_archive.path()).arg("--no-sync").current_dir(project.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    ");
+
+    let pyproject_toml = fs_err::read_to_string(project.join("pyproject.toml"))?;
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "ok",
+            "tqdm",
+        ]
+
+        [tool.uv.sources]
+        ok = { path = "../relative_archives/ok-1.0.0-py3-none-any.whl" }
+        tqdm = { path = "[TEMP_DIR]/absolute_archives/tqdm-1000.0.0-py3-none-any.whl" }
         "#
         );
     });


### PR DESCRIPTION
## Summary

Follow-up to #18176. This fixes the remaining absolute/relative path issues when `uv add` edits `pyproject.toml`.

`uv add` now preserves the user's path form:

- Relative paths remain relative.
- Absolute paths and literal `file://` URLs remain absolute.
- URLs containing expanded variables remain relative, preserving the portability behavior from #18680 for both named and unnamed requirements.

This applies to local directories and local archives.

* Closes https://github.com/astral-sh/uv/issues/17307
* Closes https://github.com/astral-sh/uv/pull/17316

## Test Plan

- Integration coverage for relative paths, absolute paths, and literal `file://` URLs.
- Integration coverage for directory and archive sources.
- Regression coverage for expanded-variable URLs.
- `cargo nextest run -E 'test(add_relative_and_absolute_paths) or test(add_relative_and_absolute_archives) or test(lock_pep508_urls_with_vars)'`
- `cargo nextest run -p uv-pep508 -p uv-pypi-types`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo xwin clippy --workspace --all-targets --all-features --locked -- -D warnings`
