### PR TITLE
Add parallel discovery of Python versions for `uv python list`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6939,6 +6939,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "owo-colors",
+ "rayon",
  "ref-cast",
  "regex",
  "reqwest",

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -67,6 +67,7 @@ tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 url = { workspace = true }
 which = { workspace = true }
+rayon = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-registry = { workspace = true }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1,4 +1,5 @@
 use itertools::{Either, Itertools};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use regex::Regex;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use same_file::is_same_file;
@@ -738,6 +739,49 @@ fn find_all_minor(
     }
 }
 
+/// Check whether an installation satisfies the standard post-query discovery filters.
+///
+/// This checks environment preference, version compatibility, and Python preference. It is
+/// shared by both [`python_installations`] (sequential) and [`find_all_python_installations`]
+/// (parallel) to ensure consistent filtering behavior.
+fn satisfies_discovery_filters(
+    installation: &PythonInstallation,
+    version: &VersionRequest,
+    environments: EnvironmentPreference,
+    preference: PythonPreference,
+) -> bool {
+    if !interpreter_satisfies_environment_preference(
+        installation.source,
+        &installation.interpreter,
+        environments,
+    ) {
+        return false;
+    }
+    let request = version.clone().into_request_for_source(installation.source);
+    if !request.matches_interpreter(&installation.interpreter) {
+        debug!(
+            "Skipping interpreter at `{}` from {}: does not satisfy request `{request}`",
+            installation.interpreter.sys_executable().user_display(),
+            installation.source,
+        );
+        return false;
+    }
+    if !preference.allows_installation(installation) {
+        return false;
+    }
+    true
+}
+
+/// In test mode, change the source to `Managed` if a version was marked as such via
+/// `TestContext::with_versions_as_managed`.
+fn fixup_managed_source_for_tests(installation: &mut PythonInstallation) {
+    if std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED).is_ok()
+        && installation.interpreter.is_managed()
+    {
+        installation.source = PythonSource::Managed;
+    }
+}
+
 /// Lazily iterate over all discoverable Python interpreters.
 ///
 /// Note interpreters may be excluded by the given [`EnvironmentPreference`], [`PythonPreference`],
@@ -755,10 +799,10 @@ fn python_installations<'a>(
     preference: PythonPreference,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    let installations = python_installations_from_executables(
+    python_installations_from_executables(
         // Perform filtering on the discovered executables based on their source. This avoids
         // unnecessary interpreter queries, which are generally expensive. We'll filter again
-        // with `interpreter_satisfies_environment_preference` after querying.
+        // with `satisfies_discovery_filters` after querying.
         python_executables(version, implementation, platform, environments, preference).filter_ok(
             move |(source, path)| {
                 source_satisfies_environment_preference(*source, path, environments)
@@ -767,39 +811,37 @@ fn python_installations<'a>(
         cache,
     )
     .filter_ok(move |installation| {
-        interpreter_satisfies_environment_preference(
-            installation.source,
-            &installation.interpreter,
-            environments,
-        )
+        satisfies_discovery_filters(installation, version, environments, preference)
     })
-    .filter_ok(move |installation| {
-        let request = version.clone().into_request_for_source(installation.source);
-        if request.matches_interpreter(&installation.interpreter) {
-            true
-        } else {
-            debug!(
-                "Skipping interpreter at `{}` from {}: does not satisfy request `{request}`",
-                installation.interpreter.sys_executable().user_display(),
-                installation.source,
-            );
-            false
-        }
+    .map_ok(|mut installation| {
+        fixup_managed_source_for_tests(&mut installation);
+        installation
     })
-    .filter_ok(move |installation| preference.allows_installation(installation));
+}
 
-    if std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED).is_ok() {
-        Either::Left(installations.map_ok(|mut installation| {
-            // In test mode, change the source to `Managed` if a version was marked as such via
-            // `TestContext::with_versions_as_managed`.
-            if installation.interpreter.is_managed() {
-                installation.source = PythonSource::Managed;
-            }
-            installation
-        }))
-    } else {
-        Either::Right(installations)
-    }
+/// Query a single Python executable, returning a [`PythonInstallation`] on success.
+///
+/// This is the shared core used by both [`python_installations_from_executables`] (sequential)
+/// and [`python_installations_from_executables_parallel`] (concurrent).
+fn query_executable(
+    source: PythonSource,
+    path: PathBuf,
+    cache: &Cache,
+) -> Result<PythonInstallation, Error> {
+    Interpreter::query(&path, cache)
+        .map(|interpreter| PythonInstallation {
+            source,
+            interpreter,
+        })
+        .inspect(|installation| {
+            debug!(
+                "Found `{}` at `{}` ({source})",
+                installation.key(),
+                path.display()
+            );
+        })
+        .map_err(|err| Error::Query(Box::new(err), path, source))
+        .inspect_err(|err| debug!("{err}"))
 }
 
 /// Lazily convert Python executables into installations.
@@ -807,23 +849,70 @@ fn python_installations_from_executables<'a>(
     executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    executables.map(|result| match result {
-        Ok((source, path)) => Interpreter::query(&path, cache)
-            .map(|interpreter| PythonInstallation {
-                source,
-                interpreter,
-            })
-            .inspect(|installation| {
-                debug!(
-                    "Found `{}` at `{}` ({source})",
-                    installation.key(),
-                    path.display()
-                );
-            })
-            .map_err(|err| Error::Query(Box::new(err), path, source))
-            .inspect_err(|err| debug!("{err}")),
+    executables.map(move |result| match result {
+        Ok((source, path)) => query_executable(source, path, cache),
         Err(err) => Err(err),
     })
+}
+
+/// Collect Python executables and query them concurrently, returning results in the
+/// original discovery order.
+fn python_installations_from_executables_parallel(
+    executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
+    cache: &Cache,
+) -> Vec<Result<PythonInstallation, Error>> {
+    let items: Vec<Result<(PythonSource, PathBuf), Error>> = executables.collect();
+    items
+        .into_par_iter()
+        .map(|result| match result {
+            Ok((source, path)) => query_executable(source, path, cache),
+            Err(err) => Err(err),
+        })
+        .collect()
+}
+
+/// Collect queried Python installations, dropping non-critical discovery errors.
+fn collect_parallel_installations_from_executables(
+    executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
+    cache: &Cache,
+) -> Result<Vec<PythonInstallation>, Error> {
+    let results = python_installations_from_executables_parallel(executables, cache);
+    let mut installations = Vec::with_capacity(results.len());
+    for result in results {
+        match result {
+            Ok(installation) => installations.push(installation),
+            Err(err) if err.is_critical() => return Err(err),
+            Err(_) => {}
+        }
+    }
+    Ok(installations)
+}
+
+/// Find Python installations that satisfy the standard discovery filters, querying
+/// interpreters concurrently.
+fn find_filtered_python_installations_parallel(
+    version: &VersionRequest,
+    implementation: Option<&ImplementationName>,
+    platform: PlatformRequest,
+    environments: EnvironmentPreference,
+    preference: PythonPreference,
+    cache: &Cache,
+) -> Result<Vec<PythonInstallation>, Error> {
+    let executables =
+        python_executables(version, implementation, platform, environments, preference).filter_ok(
+            move |(source, path)| {
+                source_satisfies_environment_preference(*source, path, environments)
+            },
+        );
+
+    let mut installations = collect_parallel_installations_from_executables(executables, cache)?;
+    installations.retain(|installation| {
+        satisfies_discovery_filters(installation, version, environments, preference)
+    });
+    for installation in &mut installations {
+        fixup_managed_source_for_tests(installation);
+    }
+    Ok(installations)
 }
 
 /// Whether a [`Interpreter`] matches the [`EnvironmentPreference`].
@@ -1015,17 +1104,21 @@ fn python_installation_from_directory(
     python_installation_from_executable(&executable, cache)
 }
 
+/// Lazily iterate over all Python executable paths on the path with the given executable name.
+fn python_executables_with_executable_name(
+    name: &str,
+) -> impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + '_ {
+    which_all(name)
+        .into_iter()
+        .flat_map(|inner| inner.map(|path| Ok((PythonSource::SearchPath, path))))
+}
+
 /// Lazily iterate over all Python installations on the path with the given executable name.
 fn python_installations_with_executable_name<'a>(
     name: &'a str,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    python_installations_from_executables(
-        which_all(name)
-            .into_iter()
-            .flat_map(|inner| inner.map(|path| Ok((PythonSource::SearchPath, path)))),
-        cache,
-    )
+    python_installations_from_executables(python_executables_with_executable_name(name), cache)
 }
 
 /// Iterate over all Python installations that satisfy the given request.
@@ -1212,6 +1305,171 @@ pub fn find_python_installations<'a>(
                 })
                 .map_ok(Ok)
             })
