### PR TITLE
Filter out unsupported environment wheels

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -296,9 +296,26 @@ pub struct Lock {
 
 impl Lock {
     /// Initialize a [`Lock`] from a [`ResolverOutput`].
-    pub fn from_resolution(resolution: &ResolverOutput, root: &Path) -> Result<Self, LockError> {
+    pub fn from_resolution(
+        resolution: &ResolverOutput,
+        root: &Path,
+        supported_environments: Vec<MarkerTree>,
+    ) -> Result<Self, LockError> {
         let mut packages = BTreeMap::new();
         let requires_python = resolution.requires_python.clone();
+        let supported_environments = supported_environments
+            .into_iter()
+            .map(|marker| requires_python.complexify_markers(marker))
+            .collect::<Vec<_>>();
+        let supported_environments_marker = if supported_environments.is_empty() {
+            None
+        } else {
+            let mut combined = MarkerTree::FALSE;
+            for marker in &supported_environments {
+                combined.or(*marker);
+            }
+            Some(UniversalMarker::new(combined, ConflictMarker::TRUE))
+        };
 
         // Determine the set of packages included at multiple versions.
         let mut seen = FxHashSet::default();
@@ -345,13 +362,16 @@ impl Lock {
             };
 
             let mut package = Package::from_annotated_dist(dist, fork_markers, root)?;
+            let mut wheel_marker = dist.marker;
+            if let Some(supported_environments_marker) = supported_environments_marker {
+                wheel_marker.and(supported_environments_marker);
+            }
             let wheels = &mut package.wheels;
             wheels.retain(|wheel| {
-                !is_wheel_unreachable(
+                !is_wheel_unreachable_for_marker(
                     &wheel.filename,
-                    resolution,
                     &requires_python,
-                    node_index,
+                    &wheel_marker,
                     None,
                 )
             });
@@ -460,7 +480,7 @@ impl Lock {
             options,
             ResolverManifest::default(),
             Conflicts::empty(),
-            vec![],
+            supported_environments,
             vec![],
             fork_markers,
         )?;
@@ -6190,11 +6210,10 @@ fn simplified_universal_markers(
 ///
 /// Returns `true` if the wheel is definitely unreachable, and `false` if it may be reachable,
 /// including if the wheel tag isn't recognized.
-pub(crate) fn is_wheel_unreachable(
+fn is_wheel_unreachable_for_marker(
     filename: &WheelFilename,
-    graph: &ResolverOutput,
     requires_python: &RequiresPython,
-    node_index: NodeIndex,
+    marker: &UniversalMarker,
     tags: Option<&Tags>,
 ) -> bool {
     if let Some(tags) = tags
@@ -6223,246 +6242,180 @@ pub(crate) fn is_wheel_unreachable(
 
     if platform_tags.iter().all(PlatformTag::is_linux) {
         if platform_tags.iter().all(PlatformTag::is_arm) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_ARM_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_ARM_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86_64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_X86_64_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_X86_64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_X86_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_X86_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_ppc64le) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_PPC64LE_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_PPC64LE_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_ppc64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_PPC64_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_PPC64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_s390x) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_S390X_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_S390X_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_riscv64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_RISCV64_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_RISCV64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_loongarch64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_LOONGARCH64_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_LOONGARCH64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_armv7l) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_ARMV7L_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_ARMV7L_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_armv6l) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*LINUX_ARMV6L_MARKERS)
-            {
+            if marker.is_disjoint(*LINUX_ARMV6L_MARKERS) {
                 return true;
             }
-        } else if graph.graph[node_index].marker().is_disjoint(*LINUX_MARKERS) {
+        } else if marker.is_disjoint(*LINUX_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_windows) {
         if platform_tags.iter().all(PlatformTag::is_arm) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*WINDOWS_ARM_MARKERS)
-            {
+            if marker.is_disjoint(*WINDOWS_ARM_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86_64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*WINDOWS_X86_64_MARKERS)
-            {
+            if marker.is_disjoint(*WINDOWS_X86_64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*WINDOWS_X86_MARKERS)
-            {
+            if marker.is_disjoint(*WINDOWS_X86_MARKERS) {
                 return true;
             }
-        } else if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*WINDOWS_MARKERS)
-        {
+        } else if marker.is_disjoint(*WINDOWS_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_macos) {
         if platform_tags.iter().all(PlatformTag::is_arm) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*MAC_ARM_MARKERS)
-            {
+            if marker.is_disjoint(*MAC_ARM_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86_64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*MAC_X86_64_MARKERS)
-            {
+            if marker.is_disjoint(*MAC_X86_64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*MAC_X86_MARKERS)
-            {
+            if marker.is_disjoint(*MAC_X86_MARKERS) {
                 return true;
             }
-        } else if graph.graph[node_index].marker().is_disjoint(*MAC_MARKERS) {
+        } else if marker.is_disjoint(*MAC_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_android) {
         if platform_tags.iter().all(PlatformTag::is_arm) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*ANDROID_ARM_MARKERS)
-            {
+            if marker.is_disjoint(*ANDROID_ARM_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86_64) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*ANDROID_X86_64_MARKERS)
-            {
+            if marker.is_disjoint(*ANDROID_X86_64_MARKERS) {
                 return true;
             }
         } else if platform_tags.iter().all(PlatformTag::is_x86) {
-            if graph.graph[node_index]
-                .marker()
-                .is_disjoint(*ANDROID_X86_MARKERS)
-            {
+            if marker.is_disjoint(*ANDROID_X86_MARKERS) {
                 return true;
             }
-        } else if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*ANDROID_MARKERS)
-        {
+        } else if marker.is_disjoint(*ANDROID_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_arm) {
-        if graph.graph[node_index].marker().is_disjoint(*ARM_MARKERS) {
+        if marker.is_disjoint(*ARM_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_x86_64) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*X86_64_MARKERS)
-        {
+        if marker.is_disjoint(*X86_64_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_x86) {
-        if graph.graph[node_index].marker().is_disjoint(*X86_MARKERS) {
+        if marker.is_disjoint(*X86_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_ppc64le) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*PPC64LE_MARKERS)
-        {
+        if marker.is_disjoint(*PPC64LE_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_ppc64) {
-        if graph.graph[node_index].marker().is_disjoint(*PPC64_MARKERS) {
+        if marker.is_disjoint(*PPC64_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_s390x) {
-        if graph.graph[node_index].marker().is_disjoint(*S390X_MARKERS) {
+        if marker.is_disjoint(*S390X_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_riscv64) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*RISCV64_MARKERS)
-        {
+        if marker.is_disjoint(*RISCV64_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_loongarch64) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*LOONGARCH64_MARKERS)
-        {
+        if marker.is_disjoint(*LOONGARCH64_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_armv7l) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*ARMV7L_MARKERS)
-        {
+        if marker.is_disjoint(*ARMV7L_MARKERS) {
             return true;
         }
     }
 
     if platform_tags.iter().all(PlatformTag::is_armv6l) {
-        if graph.graph[node_index]
-            .marker()
-            .is_disjoint(*ARMV6L_MARKERS)
-        {
+        if marker.is_disjoint(*ARMV6L_MARKERS) {
             return true;
         }
     }
 
     false
+}
+
+pub(crate) fn is_wheel_unreachable(
+    filename: &WheelFilename,
+    graph: &ResolverOutput,
+    requires_python: &RequiresPython,
+    node_index: NodeIndex,
+    tags: Option<&Tags>,
+) -> bool {
+    is_wheel_unreachable_for_marker(
+        filename,
+        requires_python,
+        graph.graph[node_index].marker(),
+        tags,
+    )
 }
 
 #[cfg(test)]

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -975,21 +975,22 @@ async fn do_lock(
             .relative_to(target.install_path())?;
 
             let previous = existing_lock.map(ValidatedLock::into_lock);
-            let lock = Lock::from_resolution(&resolution, target.install_path())?
-                .with_manifest(manifest)
-                .with_conflicts(conflicts)
-                .with_supported_environments(
-                    environments
-                        .cloned()
-                        .map(SupportedEnvironments::into_markers)
-                        .unwrap_or_default(),
-                )
-                .with_required_environments(
-                    required_environments
-                        .cloned()
-                        .map(SupportedEnvironments::into_markers)
-                        .unwrap_or_default(),
-                );
+            let lock = Lock::from_resolution(
+                &resolution,
+                target.install_path(),
+                environments
+                    .cloned()
+                    .map(SupportedEnvironments::into_markers)
+                    .unwrap_or_default(),
+            )?
+            .with_manifest(manifest)
+            .with_conflicts(conflicts)
+            .with_required_environments(
+                required_environments
+                    .cloned()
+                    .map(SupportedEnvironments::into_markers)
+                    .unwrap_or_default(),
+            );
 
             if previous.as_ref().is_some_and(|previous| *previous == lock) {
                 Ok(LockResult::Unchanged(lock))

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -33808,6 +33808,81 @@ fn lock_unsupported_wheel_url_required_platform() -> Result<()> {
     Ok(())
 }
 
+// TODO(charlie): This produces an empty entry in the lockfile (`pywin32` has no wheels for the
+// set of supported environments, and no source distribution).
+#[test]
+fn lock_supported_environment_wheel_only_package_can_produce_empty_entry() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2025-01-30T00:00:00Z");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = "~=3.12.0"
+        dependencies = ["pywin32"]
+
+        [tool.uv]
+        environments = ["sys_platform == 'linux' and platform_machine == 'x86_64'"]
+        "#,
+    )?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.lock(),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "
+    );
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = "==3.12.*"
+        resolution-markers = [
+            "platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+        supported-markers = [
+            "platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+
+        [options]
+        exclude-newer = "2025-01-30T00:00:00Z"
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "pywin32", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "pywin32" }]
+
+        [[package]]
+        name = "pywin32"
+        version = "308"
+        source = { registry = "https://pypi.org/simple" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// If an index is filtered out (e.g., it's the second `default = true` index defined in the file),
 /// we should still consider the lockfile valid if it's referenced by name, regardless of whether
 /// it's defined in a dependency group or the top-level `project.dependencies` field.

--- a/crates/uv/tests/it/lock_conflict.rs
+++ b/crates/uv/tests/it/lock_conflict.rs
@@ -2259,6 +2259,111 @@ fn group_default() -> Result<()> {
     Ok(())
 }
 
+/// Ref: <https://github.com/astral-sh/uv/issues/18428>
+#[test]
+fn groups_respect_supported_environments_when_filtering_wheels() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_exclude_newer("2025-09-28T00:00:00Z");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["markupsafe"]
+
+        [dependency-groups]
+        a = []
+        b = []
+
+        [tool.uv]
+        environments = [
+            "sys_platform == 'linux' and platform_machine == 'x86_64'",
+        ]
+        conflicts = [
+            [
+                { group = "a" },
+                { group = "b" },
+            ],
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // The `markupsafe` entry should only include wheels for Linux x86.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock,
+            @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+        resolution-markers = [
+            "platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+        supported-markers = [
+            "platform_machine == 'x86_64' and sys_platform == 'linux'",
+        ]
+        conflicts = [[
+            { package = "project", group = "a" },
+            { package = "project", group = "b" },
+        ]]
+
+        [options]
+        exclude-newer = "2025-09-28T00:00:00Z"
+
+        [[package]]
+        name = "markupsafe"
+        version = "3.0.3"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+            { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+            { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+            { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+            { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+            { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+            { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+            { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+            { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+            { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "markupsafe", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-7-project-a' and extra == 'group-7-project-b') or (sys_platform != 'linux' and extra == 'group-7-project-a' and extra == 'group-7-project-b')" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "markupsafe" }]
+
+        [package.metadata.requires-dev]
+        a = []
+        b = []
+        "#
+        );
+    });
+
+    Ok(())
+}
+
 /// This tests a case where we declare an extra and a group as conflicting.
 #[test]
 fn mixed() -> Result<()> {


### PR DESCRIPTION
## Summary

The issue here is that once conflicts are introduced, the markers in the lockfile get too complicated for our basic environment checks. We should _also_ filter by supported environments here.

Closes https://github.com/astral-sh/uv/issues/18428.
