### PR TITLE
fix: disable permission preservation in untar_zst_file

### DIFF
--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -714,6 +714,7 @@ pub fn untar_zst_file<R: std::io::Read>(reader: R, target: impl AsRef<Path>) -> 
     let decompressed = zstd::Decoder::new(reader).map_err(Error::Io)?;
     let mut archive = tar::Archive::new(decompressed);
     archive.set_preserve_mtime(false);
+    archive.set_preserve_permissions(false);
     archive.unpack(target).map_err(Error::io_or_compression)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

All async tar extraction paths (`untar_zst`, `untar_xz`, `untar_gz`) set `set_preserve_permissions(false)` via the `tokio_tar::ArchiveBuilder`, but the sync `untar_zst_file` function does not.

On Unix the `tar` crate defaults to preserving archive permissions, so a `.whl.zst` archive with unexpected permission bits (setuid, world-writable, etc.) would carry those through to the extracted files. Adding the missing call matches the behavior of the async paths.

## Test Plan

One-line addition. `cargo test -p uv-extract` and `cargo clippy -p uv-extract` pass.