### PR TITLE
Use `--only-group` for documentation run command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,7 +269,7 @@ To preview any changes to the documentation locally:
 3. Run the development server with:
 
    ```shell
-   uv run --group docs mkdocs serve -f mkdocs.yml
+   uv run --only-group docs mkdocs serve -f mkdocs.yml
    ```
 
 The documentation should then be available locally at


### PR DESCRIPTION
Otherwise, we build uv from source which is not desirable.