### PR TITLE
Prefer hardlinks over reflinks for Mach-O executables to reduce security scanning overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6540,6 +6540,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-shell",
  "uv-trampoline-builder",
+ "uv-unix",
  "uv-warnings",
  "walkdir",
 ]
@@ -7271,7 +7272,9 @@ dependencies = [
 name = "uv-unix"
 version = "0.0.32"
 dependencies = [
+ "goblin",
  "nix 0.31.2",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,6 +7272,7 @@ dependencies = [
 name = "uv-unix"
 version = "0.0.32"
 dependencies = [
+ "fs-err",
  "goblin",
  "nix 0.31.2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ goblin = { version = "0.10.0", default-features = false, features = [
   "std",
   "elf32",
   "elf64",
+  "mach64",
   "endian_fd",
 ] }
 h2 = { version = "0.4.7" }

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -140,6 +140,11 @@ pub struct LinkOptions<'a, F = fn(&Path) -> bool> {
     copy_locks: Option<&'a CopyLocks>,
     /// What to do when the destination directory already exists.
     on_existing_directory: OnExistingDirectory,
+    /// Predicate that returns `true` for source files that prefer their inode to be preserved.
+    ///
+    /// When in [`LinkMode::Clone`] mode, files matching this predicate will be hard-linked
+    /// instead of reflinked (copy-on-write).
+    wants_preserved_inode: Option<fn(&Path) -> bool>,
 }
 
 impl LinkOptions<'static> {
@@ -150,6 +155,7 @@ impl LinkOptions<'static> {
             needs_mutable_copy: |_| false,
             copy_locks: None,
             on_existing_directory: OnExistingDirectory::default(),
+            wants_preserved_inode: None,
         }
     }
 }
@@ -174,6 +180,7 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: f,
             copy_locks: self.copy_locks,
             on_existing_directory: self.on_existing_directory,
+            wants_preserved_inode: self.wants_preserved_inode,
         }
     }
 
@@ -188,6 +195,7 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: self.needs_mutable_copy,
             copy_locks: Some(locks),
             on_existing_directory: self.on_existing_directory,
+            wants_preserved_inode: self.wants_preserved_inode,
         }
     }
 
@@ -199,6 +207,25 @@ impl<'a, F> LinkOptions<'a, F> {
             needs_mutable_copy: self.needs_mutable_copy,
             copy_locks: self.copy_locks,
             on_existing_directory,
+            wants_preserved_inode: self.wants_preserved_inode,
+        }
+    }
+
+    /// Set a predicate for files that prefer their inode to be preserved when linking.
+    ///
+    /// This does not guarantee preservation of the inode.
+    ///
+    /// When in [`LinkMode::Clone`] mode, files matching this predicate will be hard-linked
+    /// rather than reflinked (copy-on-write). This keeps the destination sharing the same
+    /// inode as the source.
+    #[must_use]
+    pub fn with_wants_preserved_inode_filter(self, f: fn(&Path) -> bool) -> Self {
+        LinkOptions {
+            mode: self.mode,
+            needs_mutable_copy: self.needs_mutable_copy,
+            copy_locks: self.copy_locks,
+            on_existing_directory: self.on_existing_directory,
+            wants_preserved_inode: Some(f),
         }
     }
 
@@ -213,6 +240,13 @@ impl<'a, F> LinkOptions<'a, F> {
             fs_err::copy(from, to)?;
             Ok(())
         }
+    }
+
+    /// Returns `true` if `path` matches the [`wants_preserved_inode`](Self::wants_preserved_inode)
+    /// predicate.
+    fn wants_preserved_inode(&self, path: &Path) -> bool {
+        self.wants_preserved_inode
+            .is_some_and(|predicate| predicate(path))
     }
 }
 
@@ -457,6 +491,10 @@ fn reflink_with_permissions(from: &Path, to: &Path) -> io::Result<()> {
 }
 
 /// Attempt to reflink a single file, falling back via [`link_file`] on failure.
