### PR TITLE
Use a Termux image with Python pre-installed instead

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -753,7 +753,7 @@ jobs:
           docker run --rm \
             -v "$PWD/uv:/uv" \
             -v "$PWD/test/integration/termux.sh:/test-termux.sh" \
-            termux/termux-docker:x86_64 \
+            ghcr.io/astral-sh/termux-python:latest \
             /entrypoint.sh bash /test-termux.sh
 
   integration-test-github-actions:

--- a/test/integration/termux.sh
+++ b/test/integration/termux.sh
@@ -5,10 +5,6 @@ set -euxo pipefail
 cp /uv /data/data/com.termux/files/usr/bin/uv
 chmod +x /data/data/com.termux/files/usr/bin/uv
 
-# Update the package index and install Python
-pkg update -y
-pkg install -y python
-
 # Test uv
 uv --version
 


### PR DESCRIPTION
Created at https://github.com/astral-sh/termux-python

Termux's package repositories seem to be horribly unstable.