### PR TITLE
Clarify `FLASH_ATTENTION_SKIP_CUDA_BUILD ` guidance for `flash-attn` installs

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -296,13 +296,14 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
 
 !!! note
 
-    The `FLASH_ATTENTION_SKIP_CUDA_BUILD` environment variable disables local CUDA compilation for
-    `flash-attn`. Use it when a compatible pre-built wheel is available for the resolved platform,
-    Python version, PyTorch version, and `flash-attn` version.
+    The `FLASH_ATTENTION_SKIP_CUDA_BUILD` environment variable enables `flash-attn` to be
+    resolved from a pre-built wheel, rather than attempting to build it from source, which
+    requires access to the CUDA development toolkit.
 
-    If no compatible wheel is available, setting `FLASH_ATTENTION_SKIP_CUDA_BUILD` can still skip the
-    CUDA build step without producing a working GPU-enabled install. If you need to rely on wheels,
-    pin versions to a known-supported combination and verify that the appropriate wheel exists.
+    If the CUDA toolkit is available during resolution, we recommend omitting the
+    `FLASH_ATTENTION_SKIP_CUDA_BUILD` variable, as setting `FLASH_ATTENTION_SKIP_CUDA_BUILD`
+    to `TRUE` can lead to an incompatible install if no compatible pre-built wheel is available
+    for the target PyTorch version, GPU version, and platform.
 
 Similarly, [`deep_gemm`](https://github.com/deepseek-ai/DeepGEMM) follows the same pattern:
 


### PR DESCRIPTION
## Summary
- replace the current `FLASH_ATTENTION_SKIP_CUDA_BUILD` wording with a more accurate description
- explain that the variable disables local CUDA compilation instead of guaranteeing a compatible wheel
- recommend pinning to a known-supported combination when relying on published wheels

Addresses #17794.