### PR TITLE
feat: `uv add --constraints <file_or_url>` to save constraints to pyproject.toml

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4237,17 +4237,21 @@ pub struct AddArgs {
     )]
     pub requirements: Vec<PathBuf>,
 
-    /// Constrain versions using the given requirements files.
+    /// Constrain versions using the given requirements files or URLs.
     ///
     /// Constraints files are `requirements.txt`-like files that only control the _version_ of a
-    /// requirement that's installed. The constraints will _not_ be added to the project's
-    /// `pyproject.toml` file, but _will_ be respected during dependency resolution.
+    /// requirement that's installed. When used on their own, the constraints _will_ be imported
+    /// into `[tool.uv].constraint-dependencies` in `pyproject.toml`. When used _with_ packages or
+    /// `-r/--requirements`, the constraints _will_ be respected during dependency resolution but
+    /// _will not_ be added to the project's `pyproject.toml` file.
     ///
-    /// This is equivalent to pip's `--constraint` option.
+    /// When used with packages or `-r/--requirements`, this is equivalent to pip's `--constraint`
+    /// option.
     #[arg(
         long,
         short,
         alias = "constraint",
+        group = "sources",
         env = EnvVars::UV_CONSTRAINT,
         value_delimiter = ' ',
         value_parser = parse_maybe_file_path,

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -391,6 +391,34 @@ impl PyProjectTomlMut {
         Ok(edit)
     }
 