+///
+/// If a [`wants_preserved_inode`](LinkOptions::wants_preserved_inode) predicate is set and the source file
+/// matches, the file is hard-linked instead of reflinked so the destination shares the
+/// original inode. On macOS this avoids cold-start code-signature re-validation.
 fn reflink_file_with_fallback<F>(
     path: &Path,
     target: &Path,
@@ -466,6 +504,12 @@ fn reflink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
+    // Hardlink files that need their inode preserved (e.g. Mach-O executables on macOS),
+    // reusing the existing hardlink machinery with its fallback and retry logic.
+    if options.wants_preserved_inode(path) {
+        return hardlink_file_with_fallback(path, target, state, options);
+    }
+
     match state.attempt {
         LinkAttempt::Initial => match reflink_with_permissions(path, target) {
             Ok(()) => Ok(state.mode_working()),
@@ -571,12 +615,11 @@ where
 }
 
 /// Clone a directory by merging into an existing destination.
+///
+/// If a [`wants_preserved_inode`](LinkOptions::wants_preserved_inode) filter is set, matching files are
+/// hard-linked instead of reflinked so they keep the source inode.
 #[cfg(target_os = "macos")]
-fn clone_dir_merge<F>(
-    src: &Path,
-    dst: &Path,
-    _options: &LinkOptions<'_, F>,
-) -> Result<(), LinkError>
+fn clone_dir_merge<F>(src: &Path, dst: &Path, options: &LinkOptions<'_, F>) -> Result<(), LinkError>
 where
     F: Fn(&Path) -> bool,
 {
@@ -590,7 +633,7 @@ where
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                    clone_dir_merge(&src_path, &dst_path, _options)?;
+                    clone_dir_merge(&src_path, &dst_path, options)?;
                 }
                 Err(err) => {
                     return Err(LinkError::Reflink {
@@ -601,7 +644,15 @@ where
                 }
             }
         } else {
-            // Try to clone the file
+            // Hardlink files that need their inode preserved, reusing the
+            // existing hardlink machinery.
+            if options.wants_preserved_inode(&src_path) {
+                let state = LinkState::new(LinkMode::Hardlink);
+                link_file(&src_path, &dst_path, state, options)?;
+                continue;
+            }
+
+            // For remaining files, use reflink (copy-on-write)
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
@@ -1992,5 +2043,125 @@ mod tests {
             "Expected Hardlink or Copy fallback, got {result:?}"
         );
         verify_test_tree(dst_dir.path());
+    }
+
+    #[cfg(unix)]
+    mod wants_preserved_inode_tests {
+        use super::*;
+        use std::os::unix::fs::MetadataExt;
+
+        /// Simple extension-based predicate for testing the plumbing.
+        fn is_so_file(path: &Path) -> bool {
+            path.extension().is_some_and(|ext| ext == "so")
+        }
+
+        #[test]
+        fn test_clone_hardlinks_matching_files() {
+            let Some(src_dir) = cow_tempdir() else {
+                eprintln!("Skipping: UV_INTERNAL__TEST_COW_FS not set");
+                return;
+            };
+            let Some(dst_dir) = cow_tempdir() else {
+                unreachable!();
+            };
+
+            fs_err::create_dir_all(src_dir.path().join("pkg")).unwrap();
+            fs_err::write(src_dir.path().join("pkg/native.so"), "native code").unwrap();
+            fs_err::write(src_dir.path().join("pkg/module.py"), "print('hello')").unwrap();
+
+            // Pre-create destination so merge is triggered
+            fs_err::create_dir_all(dst_dir.path().join("pkg")).unwrap();
+            fs_err::write(dst_dir.path().join("pkg/.gitkeep"), "").unwrap();
+
+            let options = LinkOptions::new(LinkMode::Clone)
+                .with_wants_preserved_inode_filter(is_so_file)
+                .with_on_existing_directory(OnExistingDirectory::Merge);
+            let result = link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
+            assert_eq!(result, LinkMode::Clone);
+
+            // .so matched the predicate → hardlinked (same inode)
+            let src_ino = fs_err::metadata(src_dir.path().join("pkg/native.so"))
+                .unwrap()
+                .ino();
+            let dst_ino = fs_err::metadata(dst_dir.path().join("pkg/native.so"))
+                .unwrap()
+                .ino();
+            assert_eq!(src_ino, dst_ino, ".so should share inode (hardlinked)");
+
+            // .py did NOT match → reflinked (different inode)
+            let src_py_ino = fs_err::metadata(src_dir.path().join("pkg/module.py"))
+                .unwrap()
+                .ino();
+            let dst_py_ino = fs_err::metadata(dst_dir.path().join("pkg/module.py"))
+                .unwrap()
+                .ino();
+            assert_ne!(
+                src_py_ino, dst_py_ino,
+                ".py should have different inode (reflinked)"
+            );
+        }
+
+        #[test]
+        fn test_clone_without_filter_reflinks_everything() {
+            let Some(src_dir) = cow_tempdir() else {
+                eprintln!("Skipping: UV_INTERNAL__TEST_COW_FS not set");
+                return;
+            };
+            let Some(dst_dir) = cow_tempdir() else {
+                unreachable!();
+            };
+
+            fs_err::create_dir_all(src_dir.path().join("pkg")).unwrap();
+            fs_err::write(src_dir.path().join("pkg/native.so"), "native code").unwrap();
+
+            fs_err::create_dir_all(dst_dir.path().join("pkg")).unwrap();
+            fs_err::write(dst_dir.path().join("pkg/.gitkeep"), "").unwrap();
+
+            // No filter → everything reflinked
+            let options = LinkOptions::new(LinkMode::Clone)
+                .with_on_existing_directory(OnExistingDirectory::Merge);
+            link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
+
+            let src_ino = fs_err::metadata(src_dir.path().join("pkg/native.so"))
+                .unwrap()
+                .ino();
+            let dst_ino = fs_err::metadata(dst_dir.path().join("pkg/native.so"))
+                .unwrap()
+                .ino();
+            assert_ne!(
+                src_ino, dst_ino,
+                ".so should be reflinked when no filter is set"
+            );
+        }
+
+        #[test]
+        fn test_walk_and_link_honours_filter() {
+            let Some(src_dir) = cow_tempdir() else {
+                eprintln!("Skipping: UV_INTERNAL__TEST_COW_FS not set");
+                return;
+            };
+            let Some(dst_dir) = cow_tempdir() else {
+                unreachable!();
+            };
+
+            fs_err::write(src_dir.path().join("lib.so"), "native").unwrap();
+            fs_err::write(src_dir.path().join("data.txt"), "data").unwrap();
+
+            // Pre-create destination to force merge
+            fs_err::write(dst_dir.path().join(".gitkeep"), "").unwrap();
+
+            let options = LinkOptions::new(LinkMode::Clone)
+                .with_wants_preserved_inode_filter(is_so_file)
+                .with_on_existing_directory(OnExistingDirectory::Merge);
+            link_dir(src_dir.path(), dst_dir.path(), &options).unwrap();
+
+            let src_ino = fs_err::metadata(src_dir.path().join("lib.so"))
+                .unwrap()
+                .ino();
+            let dst_ino = fs_err::metadata(dst_dir.path().join("lib.so"))
+                .unwrap()
+                .ino();
+            assert_eq!(src_ino, dst_ino, ".so should share inode (hardlinked)");
+        }
     }
 }

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -222,11 +222,8 @@ impl<'a, F> LinkOptions<'a, F> {
     #[must_use]
     pub fn with_wants_preserved_inode_filter(self, f: fn(&Path) -> bool) -> Self {
         LinkOptions {
-            mode: self.mode,
-            needs_mutable_copy: self.needs_mutable_copy,
-            copy_locks: self.copy_locks,
-            on_existing_directory: self.on_existing_directory,
             wants_preserved_inode: Some(f),
+            ..self
         }
     }
 

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -644,8 +644,7 @@ where
                 }
             }
         } else {
-            // Hardlink files that need their inode preserved, reusing the
-            // existing hardlink machinery.
+            // Hardlink files that want their inode preserved
             if options.wants_preserved_inode(&src_path) {
                 let state = LinkState::new(LinkMode::Hardlink);
                 link_file(&src_path, &dst_path, state, options)?;

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -213,7 +213,8 @@ impl<'a, F> LinkOptions<'a, F> {
 
     /// Set a predicate for files that prefer their inode to be preserved when linking.
     ///
-    /// This does not guarantee preservation of the inode.
+    /// This does not guarantee preservation of the inode, e.g., a copy fallback may still
+    /// occur for files on different file systems.
     ///
     /// When in [`LinkMode::Clone`] mode, files matching this predicate will be hard-linked
     /// rather than reflinked (copy-on-write). This keeps the destination sharing the same

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -652,7 +652,6 @@ where
                 continue;
             }
 
-            // For remaining files, use reflink (copy-on-write)
             match reflink_copy::reflink(&src_path, &dst_path) {
                 Ok(()) => {}
                 Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {

--- a/crates/uv-fs/src/link.rs
+++ b/crates/uv-fs/src/link.rs
@@ -494,7 +494,7 @@ fn reflink_with_permissions(from: &Path, to: &Path) -> io::Result<()> {
 ///
 /// If a [`wants_preserved_inode`](LinkOptions::wants_preserved_inode) predicate is set and the source file
 /// matches, the file is hard-linked instead of reflinked so the destination shares the
-/// original inode. On macOS this avoids cold-start code-signature re-validation.
+/// original inode.
 fn reflink_file_with_fallback<F>(
     path: &Path,
     target: &Path,
@@ -504,8 +504,7 @@ fn reflink_file_with_fallback<F>(
 where
     F: Fn(&Path) -> bool,
 {
-    // Hardlink files that need their inode preserved (e.g. Mach-O executables on macOS),
-    // reusing the existing hardlink machinery with its fallback and retry logic.
+    // Hardlink files that need their inode preserved
     if options.wants_preserved_inode(path) {
         return hardlink_file_with_fallback(path, target, state, options);
     }

--- a/crates/uv-install-wheel/Cargo.toml
+++ b/crates/uv-install-wheel/Cargo.toml
@@ -47,6 +47,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+uv-unix = { workspace = true }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 same-file = { workspace = true }
 self-replace = { workspace = true }

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -265,10 +265,19 @@ pub fn link_wheel_files(
 
     // The `RECORD` file is modified during installation, so it needs a real
     // copy rather than a link back to the cache.
-    let options = LinkOptions::new(link_mode)
+    let mut options = LinkOptions::new(link_mode)
         .with_mutable_copy_filter(|p: &Path| p.ends_with("RECORD"))
         .with_copy_locks(state.copy_locks())
         .with_on_existing_directory(OnExistingDirectory::Merge);
+
+    // On macOS, hardlink Mach-O executables instead of reflinking to preserve the inode.
+    // Code-signature verification is cached per-inode; reflinking creates a new inode and
+    // forces expensive re-validation on first execution.
+    #[cfg(target_os = "macos")]
+    {
+        options = options.with_wants_preserved_inode_filter(wants_preserved_inode);
+    }
+
     let used_link_mode = link_dir(wheel, site_packages, &options)?;
 
     if used_link_mode == LinkMode::Clone {
@@ -322,4 +331,20 @@ fn register_installed_paths(
         }
     }
     Ok(count)
+}
+
+/// Check if a file should be hardlinked to preserve its inode when cloning on macOS.
+///
+/// Skips known non-executable extensions (`.py`, `.pyc`, etc.) to avoid opening every file,
+/// then falls through to Mach-O magic-byte detection for the rest.
+#[cfg(target_os = "macos")]
+fn wants_preserved_inode(path: &std::path::Path) -> bool {
+    // Fast-reject extensions that are never Mach-O.
+    if let Some(ext) = path.extension() {
+        if ext == "py" || ext == "pyc" || ext == "pyo" || ext == "pyd" || ext == "a" || ext == "pth"
+        {
+            return false;
+        }
+    }
+    uv_unix::macho::is_macos_executable(path)
 }

--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -265,7 +265,7 @@ pub fn link_wheel_files(
 
     // The `RECORD` file is modified during installation, so it needs a real
     // copy rather than a link back to the cache.
-    let mut options = LinkOptions::new(link_mode)
+    let options = LinkOptions::new(link_mode)
         .with_mutable_copy_filter(|p: &Path| p.ends_with("RECORD"))
         .with_copy_locks(state.copy_locks())
         .with_on_existing_directory(OnExistingDirectory::Merge);
@@ -274,9 +274,7 @@ pub fn link_wheel_files(
     // Code-signature verification is cached per-inode; reflinking creates a new inode and
     // forces expensive re-validation on first execution.
     #[cfg(target_os = "macos")]
-    {
-        options = options.with_wants_preserved_inode_filter(wants_preserved_inode);
-    }
+    let options = options.with_wants_preserved_inode_filter(wants_preserved_inode);
 
     let used_link_mode = link_dir(wheel, site_packages, &options)?;
 

--- a/crates/uv-unix/Cargo.toml
+++ b/crates/uv-unix/Cargo.toml
@@ -16,5 +16,9 @@ doctest = false
 workspace = true
 
 [target.'cfg(unix)'.dependencies]
+goblin = { workspace = true }
 nix = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(unix)'.dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/uv-unix/Cargo.toml
+++ b/crates/uv-unix/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [target.'cfg(unix)'.dependencies]
+fs-err = { workspace = true }
 goblin = { workspace = true }
 nix = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/uv-unix/src/lib.rs
+++ b/crates/uv-unix/src/lib.rs
@@ -4,6 +4,9 @@
 
 #![cfg(unix)]
 
+#[cfg(target_os = "macos")]
+pub mod macho;
+
 mod resource_limits;
 
 pub use resource_limits::{OpenFileLimitError, adjust_open_file_limit};

--- a/crates/uv-unix/src/macho.rs
+++ b/crates/uv-unix/src/macho.rs
@@ -1,0 +1,81 @@
+//! Mach-O executable detection for macOS.
+
+use std::path::Path;
+
+use goblin::mach::{fat, header};
+
+/// Mach-O and universal-binary magic numbers, as big-endian byte arrays for direct comparison
+/// against the first four bytes of a file.
+const MACH_O_MAGICS: [[u8; 4]; 6] = [
+    (header::MH_MAGIC).to_be_bytes(),
+    (header::MH_CIGAM).to_be_bytes(),
+    (header::MH_MAGIC_64).to_be_bytes(),
+    (header::MH_CIGAM_64).to_be_bytes(),
+    (fat::FAT_MAGIC).to_be_bytes(),
+    (fat::FAT_CIGAM).to_be_bytes(),
+];
+
+/// Check if a file is a Mach-O executable by reading its magic bytes.
+pub fn is_macos_executable(path: &Path) -> bool {
+    use std::io::Read;
+
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+
+    let mut buf = [0u8; 4];
+    if file.read_exact(&mut buf).is_err() {
+        return false;
+    }
+
+    MACH_O_MAGICS.contains(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn create_file(dir: &TempDir, name: &str, content: &[u8]) -> PathBuf {
+        let path = dir.path().join(name);
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_by_magic_bytes() {
+        let dir = TempDir::new().unwrap();
+
+        // All six magic variants
+        for (i, magic) in MACH_O_MAGICS.iter().enumerate() {
+            let name = format!("bin_{i}");
+            assert!(
+                is_macos_executable(&create_file(&dir, &name, magic)),
+                "MACH_O_MAGICS[{i}] should be detected"
+            );
+        }
+
+        // Non-Mach-O
+        assert!(!is_macos_executable(&create_file(
+            &dir,
+            "random",
+            b"\x00\x01\x02\x03more"
+        )));
+        assert!(!is_macos_executable(&create_file(&dir, "empty", b"")));
+        assert!(!is_macos_executable(&create_file(
+            &dir,
+            "short",
+            b"\xCF\xFA"
+        )));
+    }
+
+    #[test]
+    fn test_nonexistent_file() {
+        assert!(!is_macos_executable(&PathBuf::from(
+            "/nonexistent/path/to/file"
+        )));
+    }
+}

--- a/crates/uv-unix/src/macho.rs
+++ b/crates/uv-unix/src/macho.rs
@@ -19,7 +19,7 @@ const MACH_O_MAGICS: [[u8; 4]; 6] = [
 pub fn is_macos_executable(path: &Path) -> bool {
     use std::io::Read;
 
-    let Ok(mut file) = std::fs::File::open(path) else {
+    let Ok(mut file) = fs_err::File::open(path) else {
         return false;
     };
 


### PR DESCRIPTION
Closes #17371

On macOS, we now attempt to preserve inodes by hardlinking instead of reflinking Mach-O binary files so that security scanning does not need to be performed again. It seems unlikely someone will manually edit a binary file and CoW semantics seem less important for these files.