### PR TITLE
Fall back to keyring.exe when WSL interop is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5826,6 +5826,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "test-log",
  "thiserror",

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -53,6 +53,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+temp-env = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -262,6 +262,26 @@ impl KeyringProvider {
         credentials.map(|(username, password)| Credentials::basic(Some(username), Some(password)))
     }
 
+    /// Returns the command names to try when spawning the keyring subprocess.
+    ///
+    /// On WSL, the `keyring` Python tool may not be installed natively but a Windows
+    /// `keyring.exe` may be available on `PATH` via WSL interop. When the `WSL_INTEROP`
+    /// environment variable is set, `keyring.exe` is included as a fallback so that a
+    /// Windows-side keyring installation can be used for credential retrieval.
+    fn keyring_commands() -> &'static [&'static str] {
+        if Self::has_wsl_interop() {
+            &["keyring", "keyring.exe"]
+        } else {
+            &["keyring"]
+        }
+    }
+
+    /// Check whether WSL interop is available by looking for the `WSL_INTEROP`
+    /// environment variable, which the WSL runtime sets when interop is enabled.
+    fn has_wsl_interop() -> bool {
+        std::env::var_os("WSL_INTEROP").is_some()
+    }
+
     #[instrument(skip(self))]
     async fn fetch_subprocess(
         &self,
@@ -269,29 +289,37 @@ impl KeyringProvider {
         username: Option<&str>,
     ) -> Option<(String, String)> {
         // https://github.com/pypa/pip/blob/24.0/src/pip/_internal/network/auth.py#L136-L141
-        let mut command = Command::new("keyring");
-        command.arg("get").arg(service_name);
+        let child = Self::keyring_commands().iter().find_map(|cmd| {
+            let mut command = Command::new(cmd);
+            command.arg("get").arg(service_name);
 
-        if let Some(username) = username {
-            command.arg(username);
-        } else {
-            command.arg("--mode").arg("creds");
-        }
-
-        let child = command
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            // If we're using `--mode creds`, we need to capture the output in order to avoid
-            // showing users an "unrecognized arguments: --mode" error; otherwise, we stream stderr
-            // so the user has visibility into keyring's behavior if it's doing something slow
-            .stderr(if username.is_some() {
-                Stdio::inherit()
+            if let Some(username) = username {
+                command.arg(username);
             } else {
-                Stdio::piped()
-            })
-            .spawn()
-            .inspect_err(|err| warn!("Failure running `keyring` command: {err}"))
-            .ok()?;
+                command.arg("--mode").arg("creds");
+            }
+
+            command
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                // If we're using `--mode creds`, we need to capture the output in order to avoid
+                // showing users an "unrecognized arguments: --mode" error; otherwise, we stream
+                // stderr so the user has visibility into keyring's behavior if it's doing
+                // something slow
+                .stderr(if username.is_some() {
+                    Stdio::inherit()
+                } else {
+                    Stdio::piped()
+                })
+                .spawn()
+                .inspect_err(|err| debug!("Failed to spawn `{cmd}`: {err}"))
+                .ok()
+        });
+
+        let Some(child) = child else {
+            warn!("Could not find a `keyring` executable");
+            return None;
+        };
 
         let output = child
             .wait_with_output()
@@ -627,5 +655,50 @@ mod tests {
             .fetch(DisplaySafeUrl::ref_cast(&url), Some("user"))
             .await;
         assert_eq!(credentials, None);
+    }
+
+    #[test]
+    fn keyring_commands_includes_keyring() {
+        // All platforms must try `keyring` as the first command.
+        assert_eq!(KeyringProvider::keyring_commands()[0], "keyring");
+    }
+
+    #[test]
+    fn has_wsl_interop_reflects_env() {
+        // When WSL_INTEROP is not set, should return false (unless actually on WSL).
+        let had_var = std::env::var_os("WSL_INTEROP").is_some();
+        if !had_var {
+            assert!(!KeyringProvider::has_wsl_interop());
+        }
+    }
+
+    #[test]
+    fn keyring_commands_without_wsl() {
+        // Without WSL_INTEROP, only `keyring` should be tried.
+        if std::env::var_os("WSL_INTEROP").is_none() {
+            assert_eq!(KeyringProvider::keyring_commands(), &["keyring"]);
+        }
+    }
+
+    #[test]
+    fn keyring_commands_with_wsl_interop() {
+        // Simulate WSL by temporarily setting WSL_INTEROP.
+        let original = std::env::var_os("WSL_INTEROP");
+        // SAFETY: This test is run serially (single-threaded test binary) and we
+        // restore the original value before returning.
+        unsafe {
+            std::env::set_var("WSL_INTEROP", "/run/WSL/1_interop");
+        }
+        assert_eq!(
+            KeyringProvider::keyring_commands(),
+            &["keyring", "keyring.exe"]
+        );
+        // Restore original state.
+        unsafe {
+            match original {
+                Some(val) => std::env::set_var("WSL_INTEROP", val),
+                None => std::env::remove_var("WSL_INTEROP"),
+            }
+        }
     }
 }

--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -683,22 +683,11 @@ mod tests {
     #[test]
     fn keyring_commands_with_wsl_interop() {
         // Simulate WSL by temporarily setting WSL_INTEROP.
-        let original = std::env::var_os("WSL_INTEROP");
-        // SAFETY: This test is run serially (single-threaded test binary) and we
-        // restore the original value before returning.
-        unsafe {
-            std::env::set_var("WSL_INTEROP", "/run/WSL/1_interop");
-        }
-        assert_eq!(
-            KeyringProvider::keyring_commands(),
-            &["keyring", "keyring.exe"]
-        );
-        // Restore original state.
-        unsafe {
-            match original {
-                Some(val) => std::env::set_var("WSL_INTEROP", val),
-                None => std::env::remove_var("WSL_INTEROP"),
-            }
-        }
+        temp_env::with_var("WSL_INTEROP", Some("/run/WSL/1_interop"), || {
+            assert_eq!(
+                KeyringProvider::keyring_commands(),
+                &["keyring", "keyring.exe"]
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary

When the subprocess keyring provider is enabled, uv only tries to spawn `keyring`. On WSL, this change also tries `keyring.exe` as a fallback when `keyring` is not found and the `WSL_INTEROP` environment variable is set, indicating that [WSL interop](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#interop-settings) is enabled.

### Why use Windows keyring from WSL?

Using the Windows-side `keyring.exe` from WSL provides a better authentication experience. Windows credential providers (e.g. `artifacts-keyring` for Azure DevOps) can use the [authorization code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow), which opens an interactive browser window for authentication. A native Linux `keyring` running inside WSL can only use the [device code flow](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code), which requires manually entering a code at a URL — and some organizations disable device code flow entirely via Conditional Access policies.

## Test Plan

- `keyring_commands_includes_keyring` — `keyring` is always the first command tried
- `has_wsl_interop_reflects_env` — reflects `WSL_INTEROP` env var
- `keyring_commands_without_wsl` — only `keyring` when not on WSL
- `keyring_commands_with_wsl_interop` — includes `keyring.exe` when `WSL_INTEROP` is set (uses `temp_env`)
- All existing `uv-auth` tests pass (25 passed)
