### PR TITLE
Use `settings::resolve_preview` for project validation

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -40,7 +40,7 @@ use uv_fs::{CWD, Simplified};
 #[cfg(feature = "self-update")]
 use uv_pep440::release_specifiers_to_ranges;
 use uv_pep508::VersionOrUrl;
-use uv_preview::{Preview, PreviewFeature};
+use uv_preview::PreviewFeature;
 use uv_pypi_types::{ParsedDirectoryUrl, ParsedUrl};
 use uv_python::PythonRequest;
 use uv_requirements::{GroupsSpecification, RequirementsSource};
@@ -111,14 +111,10 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
 
     if !skip_project_validation {
         if let Some(project_path) = cli.top_level.global_args.project.as_ref() {
-            // Resolve the preview flags until this becomes stabilized. We check CLI args and
-            // the `UV_PREVIEW` env var, but not workspace config (which requires reading from
-            // the project directory that may not exist).
-            let preview = Preview::from_args(
-                cli.top_level.global_args.preview || environment.preview.value == Some(true),
-                cli.top_level.global_args.no_preview,
-                &cli.top_level.global_args.preview_features,
-            );
+            // Resolve the preview flags until this becomes stabilized. We do
+            // not pass a workspace configuration as this would require reading
+            // from the project directory which might not exist.
+            let preview = settings::resolve_preview(&cli.top_level.global_args, None, &environment);
             if !project_dir.exists() {
                 if preview.is_enabled(PreviewFeature::ProjectDirectoryMustExist) {
                     bail!(

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -213,7 +213,7 @@ fn resolve_python_preference(
 }
 
 /// Resolve the preview setting from CLI, environment, and workspace config.
-fn resolve_preview(
+pub(crate) fn resolve_preview(
     args: &GlobalArgs,
     workspace: Option<&FilesystemOptions>,
     environment: &EnvironmentOptions,


### PR DESCRIPTION
## Summary

The affected code was manually implementing part of the full logic which was already available in `settings::resolve_preview` so this PR just makes the project validation code use this function instead.

## Test Plan

Existing test coverage.