### PR TITLE
Add minimal clarifying install-python.md note

### DIFF
--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -31,7 +31,7 @@ version to your `PATH`:
 $ python3.13
 ```
 
-uv only installs a _versioned_ executable by default. To install `python` and `python3` executables,
+uv only installs a _versioned_ executable by default. To install `python` and `python3` executables in your path,
 include the experimental `--default` option:
 
 ```console


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add a couple words to clarify that the Python or Python3 executable is meant to be that easily usable version of Python as found in your path variable. 

When getting started on a fresh machine the existing wording didn't make it obvious to me what it meant to have a Python executable considering I thought it was just a convenient alias. I tried to add the shortest useful description I could to keep it inline with the existing documentation here. 

## Test Plan

It adds a couple words in the English documentation and would have been enough to help me understand what was meant by Python and Python3 executables.
