### PR TITLE
Move Pyodide to Tier 2 in the Python support policy

### DIFF
--- a/docs/reference/policies/python.md
+++ b/docs/reference/policies/python.md
@@ -26,6 +26,7 @@ uv has Tier 2 support for:
 
 - PyPy
 - GraalPy
+- Pyodide
 
 uv is "expected to work" with these implementations. uv also supports managed installations of these
 Python implementations, but the builds are not maintained by Astral.
@@ -33,6 +34,5 @@ Python implementations, but the builds are not maintained by Astral.
 uv has Tier 3 support for:
 
 - Pyston
-- Pyodide
 
 uv "should work" with these implementations, but stability may vary.


### PR DESCRIPTION
We support managed installs of these now.