### PR TITLE
Fix macOS platform tag detection for conda interpreters (#14267)

### DIFF
--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -519,11 +519,42 @@ def get_operating_system_and_architecture():
                 architecture = "i386"
 
         version = version.split(".")
+
+        # Detect Apple's SYSTEM_VERSION_COMPAT shim (macOS 11 Big Sur+).
+        # When Python was built against an older SDK (e.g. conda with
+        # MACOSX_DEPLOYMENT_TARGET=10.15), platform.mac_ver() returns
+        # "10.16" instead of the real macOS version. Re-query with the
+        # shim disabled, matching the behavior of the `packaging` library:
+        # https://github.com/pypa/packaging/blob/main/src/packaging/tags.py
+        # See: https://github.com/astral-sh/uv/issues/14267
+        if int(version[0]) == 10 and int(version[1]) == 16:
+            try:
+                import subprocess
+
+                real_version = subprocess.run(
+                    [
+                        sys.executable,
+                        "-sS",
+                        "-c",
+                        "import platform; print(platform.mac_ver()[0])",
+                    ],
+                    check=True,
+                    env={"SYSTEM_VERSION_COMPAT": "0"},
+                    stdout=subprocess.PIPE,
+                    text=True,
+                ).stdout.strip()
+                if real_version:
+                    version = real_version.split(".")
+            except (subprocess.CalledProcessError, OSError):
+                # On failure, `version` remains "10.16" as before
+                pass
+
         operating_system = {
             "name": "macos",
             "major": int(version[0]),
             "minor": int(version[1]),
         }
+
     elif operating_system == "ios":
         ios_ver = platform.ios_ver()
         version = ios_ver.release.split(".")


### PR DESCRIPTION
This PR fixes issue #14267 on Intel Macs with conda Python builds.

## Details

On Intel Macs running macOS 11+, conda's Python is built with `MACOSX_DEPLOYMENT_TARGET=10.15`. When `platform.mac_ver()` is called, Apple's `SYSTEM_VERSION_COMPAT` shim returns `"10.16"` instead of the real OS version. This causes `uv` to generate macosx-10.16 platform tags, missing packages that only publish wheels for macOS 11.0+ (e.g. `pyarrow`, `greenlet`, `duckdb`, `tabmat`).

This patch detects the fake "10.16" version and re-query with `SYSTEM_VERSION_COMPAT=0` to get the real macOS version. It uses the exact same approach as the `packaging` library used by pip (see [here](https://github.com/pypa/packaging/blob/f2bbd4f578644865bc5cb2534768e46563ee7f66/src/packaging/tags.py#L436)).

With this patch, `uv pip install pyarrow greenlet duckdb tabmat` correctly installs all four binary wheels in a minimal `conda` environment my Intel iMac (2020) running macOS 14.8.3 instead of trying (and failing) to build the packages from source.