### PR TITLE
Improve distribution id performance

### DIFF
--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -48,14 +48,14 @@ impl FilePins {
             .map(|pin| &pin.dist)
     }
 
-    /// Return the distribution id whose metadata was used during resolution.
-    pub(crate) fn metadata_id(
+    /// Return the pinned distribution and its metadata id in a single lookup.
+    pub(crate) fn dist_and_id(
         &self,
         name: &PackageName,
         version: &uv_pep440::Version,
-    ) -> Option<&DistributionId> {
+    ) -> Option<(&ResolvedDist, &DistributionId)> {
         self.0
             .get(&(name.clone(), version.clone()))
-            .map(|pin| &pin.metadata_id)
+            .map(|pin| (&pin.dist, &pin.metadata_id))
     }
 }

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -456,14 +456,11 @@ impl ResolverOutput {
                 Some(metadata),
             )
         } else {
-            let dist = pins
-                .get(name, version)
-                .expect("Every package should be pinned")
-                .clone();
+            let (dist, metadata_id) = pins
+                .dist_and_id(name, version)
+                .expect("Every package should be pinned");
+            let dist = dist.clone();
             let hashes_id = dist.distribution_id();
-            let metadata_id = pins
-                .metadata_id(name, version)
-                .expect("Every package should have pinned metadata");
 
             // Track yanks for any registry distributions.
             match dist.yanked() {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1810,17 +1810,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     return Ok(Dependencies::Unforkable(Vec::default()));
                 }
 
-                let (distribution_id, task) = if let Some(distribution_id) =
-                    pins.metadata_id(name, version)
+                // Look up the distribution ID from the pins (common case) or fork URLs.
+                let owned_id;
+                let distribution_id = if let Some((_, metadata_id)) =
+                    pins.dist_and_id(name, version)
                 {
-                    (
-                        distribution_id.clone(),
-                        pins.get(name, version)
-                            .map_or_else(|| format!("{name}=={version}"), ToString::to_string),
-                    )
+                    metadata_id
                 } else if let Some(url) = fork_urls.get(name) {
                     let dist = Dist::from_url(name.clone(), url.clone())?;
-                    (dist.distribution_id(), dist.to_string())
+                    owned_id = dist.distribution_id();
+                    &owned_id
                 } else {
                     debug_assert!(
                         false,
@@ -1845,8 +1844,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 let response = self
                     .index
                     .distributions()
-                    .wait_blocking(&distribution_id)
-                    .ok_or_else(|| ResolveError::UnregisteredTask(task))?;
+                    .wait_blocking(distribution_id)
+                    .ok_or_else(|| ResolveError::UnregisteredTask(format!("{name}=={version}")))?;
 
                 let metadata = match &*response {
                     MetadataResponse::Found(archive) => &archive.metadata,


### PR DESCRIPTION
Improve the performance for https://github.com/astral-sh/uv/pull/18373.

```
$ hyperfine --warmup 3 --runs 30 \
    '/tmp/uv-0-baseline lock --project /home/konsti/projects/airflow' \
    '/tmp/uv-1-or-insert-with lock --project /home/konsti/projects/airflow' \
    '/tmp/uv-2-single-lookup lock --project /home/konsti/projects/airflow' \

Benchmark 1: /tmp/uv-0-baseline lock --project /home/konsti/projects/airflow
Time (mean ± σ):     147.1 ms ±  10.1 ms    [User: 108.4 ms, System: 23.6 ms]
Range (min … max):   130.5 ms … 165.9 ms    30 runs

Benchmark 2: /tmp/uv-1-or-insert-with lock --project /home/konsti/projects/airflow
Time (mean ± σ):     141.3 ms ±   7.3 ms    [User: 106.3 ms, System: 21.3 ms]
Range (min … max):   131.5 ms … 160.6 ms    30 runs

Benchmark 3: /tmp/uv-2-single-lookup lock --project /home/konsti/projects/airflow
Time (mean ± σ):     139.6 ms ±   7.3 ms    [User: 104.7 ms, System: 21.8 ms]
Range (min … max):   128.3 ms … 160.9 ms    30 runs

Summary
/tmp/uv-2-single-lookup lock --project /home/konsti/projects/airflow ran
 1.01 ± 0.07 times faster than /tmp/uv-1-or-insert-with lock --project /home/konsti/projects/airflow
 1.05 ± 0.09 times faster than /tmp/uv-0-baseline lock --project /home/konsti/projects/airflow
```