### PR TITLE
Upgrade the release build runners from Windows 2022 -> 2025

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -235,10 +235,10 @@ jobs:
         platform:
           - target: x86_64-pc-windows-msvc
             arch: x64
-            runner: github-windows-2022-x86_64-8
+            runner: github-windows-2025-x86_64-8
           - target: i686-pc-windows-msvc
             arch: x86
-            runner: github-windows-2022-x86_64-8
+            runner: github-windows-2025-x86_64-8
           - target: aarch64-pc-windows-msvc
             arch: arm64
             runner: github-windows-11-aarch64-8


### PR DESCRIPTION
Needed for WinGet in #17543

The `windows-latest` label already changed https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/

I don't think this should affect users.