### PR TITLE
Add missing `riscv64gc-unknown-linux-musl` entry to `dist-workspace`

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -30,6 +30,7 @@ targets = [
     "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
     "riscv64gc-unknown-linux-gnu",
+    "riscv64gc-unknown-linux-musl",
     "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",


### PR DESCRIPTION
This looks omitted from https://github.com/astral-sh/uv/pull/18228 and I noticed a warning from the new release step  from https://github.com/astral-sh/uv/pull/18625