### PR TITLE
Move UV_RUN_MAX_RECURSION_DEPTH parsing to EnvironmentOptions

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3763,7 +3763,7 @@ pub struct RunArgs {
     /// cleared, uv will fail to detect the recursion depth.
     ///
     /// If uv reaches the maximum recursion depth, it will exit with an error.
-    #[arg(long, hide = true, env = EnvVars::UV_RUN_MAX_RECURSION_DEPTH)]
+    #[arg(long, hide = true)]
     pub max_recursion_depth: Option<u32>,
 
     /// The platform for which requirements should be installed.

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -636,6 +636,7 @@ pub struct EnvironmentOptions {
     pub install_mirrors: PythonInstallMirrors,
     pub log_context: Option<bool>,
     pub lfs: Option<bool>,
+    pub run_max_recursion_depth: Option<u32>,
     pub http_connect_timeout: Duration,
     pub http_read_timeout: Duration,
     /// There's no upload timeout in reqwest, instead we have to use a read timeout as upload
@@ -719,6 +720,10 @@ impl EnvironmentOptions {
             },
             log_context: parse_boolish_environment_variable(EnvVars::UV_LOG_CONTEXT)?,
             lfs: parse_boolish_environment_variable(EnvVars::UV_GIT_LFS)?,
+            run_max_recursion_depth: parse_integer_environment_variable(
+                EnvVars::UV_RUN_MAX_RECURSION_DEPTH,
+                None,
+            )?,
             http_read_timeout_upload: parse_integer_environment_variable(
                 EnvVars::UV_UPLOAD_HTTP_TIMEOUT,
                 Some("value should be an integer number of seconds"),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -695,7 +695,9 @@ impl RunSettings {
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
-            max_recursion_depth: max_recursion_depth.unwrap_or(Self::DEFAULT_MAX_RECURSION_DEPTH),
+            max_recursion_depth: max_recursion_depth
+                .or(environment.run_max_recursion_depth)
+                .unwrap_or(Self::DEFAULT_MAX_RECURSION_DEPTH),
         }
     }
 }


### PR DESCRIPTION
## Summary

Part of #14720.

This PR moves parsing of `UV_RUN_MAX_RECURSION_DEPTH` from Clap's env handling into `EnvironmentOptions`, then wires it into `RunSettings` resolution.

Changes:
- Removed `env = EnvVars::UV_RUN_MAX_RECURSION_DEPTH` from `RunArgs::max_recursion_depth`.
- Added `run_max_recursion_depth: Option<u32>` to `EnvironmentOptions` and parsed it in `EnvironmentOptions::new()`.
- Updated `RunSettings::resolve` to read `max_recursion_depth` from CLI first, then environment options, then fallback default.

This keeps the existing precedence (`--max-recursion-depth` overrides env) while consolidating env parsing in `EnvironmentOptions`.

## Testing

- `cargo fmt --all`
- `cargo check -p uv -p uv-cli -p uv-settings`
- `cargo test -p uv --test it detect_infinite_recursion`
