### PR TITLE
fix: handle BrokenPipe in shell completion generation

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1403,7 +1403,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             anyhow::bail!(message);
         }
         Commands::GenerateShellCompletion(args) => {
-            args.shell.generate(&mut Cli::command(), &mut stdout());
+            let mut buffer = Vec::new();
+            args.shell.generate(&mut Cli::command(), &mut buffer);
+            if let Err(err) = std::io::Write::write_all(&mut stdout(), &buffer) {
+                if err.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(err.into());
+                }
+            }
             Ok(ExitStatus::Success)
         }
         Commands::Tool(ToolNamespace {
@@ -1436,7 +1442,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                         uvx = uvx.arg(arg);
                     }
                 }
-                shell.generate(&mut uvx, &mut stdout());
+                let mut buffer = Vec::new();
+                shell.generate(&mut uvx, &mut buffer);
+                if let Err(err) = std::io::Write::write_all(&mut stdout(), &buffer) {
+                    if err.kind() != std::io::ErrorKind::BrokenPipe {
+                        return Err(err.into());
+                    }
+                }
                 return Ok(ExitStatus::Success);
             }
 


### PR DESCRIPTION
## Summary

Fixes #12244

When `uv generate-shell-completion fish | source` runs during a terminal resize, the pipe reader closes and `clap_complete`'s `generate()` panics with `BrokenPipe` (OS error 32):

```
thread 'main2' panicked at clap_complete.../fish.rs: failed to write completion file: BrokenPipe
```

This is a common scenario in fish shell where completions are re-sourced automatically on window resize.

The fix buffers completion output into a `Vec<u8>` first, then writes to stdout with explicit `BrokenPipe` handling. A broken pipe on stdout means the reader disconnected, which is standard and not worth panicking over. Both code paths are patched:

- **Line ~1406**: `uv generate-shell-completion` 
- **Line ~1439**: `uvx --generate-shell-completion`

Credit to @geofft for identifying the root cause in the issue thread and @isnakode for suggesting the buffer approach.

## Test plan

- [x] `cargo check -p uv` compiles cleanly
- [x] `cargo fmt --check` passes
- [ ] `uv generate-shell-completion fish | head -1` exits without panic
- [ ] `uv generate-shell-completion bash` still produces correct output

AI Disclosure: AI-assisted development per astral-sh AI policy. All code reviewed and tested by a human.