### PR TITLE
Pin termux test packages to improve job stability

### DIFF
--- a/test/integration/termux.sh
+++ b/test/integration/termux.sh
@@ -21,7 +21,7 @@ pkg install -y python=3.13.12-5 \
     ncurses-ui-libs=6.6.20260124+really6.5.20250830 \
     openssl=1:3.6.1 \
     readline=8.3.1-2 \
-    zlib=1.3.2 \
+    zlib=1.3.2
 
 # Test uv
 uv --version


### PR DESCRIPTION
I'm seeing this flake when the package index is partially changed. I'm _hoping_ this resolve that issue?

See https://github.com/astral-sh/uv/actions/runs/23090030294/job/67073331237?pr=18461 for example