### PR TITLE
Fix platform tags for conda interpreters on Intel Macs (#14267)

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -971,6 +971,12 @@ impl InterpreterInfo {
             .arg("-B") // Don't write bytecode.
             .arg("-c")
             .arg(script)
+            // Disable Apple's SYSTEM_VERSION_COMPAT shim so that
+            // `platform.mac_ver()` reports the real macOS version
+            // instead of "10.16" for interpreters built against
+            // older SDKs (e.g., conda with MACOSX_DEPLOYMENT_TARGET=10.15).
+            // See: https://github.com/astral-sh/uv/issues/14267
+            .env("SYSTEM_VERSION_COMPAT", "0")
             .output()
             .map_err(|err| {
                 match err.kind() {


### PR DESCRIPTION
Conda interpreters built against older macOS SDKs (e.g.,
MACOSX_DEPLOYMENT_TARGET=10.15) trigger Apple's compatibility   shim,
causing `platform.mac_ver()` to return "10.16" instead of the real macOS
version. This leads to incorrect platform tags (e.g., `macosx_10_16`
instead of `macosx_14_0`), which prevents uv from seeing the correct
list of available packages.

Setting `SYSTEM_VERSION_COMPAT=0` on the subprocess disables the shim so the script sees the true OS version.

Fixes #14267

This PR is 1 line of Rust. It supersedes [this patch](https://github.com/astral-sh/uv/pull/18416) which was 20 lines of Python.