### PR TITLE
docs: clarify that --exclude may be provided multiple times

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2544,6 +2544,8 @@ pub struct PipFreezeArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
+    ///
+    /// May be provided multiple times.
     #[arg(long)]
     pub r#exclude: Vec<PackageName>,
 
@@ -2615,6 +2617,8 @@ pub struct PipListArgs {
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.
+    ///
+    /// May be provided multiple times.
     #[arg(long, value_hint = ValueHint::Other)]
     pub r#exclude: Vec<PackageName>,
 


### PR DESCRIPTION
Fixes #18429. Clarified in the docs that the --exclude flag in uv pip freeze and uv pip list accepts multiple values, matching the existing documentation style.