### PR TITLE
Exit with nonzero on audit findings

### DIFF
--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -255,9 +255,7 @@ pub(crate) async fn audit(
         n_packages: auditable.len(),
         findings: all_findings,
     };
-    display.render()?;
-
-    Ok(ExitStatus::Success)
+    display.render()
 }
 
 struct AuditResults {
@@ -267,7 +265,7 @@ struct AuditResults {
 }
 
 impl AuditResults {
-    fn render(&self) -> Result<()> {
+    fn render(&self) -> Result<ExitStatus> {
         let (vulns, statuses): (Vec<_>, Vec<_>) =
             self.findings.iter().partition_map(|finding| match finding {
                 Finding::Vulnerability(vuln) => itertools::Either::Left(vuln),
@@ -299,6 +297,8 @@ impl AuditResults {
             "Found {vuln_banner} and {status_banner} in {packages}",
             packages = format!("{npackages} packages", npackages = self.n_packages).bold()
         )?;
+
+        let has_findings = !vulns.is_empty() || !statuses.is_empty();
 
         if !vulns.is_empty() {
             writeln!(self.printer.stdout_important(), "\nVulnerabilities:\n")?;
@@ -365,6 +365,10 @@ impl AuditResults {
             // any adverse project statuses at the moment.
         }
 
-        Ok(())
+        if has_findings {
+            Ok(ExitStatus::Failure)
+        } else {
+            Ok(ExitStatus::Success)
+        }
     }
 }


### PR DESCRIPTION
## Summary

We now exit with a non-zero code if the `uv audit` run produced findings.

See https://github.com/astral-sh/uv/issues/18506.

Atop #18511.

## Test Plan

None yet.