### PR TITLE
Mark `--native-tls` and `UV_NATIVE_TLS` as deprecated

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -236,8 +236,8 @@ pub struct GlobalArgs {
     )]
     pub color: Option<ColorChoice>,
 
-    /// Whether to load TLS certificates from the platform's native certificate store [env:
-    /// UV_NATIVE_TLS=]
+    /// (Deprecated: use `--system-certs` instead.) Whether to load TLS certificates from the
+    /// platform's native certificate store [env: UV_NATIVE_TLS=]
     ///
     /// By default, uv uses bundled Mozilla root certificates. When enabled, this flag loads
     /// certificates from the platform's native certificate store instead.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -110,6 +110,7 @@ impl EnvVars {
     /// Equivalent to the `--native-tls` command-line argument. If set to `true`, uv will
     /// load TLS certificates from the platform's native certificate store instead of the
     /// bundled Mozilla root certificates.
+    /// (Deprecated: use `UV_SYSTEM_CERTS` instead.)
     #[attr_added_in("0.1.19")]
     pub const UV_NATIVE_TLS: &'static str = "UV_NATIVE_TLS";
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -287,6 +287,30 @@ impl NetworkSettings {
             Connectivity::Online
         };
 
+        if args.native_tls {
+            warn_user_once!(
+                "The `--native-tls` flag is deprecated and will be removed in a future release. Use `--system-certs` instead."
+            );
+        }
+        if args.no_native_tls {
+            warn_user_once!(
+                "The `--no-native-tls` flag is deprecated and will be removed in a future release. Use `--no-system-certs` instead."
+            );
+        }
+        if environment.native_tls.value.is_some() {
+            warn_user_once!(
+                "The `UV_NATIVE_TLS` environment variable is deprecated and will be removed in a future release. Use `UV_SYSTEM_CERTS` instead."
+            );
+        }
+        if workspace
+            .and_then(|workspace| workspace.globals.native_tls)
+            .is_some()
+        {
+            warn_user_once!(
+                "The `native-tls` setting is deprecated and will be removed in a future release. Use `system-certs` instead."
+            );
+        }
+
         // Resolve whether to use system certificates.
         //
         // `--native-tls` is a legacy alias for `--system-certs` — it enables system certificates

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -9031,6 +9031,7 @@ fn system_certs_cli_aliases_override_env() {
     }
 
     ----- stderr -----
+    warning: The `--no-native-tls` flag is deprecated and will be removed in a future release. Use `--no-system-certs` instead.
     "#
     );
 
@@ -9155,6 +9156,7 @@ fn system_certs_cli_aliases_override_env() {
     }
 
     ----- stderr -----
+    warning: The `UV_NATIVE_TLS` environment variable is deprecated and will be removed in a future release. Use `UV_SYSTEM_CERTS` instead.
     "#
     );
 }
@@ -9416,6 +9418,7 @@ fn system_certs_config_aliases() -> anyhow::Result<()> {
     }
 
     ----- stderr -----
+    warning: The `native-tls` setting is deprecated and will be removed in a future release. Use `system-certs` instead.
     "#
     );
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/18689.