+    /// Adds a constraint to `[tool.uv].constraint-dependencies`.
+    ///
+    /// The requirement is written using uv's normalized requirement formatting instead of
+    /// preserving the exact original text from an input constraints file.
+    ///
+    /// Returns an [`ArrayEdit`] indicating whether the constraint was added or updated.
+    pub fn add_constraint_dependency(&mut self, req: &Requirement) -> Result<ArrayEdit, Error> {
+        // Get or create `tool.uv.constraint-dependencies`.
+        let constraint_dependencies = self
+            .doc
+            .entry("tool")
+            .or_insert(implicit())
+            .as_table_mut()
+            .ok_or(Error::MalformedSources)?
+            .entry("uv")
+            .or_insert(Item::Table(Table::new()))
+            .as_table_mut()
+            .ok_or(Error::MalformedSources)?
+            .entry("constraint-dependencies")
+            .or_insert(Item::Value(Value::Array(Array::new())))
+            .as_array_mut()
+            .ok_or(Error::MalformedDependencies)?;
+
+        let edit = add_dependency(req, constraint_dependencies, false, false)?;
+
+        Ok(edit)
+    }
+
     /// Add an [`Index`] to `tool.uv.index`.
     pub fn add_index(&mut self, index: &Index) -> Result<(), Error> {
         let size = self.doc.len();

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -330,6 +330,10 @@ pub(crate) async fn add(
         .clone()
         .keyring(settings.resolver.keyring_provider);
 
+    // True if the user passes `uv add --constraints <file_or_url>`,
+    // i.e. `uv add` with no packages
+    let only_constraints = requirements.is_empty() && !constraints.is_empty();
+
     // Read the requirements.
     let RequirementsSpecification {
         requirements,
@@ -636,6 +640,14 @@ pub(crate) async fn add(
         index,
         &mut toml,
     )?;
+
+    // Write constraints to `[tool.uv].constraint-dependencies`
+    if only_constraints {
+        for constraint in &constraints {
+            let requirement = constraint.requirement.clone().into();
+            toml.add_constraint_dependency(&requirement)?;
+        }
+    }
 
     // If no requirements were added but a dependency group or optional dependency was specified,
     // ensure the group/extra exists. This handles the case where `uv add -r requirements.txt

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1119,7 +1119,7 @@ fn add_raw_error() -> Result<()> {
     ----- stderr -----
     error: the argument '--tag <TAG>' cannot be used with '--raw'
 
-    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     ");
@@ -2362,7 +2362,7 @@ fn disallow_group_script_add() -> Result<()> {
     ----- stderr -----
     error: the argument '--group <GROUP>' cannot be used with '--script <SCRIPT>'
 
-    Usage: uv add --cache-dir [CACHE_DIR] --group <GROUP> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add --cache-dir [CACHE_DIR] --group <GROUP> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     ");
@@ -4595,7 +4595,7 @@ fn add_reject_multiple_git_ref_flags() {
     ----- stderr -----
     error: the argument '--tag <TAG>' cannot be used with '--branch <BRANCH>'
 
-    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     "
@@ -4616,7 +4616,7 @@ fn add_reject_multiple_git_ref_flags() {
     ----- stderr -----
     error: the argument '--tag <TAG>' cannot be used with '--rev <REV>'
 
-    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     "
@@ -4637,7 +4637,7 @@ fn add_reject_multiple_git_ref_flags() {
     ----- stderr -----
     error: the argument '--tag <TAG>' cannot be used multiple times
 
-    Usage: uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     "
@@ -5797,9 +5797,9 @@ fn add_requirements_file() -> Result<()> {
 
     ----- stderr -----
     error: the following required arguments were not provided:
-      <PACKAGES|--requirements <REQUIREMENTS>>
+      <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
-    Usage: uv add --cache-dir [CACHE_DIR] --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>>
+    Usage: uv add --cache-dir [CACHE_DIR] --exclude-newer <EXCLUDE_NEWER> <PACKAGES|--requirements <REQUIREMENTS>|--constraints <CONSTRAINTS>>
 
     For more information, try '--help'.
     ");
@@ -15226,6 +15226,659 @@ fn add_git_lfs_error() -> Result<()> {
     ----- stderr -----
     error: `typing-extensions` did not resolve to a Git repository, but a Git extension (`--lfs`) was provided.
     ");
+
+    Ok(())
+}
+
+/// Import constraints from a requirements file, ignoring comments and blank lines, and normalize
+/// constraint formatting
+#[test]
+fn add_constraints_from_file() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+
+    constraints_txt.write_str(indoc! {r"
+        # This is a comment
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "boto3==1.40.0",
+            "numpy<2",
+            "requests>=2.31,<3",
+        ]
+        "#
+        );
+    });
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        constraints = [
+            { name = "boto3", specifier = "==1.40.0" },
+            { name = "numpy", specifier = "<2" },
+            { name = "requests", specifier = ">=2.31,<3" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Import constraints from a remote requirements file, ignoring comments and blank lines, and
+/// normalize constraint formatting
+#[tokio::test]
+async fn add_constraints_from_url() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/constraints.txt"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {r"
+            # This is a comment
+            requests >= 2.31, < 3
+
+            boto3 == 1.40.0
+
+            numpy < 2
+        "}))
+        .mount(&server)
+        .await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg(format!("{}/constraints.txt", server.uri()))
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "boto3==1.40.0",
+            "numpy<2",
+            "requests>=2.31,<3",
+        ]
+        "#
+        );
+    });
+
+    let lock = context.read("uv.lock");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        constraints = [
+            { name = "boto3", specifier = "==1.40.0" },
+            { name = "numpy", specifier = "<2" },
+            { name = "requests", specifier = ">=2.31,<3" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Merge imported constraints into existing `constraint-dependencies`.
+#[test]
+fn add_constraints_updates_existing() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = ["numpy<2", "requests>=2.31,<3"]
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "boto3==1.40.0",
+            "numpy<2",
+            "requests>=2.31,<3",
+        ]
+        "#
+        );
+    });
+
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.32, < 3
+
+        boto3 == 1.34.0
+    "})?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "boto3==1.34.0",
+            "numpy<2",
+            "requests>=2.32,<3",
+        ]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Preserve existing ordering when `constraint-dependencies` is intentionally unsorted.
+#[test]
+fn add_constraints_preserves_unsorted_order() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = ["requests>=2.31,<3", "boto3==1.40.0"]
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str("numpy < 2")?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "requests>=2.31,<3",
+            "boto3==1.40.0",
+            "numpy<2",
+        ]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Import constraints without creating a lockfile when `--frozen` is set.
+#[test]
+fn add_constraints_frozen() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    context
+        .add()
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        constraint-dependencies = [
+            "boto3==1.40.0",
+            "numpy<2",
+            "requests>=2.31,<3",
+        ]
+        "#
+        );
+    });
+
+    assert!(!context.temp_dir.child("uv.lock").exists());
+
+    Ok(())
+}
+
+/// Warn and leave `pyproject.toml` unchanged when the constraints file is empty.
+#[test]
+fn add_constraints_empty_file() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str("")?;
+
+    uv_snapshot!(context.filters(), context.add().arg("--constraints").arg("constraints.txt").arg("--frozen"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Requirements file `constraints.txt` does not contain any dependencies
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// Error on missing or invalid constraints files.
+#[test]
+fn add_constraints_error() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("--constraints").arg("nonexistent.txt").arg("--frozen"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: File not found: `nonexistent.txt`
+    ");
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        not valid!!!
+    "})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("--constraints").arg("constraints.txt").arg("--frozen"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Couldn't parse requirement in `constraints.txt` at position 0
+      Caused by: Expected one of `@`, `(`, `<`, `=`, `>`, `~`, `!`, `;`, found `v`
+    not valid!!!
+        ^
+    ");
+
+    Ok(())
+}
+
+/// When packages are added, constraints affect resolution but are not imported.
+#[test]
+fn add_package_with_constraints_does_not_import_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    // `uv add <package> --constraints ...` should only use constraints during resolution.
+    // so it will not add it to the pyproject.toml file. This is existing behavior.
+    context
+        .add()
+        .arg("iniconfig==2.0.0")
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig==2.0.0",
+        ]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// When requirements are added, constraints are not imported even if the requirements file is
+/// empty.
+#[test]
+fn add_empty_requirements_with_constraints_does_not_import_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("")?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .add()
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--constraints")
+            .arg("constraints.txt")
+            .arg("--frozen"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Requirements file `requirements.txt` does not contain any dependencies
+    "
+    );
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+/// When requirements are added, constraints are not imported.
+#[test]
+fn add_requirements_with_constraints_does_not_import_constraints() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("iniconfig==2.0.0\n")?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str(indoc! {r"
+        requests >= 2.31, < 3
+
+        boto3 == 1.40.0
+
+        numpy < 2
+    "})?;
+
+    context
+        .add()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--constraints")
+        .arg("constraints.txt")
+        .arg("--frozen")
+        .assert()
+        .success();
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig==2.0.0",
+        ]
+        "#
+        );
+    });
 
     Ok(())
 }

