### PR TITLE
Move parsing UV_RUN_RECURSION_DEPTH to EnvironmentOptions

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -636,6 +636,7 @@ pub struct EnvironmentOptions {
     pub install_mirrors: PythonInstallMirrors,
     pub log_context: Option<bool>,
     pub lfs: Option<bool>,
+    pub run_recursion_depth: Option<u32>,
     pub http_connect_timeout: Duration,
     pub http_read_timeout: Duration,
     /// There's no upload timeout in reqwest, instead we have to use a read timeout as upload
@@ -719,6 +720,10 @@ impl EnvironmentOptions {
             },
             log_context: parse_boolish_environment_variable(EnvVars::UV_LOG_CONTEXT)?,
             lfs: parse_boolish_environment_variable(EnvVars::UV_GIT_LFS)?,
+            run_recursion_depth: parse_integer_environment_variable(
+                EnvVars::UV_RUN_RECURSION_DEPTH,
+                None,
+            )?,
             http_read_timeout_upload: parse_integer_environment_variable(
                 EnvVars::UV_UPLOAD_HTTP_TIMEOUT,
                 Some("value should be an integer number of seconds"),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::env::VarError;
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io;
@@ -110,12 +109,12 @@ pub(crate) async fn run(
     printer: Printer,
     env_file: EnvFile,
     preview: Preview,
+    recursion_depth: u32,
     max_recursion_depth: u32,
 ) -> anyhow::Result<ExitStatus> {
     // Check if max recursion depth was exceeded. This most commonly happens
     // for scripts with a shebang line like `#!/usr/bin/env -S uv run`, so try
     // to provide guidance for that case.
-    let recursion_depth = read_recursion_depth_from_environment_variable()?;
     if recursion_depth > max_recursion_depth {
         bail!(
             r"
@@ -1870,27 +1869,6 @@ fn is_python_zipapp(target: &Path) -> bool {
         }
     }
     false
-}
-
-/// Read and parse recursion depth from the environment.
-///
-/// Returns Ok(0) if `EnvVars::UV_RUN_RECURSION_DEPTH` is not set.
-///
-/// Returns an error if `EnvVars::UV_RUN_RECURSION_DEPTH` is set to a value
-/// that cannot ber parsed as an integer.
-fn read_recursion_depth_from_environment_variable() -> anyhow::Result<u32> {
-    let envvar = match std::env::var(EnvVars::UV_RUN_RECURSION_DEPTH) {
-        Ok(val) => val,
-        Err(VarError::NotPresent) => return Ok(0),
-        Err(e) => {
-            return Err(e)
-                .with_context(|| format!("invalid value for {}", EnvVars::UV_RUN_RECURSION_DEPTH));
-        }
-    };
-
-    envvar
-        .parse::<u32>()
-        .with_context(|| format!("invalid value for {}", EnvVars::UV_RUN_RECURSION_DEPTH))
 }
 
 #[derive(Error, Debug)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2163,6 +2163,7 @@ async fn run_project(
                 printer,
                 args.env_file,
                 globals.preview,
+                args.recursion_depth,
                 args.max_recursion_depth,
             ))
             .await

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -556,6 +556,7 @@ pub(crate) struct RunSettings {
     pub(crate) refresh: Refresh,
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) env_file: EnvFile,
+    pub(crate) recursion_depth: u32,
     pub(crate) max_recursion_depth: u32,
 }
 
@@ -636,6 +637,7 @@ impl RunSettings {
         let isolated = isolated || environment.isolated.value == Some(true);
         let show_resolution = show_resolution || environment.show_resolution.value == Some(true);
         let no_env_file = no_env_file || environment.no_env_file.value == Some(true);
+        let recursion_depth = environment.run_recursion_depth.unwrap_or(0);
 
         Self {
             lock_check: resolve_lock_check(locked),
@@ -692,6 +694,7 @@ impl RunSettings {
                 filesystem,
             ),
             env_file: EnvFile::from_args(env_file, no_env_file),
+            recursion_depth,
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -5846,6 +5846,29 @@ fn detect_infinite_recursion() -> Result<()> {
 }
 
 #[test]
+fn run_invalid_recursion_depth_env_var() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .run()
+            .env(EnvVars::UV_RUN_RECURSION_DEPTH, "invalid")
+            .arg("--")
+            .arg("python")
+            .arg("--version"),
+        @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse environment variable `UV_RUN_RECURSION_DEPTH` with invalid value `invalid`: invalid digit found in string
+    "#
+    );
+}
+
+#[test]
 fn run_uv_variable() {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
## Summary
This follows the small-slice approach requested in #14720 by moving parsing for `UV_RUN_RECURSION_DEPTH` into `EnvironmentOptions`.

Today, `uv run` reads `UV_RUN_RECURSION_DEPTH` directly inside `commands/project/run.rs` while other non-CLI environment variables are gradually being centralized in `EnvironmentOptions`. That split means this one variable still bypasses the shared environment parsing path and the resolved settings flow.

This change keeps the behavior the same while aligning it with the newer pattern:
- `UV_RUN_RECURSION_DEPTH` is parsed once in `EnvironmentOptions`
- the resolved value is carried through `RunSettings`
- `commands::run` uses the resolved value instead of reading from the environment directly
- child processes still increment `UV_RUN_RECURSION_DEPTH` exactly as before

The user-facing recursion guard is unchanged: `uv run` still errors once the configured recursion limit is exceeded, and subprocesses still receive the incremented depth counter. I also added a focused integration test for an invalid `UV_RUN_RECURSION_DEPTH` value so the env-var failure path stays covered after the refactor.

## Testing
- `CARGO_TARGET_DIR=/tmp/uv-target cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/uv-target cargo test -p uv --test it run::detect_infinite_recursion -- --exact`
- `CARGO_TARGET_DIR=/tmp/uv-target cargo test -p uv --test it run::run_invalid_recursion_depth_env_var -- --exact`

Relates #14720
