### PR TITLE
Use a Depot runner for simulated benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -96,7 +96,7 @@ jobs:
 
   benchmarks-simulated:
     name: "simulated"
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-4
     if: ${{ github.repository == 'astral-sh/uv' }}
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Hopefully, this means we will get consistent hardware and improve stability