--- a/docs/concepts/projects/dependencies.md
+++ b/docs/concepts/projects/dependencies.md
@@ -86,6 +86,19 @@ Dependencies declared in a `requirements.txt` file can be added to the project w
 uv add -r requirements.txt
 ```
 
+Constraints can be imported separately from a local file or URL:
+
+```console
+$ uv add -c constraints.txt
+$ uv add -c https://example.com/constraints.txt
+```
+
+When `uv add` is invoked with `--constraints` on its own, uv writes the imported constraints to
+`[tool.uv].constraint-dependencies` in the project's `pyproject.toml`.
+
+If packages or `-r/--requirements` inputs are provided alongside `--constraints`, the constraints
+are only applied during resolution and are not added to `pyproject.toml`.
+
 See the [pip migration guide](../../guides/migration/pip-to-project.md#importing-requirements-files)
 for more details.
 

--- a/docs/guides/migration/pip-to-project.md
+++ b/docs/guides/migration/pip-to-project.md
@@ -366,6 +366,18 @@ $ uv add -r requirements.in -c requirements.txt
 
 Your existing versions will be retained when producing a `uv.lock` file.
 
+If you want to persist those constraints in the project configuration for future locks and syncs,
+you can also import them directly from a local file or URL into `[tool.uv].constraint-dependencies`:
+
+```console
+$ uv add -c requirements.txt
+$ uv add -c https://example.com/requirements.txt
+```
+
+When `--constraints` is used on its own, uv imports the constraints into
+`[tool.uv].constraint-dependencies`. When it is combined with packages or `--requirements`, the
+constraints are only used during resolution and are not added to `pyproject.toml`.
+
 #### Importing platform-specific constraints
 
 If your platform-specific dependencies have been compiled into separate files, you can still

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -139,6 +139,23 @@ all dependencies from the file:
 
 ```console
 $ # Add all dependencies from `requirements.txt`.
+$ uv add -r requirements.txt
+```
+
+If you have a separate constraints file, you can import it from a local file or URL. When `uv add`
+is invoked with `--constraints` on its own, uv writes the constraints to
+`[tool.uv].constraint-dependencies`:
+
+```console
+$ uv add -c constraints.txt
+$ uv add -c https://example.com/constraints.txt
+```
+
+If you provide packages or `-r/--requirements` inputs too, the constraints are only used during
+resolution and are not added to `pyproject.toml`:
+
+```console
+$ uv add fastapi -c constraints.txt
 $ uv add -r requirements.txt -c constraints.txt
 ```
 


### PR DESCRIPTION
## Summary
closes #16508

Adds the ability to ergonomically save constraints into the `pyproject.toml` in order to maintain reproducible environments when using file or url constraints; `uv add --constraints <file_or_url>`

It is still backwards compatible with the existing behavior from `uv add <package> --constraints <constraints_source>` 

For further info, I added a supplemental comment below that captures some decisions and overview info...

## Test Plan
Added tests to `crates/uv/tests/it/edit.rs` and then also tested this locally
```
cargo nextest run --package uv -E 'test(~add_constraints) | test(~does_not_import_constraints)'
```

### Local Testing: Existing (System `uv`) vs. Proposed (Local Dev `uv`)
installing constraints from local file
<img width="1915" height="765" alt="image" src="https://github.com/user-attachments/assets/95f2ba5b-86fd-4e93-8ff3-fc8a656151d8" />

installing constraints from url
<img width="1915" height="734" alt="image" src="https://github.com/user-attachments/assets/6386ee7a-80ef-40e4-8420-17754c147b2f" />

preserving existing behavior
<img width="1918" height="712" alt="image" src="https://github.com/user-attachments/assets/bcf383d9-39b3-4e56-b427-b5b80dca5e07" />


