### PR TITLE
Improve error handling for platform detection in Python downloads

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -351,7 +351,10 @@ impl PythonDownloadRequest {
     ///
     /// Platform information is pulled from the environment.
     pub fn fill_platform(mut self) -> Result<Self, Error> {
-        let platform = Platform::from_env()?;
+        let platform = Platform::from_env().map_err(|err| match err {
+            platform::Error::LibcDetectionError(err) => Error::LibcDetection(err),
+            err => Error::InvalidRequestPlatform(err),
+        })?;
         if self.arch.is_none() {
             self.arch = Some(ArchRequest::Environment(platform.arch));
         }


### PR DESCRIPTION
I noticed this weird error chain in https://github.com/astral-sh/uv/issues/8635#issuecomment-4055185865

```
error: Failed to parse request part 
    Caused by: Could not read ELF interpreter from any of the following paths: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
```