### PR TITLE
docs: Add migration guides from pip, poetry, and pipenv

### DIFF
--- a/docs/guides/migration/index.md
+++ b/docs/guides/migration/index.md
@@ -3,12 +3,9 @@
 Learn how to migrate from other tools to uv:
 
 - [Migrate from pip to uv projects](./pip-to-project.md)
-
-!!! note
-
-    Other guides, such as migrating from another project management tool, or from pip to `uv pip`
-    are not yet available. See [#5200](https://github.com/astral-sh/uv/issues/5200) to track
-    progress.
+- [Migrate from pip to `uv pip`](./pip.md)
+- [Migrate from Poetry to uv](./poetry.md)
+- [Migrate from Pipenv to uv](./pipenv.md)
 
 Or, explore the [integration guides](../integration/index.md) to learn how to use uv with other
 software.

--- a/docs/guides/migration/pip.md
+++ b/docs/guides/migration/pip.md
@@ -1,0 +1,91 @@
+# Migrating from pip to uv
+
+This guide covers replacing `pip` and `pip-tools` commands with their `uv` equivalents. For
+migrating a pip-based project to uv's project interface, see
+[Migrating from pip to a uv project](./pip-to-project.md).
+
+## Command mapping
+
+### Package installation
+
+| pip | uv |
+| --- | --- |
+| `pip install flask` | `uv pip install flask` |
+| `pip install flask==3.0.0` | `uv pip install flask==3.0.0` |
+| `pip install -r requirements.txt` | `uv pip install -r requirements.txt` |
+| `pip install -e .` | `uv pip install -e .` |
+| `pip install --upgrade flask` | `uv pip install --upgrade flask` |
+
+### Package removal
+
+| pip | uv |
+| --- | --- |
+| `pip uninstall flask` | `uv pip uninstall flask` |
+| `pip uninstall -r requirements.txt` | `uv pip uninstall -r requirements.txt` |
+
+### Inspecting packages
+
+| pip | uv |
+| --- | --- |
+| `pip list` | `uv pip list` |
+| `pip show flask` | `uv pip show flask` |
+| `pip freeze` | `uv pip freeze` |
+| `pip check` | `uv pip check` |
+
+### pip-tools
+
+| pip-tools | uv |
+| --- | --- |
+| `pip-compile requirements.in` | `uv pip compile requirements.in` |
+| `pip-compile --generate-hashes` | `uv pip compile --generate-hashes` |
+| `pip-sync requirements.txt` | `uv pip sync requirements.txt` |
+
+### Virtual environments
+
+| pip / venv | uv |
+| --- | --- |
+| `python -m venv .venv` | `uv venv` |
+| `python -m venv --python 3.12 .venv` | `uv venv --python 3.12` |
+| `source .venv/bin/activate && pip install flask` | `uv pip install flask` (auto-detects `.venv`) |
+
+## Key differences
+
+**No activation required.** uv detects the `.venv` in the current directory automatically. You
+don't need to activate the virtual environment before running `uv pip` commands.
+
+**Faster.** uv uses a global cache and parallel downloads. Expect 10-100x faster installs on warm
+cache.
+
+**Universal resolution.** `uv pip compile --universal` generates a single lockfile that works
+across platforms — no need for per-platform requirements files.
+
+**Stricter by default.** uv won't install into the system Python unless you pass `--system`. This
+prevents accidental pollution of global environments.
+
+## Workflow comparison
+
+```mermaid
+graph LR
+    subgraph "pip workflow"
+        A1[python -m venv .venv] --> A2[source .venv/bin/activate]
+        A2 --> A3[pip install -r requirements.txt]
+        A3 --> A4[pip freeze > requirements.txt]
+        A4 --> A5[python app.py]
+    end
+
+    subgraph "uv workflow"
+        B1[uv venv] --> B2[uv pip install -r requirements.txt]
+        B2 --> B3[uv pip freeze > requirements.txt]
+        B3 --> B4[python app.py]
+    end
+```
+
+## Gotchas
+
+- `uv pip install` requires an active virtual environment (or `--system`). If there's no `.venv` in
+  the working directory and no `VIRTUAL_ENV` set, it will error rather than silently installing into
+  the system Python.
+- `uv pip compile` produces universal output by default when using `--universal`. Without it, the
+  output is platform-specific, matching pip-tools behavior.
+- Hash-checking mode works the same way: `uv pip compile --generate-hashes` and
+  `uv pip install --require-hashes`.

--- a/docs/guides/migration/pipenv.md
+++ b/docs/guides/migration/pipenv.md
@@ -1,0 +1,207 @@
+# Migrating from Pipenv to uv
+
+This guide covers converting a Pipenv project to uv. Pipenv uses `Pipfile` and `Pipfile.lock`; uv
+uses `pyproject.toml` and `uv.lock`.
+
+## Command mapping
+
+| Pipenv | uv | Notes |
+| --- | --- | --- |
+| `pipenv install` | `uv sync` | Install from lockfile |
+| `pipenv install flask` | `uv add flask` | |
+| `pipenv install pytest --dev` | `uv add pytest --dev` | |
+| `pipenv uninstall flask` | `uv remove flask` | |
+| `pipenv update` | `uv lock --upgrade && uv sync` | |
+| `pipenv lock` | `uv lock` | |
+| `pipenv run pytest` | `uv run pytest` | |
+| `pipenv shell` | `source .venv/bin/activate` | uv doesn't have a shell command |
+| `pipenv graph` | `uv tree` | |
+| `pipenv check` | `uv pip check` | After `uv sync` |
+| `pipenv --python 3.12` | `uv python pin 3.12` | |
+| `pipenv --rm` | `rm -rf .venv` | |
+
+## Converting from Pipfile
+
+### Before (Pipfile)
+
+```toml
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = ">=3.0"
+sqlalchemy = {version = ">=2.0", extras = ["asyncio"]}
+requests = "*"
+
+[dev-packages]
+pytest = ">=8.0"
+ruff = "*"
+
+[requires]
+python_version = "3.12"
+```
+
+### After (pyproject.toml)
+
+```toml
+[project]
+name = "myapp"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "flask>=3.0",
+    "sqlalchemy[asyncio]>=2.0",
+    "requests",
+]
+
+[dependency-groups]
+dev = ["pytest>=8.0", "ruff"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+### What changed
+
+- `[packages]` becomes `[project.dependencies]`.
+- `[dev-packages]` becomes `[dependency-groups] dev`.
+- `"*"` (any version) becomes an unpinned dependency — just list the package name.
+- `[requires] python_version` becomes `requires-python`.
+- The `[[source]]` section is removed if using the default PyPI. Custom indexes go in
+  `[[tool.uv.index]]`.
+
+## Step-by-step migration
+
+1. **Create a `pyproject.toml`** — either manually or with uv:
+
+    ```console
+    $ uv init
+    ```
+
+2. **Add your dependencies.** You can read them from the Pipfile or add them one at a time:
+
+    ```console
+    $ uv add flask "sqlalchemy[asyncio]" requests
+    $ uv add --dev pytest ruff
+    ```
+
+3. **Generate the lockfile:**
+
+    ```console
+    $ uv lock
+    ```
+
+4. **Install:**
+
+    ```console
+    $ uv sync
+    ```
+
+5. **Remove Pipenv artifacts:**
+
+    ```console
+    $ rm Pipfile Pipfile.lock
+    ```
+
+6. **Verify:**
+
+    ```console
+    $ uv run pytest
+    ```
+
+## Dependency resolution flow
+
+The following diagram shows how uv resolves and installs dependencies:
+
+```mermaid
+graph TD
+    A[pyproject.toml] -->|uv lock| B[uv.lock]
+    B -->|uv sync| C[.venv]
+    C -->|uv run| D[Execute command]
+    A -->|uv add pkg| A
+    A -.->|uv lock --upgrade| B
+```
+
+Compare this with the Pipenv flow:
+
+```mermaid
+graph TD
+    A[Pipfile] -->|pipenv lock| B[Pipfile.lock]
+    B -->|pipenv install| C[virtualenv]
+    C -->|pipenv run| D[Execute command]
+    A -->|pipenv install pkg| A
+    A -->|pipenv install pkg| B
+    A -->|pipenv install pkg| C
+```
+
+The key difference: uv separates locking (`uv lock`) from syncing (`uv sync`). Adding a dependency
+with `uv add` updates `pyproject.toml` and the lockfile, but `uv sync` or `uv run` is needed to
+install. This gives you more control and makes the operations predictable.
+
+## Handling Pipfile features
+
+### Custom indexes
+
+Pipfile:
+
+```toml
+[[source]]
+url = "https://pypi.example.com/simple/"
+verify_ssl = true
+name = "private"
+```
+
+uv:
+
+```toml
+[[tool.uv.index]]
+name = "private"
+url = "https://pypi.example.com/simple/"
+```
+
+### Python version
+
+Pipfile:
+
+```toml
+[requires]
+python_version = "3.12"
+```
+
+uv:
+
+```toml
+[project]
+requires-python = ">=3.12"
+```
+
+Or pin to an exact version with:
+
+```console
+$ uv python pin 3.12
+```
+
+### Environment variables
+
+Pipenv loads `.env` files automatically. uv does not. Use `uv run` with your preferred env loader,
+or set variables in your shell before running commands:
+
+```console
+$ env $(cat .env | xargs) uv run python app.py
+```
+
+Or use a tool like [direnv](https://direnv.net/) or
+[python-dotenv](https://pypi.org/project/python-dotenv/).
+
+## What you gain
+
+- **Speed.** uv is 10-100x faster for installs and resolution.
+- **Universal lockfile.** `uv.lock` resolves for all platforms at once. Pipenv's `Pipfile.lock` is
+  platform-specific.
+- **Standards-based.** `pyproject.toml` with PEP 621 metadata works with any Python tooling, not
+  just Pipenv.
+- **Built-in Python management.** `uv python install 3.12` — no need for pyenv alongside Pipenv.
+- **Deterministic.** Separate lock and sync steps make the process transparent.

--- a/docs/guides/migration/poetry.md
+++ b/docs/guides/migration/poetry.md
@@ -1,0 +1,157 @@
+# Migrating from Poetry to uv
+
+This guide covers converting a Poetry project to uv. Both tools manage dependencies through
+`pyproject.toml`, so the transition is mostly about updating configuration and learning the new
+commands.
+
+## Command mapping
+
+| Poetry | uv | Notes |
+| --- | --- | --- |
+| `poetry init` | `uv init` | |
+| `poetry install` | `uv sync` | Installs from lockfile |
+| `poetry add flask` | `uv add flask` | |
+| `poetry add flask --group dev` | `uv add flask --dev` | Or `--group dev` |
+| `poetry add flask --group docs` | `uv add flask --group docs` | |
+| `poetry remove flask` | `uv remove flask` | |
+| `poetry update` | `uv lock --upgrade` | Refreshes the lockfile |
+| `poetry update flask` | `uv lock --upgrade-package flask` | |
+| `poetry lock` | `uv lock` | |
+| `poetry run pytest` | `uv run pytest` | |
+| `poetry shell` | `source .venv/bin/activate` | uv doesn't have a shell command |
+| `poetry build` | `uv build` | |
+| `poetry publish` | `uv publish` | |
+| `poetry show` | `uv pip show` or `uv tree` | `uv tree` for dependency tree |
+| `poetry env use 3.12` | `uv python pin 3.12` | |
+
+## Converting `pyproject.toml`
+
+Poetry uses a `[tool.poetry]` section. uv uses standard `[project]` metadata (PEP 621).
+
+### Before (Poetry)
+
+```toml
+[tool.poetry]
+name = "myapp"
+version = "0.1.0"
+description = "My application"
+authors = ["Dev <dev@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+flask = "^3.0"
+sqlalchemy = {version = "^2.0", extras = ["asyncio"]}
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+ruff = "^0.4"
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "^7.0"
+
+[tool.poetry.scripts]
+serve = "myapp.cli:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+```
+
+### After (uv)
+
+```toml
+[project]
+name = "myapp"
+version = "0.1.0"
+description = "My application"
+authors = [{name = "Dev", email = "dev@example.com"}]
+requires-python = ">=3.11"
+dependencies = [
+    "flask>=3.0,<4",
+    "sqlalchemy[asyncio]>=2.0,<3",
+]
+
+[project.scripts]
+serve = "myapp.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "ruff>=0.4"]
+docs = ["sphinx>=7.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+### What changed
+
+- `[tool.poetry.dependencies]` moves to `[project.dependencies]` using
+  [PEP 508](https://peps.python.org/pep-0508/) syntax.
+- Poetry's `^3.0` (caret) becomes `>=3.0,<4`. Poetry's `~3.0` (tilde) becomes `>=3.0,<3.1`.
+- `python = "^3.11"` becomes `requires-python = ">=3.11"`.
+- Dev and optional groups move to `[dependency-groups]`.
+- The build backend changes — `hatchling` or `setuptools` are common choices.
+- `[tool.poetry.scripts]` becomes `[project.scripts]`.
+
+## Step-by-step migration
+
+1. **Convert the `pyproject.toml`** as shown above. You can do this manually or start fresh:
+
+    ```console
+    $ uv init
+    $ uv add flask "sqlalchemy[asyncio]"
+    $ uv add --dev pytest ruff
+    $ uv add --group docs sphinx
+    ```
+
+2. **Generate the lockfile:**
+
+    ```console
+    $ uv lock
+    ```
+
+3. **Install everything:**
+
+    ```console
+    $ uv sync --all-groups
+    ```
+
+4. **Remove Poetry artifacts:**
+
+    ```console
+    $ rm poetry.lock
+    ```
+
+5. **Verify:**
+
+    ```console
+    $ uv run pytest
+    ```
+
+## Handling private indexes
+
+Poetry:
+
+```toml
+[[tool.poetry.source]]
+name = "private"
+url = "https://pypi.example.com/simple/"
+```
+
+uv:
+
+```toml
+[[tool.uv.index]]
+name = "private"
+url = "https://pypi.example.com/simple/"
+```
+
+See [index configuration](../../concepts/indexes.md) for authentication and priority options.
+
+## What you gain
+
+- **Speed.** uv resolves and installs significantly faster than Poetry.
+- **Universal lockfile.** `uv.lock` works across platforms out of the box — Poetry's `poetry.lock`
+  is also cross-platform but uses a custom format.
+- **No plugin system needed.** Python version management, tool running, and builds are all built in.
+- **Standards-based.** PEP 621 metadata works with any build backend, not just Poetry's.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,9 @@ nav:
       - Migration:
           - guides/migration/index.md
           - From pip to a uv project: guides/migration/pip-to-project.md
+          - From pip to uv pip: guides/migration/pip.md
+          - From Poetry: guides/migration/poetry.md
+          - From Pipenv: guides/migration/pipenv.md
       - Integrations:
           - guides/integration/index.md
           - Docker: guides/integration/docker.md


### PR DESCRIPTION
## Summary

Adds three new migration guides to `docs/guides/migration/`, addressing #5200:

- **From pip to `uv pip`** — command-by-command mapping table for `pip`, `pip-tools`, and `venv` equivalents, plus a Mermaid workflow comparison diagram
- **From Poetry to uv** — command mapping, `pyproject.toml` conversion (Poetry format to PEP 621), step-by-step walkthrough, private index config
- **From Pipenv to uv** — command mapping, `Pipfile` to `pyproject.toml` conversion, Mermaid diagrams comparing dependency resolution flows, env variable handling

Also updates `docs/guides/migration/index.md` to link the new guides (removing the "not yet available" note) and adds nav entries in `mkdocs.yml`.

## Test plan

- [ ] Verify `mkdocs serve` renders all three guides correctly
- [ ] Confirm navigation links work from the migration index page
- [ ] Review command mappings for accuracy against current uv CLI