+        }
+    }
+}
+
+/// Find all Python installations that satisfy the given request, querying interpreters
+/// concurrently.
+///
+/// Unlike [`find_python_installations`], this eagerly collects matching installations instead of
+/// returning a lazy iterator. Non-critical discovery errors are dropped, while critical errors are
+/// propagated immediately.
+pub fn find_all_python_installations(
+    request: &PythonRequest,
+    environments: EnvironmentPreference,
+    preference: PythonPreference,
+    cache: &Cache,
+) -> Result<Vec<PythonInstallation>, Error> {
+    let sources = DiscoveryPreferences {
+        python_preference: preference,
+        environment_preference: environments,
+    }
+    .sources(request);
+
+    match request {
+        PythonRequest::File(path) => {
+            if !preference.allows_source(PythonSource::ProvidedPath) {
+                return Err(Error::SourceNotAllowed(
+                    request.clone(),
+                    PythonSource::ProvidedPath,
+                    preference,
+                ));
+            }
+            debug!("Checking for Python interpreter at {request}");
+            match python_installation_from_executable(path, cache) {
+                Ok(installation) => Ok(vec![installation]),
+                Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => Ok(vec![]),
+                Err(err) => Err(Error::Query(
+                    Box::new(err),
+                    path.clone(),
+                    PythonSource::ProvidedPath,
+                )),
+            }
+        }
+        PythonRequest::Directory(path) => {
+            if !preference.allows_source(PythonSource::ProvidedPath) {
+                return Err(Error::SourceNotAllowed(
+                    request.clone(),
+                    PythonSource::ProvidedPath,
+                    preference,
+                ));
+            }
+            debug!("Checking for Python interpreter in {request}");
+            match python_installation_from_directory(path, cache) {
+                Ok(installation) => Ok(vec![installation]),
+                Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => Ok(vec![]),
+                Err(err) => Err(Error::Query(
+                    Box::new(err),
+                    path.clone(),
+                    PythonSource::ProvidedPath,
+                )),
+            }
+        }
+        PythonRequest::ExecutableName(name) => {
+            if !preference.allows_source(PythonSource::SearchPath) {
+                return Err(Error::SourceNotAllowed(
+                    request.clone(),
+                    PythonSource::SearchPath,
+                    preference,
+                ));
+            }
+            debug!("Searching for Python interpreter with {request}");
+            let mut installations = collect_parallel_installations_from_executables(
+                python_executables_with_executable_name(name),
+                cache,
+            )?;
+            installations.retain(|installation| {
+                interpreter_satisfies_environment_preference(
+                    installation.source,
+                    &installation.interpreter,
+                    environments,
+                )
+            });
+            Ok(installations)
+        }
+        PythonRequest::Any => {
+            debug!("Searching for any Python interpreter in {sources}");
+            find_filtered_python_installations_parallel(
+                &VersionRequest::Any,
+                None,
+                PlatformRequest::default(),
+                environments,
+                preference,
+                cache,
+            )
+        }
+        PythonRequest::Default => {
+            debug!("Searching for default Python interpreter in {sources}");
+            find_filtered_python_installations_parallel(
+                &VersionRequest::Default,
+                None,
+                PlatformRequest::default(),
+                environments,
+                preference,
+                cache,
+            )
+        }
+        PythonRequest::Version(version) => {
+            if let Err(err) = version.check_supported() {
+                return Err(Error::InvalidVersionRequest(err));
+            }
+            debug!("Searching for {request} in {sources}");
+            find_filtered_python_installations_parallel(
+                version,
+                None,
+                PlatformRequest::default(),
+                environments,
+                preference,
+                cache,
+            )
+        }
+        PythonRequest::Implementation(implementation) => {
+            debug!("Searching for a {request} interpreter in {sources}");
+            let mut installations = find_filtered_python_installations_parallel(
+                &VersionRequest::Default,
+                Some(implementation),
+                PlatformRequest::default(),
+                environments,
+                preference,
+                cache,
+            )?;
+            installations.retain(|inst| implementation.matches_interpreter(&inst.interpreter));
+            Ok(installations)
+        }
+        PythonRequest::ImplementationVersion(implementation, version) => {
+            if let Err(err) = version.check_supported() {
+                return Err(Error::InvalidVersionRequest(err));
+            }
+            debug!("Searching for {request} in {sources}");
+            let mut installations = find_filtered_python_installations_parallel(
+                version,
+                Some(implementation),
+                PlatformRequest::default(),
+                environments,
+                preference,
+                cache,
+            )?;
+            installations.retain(|inst| implementation.matches_interpreter(&inst.interpreter));
+            Ok(installations)
+        }
+        PythonRequest::Key(request) => {
+            if let Some(version) = request.version() {
+                if let Err(err) = version.check_supported() {
+                    return Err(Error::InvalidVersionRequest(err));
+                }
+            }
+            debug!("Searching for {request} in {sources}");
+            let mut installations = find_filtered_python_installations_parallel(
+                request.version().unwrap_or(&VersionRequest::Default),
+                request.implementation(),
+                request.platform(),
+                environments,
+                preference,
+                cache,
+            )?;
+            installations.retain(|inst| request.satisfied_by_interpreter(&inst.interpreter));
+            Ok(installations)
         }
     }
 }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -740,10 +740,6 @@ fn find_all_minor(
 }
 
 /// Check whether an installation satisfies the standard post-query discovery filters.
