### PR TITLE
Use a GitHub App for authentication during release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,9 @@ jobs:
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"
+    environment:
+      name: release
+      deployment: false
     permissions:
       "attestations": "write"
       "contents": "write"


### PR DESCRIPTION
In short, we can

1. Create a GitHub Application (`astral-release-authenticator`)
1. Use a GitHub ruleset to prevent all tag creation with a bypass for the above actor
1. Use [actions/create-github-app-token](https://github.com/actions/create-github-app-token) to create an ephemeral token during a release workflow.

This prevents anyone from creating releases or pushing tags manually.