### PR TITLE
fix: complete executable names instead of all files in zsh shell completions

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1403,7 +1403,12 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             anyhow::bail!(message);
         }
         Commands::GenerateShellCompletion(args) => {
-            args.shell.generate(&mut Cli::command(), &mut stdout());
+            let mut cmd = Cli::command();
+            // For `uv run`, `uv tool run`, and `uv tool uvx`, disable external subcommand
+            // completion so that the zsh completer suggests executable command names
+            // (`_command_names -e`) instead of all files (`_default`).
+            patch_command_completions(&mut cmd);
+            args.shell.generate(&mut cmd, &mut stdout());
             Ok(ExitStatus::Success)
         }
         Commands::Tool(ToolNamespace {
@@ -1436,6 +1441,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                         uvx = uvx.arg(arg);
                     }
                 }
+                patch_command_completions(&mut uvx);
                 shell.generate(&mut uvx, &mut stdout());
                 return Ok(ExitStatus::Success);
             }
@@ -2763,6 +2769,7 @@ where
         runtime.shutdown_background();
         result
     };
+
     let result = std::thread::Builder::new()
         .name("main2".to_owned())
         .stack_size(min_stack_size)
@@ -2787,4 +2794,39 @@ where
             ExitStatus::Error.into()
         }
     }
+}
+
+/// Modify a [`clap::Command`] tree so that subcommands which accept external commands
+/// (i.e. `uv run`, `uv tool run`, `uv tool uvx`) complete executable names instead of
+/// all files. This is only used when generating shell completion scripts.
+fn patch_command_completions(cmd: &mut clap::Command) {
+    let arg = clap::Arg::new("command")
+        .num_args(1..)
+        .trailing_var_arg(true)
+        .value_hint(clap::ValueHint::CommandName);
+
+    // Patch `run` subcommand directly on `cmd`.
+    if let Some(run_cmd) = cmd.find_subcommand_mut("run") {
+        *run_cmd = replace_external_subcommands(run_cmd, arg.clone());
+    }
+
+    // Patch `tool run` and `tool uvx`.
+    if let Some(tool_cmd) = cmd.find_subcommand_mut("tool") {
+        for name in &["run", "uvx"] {
+            if let Some(sub) = tool_cmd.find_subcommand_mut(name) {
+                *sub = replace_external_subcommands(sub, arg.clone());
+            }
+        }
+    }
+}
+
+/// Replace the external subcommand on a command with a positional arg.
+///
+/// Clears both the `allow_external_subcommands` flag and the `external_value_parser`
+/// (which would otherwise re-enable the flag during `build()`).
+fn replace_external_subcommands(cmd: &mut clap::Command, arg: clap::Arg) -> clap::Command {
+    cmd.clone()
+        .allow_external_subcommands(false)
+        .external_subcommand_value_parser(None::<clap::builder::ValueParser>)
+        .arg(arg)
 }

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -1097,6 +1097,36 @@ fn help_with_version() {
     ");
 }
 
+/// Ensure `uv run` completions suggest executable names, not all files.
+///
+/// See: <https://github.com/astral-sh/uv/issues/18549>
+#[test]
+fn zsh_completion_run_no_file_completions() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    let output = context
+        .command()
+        .arg("generate-shell-completion")
+        .arg("zsh")
+        .output()
+        .expect("failed to run generate-shell-completion");
+
+    let stdout = String::from_utf8(output.stdout).expect("invalid utf8");
+
+    // The zsh completion script should NOT contain `_default` for external subcommands,
+    // which would complete all files instead of just executable commands.
+    assert!(
+        !stdout.contains("external_command:_default"),
+        "zsh completions should not use _default for external subcommand completion"
+    );
+
+    // It should use `_command_names -e` to complete executable names.
+    assert!(
+        stdout.contains("_command_names -e"),
+        "zsh completions should use _command_names for run subcommands"
+    );
+}
+
 #[test]
 fn help_with_no_pager() {
     let context = uv_test::test_context_with_versions!(&[]);


### PR DESCRIPTION
## Summary

Fixes #18549

`uv run <tab>` in zsh completes all files instead of executable command names. The root cause is that clap_complete's zsh generator hardcodes `"*::external_command:_default"` when `allow_external_subcommands` is set. The `_default` zsh function completes all files, but `uv run` should only suggest executable commands.

This patch modifies the `Command` tree *before* generating completion scripts so that `run`, `tool run`, and `tool uvx` subcommands use a positional arg with `ValueHint::CommandName` instead of external subcommands. This makes the zsh generator emit `_command_names -e` (executables only) instead of `_default` (all files).

The fix only affects completion script generation, not runtime argument parsing.

## Test Plan

Added an integration test `zsh_completion_run_no_file_completions` that:
- Verifies the zsh completion output does **not** contain `external_command:_default`
- Verifies the output **does** contain `_command_names -e`

```
cargo test -p uv --test it -- zsh_completion_run_no_file_completions
```