-///
-/// This checks environment preference, version compatibility, and Python preference. It is
-/// shared by both [`python_installations`] (sequential) and [`find_all_python_installations`]
-/// (parallel) to ensure consistent filtering behavior.
 fn satisfies_discovery_filters(
     installation: &PythonInstallation,
     version: &VersionRequest,
@@ -774,7 +770,7 @@ fn satisfies_discovery_filters(
 
 /// In test mode, change the source to `Managed` if a version was marked as such via
 /// `TestContext::with_versions_as_managed`.
-fn fixup_managed_source_for_tests(installation: &mut PythonInstallation) {
+fn update_installation_source_for_tests(installation: &mut PythonInstallation) {
     if std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED).is_ok()
         && installation.interpreter.is_managed()
     {
@@ -799,7 +795,7 @@ fn python_installations<'a>(
     preference: PythonPreference,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    python_installations_from_executables(
+    iter_python_installations_from_executables(
         // Perform filtering on the discovered executables based on their source. This avoids
         // unnecessary interpreter queries, which are generally expensive. We'll filter again
         // with `satisfies_discovery_filters` after querying.
@@ -814,16 +810,13 @@ fn python_installations<'a>(
         satisfies_discovery_filters(installation, version, environments, preference)
     })
     .map_ok(|mut installation| {
-        fixup_managed_source_for_tests(&mut installation);
+        update_installation_source_for_tests(&mut installation);
         installation
     })
 }
 
 /// Query a single Python executable, returning a [`PythonInstallation`] on success.
-///
-/// This is the shared core used by both [`python_installations_from_executables`] (sequential)
-/// and [`python_installations_from_executables_parallel`] (concurrent).
-fn query_executable(
+fn python_installation_from_executable(
     source: PythonSource,
     path: PathBuf,
     cache: &Cache,
@@ -845,38 +838,31 @@ fn query_executable(
 }
 
 /// Lazily convert Python executables into installations.
-fn python_installations_from_executables<'a>(
+fn iter_python_installations_from_executables<'a>(
     executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
     executables.map(move |result| match result {
-        Ok((source, path)) => query_executable(source, path, cache),
+        Ok((source, path)) => python_installation_from_executable(source, path, cache),
         Err(err) => Err(err),
     })
 }
 
-/// Collect Python executables and query them concurrently, returning results in the
-/// original discovery order.
-fn python_installations_from_executables_parallel(
-    executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
-    cache: &Cache,
-) -> Vec<Result<PythonInstallation, Error>> {
-    let items: Vec<Result<(PythonSource, PathBuf), Error>> = executables.collect();
-    items
-        .into_par_iter()
-        .map(|result| match result {
-            Ok((source, path)) => query_executable(source, path, cache),
-            Err(err) => Err(err),
-        })
-        .collect()
-}
-
-/// Collect queried Python installations, dropping non-critical discovery errors.
-fn collect_parallel_installations_from_executables(
+/// Collect queried Python installations from executables, dropping non-critical discovery
+/// errors.
+fn collect_python_installations_from_executables(
     executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
     cache: &Cache,
 ) -> Result<Vec<PythonInstallation>, Error> {
-    let results = python_installations_from_executables_parallel(executables, cache);
+    let items: Vec<Result<(PythonSource, PathBuf), Error>> = executables.collect();
+    let results: Vec<Result<PythonInstallation, Error>> = items
+        .into_par_iter()
+        .map(|result| match result {
+            Ok((source, path)) => python_installation_from_executable(source, path, cache),
+            Err(err) => Err(err),
+        })
+        .collect();
+
     let mut installations = Vec::with_capacity(results.len());
     for result in results {
         match result {
@@ -890,7 +876,7 @@ fn collect_parallel_installations_from_executables(
 
 /// Find Python installations that satisfy the standard discovery filters, querying
 /// interpreters concurrently.
-fn find_filtered_python_installations_parallel(
+fn find_matching_python_installations(
     version: &VersionRequest,
     implementation: Option<&ImplementationName>,
     platform: PlatformRequest,
@@ -905,12 +891,12 @@ fn find_filtered_python_installations_parallel(
             },
         );
 
-    let mut installations = collect_parallel_installations_from_executables(executables, cache)?;
+    let mut installations = collect_python_installations_from_executables(executables, cache)?;
     installations.retain(|installation| {
         satisfies_discovery_filters(installation, version, environments, preference)
     });
     for installation in &mut installations {
-        fixup_managed_source_for_tests(installation);
+        update_installation_source_for_tests(installation);
     }
     Ok(installations)
 }
@@ -1085,7 +1071,7 @@ impl Error {
 }
 
 /// Create a [`PythonInstallation`] from a Python interpreter path.
-fn python_installation_from_executable(
+fn python_installation_from_provided_executable(
     path: &PathBuf,
     cache: &Cache,
 ) -> Result<PythonInstallation, crate::interpreter::Error> {
@@ -1101,11 +1087,11 @@ fn python_installation_from_directory(
     cache: &Cache,
 ) -> Result<PythonInstallation, crate::interpreter::Error> {
     let executable = virtualenv_python_executable(path);
-    python_installation_from_executable(&executable, cache)
+    python_installation_from_provided_executable(&executable, cache)
 }
 
 /// Lazily iterate over all Python executable paths on the path with the given executable name.
-fn python_executables_with_executable_name(
+fn python_executables_with_name(
     name: &str,
 ) -> impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + '_ {
     which_all(name)
@@ -1114,11 +1100,11 @@ fn python_executables_with_executable_name(
 }
 
 /// Lazily iterate over all Python installations on the path with the given executable name.
-fn python_installations_with_executable_name<'a>(
+fn python_installations_with_name<'a>(
     name: &'a str,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
-    python_installations_from_executables(python_executables_with_executable_name(name), cache)
+    iter_python_installations_from_executables(python_executables_with_name(name), cache)
 }
 
 /// Iterate over all Python installations that satisfy the given request.
@@ -1138,7 +1124,7 @@ pub fn find_python_installations<'a>(
         PythonRequest::File(path) => Box::new(iter::once({
             if preference.allows_source(PythonSource::ProvidedPath) {
                 debug!("Checking for Python interpreter at {request}");
-                match python_installation_from_executable(path, cache) {
+                match python_installation_from_provided_executable(path, cache) {
                     Ok(installation) => Ok(Ok(installation)),
                     Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => {
                         Ok(Err(PythonNotFound {
@@ -1191,7 +1177,7 @@ pub fn find_python_installations<'a>(
             if preference.allows_source(PythonSource::SearchPath) {
                 debug!("Searching for Python interpreter with {request}");
                 Box::new(
-                    python_installations_with_executable_name(name, cache)
+                    python_installations_with_name(name, cache)
                         .filter_ok(move |installation| {
                             interpreter_satisfies_environment_preference(
                                 installation.source,
@@ -1337,7 +1323,7 @@ pub fn find_all_python_installations(
                 ));
             }
             debug!("Checking for Python interpreter at {request}");
-            match python_installation_from_executable(path, cache) {
+            match python_installation_from_provided_executable(path, cache) {
                 Ok(installation) => Ok(vec![installation]),
                 Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => Ok(vec![]),
                 Err(err) => Err(Error::Query(
@@ -1375,8 +1361,8 @@ pub fn find_all_python_installations(
                 ));
             }
             debug!("Searching for Python interpreter with {request}");
-            let mut installations = collect_parallel_installations_from_executables(
-                python_executables_with_executable_name(name),
+            let mut installations = collect_python_installations_from_executables(
+                python_executables_with_name(name),
                 cache,
             )?;
             installations.retain(|installation| {
@@ -1390,7 +1376,7 @@ pub fn find_all_python_installations(
         }
         PythonRequest::Any => {
             debug!("Searching for any Python interpreter in {sources}");
-            find_filtered_python_installations_parallel(
+            find_matching_python_installations(
                 &VersionRequest::Any,
                 None,
                 PlatformRequest::default(),
@@ -1401,7 +1387,7 @@ pub fn find_all_python_installations(
         }
         PythonRequest::Default => {
             debug!("Searching for default Python interpreter in {sources}");
-            find_filtered_python_installations_parallel(
+            find_matching_python_installations(
                 &VersionRequest::Default,
                 None,
                 PlatformRequest::default(),
@@ -1415,7 +1401,7 @@ pub fn find_all_python_installations(
                 return Err(Error::InvalidVersionRequest(err));
             }
             debug!("Searching for {request} in {sources}");
-            find_filtered_python_installations_parallel(
+            find_matching_python_installations(
                 version,
                 None,
                 PlatformRequest::default(),
@@ -1426,7 +1412,7 @@ pub fn find_all_python_installations(
         }
         PythonRequest::Implementation(implementation) => {
             debug!("Searching for a {request} interpreter in {sources}");
-            let mut installations = find_filtered_python_installations_parallel(
+            let mut installations = find_matching_python_installations(
                 &VersionRequest::Default,
                 Some(implementation),
                 PlatformRequest::default(),
@@ -1442,7 +1428,7 @@ pub fn find_all_python_installations(
                 return Err(Error::InvalidVersionRequest(err));
             }
             debug!("Searching for {request} in {sources}");
-            let mut installations = find_filtered_python_installations_parallel(
+            let mut installations = find_matching_python_installations(
                 version,
                 Some(implementation),
                 PlatformRequest::default(),
@@ -1460,7 +1446,7 @@ pub fn find_all_python_installations(
                 }
             }
             debug!("Searching for {request} in {sources}");
-            let mut installations = find_filtered_python_installations_parallel(
+            let mut installations = find_matching_python_installations(
                 request.version().unwrap_or(&VersionRequest::Default),
                 request.implementation(),
                 request.platform(),

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -559,7 +559,7 @@ fn python_executables<'a>(
 
     // Limit the search to the relevant environment preference; this avoids unnecessary work like
     // traversal of the file system. Subsequent filtering should be done by the caller with
-    // `source_satisfies_environment_preference` and `interpreter_satisfies_environment_preference`.
+    // `source_satisfies_environment_preference` and `EnvironmentPreference::allows_installation`.
     match environments {
         EnvironmentPreference::OnlyVirtual => {
             Box::new(from_parent_interpreter.chain(from_virtual_environments))
@@ -739,45 +739,6 @@ fn find_all_minor(
     }
 }
 
-/// Check whether an installation satisfies the standard post-query discovery filters.
-fn satisfies_discovery_filters(
-    installation: &PythonInstallation,
-    version: &VersionRequest,
-    environments: EnvironmentPreference,
-    preference: PythonPreference,
-) -> bool {
-    if !interpreter_satisfies_environment_preference(
-        installation.source,
-        &installation.interpreter,
-        environments,
-    ) {
-        return false;
-    }
-    let request = version.clone().into_request_for_source(installation.source);
-    if !request.matches_interpreter(&installation.interpreter) {
-        debug!(
-            "Skipping interpreter at `{}` from {}: does not satisfy request `{request}`",
-            installation.interpreter.sys_executable().user_display(),
-            installation.source,
-        );
-        return false;
-    }
-    if !preference.allows_installation(installation) {
-        return false;
-    }
-    true
-}
-
-/// In test mode, change the source to `Managed` if a version was marked as such via
-/// `TestContext::with_versions_as_managed`.
-fn update_installation_source_for_tests(installation: &mut PythonInstallation) {
-    if std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED).is_ok()
-        && installation.interpreter.is_managed()
-    {
-        installation.source = PythonSource::Managed;
-    }
-}
-
 /// Lazily iterate over all discoverable Python interpreters.
 ///
 /// Note interpreters may be excluded by the given [`EnvironmentPreference`], [`PythonPreference`],
@@ -798,7 +759,7 @@ fn python_installations<'a>(
     iter_python_installations_from_executables(
         // Perform filtering on the discovered executables based on their source. This avoids
         // unnecessary interpreter queries, which are generally expensive. We'll filter again
-        // with `satisfies_discovery_filters` after querying.
+        // with `PythonInstallation::satisfies_preferences` after querying.
         python_executables(version, implementation, platform, environments, preference).filter_ok(
             move |(source, path)| {
                 source_satisfies_environment_preference(*source, path, environments)
@@ -807,12 +768,9 @@ fn python_installations<'a>(
         cache,
     )
     .filter_ok(move |installation| {
-        satisfies_discovery_filters(installation, version, environments, preference)
+        installation.satisfies_preferences(version, environments, preference)
     })
-    .map_ok(|mut installation| {
-        update_installation_source_for_tests(&mut installation);
-        installation
-    })
+    .map_ok(PythonInstallation::maybe_with_test_source)
 }
 
 /// Query a single Python executable, returning a [`PythonInstallation`] on success.
@@ -850,6 +808,8 @@ fn iter_python_installations_from_executables<'a>(
 
 /// Collect queried Python installations from executables, dropping non-critical discovery
 /// errors.
+///
+/// See [`iter_python_installations_from_executables`] for a lazy, sequential alternative.
 fn collect_python_installations_from_executables(
     executables: impl Iterator<Item = Result<(PythonSource, PathBuf), Error>>,
     cache: &Cache,
@@ -874,9 +834,9 @@ fn collect_python_installations_from_executables(
     Ok(installations)
 }
 
-/// Find Python installations that satisfy the standard discovery filters, querying
+/// Find all Python installations that satisfy the standard discovery filters, querying
 /// interpreters concurrently.
-fn find_matching_python_installations(
+fn find_all_matching_python_installations(
     version: &VersionRequest,
     implementation: Option<&ImplementationName>,
     platform: PlatformRequest,
@@ -893,11 +853,12 @@ fn find_matching_python_installations(
 
     let mut installations = collect_python_installations_from_executables(executables, cache)?;
     installations.retain(|installation| {
-        satisfies_discovery_filters(installation, version, environments, preference)
+        installation.satisfies_preferences(version, environments, preference)
     });
-    for installation in &mut installations {
-        update_installation_source_for_tests(installation);
-    }
+    let installations = installations
+        .into_iter()
+        .map(PythonInstallation::maybe_with_test_source)
+        .collect();
     Ok(installations)
 }
 
@@ -958,7 +919,7 @@ fn interpreter_satisfies_environment_preference(
 
 /// Returns true if a [`PythonSource`] could satisfy the [`EnvironmentPreference`].
 ///
-/// This is useful as a pre-filtering step. Use of [`interpreter_satisfies_environment_preference`]
+/// This is useful as a pre-filtering step. Use of [`EnvironmentPreference::allows_installation`]
 /// is required to determine if an [`Interpreter`] satisfies the preference.
 ///
 /// The interpreter path is only used for debug messages.
@@ -1070,24 +1031,16 @@ impl Error {
     }
 }
 
-/// Create a [`PythonInstallation`] from a Python interpreter path.
-fn python_installation_from_provided_executable(
-    path: &PathBuf,
-    cache: &Cache,
-) -> Result<PythonInstallation, crate::interpreter::Error> {
-    Ok(PythonInstallation {
-        source: PythonSource::ProvidedPath,
-        interpreter: Interpreter::query(path, cache)?,
-    })
-}
-
 /// Create a [`PythonInstallation`] from a Python installation root directory.
 fn python_installation_from_directory(
     path: &PathBuf,
     cache: &Cache,
 ) -> Result<PythonInstallation, crate::interpreter::Error> {
     let executable = virtualenv_python_executable(path);
-    python_installation_from_provided_executable(&executable, cache)
+    Ok(PythonInstallation {
+        source: PythonSource::ProvidedPath,
+        interpreter: Interpreter::query(&executable, cache)?,
+    })
 }
 
 /// Lazily iterate over all Python executable paths on the path with the given executable name.
@@ -1124,8 +1077,11 @@ pub fn find_python_installations<'a>(
         PythonRequest::File(path) => Box::new(iter::once({
             if preference.allows_source(PythonSource::ProvidedPath) {
                 debug!("Checking for Python interpreter at {request}");
-                match python_installation_from_provided_executable(path, cache) {
-                    Ok(installation) => Ok(Ok(installation)),
+                match Interpreter::query(path, cache) {
+                    Ok(interpreter) => Ok(Ok(PythonInstallation {
+                        source: PythonSource::ProvidedPath,
+                        interpreter,
+                    })),
                     Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => {
                         Ok(Err(PythonNotFound {
                             request: request.clone(),
@@ -1179,11 +1135,7 @@ pub fn find_python_installations<'a>(
                 Box::new(
                     python_installations_with_name(name, cache)
                         .filter_ok(move |installation| {
-                            interpreter_satisfies_environment_preference(
-                                installation.source,
-                                &installation.interpreter,
-                                environments,
-                            )
+                            environments.allows_installation(installation)
                         })
                         .map_ok(Ok),
                 )
@@ -1315,16 +1267,13 @@ pub fn find_all_python_installations(
 
     match request {
         PythonRequest::File(path) => {
-            if !preference.allows_source(PythonSource::ProvidedPath) {
-                return Err(Error::SourceNotAllowed(
-                    request.clone(),
-                    PythonSource::ProvidedPath,
-                    preference,
-                ));
-            }
+            preference.check_allows_request_source(request, PythonSource::ProvidedPath)?;
             debug!("Checking for Python interpreter at {request}");
-            match python_installation_from_provided_executable(path, cache) {
-                Ok(installation) => Ok(vec![installation]),
+            match Interpreter::query(path, cache) {
+                Ok(interpreter) => Ok(vec![PythonInstallation {
+                    source: PythonSource::ProvidedPath,
+                    interpreter,
+                }]),
                 Err(InterpreterError::NotFound(_) | InterpreterError::BrokenLink(_)) => Ok(vec![]),
                 Err(err) => Err(Error::Query(
                     Box::new(err),
@@ -1334,13 +1283,7 @@ pub fn find_all_python_installations(
             }
         }
         PythonRequest::Directory(path) => {
-            if !preference.allows_source(PythonSource::ProvidedPath) {
-                return Err(Error::SourceNotAllowed(
-                    request.clone(),
-                    PythonSource::ProvidedPath,
-                    preference,
-                ));
-            }
+            preference.check_allows_request_source(request, PythonSource::ProvidedPath)?;
             debug!("Checking for Python interpreter in {request}");
             match python_installation_from_directory(path, cache) {
                 Ok(installation) => Ok(vec![installation]),
@@ -1353,30 +1296,18 @@ pub fn find_all_python_installations(
             }
         }
         PythonRequest::ExecutableName(name) => {
-            if !preference.allows_source(PythonSource::SearchPath) {
-                return Err(Error::SourceNotAllowed(
-                    request.clone(),
-                    PythonSource::SearchPath,
-                    preference,
-                ));
-            }
+            preference.check_allows_request_source(request, PythonSource::SearchPath)?;
             debug!("Searching for Python interpreter with {request}");
             let mut installations = collect_python_installations_from_executables(
                 python_executables_with_name(name),
                 cache,
             )?;
-            installations.retain(|installation| {
-                interpreter_satisfies_environment_preference(
-                    installation.source,
-                    &installation.interpreter,
-                    environments,
-                )
-            });
+            installations.retain(|installation| environments.allows_installation(installation));
             Ok(installations)
         }
         PythonRequest::Any => {
             debug!("Searching for any Python interpreter in {sources}");
-            find_matching_python_installations(
+            find_all_matching_python_installations(
                 &VersionRequest::Any,
                 None,
                 PlatformRequest::default(),
@@ -1387,7 +1318,7 @@ pub fn find_all_python_installations(
         }
         PythonRequest::Default => {
             debug!("Searching for default Python interpreter in {sources}");
-            find_matching_python_installations(
+            find_all_matching_python_installations(
                 &VersionRequest::Default,
                 None,
                 PlatformRequest::default(),
@@ -1401,7 +1332,7 @@ pub fn find_all_python_installations(
                 return Err(Error::InvalidVersionRequest(err));
             }
             debug!("Searching for {request} in {sources}");
-            find_matching_python_installations(
+            find_all_matching_python_installations(
                 version,
                 None,
                 PlatformRequest::default(),
@@ -1412,7 +1343,7 @@ pub fn find_all_python_installations(
         }
         PythonRequest::Implementation(implementation) => {
             debug!("Searching for a {request} interpreter in {sources}");
-            let mut installations = find_matching_python_installations(
+            let mut installations = find_all_matching_python_installations(
                 &VersionRequest::Default,
                 Some(implementation),
                 PlatformRequest::default(),
@@ -1428,7 +1359,7 @@ pub fn find_all_python_installations(
                 return Err(Error::InvalidVersionRequest(err));
             }
             debug!("Searching for {request} in {sources}");
-            let mut installations = find_matching_python_installations(
+            let mut installations = find_all_matching_python_installations(
                 version,
                 Some(implementation),
                 PlatformRequest::default(),
@@ -1446,7 +1377,7 @@ pub fn find_all_python_installations(
                 }
             }
             debug!("Searching for {request} in {sources}");
-            let mut installations = find_matching_python_installations(
+            let mut installations = find_all_matching_python_installations(
                 request.version().unwrap_or(&VersionRequest::Default),
                 request.implementation(),
                 request.platform(),
@@ -2597,6 +2528,19 @@ impl PythonPreference {
         }
     }
 
+    /// Check that this preference allows the given source, returning an error if not.
+    fn check_allows_request_source(
+        self,
+        request: &PythonRequest,
+        source: PythonSource,
+    ) -> Result<(), Error> {
+        if self.allows_source(source) {
+            Ok(())
+        } else {
+            Err(Error::SourceNotAllowed(request.clone(), source, self))
+        }
+    }
+
     pub(crate) fn allows_managed(self) -> bool {
         match self {
             Self::OnlySystem => false,
@@ -2708,6 +2652,19 @@ impl EnvironmentPreference {
             // For immutable operations, we allow discovery of the system environment
             (false, false) => Self::Any,
         }
+    }
+
+    /// Returns `true` if the given installation is allowed by this preference.
+    ///
+    /// In contrast, [`source_satisfies_environment_preference`] only checks if a
+    /// [`PythonSource`] **could** satisfy the preference as a pre-filtering step. We cannot
+    /// definitively know if a Python interpreter is in a virtual environment until we query it.
+    pub(crate) fn allows_installation(self, installation: &PythonInstallation) -> bool {
+        interpreter_satisfies_environment_preference(
+            installation.source,
+            &installation.interpreter,
+            self,
+        )
     }
 }
 
@@ -3137,6 +3094,13 @@ impl VersionRequest {
             },
             _ => self,
         }
+    }
+
+    /// Check if an installation matches the request, adjusting the request for the installation's
+    /// source.
+    pub(crate) fn matches_installation(&self, installation: &PythonInstallation) -> bool {
+        let request = self.clone().into_request_for_source(installation.source);
+        request.matches_interpreter(&installation.interpreter)
     }
 
     /// Check if a interpreter matches the request.

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use ref_cast::RefCast;
 use reqwest_retry::policies::ExponentialBackoff;
 use tracing::{debug, info};
+use uv_fs::Simplified;
 use uv_warnings::warn_user;
 
 use uv_cache::Cache;
@@ -15,7 +16,8 @@ use uv_pep440::{Prerelease, Version};
 use uv_platform::{Arch, Libc, Os, Platform};
 
 use crate::discovery::{
-    EnvironmentPreference, PythonRequest, find_best_python_installation, find_python_installation,
+    EnvironmentPreference, PythonRequest, VersionRequest, find_best_python_installation,
+    find_python_installation,
 };
 use crate::downloads::{
     DownloadResult, ManagedPythonDownload, ManagedPythonDownloadList, PythonDownloadRequest,
@@ -43,6 +45,50 @@ impl PythonInstallation {
             source,
             interpreter,
         }
+    }
+
+    /// Return a new installation with the given [`PythonSource`].
+    #[must_use]
+    pub(crate) fn with_source(self, source: PythonSource) -> Self {
+        Self { source, ..self }
+    }
+
+    /// In test mode, change the source to [`PythonSource::Managed`] if the interpreter was
+    /// marked as managed via `TestContext::with_versions_as_managed`.
+    #[must_use]
+    pub(crate) fn maybe_with_test_source(self) -> Self {
+        if std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_PYTHON_MANAGED).is_ok()
+            && self.interpreter.is_managed()
+        {
+            self.with_source(PythonSource::Managed)
+        } else {
+            self
+        }
+    }
+
+    /// Check whether this installation satisfies the standard post-query discovery filters:
+    /// environment preference, version request, and Python preference.
+    pub(crate) fn satisfies_preferences(
+        &self,
+        version: &VersionRequest,
+        environments: EnvironmentPreference,
+        preference: PythonPreference,
+    ) -> bool {
+        if !environments.allows_installation(self) {
+            return false;
+        }
+        if !version.matches_installation(self) {
+            debug!(
+                "Skipping interpreter at `{}` from {}: does not satisfy request `{version}`",
+                self.interpreter.sys_executable().user_display(),
+                self.source,
+            );
+            return false;
+        }
+        if !preference.allows_installation(self) {
+            return false;
+        }
+        true
     }
 
     /// Find an installed [`PythonInstallation`].

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -7,7 +7,7 @@ use uv_static::EnvVars;
 pub use crate::discovery::{
     EnvironmentPreference, Error as DiscoveryError, PythonDownloads, PythonNotFound,
     PythonPreference, PythonRequest, PythonSource, PythonVariant, VersionRequest,
-    find_python_installations,
+    find_all_python_installations, find_python_installations,
 };
 pub use crate::downloads::PlatformRequest;
 pub use crate::environment::{InvalidEnvironmentKind, PythonEnvironment};

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -15,8 +15,8 @@ use uv_python::downloads::{
     Error as PythonDownloadError, ManagedPythonDownloadList, PythonDownloadRequest,
 };
 use uv_python::{
-    DiscoveryError, EnvironmentPreference, PythonDownloads, PythonInstallation, PythonNotFound,
-    PythonPreference, PythonRequest, PythonSource, find_python_installations,
+    EnvironmentPreference, PythonDownloads, PythonPreference, PythonRequest, PythonSource,
+    find_all_python_installations,
 };
 
 use crate::commands::ExitStatus;
@@ -137,40 +137,31 @@ pub(crate) async fn list(
         }
     }
 
-    let installed =
-        match kinds {
-            PythonListKinds::Installed | PythonListKinds::Default => {
-                // While usually [`PythonPreference::OnlyManaged`] means we can skip searching the `PATH`,
-                // in `uv python list` we want to enumerate links to managed Python interpreters for inspection.
-                // Consequently, we widen the preference here and perform post-filtering.
-                let discovery_preference = if python_preference == PythonPreference::OnlyManaged {
-                    PythonPreference::Managed
-                } else {
-                    python_preference
-                };
-                Some(find_python_installations(
+    let installed = match kinds {
+        PythonListKinds::Installed | PythonListKinds::Default => {
+            // While usually [`PythonPreference::OnlyManaged`] means we can skip searching the
+            // `PATH`, in `uv python list` we want to enumerate links to managed Python
+            // interpreters for inspection. Consequently, we widen the preference here and
+            // perform post-filtering.
+            let discovery_preference = if python_preference == PythonPreference::OnlyManaged {
+                PythonPreference::Managed
+            } else {
+                python_preference
+            };
+            let mut installations = find_all_python_installations(
                 request.as_ref().unwrap_or(&PythonRequest::Any),
                 EnvironmentPreference::OnlySystem,
                 discovery_preference,
                 cache,
-            )
-            // Raise discovery errors if critical
-            .filter(|result| {
-                result
-                    .as_ref()
-                    .err()
-                    .is_none_or(DiscoveryError::is_critical)
-            })
-            .collect::<Result<Vec<Result<PythonInstallation, PythonNotFound>>, DiscoveryError>>()?
-            .into_iter()
-            // Drop any "missing" installations
-            .filter_map(Result::ok)
-            // Apply the `PythonPreference` to discovered interpreters, since we may have
-            // expanded it above
-            .filter(|installation| python_preference.allows_installation(installation)))
-            }
-            PythonListKinds::Downloads => None,
-        };
+            )?;
+            // Apply the original `PythonPreference` to discovered interpreters, since we may
+            // have expanded it above.
+            installations
+                .retain(|installation| python_preference.allows_installation(installation));
+            Some(installations)
+        }
+        PythonListKinds::Downloads => None,
+    };
 
     if let Some(installed) = installed {
         for installation in installed {


### PR DESCRIPTION
Currently, Python discovery happens sequentially — which is good most of the time because uv will lazily exit once it finds a satisfactory version. However, in `uv python list`, uv needs to query all interpreters on the system which makes sequential discovery quite slow.

Here, we add parallelization to discovery. Annoyingly, it means a fair amount of code repetition, but I've done my best to minimize that.

In the long-term, we may want to consolidate these code paths such that uv can do prefetching during normal discovery, since technically if the interpreter we want is far down the PATH then laziness does not save us anything.

```
Benchmark 1: main
  Time (mean ± σ):      3.108 s ±  0.026 s    [User: 2.290 s, System: 0.386 s]
  Range (min … max):    3.072 s …  3.157 s    8 runs

Benchmark 2: branch
  Time (mean ± σ):     414.1 ms ±  11.1 ms    [User: 2955.2 ms, System: 743.7 ms]
  Range (min … max):   398.1 ms … 429.5 ms    8 runs

Summary
  branch ran
    7.51 ± 0.21 times faster than main
```
