### PR TITLE
Plumb top-level concurrency into `uv audit`

### DIFF
--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -19,7 +19,7 @@ use uv_configuration::Concurrency;
 use uv_pep440::Version;
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
-const API_BASE: &str = "https://api.osv.dev/";
+pub const API_BASE: &str = "https://api.osv.dev/";
 
 /// Errors during OSV service interactions.
 #[derive(Debug, thiserror::Error)]
@@ -185,16 +185,6 @@ pub struct Osv {
     base_url: DisplaySafeUrl,
     client: ClientWithMiddleware,
     concurrency: Concurrency,
-}
-
-impl Default for Osv {
-    fn default() -> Self {
-        Self {
-            base_url: DisplaySafeUrl::parse(API_BASE).expect("impossible: embedded URL is invalid"),
-            client: ClientWithMiddleware::default(),
-            concurrency: Concurrency::default(),
-        }
-    }
 }
 
 impl Osv {
@@ -416,16 +406,8 @@ mod tests {
     use crate::service::osv::RangeType;
     use crate::types::{Dependency, Finding};
 
-    use super::API_BASE;
     use super::Event;
     use super::Osv;
-
-    /// Ensures that the default OSV client is configured with our default OSV API base URL.
-    #[test]
-    fn test_osv_default() {
-        let osv = Osv::default();
-        assert_eq!(osv.base_url.as_str(), API_BASE);
-    }
 
     #[test]
     fn test_deserialize_events() {

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -27,6 +27,7 @@ use uv_configuration::{Concurrency, DependencyGroups, ExtrasSpecification, Targe
 use uv_normalize::{DefaultExtras, DefaultGroups};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{PythonDownloads, PythonPreference, PythonVersion};
+use uv_redacted::DisplaySafeUrl;
 use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_warnings::warn_user;
@@ -214,8 +215,14 @@ pub(crate) async fn audit(
         .collect();
 
     // Perform the audit.
-    // TODO: Use `client_builder` to produce an HTTP client through our normal process here.
-    let service = osv::Osv::default();
+    let base_client = client_builder.build();
+    let osv_url =
+        DisplaySafeUrl::parse(osv::API_BASE).expect("impossible: embedded URL is invalid");
+    let service = osv::Osv::new(
+        base_client.for_host(&osv_url).raw_client().clone(),
+        None,
+        concurrency,
+    );
     trace!("Auditing {n} dependencies against OSV", n = auditable.len());
 
     let reporter = AuditReporter::from(printer);


### PR DESCRIPTION
## Summary

Follows #18394. This plumbs the actual concurrency settings (rather than their default) and removes the default impl for `Osv`.

## Test Plan

NFC.