### PR TITLE
fix: ignore empty SSL_CERT_FILE environment variable

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -480,7 +480,9 @@ impl<'a> BaseClientBuilder<'a> {
         // Checks for the presence of `SSL_CERT_FILE`.
         // Certificate loading support is delegated to `rustls-native-certs`.
         // See https://github.com/rustls/rustls-native-certs/blob/813790a297ad4399efe70a8e5264ca1b420acbec/src/lib.rs#L118-L125
-        let ssl_cert_file_exists = env::var_os(EnvVars::SSL_CERT_FILE).is_some_and(|path| {
+        let ssl_cert_file_exists = env::var_os(EnvVars::SSL_CERT_FILE)
+            .filter(|v| !v.is_empty())
+            .is_some_and(|path| {
             let path = Path::new(&path);
             match path.metadata() {
                 Ok(metadata) if metadata.is_file() => true,


### PR DESCRIPTION
Apply the same filtering logic used for other environment variables
(e.g., NO_COLOR, FORCE_COLOR) to SSL_CERT_FILE. Empty values should
be ignored rather than treated as valid paths.

This aligns with the behavior of other environment variable handling
in the codebase and prevents issues when SSL_CERT_FILE is set to an
empty string.

Fixes #16712