### PR TITLE
Discover versioned Python executables when `requires-python` pins a version

### DIFF
--- a/crates/uv-distribution-types/src/requires_python.rs
+++ b/crates/uv-distribution-types/src/requires_python.rs
@@ -279,6 +279,11 @@ impl RequiresPython {
         &self.specifiers
     }
 
+    /// Consumes `self` and returns the [`VersionSpecifiers`] for the `Requires-Python` specifier.
+    pub fn into_specifiers(self) -> VersionSpecifiers {
+        self.specifiers
+    }
+
     /// Returns `true` if the `Requires-Python` specifier is unbounded.
     pub fn is_unbounded(&self) -> bool {
         self.range.lower().as_ref() == Bound::Unbounded

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -2641,8 +2641,7 @@ impl VersionRequest {
     /// Create a [`VersionRequest`] from [`VersionSpecifiers`].
     ///
     /// If the specifiers consist of a single `==` constraint, the version is parsed as a
-    /// concrete version request (e.g., `MajorMinorPatch`) rather than a range. This ensures that
-    /// version-specific executable names (like `python3.12`) are included during discovery.
+    /// concrete version request (e.g., `MajorMinorPatch`) rather than a range.
     pub fn from_specifiers(specifiers: VersionSpecifiers, variant: PythonVariant) -> Self {
         if let [specifier] = specifiers.iter().as_slice() {
             if specifier.operator() == &uv_pep440::Operator::Equal {

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1753,6 +1753,19 @@ impl PythonVariant {
     }
 }
 impl PythonRequest {
+    /// Create a request from a `Requires-Python` constraint.
+    pub fn from_requires_python(requires_python: RequiresPython) -> Option<Self> {
+        let specifiers = requires_python.into_specifiers();
+        if specifiers.is_empty() {
+            return None;
+        }
+
+        Some(Self::Version(VersionRequest::from_specifiers(
+            specifiers,
+            PythonVariant::Default,
+        )))
+    }
+
     /// Create a request from a string.
     ///
     /// This cannot fail, which means weird inputs will be parsed as [`PythonRequest::File`] or
@@ -2625,6 +2638,22 @@ impl fmt::Display for ExecutableName {
 }
 
 impl VersionRequest {
+    /// Create a [`VersionRequest`] from [`VersionSpecifiers`].
+    ///
+    /// If the specifiers consist of a single `==` constraint, the version is parsed as a
+    /// concrete version request (e.g., `MajorMinorPatch`) rather than a range. This ensures that
+    /// version-specific executable names (like `python3.12`) are included during discovery.
+    pub fn from_specifiers(specifiers: VersionSpecifiers, variant: PythonVariant) -> Self {
+        if let [specifier] = specifiers.iter().as_slice() {
+            if specifier.operator() == &uv_pep440::Operator::Equal {
+                if let Ok(request) = Self::from_str(&specifier.version().to_string()) {
+                    return request;
+                }
+            }
+        }
+        Self::Range(specifiers, variant)
+    }
+
     /// Drop any patch or prerelease information from the version request.
     #[must_use]
     pub fn only_minor(self) -> Self {
@@ -3328,12 +3357,7 @@ fn parse_version_specifiers_request(
     if specifiers.is_empty() {
         return Err(Error::InvalidVersionRequest(s.to_string()));
     }
-    if let [specifier] = specifiers.iter().as_slice() {
-        if specifier.operator() == &uv_pep440::Operator::Equal {
-            return VersionRequest::from_str(&specifier.version().to_string());
-        }
-    }
-    Ok(VersionRequest::Range(specifiers, variant))
+    Ok(VersionRequest::from_specifiers(specifiers, variant))
 }
 
 impl From<&PythonVersion> for VersionRequest {
@@ -4140,6 +4164,71 @@ mod tests {
             VersionRequest::from_str("3.13tt"),
             Err(Error::InvalidVersionRequest(_))
         ));
+
+        // `==` specifiers are parsed as concrete version requests via `from_specifiers`
+        assert_eq!(
+            VersionRequest::from_str("==3.12").unwrap(),
+            VersionRequest::MajorMinor(3, 12, PythonVariant::Default)
+        );
+        assert_eq!(
+            VersionRequest::from_str("==3.12.1").unwrap(),
+            VersionRequest::MajorMinorPatch(3, 12, 1, PythonVariant::Default)
+        );
+    }
+
+    #[test]
+    fn version_request_from_specifiers() {
+        // A single `==` specifier is parsed as a concrete version request
+        assert_eq!(
+            VersionRequest::from_specifiers(
+                VersionSpecifiers::from_str("==3.12").unwrap(),
+                PythonVariant::Default
+            ),
+            VersionRequest::MajorMinor(3, 12, PythonVariant::Default)
+        );
+        assert_eq!(
+            VersionRequest::from_specifiers(
+                VersionSpecifiers::from_str("==3.12.1").unwrap(),
+                PythonVariant::Default
+            ),
+            VersionRequest::MajorMinorPatch(3, 12, 1, PythonVariant::Default)
+        );
+
+        // Wildcard `==` specifiers remain as ranges
+        assert_eq!(
+            VersionRequest::from_specifiers(
+                VersionSpecifiers::from_str("==3.12.*").unwrap(),
+                PythonVariant::Default
+            ),
+            VersionRequest::Range(
+                VersionSpecifiers::from_str("==3.12.*").unwrap(),
+                PythonVariant::Default
+            )
+        );
+
+        // Range specifiers remain as ranges
+        assert_eq!(
+            VersionRequest::from_specifiers(
+                VersionSpecifiers::from_str(">=3.12").unwrap(),
+                PythonVariant::Default
+            ),
+            VersionRequest::Range(
+                VersionSpecifiers::from_str(">=3.12").unwrap(),
+                PythonVariant::Default
+            )
+        );
+
+        // Multi-specifier constraints remain as ranges
+        assert_eq!(
+            VersionRequest::from_specifiers(
+                VersionSpecifiers::from_str(">=3.12,<3.14").unwrap(),
+                PythonVariant::Default
+            ),
+            VersionRequest::Range(
+                VersionSpecifiers::from_str(">=3.12,<3.14").unwrap(),
+                PythonVariant::Default
+            )
+        );
     }
 
     #[test]

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -24,7 +24,7 @@ use uv_distribution_filename::{
 };
 use uv_distribution_types::{
     ConfigSettings, DependencyMetadata, ExtraBuildVariables, Index, IndexLocations,
-    PackageConfigSettings, Requirement, RequiresPython, SourceDist,
+    PackageConfigSettings, Requirement, SourceDist,
 };
 use uv_fs::{Simplified, relative_to};
 use uv_install_wheel::LinkMode;
@@ -33,8 +33,7 @@ use uv_pep440::Version;
 use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonEnvironment, PythonInstallation,
-    PythonPreference, PythonRequest, PythonVariant, PythonVersionFile, VersionFileDiscoveryOptions,
-    VersionRequest,
+    PythonPreference, PythonRequest, PythonVersionFile, VersionFileDiscoveryOptions,
 };
 use uv_requirements::RequirementsSource;
 use uv_resolver::{ExcludeNewer, FlatIndex};
@@ -529,14 +528,7 @@ async fn build_package(
         if let Ok(workspace) = workspace {
             let groups = DependencyGroupsWithDefaults::none();
             interpreter_request = find_requires_python(workspace, &groups)?
-                .as_ref()
-                .map(RequiresPython::specifiers)
-                .map(|specifiers| {
-                    PythonRequest::Version(VersionRequest::Range(
-                        specifiers.clone(),
-                        PythonVariant::Default,
-                    ))
-                });
+                .and_then(PythonRequest::from_requires_python);
         }
     }
 

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -652,10 +652,8 @@ async fn determine_requires_python(
         .flatten()
     {
         // (3) `requires-python` from the workspace
-        let python_request = PythonRequest::Version(VersionRequest::Range(
-            requires_python.specifiers().clone(),
-            PythonVariant::Default,
-        ));
+        let python_request = PythonRequest::from_requires_python(requires_python.clone())
+            .unwrap_or(PythonRequest::Default);
 
         // Pin to the minor version.
         let python_pin = if pin_python {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1217,14 +1217,8 @@ impl WorkspacePython {
         } else {
             // (3) `requires-python` in `pyproject.toml`
             let request = requires_python
-                .as_ref()
-                .map(RequiresPython::specifiers)
-                .map(|specifiers| {
-                    PythonRequest::Version(VersionRequest::Range(
-                        specifiers.clone(),
-                        PythonVariant::Default,
-                    ))
-                });
+                .clone()
+                .and_then(PythonRequest::from_requires_python);
             let source = PythonRequestSource::RequiresPython;
             (source, request)
         };
@@ -1318,7 +1312,7 @@ impl ScriptPython {
             )
         } else if let Some(specifiers) = script.metadata().requires_python.as_ref() {
             // (3) `requires-python` from script metadata
-            let request = PythonRequest::Version(VersionRequest::Range(
+            let request = PythonRequest::Version(VersionRequest::from_specifiers(
                 specifiers.clone(),
                 PythonVariant::Default,
             ));
@@ -1326,14 +1320,8 @@ impl ScriptPython {
         } else {
             // (4) `requires-python` from workspace `pyproject.toml`
             let request = workspace_requires_python
-                .as_ref()
-                .map(RequiresPython::specifiers)
-                .map(|specifiers| {
-                    PythonRequest::Version(VersionRequest::Range(
-                        specifiers.clone(),
-                        PythonVariant::Default,
-                    ))
-                });
+                .clone()
+                .and_then(PythonRequest::from_requires_python);
             (PythonRequestSource::RequiresPython, request)
         };
 

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -129,7 +129,7 @@ pub(crate) async fn refine_interpreter(
         Bound::Unbounded => unreachable!("`requires-python` should never be unbounded"),
     };
 
-    let requires_python_request = PythonRequest::Version(VersionRequest::Range(
+    let requires_python_request = PythonRequest::Version(VersionRequest::from_specifiers(
         VersionSpecifiers::from_iter([lower_bound, upper_bound]),
         PythonVariant::default(),
     ));

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -1600,8 +1600,6 @@ fn python_find_search_path() {
 /// when only a version-specific executable (e.g., `python3.12`) is available.
 ///
 /// This is a regression test for <https://github.com/astral-sh/uv/issues/9695>.
-/// The `==` specifier must be converted to a concrete `VersionRequest` (e.g., `MajorMinor`)
-/// so that version-specific executable names like `python3.12` are included during discovery.
 #[test]
 #[cfg(unix)]
 fn python_find_project_requires_python_equal() {

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -1595,3 +1595,48 @@ fn python_find_search_path() {
     ----- stderr -----
     ");
 }
+
+/// When `requires-python` uses `==`, we should find the correct interpreter even
+/// when only a version-specific executable (e.g., `python3.12`) is available.
+///
+/// This is a regression test for <https://github.com/astral-sh/uv/issues/9695>.
+/// The `==` specifier must be converted to a concrete `VersionRequest` (e.g., `MajorMinor`)
+/// so that version-specific executable names like `python3.12` are included during discovery.
+#[test]
+#[cfg(unix)]
+fn python_find_project_requires_python_equal() {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
+
+    // Set up a directory where the Python 3.12 executable is named `python3.12` (not `python3`).
+    // This simulates the scenario from the original issue where `python3` points to a different
+    // version and only `python3.12` is available for the desired version.
+    let child = context.temp_dir.child("child");
+    child.create_dir_all().unwrap();
+
+    let python_3_12 = &context.python_versions.last().unwrap().1;
+    fs_err::os::unix::fs::symlink(python_3_12, child.join("python3.12")).unwrap();
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = "==3.12"
+        dependencies = []
+    "#})
+        .unwrap();
+
+    // Without the `==` special-casing, this would only search for `python3` and `python`,
+    // missing the `python3.12` executable entirely.
+    uv_snapshot!(context.filters(), context.python_find()
+        .env(EnvVars::UV_PYTHON_SEARCH_PATH, child.path()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/child/python3.12
+
+    ----- stderr -----
+    warning: The resolved Python interpreter (Python 3.12.[X]) is incompatible with the project's Python requirement: `==3.12` (from `project.requires-python`)
+    "#);
+}


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/9695
Follows https://github.com/astral-sh/uv/pull/9697

Consolidates `requires-python` conversion into `PythonRequest` so we can handle this logic once.