### PR TITLE
docs: mention uvw in the GUI script guide

### DIFF
--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -357,9 +357,8 @@ root.mainloop()
 PS> uv run example.pyw
 ```
 
-Use `uvw` instead if you want to avoid opening a console window for `uv` itself, e.g., when
-running a GUI in the background. `uvw` is a Windows-only alias for `uv` and accepts all the same
-options.
+Use `uvw` instead if you want to avoid opening a console window for `uv` itself, e.g., when running
+a GUI in the background. `uvw` is a Windows-only alias for `uv` and accepts all the same options.
 
 ```console
 PS> uvw run example.pyw


### PR DESCRIPTION
## Summary
- document the Windows-only `uvw` alias in the GUI scripts guide
- show that `uvw` accepts the same arguments as `uv`
- add a `--gui-script` example for GUI scripts that do not use the `.pyw` extension

Addresses #17912.