### PR TITLE
Disable deployment on environment use

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -137,6 +137,7 @@ jobs:
       attestations: write # for GHCR attestations
     environment:
       name: ${{ needs.docker-plan.outputs.push-version == 'true' && 'release' || (needs.docker-plan.outputs.push == 'true' && 'release-test' || '') }}
+      deployment: false
     outputs:
       image-tags: ${{ steps.meta.outputs.tags }}
       image-annotations: ${{ steps.meta.outputs.annotations }}
@@ -228,6 +229,7 @@ jobs:
     timeout-minutes: 5
     environment:
       name: ${{ needs.docker-plan.outputs.push-version == 'true' && 'release' || (needs.docker-plan.outputs.push == 'true' && 'release-test' || '') }}
+      deployment: false
     needs:
       - docker-plan
       - docker-publish-base
@@ -403,6 +405,7 @@ jobs:
       attestations: write # for GHCR attestations
     environment:
       name: ${{ needs.docker-plan.outputs.push-version == 'true' && 'release' || (needs.docker-plan.outputs.push == 'true' && 'release-test' || '') }}
+      deployment: false
     needs:
       - docker-plan
       - docker-publish-base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,9 @@ jobs:
     runs-on: ubuntu-latest
     # Only the main repository is a trusted publisher
     if: ${{ github.repository == 'astral-sh/uv' && github.event.pull_request.head.repo.fork != true && needs.plan.outputs.test-publish == 'true' }}
-    environment: uv-test-publish
+    environment:
+      name: uv-test-publish
+      deployment: false
     env:
       # No dbus in GitHub Actions
       PYTHON_KEYRING_BACKEND: keyrings.alt.file.PlaintextKeyring

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
+      deployment: false
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-mirror.yml
+++ b/.github/workflows/publish-mirror.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
+      deployment: false
     env:
       VERSION: ${{ fromJson(inputs.plan).announcement_tag }}
     steps:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
+      deployment: false
     permissions:
       id-token: write # For PyPI's trusted publishing
     steps:
@@ -35,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: release
+      deployment: false
     permissions:
       id-token: write # For PyPI's trusted publishing
     steps:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -907,7 +907,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.fork != true }}
-    environment: uv-test-registries
+    environment:
+      name: uv-test-registries
+      deployment: false
     env:
       PYTHON_VERSION: 3.12
     steps:


### PR DESCRIPTION
See https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/#github-actions-now-allows-developers-to-use-environments-without-auto-deployment