### PR TITLE
Use `editpe` for trampoline resource edits

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -797,6 +797,27 @@ jobs:
             ghcr.io/astral-sh/termux-python:latest \
             /entrypoint.sh bash /test-termux.sh
 
+  integration-test-windows-nanoserver:
+    name: "windows nanoserver"
+    timeout-minutes: 15
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Download binary"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: uv-windows-x86_64-${{ inputs.sha }}
+
+      - name: "Run uv on Windows NanoServer"
+        run: |
+          docker run --rm `
+            -v "${{ github.workspace }}:C:\uv" `
+            mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022 `
+            pwsh -ExecutionPolicy Bypass -File C:\uv\test\integration\windows-nanoserver.ps1
+
   integration-test-github-actions:
     name: "github actions"
     timeout-minutes: 10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,8 +1439,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "editpe"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614fce8b3477e83c2c52a5195e77c35e93ee4740b552643eb99e31c5e9a26625"
+source = "git+https://github.com/zanieb/editpe?rev=e4a9afbf8b70d67ef31b1df9783d11b19eedc928#e4a9afbf8b70d67ef31b1df9783d11b19eedc928"
 dependencies = [
  "debug-ignore",
  "foldhash 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1435,20 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "editpe"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614fce8b3477e83c2c52a5195e77c35e93ee4740b552643eb99e31c5e9a26625"
+dependencies = [
+ "debug-ignore",
+ "foldhash 0.2.0",
+ "indexmap",
+ "log",
+ "thiserror",
+ "zerocopy",
+]
 
 [[package]]
 name = "either"
@@ -7469,6 +7489,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "astral_async_zip",
+ "editpe",
  "fs-err",
  "futures-lite",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,8 +1518,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "editpe"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614fce8b3477e83c2c52a5195e77c35e93ee4740b552643eb99e31c5e9a26625"
+source = "git+https://github.com/zanieb/editpe?rev=e4a9afbf8b70d67ef31b1df9783d11b19eedc928#e4a9afbf8b70d67ef31b1df9783d11b19eedc928"
 dependencies = [
  "debug-ignore",
  "foldhash 0.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "debug-ignore"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
+
+[[package]]
 name = "defmt"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1514,20 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "editpe"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614fce8b3477e83c2c52a5195e77c35e93ee4740b552643eb99e31c5e9a26625"
+dependencies = [
+ "debug-ignore",
+ "foldhash 0.2.0",
+ "indexmap",
+ "log",
+ "thiserror",
+ "zerocopy",
+]
 
 [[package]]
 name = "either"
@@ -7601,6 +7621,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "astral_async_zip",
+ "editpe",
  "fs-err",
  "futures-lite",
  "goblin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,8 +1517,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "editpe"
-version = "0.2.3"
-source = "git+https://github.com/zanieb/editpe?rev=e4a9afbf8b70d67ef31b1df9783d11b19eedc928#e4a9afbf8b70d67ef31b1df9783d11b19eedc928"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de488f8727e67269a918bcb5b35b1b9ee59b2ae2859743ffdd6288de9701c5e6"
 dependencies = [
  "debug-ignore",
  "foldhash 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
+editpe = { version = "0.2.3", default-features = false, features = ["std"] }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 embed-manifest = { version = "1.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
+editpe = { version = "0.2.3", default-features = false, features = ["std"] }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 embed-manifest = { version = "1.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
-editpe = { version = "0.2.3", default-features = false, features = ["std"] }
+editpe = { git = "https://github.com/zanieb/editpe", rev = "e4a9afbf8b70d67ef31b1df9783d11b19eedc928", default-features = false, features = ["std"] }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 embed-manifest = { version = "1.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
-editpe = { git = "https://github.com/zanieb/editpe", rev = "e4a9afbf8b70d67ef31b1df9783d11b19eedc928", default-features = false, features = ["std"] }
+editpe = { version = "0.2.4", default-features = false, features = ["std"] }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 embed-manifest = { version = "1.5.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
-editpe = { version = "0.2.3", default-features = false, features = ["std"] }
+editpe = { git = "https://github.com/zanieb/editpe", rev = "e4a9afbf8b70d67ef31b1df9783d11b19eedc928", default-features = false, features = ["std"] }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 embed-manifest = { version = "1.5.0" }

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -27,13 +27,13 @@ name = "normalize-pe-timestamps"
 uv-fs = { workspace = true }
 
 anyhow = { workspace = true }
-editpe = { workspace = true }
 fs-err = { workspace = true }
 goblin = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 async_zip = { workspace = true }
+editpe = { workspace = true }
 futures-lite = { workspace = true }
 windows = { workspace = true }
 

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -26,15 +26,18 @@ name = "normalize-pe-timestamps"
 [dependencies]
 uv-fs = { workspace = true }
 
-anyhow = {workspace = true }
-fs-err = {workspace = true }
+anyhow = { workspace = true }
+editpe = { workspace = true }
+fs-err = { workspace = true }
 goblin = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 async_zip = { workspace = true }
 futures-lite = { workspace = true }
+
+[target.'cfg(all(target_os = "windows", target_arch = "x86"))'.dependencies]
+tempfile = { workspace = true }
 windows = { workspace = true }
 
 [dev-dependencies]
@@ -43,6 +46,7 @@ assert_fs = { workspace = true }
 anyhow = { workspace = true }
 fs-err = { workspace = true }
 rcgen = { workspace = true }
+tempfile = { workspace = true }
 which = { workspace = true }
 
 [lib]

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -35,10 +35,10 @@ thiserror = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 async_zip = { workspace = true }
 futures-lite = { workspace = true }
+windows = { workspace = true }
 
 [target.'cfg(all(target_os = "windows", target_arch = "x86"))'.dependencies]
 tempfile = { workspace = true }
-windows = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -37,9 +37,6 @@ editpe = { workspace = true }
 futures-lite = { workspace = true }
 windows = { workspace = true }
 
-[target.'cfg(all(target_os = "windows", target_arch = "x86"))'.dependencies]
-tempfile = { workspace = true }
-
 [dev-dependencies]
 assert_cmd = { workspace = true }
 assert_fs = { workspace = true }

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -2,6 +2,10 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::Utf8Error;
 
+#[cfg(windows)]
+use editpe::{
+    Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
+};
 use fs_err::File;
 use thiserror::Error;
 
@@ -269,17 +273,9 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
     })
 }
 
-/// Write PE resources into a launcher binary using the `editpe` crate.
-///
-/// This directly manipulates the PE resource section without using Windows API calls
-/// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
-/// on minimal Windows environments such as Nano Server.
+/// Write PE resources into a launcher binary.
 #[cfg(windows)]
 fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
-    use editpe::{
-        Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
-    };
-
     let mut image = Image::parse(launcher_data.to_vec())?;
 
     let mut resource_directory = image

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -274,7 +274,7 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
 /// This directly manipulates the PE resource section without using Windows API calls
 /// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
 /// on minimal Windows environments such as Nano Server.
-#[cfg(all(windows, not(target_arch = "x86")))]
+#[cfg(windows)]
 fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
     use editpe::{
         Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
@@ -316,70 +316,6 @@ fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<
     image.set_resource_directory(resource_directory)?;
 
     Ok(image.data().to_vec())
-}
-
-/// Write PE resources into a launcher binary using the Win32 resource APIs.
-///
-/// The `editpe` crate currently produces invalid PE32 output for the 32-bit trampolines,
-/// so keep the previous update path for i686 while using `editpe` for the Nano Server
-/// supported targets.
-#[cfg(all(windows, target_arch = "x86"))]
-fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir.path().join("uv-trampoline.exe");
-
-    fs_err::write(&temp_file, launcher_data)?;
-    write_resources_with_winapi(&temp_file, resources)?;
-
-    Ok(fs_err::read(&temp_file)?)
-}
-
-#[cfg(all(windows, target_arch = "x86"))]
-fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Result<(), Error> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows::Win32::System::LibraryLoader::{
-        BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
-    };
-
-    let path_wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
-
-    // SAFETY: `path_wide` and each `name_wide` are null-terminated UTF-16 strings, and the
-    // resource buffers live for the duration of each Win32 call.
-    #[allow(unsafe_code)]
-    unsafe {
-        let map_err = |err: windows::core::Error| Error::WriteResources {
-            path: path.to_path_buf(),
-            err: io::Error::from_raw_os_error(err.code().0),
-        };
-
-        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_wide.as_ptr()), false)
-            .map_err(map_err)?;
-
-        for (name, data) in resources {
-            let name_wide = name
-                .encode_utf16()
-                .chain(std::iter::once(0))
-                .collect::<Vec<_>>();
-
-            UpdateResourceW(
-                handle,
-                windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
-                windows::core::PCWSTR(name_wide.as_ptr()),
-                0,
-                Some(data.as_ptr().cast()),
-                u32::try_from(data.len()).map_err(|_| Error::ResourceTooLarge)?,
-            )
-            .map_err(&map_err)?;
-        }
-
-        EndUpdateResourceW(handle, false).map_err(map_err)?;
-    }
-
-    Ok(())
 }
 
 /// Safely read a named resource from a loaded PE image.
@@ -710,7 +646,6 @@ if __name__ == "__main__":
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
     fn empty_kind_resource_is_rejected() -> Result<()> {
         let temp_dir = assert_fs::TempDir::new()?;
         let launcher_path = temp_dir.child("launcher.console.exe");

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -30,18 +30,18 @@ const LAUNCHER_AARCH64_CONSOLE: &[u8] =
 
 // https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types
 #[cfg(windows)]
-const RT_RCDATA: u16 = 10;
+const RT_RCDATA: u32 = 10;
 
-// Resource IDs matching uv-trampoline
+// Resource names matching uv-trampoline
 #[cfg(windows)]
-const RESOURCE_TRAMPOLINE_KIND: windows::core::PCWSTR = windows::core::w!("UV_TRAMPOLINE_KIND");
+const RESOURCE_TRAMPOLINE_KIND: &str = "UV_TRAMPOLINE_KIND";
 #[cfg(windows)]
-const RESOURCE_PYTHON_PATH: windows::core::PCWSTR = windows::core::w!("UV_PYTHON_PATH");
+const RESOURCE_PYTHON_PATH: &str = "UV_PYTHON_PATH";
 // Note: This does not need to be looked up as a resource, as we rely on `zipimport`
 // to do the loading work. Still, keeping the content under a resource means that it
 // sits nicely under the PE format.
 #[cfg(windows)]
-const RESOURCE_SCRIPT_DATA: windows::core::PCWSTR = windows::core::w!("UV_SCRIPT_DATA");
+const RESOURCE_SCRIPT_DATA: &str = "UV_SCRIPT_DATA";
 
 #[derive(Debug)]
 pub struct Launcher {
@@ -66,61 +66,35 @@ impl Launcher {
     /// Returns `Err` if the file looks like a trampoline executable but is formatted incorrectly.
     #[cfg(windows)]
     pub fn try_from_path(path: &Path) -> Result<Option<Self>, Error> {
-        use std::os::windows::ffi::OsStrExt;
-        use windows::Win32::System::LibraryLoader::LOAD_LIBRARY_AS_DATAFILE;
-        use windows::Win32::System::LibraryLoader::LoadLibraryExW;
-
-        let path_str = path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect::<Vec<_>>();
-
-        // SAFETY: winapi call; null-terminated strings
-        #[allow(unsafe_code)]
-        let Some(module) = (unsafe {
-            LoadLibraryExW(
-                windows::core::PCWSTR(path_str.as_ptr()),
-                None,
-                LOAD_LIBRARY_AS_DATAFILE,
-            )
-            .ok()
-        }) else {
+        let data = fs_err::read(path)?;
+        let Ok(image) = editpe::Image::parse(data) else {
             return Ok(None);
         };
 
-        let result = (|| {
-            let Some(kind_data) = read_resource(module, RESOURCE_TRAMPOLINE_KIND) else {
-                return Ok(None);
-            };
-            let Some(kind) = LauncherKind::from_resource_value(kind_data[0]) else {
-                return Err(Error::UnprocessableMetadata);
-            };
-
-            let Some(path_data) = read_resource(module, RESOURCE_PYTHON_PATH) else {
-                return Ok(None);
-            };
-            let python_path = PathBuf::from(
-                String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
-            );
-
-            let script_data = read_resource(module, RESOURCE_SCRIPT_DATA);
-
-            Ok(Some(Self {
-                kind,
-                python_path,
-                script_data,
-            }))
-        })();
-
-        // SAFETY: winapi call; handle is known to be valid.
-        #[allow(unsafe_code)]
-        unsafe {
-            windows::Win32::Foundation::FreeLibrary(module)
-                .map_err(|err| Error::Io(io::Error::from_raw_os_error(err.code().0)))?;
+        let Some(kind_data) = read_resource_from_image(&image, RESOURCE_TRAMPOLINE_KIND) else {
+            return Ok(None);
+        };
+        let Some(&kind_value) = kind_data.first() else {
+            return Err(Error::UnprocessableMetadata);
+        };
+        let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
+            return Err(Error::UnprocessableMetadata);
         };
 
-        result
+        let Some(path_data) = read_resource_from_image(&image, RESOURCE_PYTHON_PATH) else {
+            return Ok(None);
+        };
+        let python_path = PathBuf::from(
+            String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
+        );
+
+        let script_data = read_resource_from_image(&image, RESOURCE_SCRIPT_DATA);
+
+        Ok(Some(Self {
+            kind,
+            python_path,
+            script_data,
+        }))
     }
 
     /// Write this trampoline launcher to a file.
@@ -140,37 +114,21 @@ impl Launcher {
 
         let python_path = self.python_path.simplified_display().to_string();
 
-        // Create temporary file for the base launcher
-        let temp_dir = tempfile::TempDir::new()?;
-        let temp_file = temp_dir
-            .path()
-            .join(format!("uv-trampoline-{}.exe", std::process::id()));
+        let launcher_bin = get_launcher_bin(is_gui)?;
 
-        // Write the launcher binary
-        fs_err::write(&temp_file, get_launcher_bin(is_gui)?)?;
-
-        // Write resources
-        let resources = &[
-            (
-                RESOURCE_TRAMPOLINE_KIND,
-                &[self.kind.to_resource_value()][..],
-            ),
+        let kind_value = [self.kind.to_resource_value()];
+        let mut resources: Vec<(&str, &[u8])> = vec![
+            (RESOURCE_TRAMPOLINE_KIND, &kind_value),
             (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
         ];
-        if let Some(script_data) = self.script_data {
-            let mut all_resources = resources.to_vec();
-            all_resources.push((RESOURCE_SCRIPT_DATA, &script_data));
-            write_resources(&temp_file, &all_resources)?;
-        } else {
-            write_resources(&temp_file, resources)?;
+        let script_data;
+        if let Some(data) = self.script_data {
+            script_data = data;
+            resources.push((RESOURCE_SCRIPT_DATA, &script_data));
         }
 
-        // Read back the complete file
-        let launcher = fs_err::read(&temp_file)?;
-        fs_err::remove_file(&temp_file)?;
-
-        // Then write it to the handle
-        file.write_all(&launcher)?;
+        let output = write_resources(launcher_bin, &resources)?;
+        file.write_all(&output)?;
 
         Ok(())
     }
@@ -196,8 +154,8 @@ pub enum LauncherKind {
     Python,
 }
 
+#[cfg(windows)]
 impl LauncherKind {
-    #[cfg(windows)]
     fn to_resource_value(self) -> u8 {
         match self {
             Self::Script => 1,
@@ -205,7 +163,6 @@ impl LauncherKind {
         }
     }
 
-    #[cfg(windows)]
     fn from_resource_value(value: u8) -> Option<Self> {
         match value {
             1 => Some(Self::Script),
@@ -241,6 +198,10 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
+    #[error("Failed to parse Windows PE image")]
+    PeRead(#[from] editpe::ImageReadError),
+    #[error("Failed to update Windows PE resources")]
+    PeWrite(#[from] editpe::ImageWriteError),
 }
 
 #[allow(clippy::unnecessary_wraps, unused_variables)]
@@ -278,35 +239,106 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
     })
 }
 
-/// Helper to write Windows PE resources
-#[cfg(windows)]
-fn write_resources(path: &Path, resources: &[(windows::core::PCWSTR, &[u8])]) -> Result<(), Error> {
-    // SAFETY: winapi calls; null-terminated strings
+/// Write PE resources into a launcher binary using the `editpe` crate.
+///
+/// This directly manipulates the PE resource section without using Windows API calls
+/// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
+/// on minimal Windows environments such as Nano Server.
+#[cfg(all(windows, not(target_arch = "x86")))]
+fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
+    use editpe::{
+        Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
+    };
+
+    let mut image = Image::parse(launcher_data.to_vec())?;
+
+    let mut resource_directory = image
+        .resource_directory()
+        .cloned()
+        .unwrap_or_else(ResourceDirectory::default);
+    let root = resource_directory.root_mut();
+
+    // Get or create the RT_RCDATA type entry.
+    let rcdata_name = ResourceEntryName::ID(RT_RCDATA);
+    if root.get(rcdata_name.clone()).is_none() {
+        root.insert(
+            rcdata_name.clone(),
+            ResourceEntry::Table(ResourceTable::default()),
+        );
+    }
+    let rcdata_table = root
+        .get_mut(rcdata_name)
+        .and_then(ResourceEntry::as_table_mut)
+        .expect("RT_RCDATA entry was just inserted");
+
+    for (name, data) in resources {
+        let entry_name = ResourceEntryName::from_string(name);
+
+        // Create language table with neutral language (0).
+        let mut language_table = ResourceTable::default();
+        let mut resource_data = ResourceData::default();
+        resource_data.set_data(data.to_vec());
+        language_table.insert(ResourceEntryName::ID(0), ResourceEntry::Data(resource_data));
+
+        rcdata_table.insert(entry_name, ResourceEntry::Table(language_table));
+    }
+
+    image.set_resource_directory(resource_directory)?;
+
+    Ok(image.data().to_vec())
+}
+
+/// Write PE resources into a launcher binary using the Win32 resource APIs.
+///
+/// The `editpe` crate currently produces invalid PE32 output for the 32-bit trampolines,
+/// so keep the previous update path for i686 while using `editpe` for the Nano Server
+/// supported targets.
+#[cfg(all(windows, target_arch = "x86"))]
+fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let temp_file = temp_dir.path().join("uv-trampoline.exe");
+
+    fs_err::write(&temp_file, launcher_data)?;
+    write_resources_with_winapi(&temp_file, resources)?;
+
+    Ok(fs_err::read(&temp_file)?)
+}
+
+#[cfg(all(windows, target_arch = "x86"))]
+fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Result<(), Error> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::Win32::System::LibraryLoader::{
+        BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
+    };
+
+    let path_wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    // SAFETY: `path_wide` and each `name_wide` are null-terminated UTF-16 strings, and the
+    // resource buffers live for the duration of each Win32 call.
     #[allow(unsafe_code)]
     unsafe {
-        use std::os::windows::ffi::OsStrExt;
-        use windows::Win32::System::LibraryLoader::{
-            BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
-        };
-
         let map_err = |err: windows::core::Error| Error::WriteResources {
             path: path.to_path_buf(),
             err: io::Error::from_raw_os_error(err.code().0),
         };
 
-        let path_str = path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect::<Vec<_>>();
-        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_str.as_ptr()), false)
+        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_wide.as_ptr()), false)
             .map_err(map_err)?;
 
         for (name, data) in resources {
+            let name_wide = name
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+
             UpdateResourceW(
                 handle,
-                windows::core::PCWSTR(RT_RCDATA as *const _),
-                *name,
+                windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
+                windows::core::PCWSTR(name_wide.as_ptr()),
                 0,
                 Some(data.as_ptr().cast()),
                 u32::try_from(data.len()).map_err(|_| Error::ResourceTooLarge)?,
@@ -320,42 +352,29 @@ fn write_resources(path: &Path, resources: &[(windows::core::PCWSTR, &[u8])]) ->
     Ok(())
 }
 
-/// Safely reads a resource from a PE file
+/// Read a named resource from a parsed PE [`Image`].
+///
+/// Navigates the PE resource directory tree: `RT_RCDATA` → `name` → first language entry.
 #[cfg(windows)]
-fn read_resource(
-    handle: windows::Win32::Foundation::HMODULE,
-    name: windows::core::PCWSTR,
-) -> Option<Vec<u8>> {
-    // SAFETY: winapi calls; null-terminated strings; all pointers are checked.
-    #[allow(unsafe_code)]
-    unsafe {
-        use windows::Win32::System::LibraryLoader::{
-            FindResourceW, LoadResource, LockResource, SizeofResource,
-        };
-        // Find the resource
-        let resource = FindResourceW(
-            Some(handle),
-            name,
-            windows::core::PCWSTR(RT_RCDATA as *const _),
-        );
-        if resource.is_invalid() {
-            return None;
-        }
+fn read_resource_from_image(image: &editpe::Image<'_>, name: &str) -> Option<Vec<u8>> {
+    use editpe::ResourceEntryName;
 
-        // Get resource size and data
-        let size = SizeofResource(Some(handle), resource);
-        if size == 0 {
-            return None;
-        }
-        let data = LoadResource(Some(handle), resource).ok()?;
-        let ptr = LockResource(data) as *const u8;
-        if ptr.is_null() {
-            return None;
-        }
+    let resource_directory = image.resource_directory()?;
+    let root = resource_directory.root();
 
-        // Copy the resource data into a Vec
-        Some(std::slice::from_raw_parts(ptr, size as usize).to_vec())
-    }
+    let rcdata_entry = root.get(ResourceEntryName::ID(RT_RCDATA))?;
+    let rcdata_table = rcdata_entry.as_table()?;
+
+    let name_entry = rcdata_table.get(ResourceEntryName::from_string(name))?;
+    let language_table = name_entry.as_table()?;
+
+    // Get the first language entry (typically ID(0) for neutral).
+    let entries = language_table.entries();
+    let first_language = entries.first()?;
+    let language_entry = language_table.get(*first_language)?;
+    let data = language_entry.as_data()?;
+
+    Some(data.data().to_vec())
 }
 
 /// Construct a Windows script launcher.
@@ -403,33 +422,16 @@ pub fn windows_script_launcher(
     let python = python_executable.as_ref();
     let python_path = python.simplified_display().to_string();
 
-    // Start with base launcher binary
-    // Create temporary file for the launcher
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir
-        .path()
-        .join(format!("uv-trampoline-{}.exe", std::process::id()));
-    fs_err::write(&temp_file, launcher_bin)?;
-
-    // Write resources
-    let resources = &[
+    let resources: &[(&str, &[u8])] = &[
         (
             RESOURCE_TRAMPOLINE_KIND,
-            &[LauncherKind::Script.to_resource_value()][..],
+            &[LauncherKind::Script.to_resource_value()],
         ),
         (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
         (RESOURCE_SCRIPT_DATA, &payload),
     ];
-    write_resources(&temp_file, resources)?;
 
-    // Read back the complete file
-    // TODO(zanieb): It's weird that we write/read from a temporary file here because in the main
-    // usage at `write_script_entrypoints` we do the same thing again. We should refactor these
-    // to avoid repeated work.
-    let launcher = fs_err::read(&temp_file)?;
-    fs_err::remove_file(temp_file)?;
-
-    Ok(launcher)
+    write_resources(launcher_bin, resources)
 }
 
 /// Construct a Windows Python launcher.
@@ -461,28 +463,15 @@ pub fn windows_python_launcher(
     let python = python_executable.as_ref();
     let python_path = python.simplified_display().to_string();
 
-    // Create temporary file for the launcher
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir
-        .path()
-        .join(format!("uv-trampoline-{}.exe", std::process::id()));
-    fs_err::write(&temp_file, launcher_bin)?;
-
-    // Write resources
-    let resources = &[
+    let resources: &[(&str, &[u8])] = &[
         (
             RESOURCE_TRAMPOLINE_KIND,
-            &[LauncherKind::Python.to_resource_value()][..],
+            &[LauncherKind::Python.to_resource_value()],
         ),
         (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
     ];
-    write_resources(&temp_file, resources)?;
 
-    // Read back the complete file
-    let launcher = fs_err::read(&temp_file)?;
-    fs_err::remove_file(temp_file)?;
-
-    Ok(launcher)
+    write_resources(launcher_bin, resources)
 }
 
 #[cfg(all(test, windows))]
@@ -662,6 +651,29 @@ if __name__ == "__main__":
             .success();
 
         println!("Signed binary: {}", bin_path.as_ref().display());
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "x86"))]
+    fn empty_kind_resource_is_rejected() -> Result<()> {
+        let temp_dir = assert_fs::TempDir::new()?;
+        let launcher_path = temp_dir.child("launcher.console.exe");
+
+        let launcher = super::write_resources(
+            super::get_launcher_bin(false)?,
+            &[
+                (super::RESOURCE_TRAMPOLINE_KIND, &[]),
+                (super::RESOURCE_PYTHON_PATH, b"C:/Python312/python.exe"),
+            ],
+        )?;
+
+        File::create(launcher_path.path())?.write_all(&launcher)?;
+
+        let error = Launcher::try_from_path(launcher_path.path())
+            .expect_err("Empty launcher kind resources should be rejected");
+        assert!(matches!(error, super::Error::UnprocessableMetadata));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -226,8 +226,10 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
+    #[cfg(windows)]
     #[error("Failed to parse Windows PE image")]
     PeRead(#[from] editpe::ImageReadError),
+    #[cfg(windows)]
     #[error("Failed to update Windows PE resources")]
     PeWrite(#[from] editpe::ImageWriteError),
 }

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -66,35 +66,63 @@ impl Launcher {
     /// Returns `Err` if the file looks like a trampoline executable but is formatted incorrectly.
     #[cfg(windows)]
     pub fn try_from_path(path: &Path) -> Result<Option<Self>, Error> {
-        let data = fs_err::read(path)?;
-        let Ok(image) = editpe::Image::parse(data) else {
+        use std::os::windows::ffi::OsStrExt;
+        use windows::Win32::System::LibraryLoader::{LOAD_LIBRARY_AS_DATAFILE, LoadLibraryExW};
+
+        let path_wide = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+
+        // SAFETY: `path_wide` is a null-terminated UTF-16 string.
+        #[allow(unsafe_code)]
+        let Some(module) = (unsafe {
+            LoadLibraryExW(
+                windows::core::PCWSTR(path_wide.as_ptr()),
+                None,
+                LOAD_LIBRARY_AS_DATAFILE,
+            )
+            .ok()
+        }) else {
             return Ok(None);
         };
 
-        let Some(kind_data) = read_resource_from_image(&image, RESOURCE_TRAMPOLINE_KIND) else {
-            return Ok(None);
-        };
-        let Some(&kind_value) = kind_data.first() else {
-            return Err(Error::UnprocessableMetadata);
-        };
-        let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
-            return Err(Error::UnprocessableMetadata);
-        };
+        let result = (|| {
+            let Some(kind_data) = read_resource(module, RESOURCE_TRAMPOLINE_KIND) else {
+                return Ok(None);
+            };
+            let Some(&kind_value) = kind_data.first() else {
+                return Err(Error::UnprocessableMetadata);
+            };
+            let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
+                return Err(Error::UnprocessableMetadata);
+            };
 
-        let Some(path_data) = read_resource_from_image(&image, RESOURCE_PYTHON_PATH) else {
-            return Ok(None);
-        };
-        let python_path = PathBuf::from(
-            String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
-        );
+            let Some(path_data) = read_resource(module, RESOURCE_PYTHON_PATH) else {
+                return Ok(None);
+            };
+            let python_path = PathBuf::from(
+                String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
+            );
 
-        let script_data = read_resource_from_image(&image, RESOURCE_SCRIPT_DATA);
+            let script_data = read_resource(module, RESOURCE_SCRIPT_DATA);
 
-        Ok(Some(Self {
-            kind,
-            python_path,
-            script_data,
-        }))
+            Ok(Some(Self {
+                kind,
+                python_path,
+                script_data,
+            }))
+        })();
+
+        // SAFETY: `module` was returned by a successful `LoadLibraryExW` call.
+        #[allow(unsafe_code)]
+        unsafe {
+            windows::Win32::Foundation::FreeLibrary(module)
+                .map_err(|err| Error::Io(io::Error::from_raw_os_error(err.code().0)))?;
+        }
+
+        result
     }
 
     /// Write this trampoline launcher to a file.
@@ -352,29 +380,44 @@ fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Resu
     Ok(())
 }
 
-/// Read a named resource from a parsed PE [`Image`].
-///
-/// Navigates the PE resource directory tree: `RT_RCDATA` → `name` → first language entry.
+/// Safely read a named resource from a loaded PE image.
 #[cfg(windows)]
-fn read_resource_from_image(image: &editpe::Image<'_>, name: &str) -> Option<Vec<u8>> {
-    use editpe::ResourceEntryName;
+fn read_resource(handle: windows::Win32::Foundation::HMODULE, name: &str) -> Option<Vec<u8>> {
+    use windows::Win32::System::LibraryLoader::{
+        FindResourceW, LoadResource, LockResource, SizeofResource,
+    };
 
-    let resource_directory = image.resource_directory()?;
-    let root = resource_directory.root();
+    let name_wide = name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
 
-    let rcdata_entry = root.get(ResourceEntryName::ID(RT_RCDATA))?;
-    let rcdata_table = rcdata_entry.as_table()?;
+    // SAFETY: `name_wide` is null-terminated, `handle` is valid, and the resource pointer is
+    // checked before reading the number of bytes reported by `SizeofResource`.
+    #[allow(unsafe_code)]
+    unsafe {
+        let resource = FindResourceW(
+            Some(handle),
+            windows::core::PCWSTR(name_wide.as_ptr()),
+            windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
+        );
+        if resource.is_invalid() {
+            return None;
+        }
 
-    let name_entry = rcdata_table.get(ResourceEntryName::from_string(name))?;
-    let language_table = name_entry.as_table()?;
+        let size = SizeofResource(Some(handle), resource);
+        if size == 0 {
+            return Some(Vec::new());
+        }
 
-    // Get the first language entry (typically ID(0) for neutral).
-    let entries = language_table.entries();
-    let first_language = entries.first()?;
-    let language_entry = language_table.get(*first_language)?;
-    let data = language_entry.as_data()?;
+        let data = LoadResource(Some(handle), resource).ok()?;
+        let pointer = LockResource(data).cast::<u8>();
+        if pointer.is_null() {
+            return None;
+        }
 
-    Some(data.data().to_vec())
+        Some(std::slice::from_raw_parts(pointer, size as usize).to_vec())
+    }
 }
 
 /// Construct a Windows script launcher.
@@ -651,6 +694,17 @@ if __name__ == "__main__":
             .success();
 
         println!("Signed binary: {}", bin_path.as_ref().display());
+    }
+
+    #[test]
+    fn malformed_trampoline_is_not_recognized() -> Result<()> {
+        let temp_dir = assert_fs::TempDir::new()?;
+        let launcher_path = temp_dir.child("malformed.exe");
+        fs_err::write(launcher_path.path(), b"MZ")?;
+
+        assert!(Launcher::try_from_path(launcher_path.path())?.is_none());
+
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -30,18 +30,18 @@ const LAUNCHER_AARCH64_CONSOLE: &[u8] =
 
 // https://learn.microsoft.com/en-us/windows/win32/menurc/resource-types
 #[cfg(windows)]
-const RT_RCDATA: u16 = 10;
+const RT_RCDATA: u32 = 10;
 
-// Resource IDs matching uv-trampoline
+// Resource names matching uv-trampoline
 #[cfg(windows)]
-const RESOURCE_TRAMPOLINE_KIND: windows::core::PCWSTR = windows::core::w!("UV_TRAMPOLINE_KIND");
+const RESOURCE_TRAMPOLINE_KIND: &str = "UV_TRAMPOLINE_KIND";
 #[cfg(windows)]
-const RESOURCE_PYTHON_PATH: windows::core::PCWSTR = windows::core::w!("UV_PYTHON_PATH");
+const RESOURCE_PYTHON_PATH: &str = "UV_PYTHON_PATH";
 // Note: This does not need to be looked up as a resource, as we rely on `zipimport`
 // to do the loading work. Still, keeping the content under a resource means that it
 // sits nicely under the PE format.
 #[cfg(windows)]
-const RESOURCE_SCRIPT_DATA: windows::core::PCWSTR = windows::core::w!("UV_SCRIPT_DATA");
+const RESOURCE_SCRIPT_DATA: &str = "UV_SCRIPT_DATA";
 
 #[derive(Debug)]
 pub struct Launcher {
@@ -66,61 +66,35 @@ impl Launcher {
     /// Returns `Err` if the file looks like a trampoline executable but is formatted incorrectly.
     #[cfg(windows)]
     pub fn try_from_path(path: &Path) -> Result<Option<Self>, Error> {
-        use std::os::windows::ffi::OsStrExt;
-        use windows::Win32::System::LibraryLoader::LOAD_LIBRARY_AS_DATAFILE;
-        use windows::Win32::System::LibraryLoader::LoadLibraryExW;
-
-        let path_str = path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect::<Vec<_>>();
-
-        // SAFETY: winapi call; null-terminated strings
-        #[allow(unsafe_code)]
-        let Some(module) = (unsafe {
-            LoadLibraryExW(
-                windows::core::PCWSTR(path_str.as_ptr()),
-                None,
-                LOAD_LIBRARY_AS_DATAFILE,
-            )
-            .ok()
-        }) else {
+        let data = fs_err::read(path)?;
+        let Ok(image) = editpe::Image::parse(data) else {
             return Ok(None);
         };
 
-        let result = (|| {
-            let Some(kind_data) = read_resource(module, RESOURCE_TRAMPOLINE_KIND) else {
-                return Ok(None);
-            };
-            let Some(kind) = LauncherKind::from_resource_value(kind_data[0]) else {
-                return Err(Error::UnprocessableMetadata);
-            };
-
-            let Some(path_data) = read_resource(module, RESOURCE_PYTHON_PATH) else {
-                return Ok(None);
-            };
-            let python_path = PathBuf::from(
-                String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
-            );
-
-            let script_data = read_resource(module, RESOURCE_SCRIPT_DATA);
-
-            Ok(Some(Self {
-                kind,
-                python_path,
-                script_data,
-            }))
-        })();
-
-        // SAFETY: winapi call; handle is known to be valid.
-        #[allow(unsafe_code)]
-        unsafe {
-            windows::Win32::Foundation::FreeLibrary(module)
-                .map_err(|err| Error::Io(io::Error::from_raw_os_error(err.code().0)))?;
+        let Some(kind_data) = read_resource_from_image(&image, RESOURCE_TRAMPOLINE_KIND) else {
+            return Ok(None);
+        };
+        let Some(&kind_value) = kind_data.first() else {
+            return Err(Error::UnprocessableMetadata);
+        };
+        let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
+            return Err(Error::UnprocessableMetadata);
         };
 
-        result
+        let Some(path_data) = read_resource_from_image(&image, RESOURCE_PYTHON_PATH) else {
+            return Ok(None);
+        };
+        let python_path = PathBuf::from(
+            String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
+        );
+
+        let script_data = read_resource_from_image(&image, RESOURCE_SCRIPT_DATA);
+
+        Ok(Some(Self {
+            kind,
+            python_path,
+            script_data,
+        }))
     }
 
     /// Write this trampoline launcher to a file.
@@ -140,37 +114,21 @@ impl Launcher {
 
         let python_path = self.python_path.simplified_display().to_string();
 
-        // Create temporary file for the base launcher
-        let temp_dir = tempfile::TempDir::new()?;
-        let temp_file = temp_dir
-            .path()
-            .join(format!("uv-trampoline-{}.exe", std::process::id()));
+        let launcher_bin = get_launcher_bin(is_gui)?;
 
-        // Write the launcher binary
-        fs_err::write(&temp_file, get_launcher_bin(is_gui)?)?;
-
-        // Write resources
-        let resources = &[
-            (
-                RESOURCE_TRAMPOLINE_KIND,
-                &[self.kind.to_resource_value()][..],
-            ),
+        let kind_value = [self.kind.to_resource_value()];
+        let mut resources: Vec<(&str, &[u8])> = vec![
+            (RESOURCE_TRAMPOLINE_KIND, &kind_value),
             (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
         ];
-        if let Some(script_data) = self.script_data {
-            let mut all_resources = resources.to_vec();
-            all_resources.push((RESOURCE_SCRIPT_DATA, &script_data));
-            write_resources(&temp_file, &all_resources)?;
-        } else {
-            write_resources(&temp_file, resources)?;
+        let script_data;
+        if let Some(data) = self.script_data {
+            script_data = data;
+            resources.push((RESOURCE_SCRIPT_DATA, &script_data));
         }
 
-        // Read back the complete file
-        let launcher = fs_err::read(&temp_file)?;
-        fs_err::remove_file(&temp_file)?;
-
-        // Then write it to the handle
-        file.write_all(&launcher)?;
+        let output = write_resources(launcher_bin, &resources)?;
+        file.write_all(&output)?;
 
         Ok(())
     }
@@ -205,8 +163,8 @@ pub enum LauncherKind {
     Python,
 }
 
+#[cfg(windows)]
 impl LauncherKind {
-    #[cfg(windows)]
     fn to_resource_value(self) -> u8 {
         match self {
             Self::Script => 1,
@@ -214,7 +172,6 @@ impl LauncherKind {
         }
     }
 
-    #[cfg(windows)]
     fn from_resource_value(value: u8) -> Option<Self> {
         match value {
             1 => Some(Self::Script),
@@ -250,6 +207,10 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
+    #[error("Failed to parse Windows PE image")]
+    PeRead(#[from] editpe::ImageReadError),
+    #[error("Failed to update Windows PE resources")]
+    PeWrite(#[from] editpe::ImageWriteError),
 }
 
 #[allow(clippy::unnecessary_wraps, unused_variables)]
@@ -287,35 +248,106 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
     })
 }
 
-/// Helper to write Windows PE resources
-#[cfg(windows)]
-fn write_resources(path: &Path, resources: &[(windows::core::PCWSTR, &[u8])]) -> Result<(), Error> {
-    // SAFETY: winapi calls; null-terminated strings
+/// Write PE resources into a launcher binary using the `editpe` crate.
+///
+/// This directly manipulates the PE resource section without using Windows API calls
+/// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
+/// on minimal Windows environments such as Nano Server.
+#[cfg(all(windows, not(target_arch = "x86")))]
+fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
+    use editpe::{
+        Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
+    };
+
+    let mut image = Image::parse(launcher_data.to_vec())?;
+
+    let mut resource_directory = image
+        .resource_directory()
+        .cloned()
+        .unwrap_or_else(ResourceDirectory::default);
+    let root = resource_directory.root_mut();
+
+    // Get or create the RT_RCDATA type entry.
+    let rcdata_name = ResourceEntryName::ID(RT_RCDATA);
+    if root.get(rcdata_name.clone()).is_none() {
+        root.insert(
+            rcdata_name.clone(),
+            ResourceEntry::Table(ResourceTable::default()),
+        );
+    }
+    let rcdata_table = root
+        .get_mut(rcdata_name)
+        .and_then(ResourceEntry::as_table_mut)
+        .expect("RT_RCDATA entry was just inserted");
+
+    for (name, data) in resources {
+        let entry_name = ResourceEntryName::from_string(name);
+
+        // Create language table with neutral language (0).
+        let mut language_table = ResourceTable::default();
+        let mut resource_data = ResourceData::default();
+        resource_data.set_data(data.to_vec());
+        language_table.insert(ResourceEntryName::ID(0), ResourceEntry::Data(resource_data));
+
+        rcdata_table.insert(entry_name, ResourceEntry::Table(language_table));
+    }
+
+    image.set_resource_directory(resource_directory)?;
+
+    Ok(image.data().to_vec())
+}
+
+/// Write PE resources into a launcher binary using the Win32 resource APIs.
+///
+/// The `editpe` crate currently produces invalid PE32 output for the 32-bit trampolines,
+/// so keep the previous update path for i686 while using `editpe` for the Nano Server
+/// supported targets.
+#[cfg(all(windows, target_arch = "x86"))]
+fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let temp_file = temp_dir.path().join("uv-trampoline.exe");
+
+    fs_err::write(&temp_file, launcher_data)?;
+    write_resources_with_winapi(&temp_file, resources)?;
+
+    Ok(fs_err::read(&temp_file)?)
+}
+
+#[cfg(all(windows, target_arch = "x86"))]
+fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Result<(), Error> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::Win32::System::LibraryLoader::{
+        BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
+    };
+
+    let path_wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    // SAFETY: `path_wide` and each `name_wide` are null-terminated UTF-16 strings, and the
+    // resource buffers live for the duration of each Win32 call.
     #[allow(unsafe_code)]
     unsafe {
-        use std::os::windows::ffi::OsStrExt;
-        use windows::Win32::System::LibraryLoader::{
-            BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
-        };
-
         let map_err = |err: windows::core::Error| Error::WriteResources {
             path: path.to_path_buf(),
             err: io::Error::from_raw_os_error(err.code().0),
         };
 
-        let path_str = path
-            .as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect::<Vec<_>>();
-        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_str.as_ptr()), false)
+        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_wide.as_ptr()), false)
             .map_err(map_err)?;
 
         for (name, data) in resources {
+            let name_wide = name
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+
             UpdateResourceW(
                 handle,
-                windows::core::PCWSTR(RT_RCDATA as *const _),
-                *name,
+                windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
+                windows::core::PCWSTR(name_wide.as_ptr()),
                 0,
                 Some(data.as_ptr().cast()),
                 u32::try_from(data.len()).map_err(|_| Error::ResourceTooLarge)?,
@@ -329,42 +361,29 @@ fn write_resources(path: &Path, resources: &[(windows::core::PCWSTR, &[u8])]) ->
     Ok(())
 }
 
-/// Safely reads a resource from a PE file
+/// Read a named resource from a parsed PE [`Image`].
+///
+/// Navigates the PE resource directory tree: `RT_RCDATA` → `name` → first language entry.
 #[cfg(windows)]
-fn read_resource(
-    handle: windows::Win32::Foundation::HMODULE,
-    name: windows::core::PCWSTR,
-) -> Option<Vec<u8>> {
-    // SAFETY: winapi calls; null-terminated strings; all pointers are checked.
-    #[allow(unsafe_code)]
-    unsafe {
-        use windows::Win32::System::LibraryLoader::{
-            FindResourceW, LoadResource, LockResource, SizeofResource,
-        };
-        // Find the resource
-        let resource = FindResourceW(
-            Some(handle),
-            name,
-            windows::core::PCWSTR(RT_RCDATA as *const _),
-        );
-        if resource.is_invalid() {
-            return None;
-        }
+fn read_resource_from_image(image: &editpe::Image<'_>, name: &str) -> Option<Vec<u8>> {
+    use editpe::ResourceEntryName;
 
-        // Get resource size and data
-        let size = SizeofResource(Some(handle), resource);
-        if size == 0 {
-            return None;
-        }
-        let data = LoadResource(Some(handle), resource).ok()?;
-        let ptr = LockResource(data) as *const u8;
-        if ptr.is_null() {
-            return None;
-        }
+    let resource_directory = image.resource_directory()?;
+    let root = resource_directory.root();
 
-        // Copy the resource data into a Vec
-        Some(std::slice::from_raw_parts(ptr, size as usize).to_vec())
-    }
+    let rcdata_entry = root.get(ResourceEntryName::ID(RT_RCDATA))?;
+    let rcdata_table = rcdata_entry.as_table()?;
+
+    let name_entry = rcdata_table.get(ResourceEntryName::from_string(name))?;
+    let language_table = name_entry.as_table()?;
+
+    // Get the first language entry (typically ID(0) for neutral).
+    let entries = language_table.entries();
+    let first_language = entries.first()?;
+    let language_entry = language_table.get(*first_language)?;
+    let data = language_entry.as_data()?;
+
+    Some(data.data().to_vec())
 }
 
 /// Construct a Windows script launcher.
@@ -412,33 +431,16 @@ pub fn windows_script_launcher(
     let python = python_executable.as_ref();
     let python_path = python.simplified_display().to_string();
 
-    // Start with base launcher binary
-    // Create temporary file for the launcher
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir
-        .path()
-        .join(format!("uv-trampoline-{}.exe", std::process::id()));
-    fs_err::write(&temp_file, launcher_bin)?;
-
-    // Write resources
-    let resources = &[
+    let resources: &[(&str, &[u8])] = &[
         (
             RESOURCE_TRAMPOLINE_KIND,
-            &[LauncherKind::Script.to_resource_value()][..],
+            &[LauncherKind::Script.to_resource_value()],
         ),
         (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
         (RESOURCE_SCRIPT_DATA, &payload),
     ];
-    write_resources(&temp_file, resources)?;
 
-    // Read back the complete file
-    // TODO(zanieb): It's weird that we write/read from a temporary file here because in the main
-    // usage at `write_script_entrypoints` we do the same thing again. We should refactor these
-    // to avoid repeated work.
-    let launcher = fs_err::read(&temp_file)?;
-    fs_err::remove_file(temp_file)?;
-
-    Ok(launcher)
+    write_resources(launcher_bin, resources)
 }
 
 /// Construct a Windows Python launcher.
@@ -470,28 +472,15 @@ pub fn windows_python_launcher(
     let python = python_executable.as_ref();
     let python_path = python.simplified_display().to_string();
 
-    // Create temporary file for the launcher
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir
-        .path()
-        .join(format!("uv-trampoline-{}.exe", std::process::id()));
-    fs_err::write(&temp_file, launcher_bin)?;
-
-    // Write resources
-    let resources = &[
+    let resources: &[(&str, &[u8])] = &[
         (
             RESOURCE_TRAMPOLINE_KIND,
-            &[LauncherKind::Python.to_resource_value()][..],
+            &[LauncherKind::Python.to_resource_value()],
         ),
         (RESOURCE_PYTHON_PATH, python_path.as_bytes()),
     ];
-    write_resources(&temp_file, resources)?;
 
-    // Read back the complete file
-    let launcher = fs_err::read(&temp_file)?;
-    fs_err::remove_file(temp_file)?;
-
-    Ok(launcher)
+    write_resources(launcher_bin, resources)
 }
 
 #[cfg(all(test, windows))]
@@ -673,6 +662,29 @@ if __name__ == "__main__":
             .success();
 
         println!("Signed binary: {}", bin_path.as_ref().display());
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "x86"))]
+    fn empty_kind_resource_is_rejected() -> Result<()> {
+        let temp_dir = assert_fs::TempDir::new()?;
+        let launcher_path = temp_dir.child("launcher.console.exe");
+
+        let launcher = super::write_resources(
+            super::get_launcher_bin(false)?,
+            &[
+                (super::RESOURCE_TRAMPOLINE_KIND, &[]),
+                (super::RESOURCE_PYTHON_PATH, b"C:/Python312/python.exe"),
+            ],
+        )?;
+
+        File::create(launcher_path.path())?.write_all(&launcher)?;
+
+        let error = Launcher::try_from_path(launcher_path.path())
+            .expect_err("Empty launcher kind resources should be rejected");
+        assert!(matches!(error, super::Error::UnprocessableMetadata));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -11,6 +11,9 @@ use thiserror::Error;
 
 use uv_fs::Simplified;
 
+#[cfg(all(test, windows))]
+mod resource_tests;
+
 #[cfg(all(windows, target_arch = "x86"))]
 const LAUNCHER_I686_GUI: &[u8] = include_bytes!("../trampolines/uv-trampoline-i686-gui.exe");
 

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -283,7 +283,7 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
 /// This directly manipulates the PE resource section without using Windows API calls
 /// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
 /// on minimal Windows environments such as Nano Server.
-#[cfg(all(windows, not(target_arch = "x86")))]
+#[cfg(windows)]
 fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
     use editpe::{
         Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
@@ -325,70 +325,6 @@ fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<
     image.set_resource_directory(resource_directory)?;
 
     Ok(image.data().to_vec())
-}
-
-/// Write PE resources into a launcher binary using the Win32 resource APIs.
-///
-/// The `editpe` crate currently produces invalid PE32 output for the 32-bit trampolines,
-/// so keep the previous update path for i686 while using `editpe` for the Nano Server
-/// supported targets.
-#[cfg(all(windows, target_arch = "x86"))]
-fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
-    let temp_dir = tempfile::TempDir::new()?;
-    let temp_file = temp_dir.path().join("uv-trampoline.exe");
-
-    fs_err::write(&temp_file, launcher_data)?;
-    write_resources_with_winapi(&temp_file, resources)?;
-
-    Ok(fs_err::read(&temp_file)?)
-}
-
-#[cfg(all(windows, target_arch = "x86"))]
-fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Result<(), Error> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows::Win32::System::LibraryLoader::{
-        BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
-    };
-
-    let path_wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
-
-    // SAFETY: `path_wide` and each `name_wide` are null-terminated UTF-16 strings, and the
-    // resource buffers live for the duration of each Win32 call.
-    #[allow(unsafe_code)]
-    unsafe {
-        let map_err = |err: windows::core::Error| Error::WriteResources {
-            path: path.to_path_buf(),
-            err: io::Error::from_raw_os_error(err.code().0),
-        };
-
-        let handle = BeginUpdateResourceW(windows::core::PCWSTR(path_wide.as_ptr()), false)
-            .map_err(map_err)?;
-
-        for (name, data) in resources {
-            let name_wide = name
-                .encode_utf16()
-                .chain(std::iter::once(0))
-                .collect::<Vec<_>>();
-
-            UpdateResourceW(
-                handle,
-                windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
-                windows::core::PCWSTR(name_wide.as_ptr()),
-                0,
-                Some(data.as_ptr().cast()),
-                u32::try_from(data.len()).map_err(|_| Error::ResourceTooLarge)?,
-            )
-            .map_err(&map_err)?;
-        }
-
-        EndUpdateResourceW(handle, false).map_err(map_err)?;
-    }
-
-    Ok(())
 }
 
 /// Safely read a named resource from a loaded PE image.
@@ -721,7 +657,6 @@ if __name__ == "__main__":
     }
 
     #[test]
-    #[cfg(not(target_arch = "x86"))]
     fn empty_kind_resource_is_rejected() -> Result<()> {
         let temp_dir = assert_fs::TempDir::new()?;
         let launcher_path = temp_dir.child("launcher.console.exe");

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -339,6 +339,7 @@ fn read_resource(handle: windows::Win32::Foundation::HMODULE, name: &str) -> Opt
     // checked before reading the number of bytes reported by `SizeofResource`.
     #[allow(unsafe_code)]
     unsafe {
+        // Find the resource
         let resource = FindResourceW(
             Some(handle),
             windows::core::PCWSTR(name_wide.as_ptr()),
@@ -348,6 +349,7 @@ fn read_resource(handle: windows::Win32::Foundation::HMODULE, name: &str) -> Opt
             return None;
         }
 
+        // Get resource size and data
         let size = SizeofResource(Some(handle), resource);
         if size == 0 {
             return Some(Vec::new());
@@ -359,6 +361,7 @@ fn read_resource(handle: windows::Win32::Foundation::HMODULE, name: &str) -> Opt
             return None;
         }
 
+        // Copy the resource data into a Vec
         Some(std::slice::from_raw_parts(pointer, size as usize).to_vec())
     }
 }

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -235,8 +235,10 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
+    #[cfg(windows)]
     #[error("Failed to parse Windows PE image")]
     PeRead(#[from] editpe::ImageReadError),
+    #[cfg(windows)]
     #[error("Failed to update Windows PE resources")]
     PeWrite(#[from] editpe::ImageWriteError),
 }

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -2,6 +2,10 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::Utf8Error;
 
+#[cfg(windows)]
+use editpe::{
+    Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
+};
 use fs_err::File;
 use thiserror::Error;
 
@@ -278,17 +282,9 @@ fn get_launcher_bin(gui: bool) -> Result<&'static [u8], Error> {
     })
 }
 
-/// Write PE resources into a launcher binary using the `editpe` crate.
-///
-/// This directly manipulates the PE resource section without using Windows API calls
-/// like `BeginUpdateResource`/`UpdateResource`/`EndUpdateResource`, which are unavailable
-/// on minimal Windows environments such as Nano Server.
+/// Write PE resources into a launcher binary.
 #[cfg(windows)]
 fn write_resources(launcher_data: &[u8], resources: &[(&str, &[u8])]) -> Result<Vec<u8>, Error> {
-    use editpe::{
-        Image, ResourceData, ResourceDirectory, ResourceEntry, ResourceEntryName, ResourceTable,
-    };
-
     let mut image = Image::parse(launcher_data.to_vec())?;
 
     let mut resource_directory = image

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -66,35 +66,63 @@ impl Launcher {
     /// Returns `Err` if the file looks like a trampoline executable but is formatted incorrectly.
     #[cfg(windows)]
     pub fn try_from_path(path: &Path) -> Result<Option<Self>, Error> {
-        let data = fs_err::read(path)?;
-        let Ok(image) = editpe::Image::parse(data) else {
+        use std::os::windows::ffi::OsStrExt;
+        use windows::Win32::System::LibraryLoader::{LOAD_LIBRARY_AS_DATAFILE, LoadLibraryExW};
+
+        let path_wide = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+
+        // SAFETY: `path_wide` is a null-terminated UTF-16 string.
+        #[allow(unsafe_code)]
+        let Some(module) = (unsafe {
+            LoadLibraryExW(
+                windows::core::PCWSTR(path_wide.as_ptr()),
+                None,
+                LOAD_LIBRARY_AS_DATAFILE,
+            )
+            .ok()
+        }) else {
             return Ok(None);
         };
 
-        let Some(kind_data) = read_resource_from_image(&image, RESOURCE_TRAMPOLINE_KIND) else {
-            return Ok(None);
-        };
-        let Some(&kind_value) = kind_data.first() else {
-            return Err(Error::UnprocessableMetadata);
-        };
-        let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
-            return Err(Error::UnprocessableMetadata);
-        };
+        let result = (|| {
+            let Some(kind_data) = read_resource(module, RESOURCE_TRAMPOLINE_KIND) else {
+                return Ok(None);
+            };
+            let Some(&kind_value) = kind_data.first() else {
+                return Err(Error::UnprocessableMetadata);
+            };
+            let Some(kind) = LauncherKind::from_resource_value(kind_value) else {
+                return Err(Error::UnprocessableMetadata);
+            };
 
-        let Some(path_data) = read_resource_from_image(&image, RESOURCE_PYTHON_PATH) else {
-            return Ok(None);
-        };
-        let python_path = PathBuf::from(
-            String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
-        );
+            let Some(path_data) = read_resource(module, RESOURCE_PYTHON_PATH) else {
+                return Ok(None);
+            };
+            let python_path = PathBuf::from(
+                String::from_utf8(path_data).map_err(|err| Error::InvalidPath(err.utf8_error()))?,
+            );
 
-        let script_data = read_resource_from_image(&image, RESOURCE_SCRIPT_DATA);
+            let script_data = read_resource(module, RESOURCE_SCRIPT_DATA);
 
-        Ok(Some(Self {
-            kind,
-            python_path,
-            script_data,
-        }))
+            Ok(Some(Self {
+                kind,
+                python_path,
+                script_data,
+            }))
+        })();
+
+        // SAFETY: `module` was returned by a successful `LoadLibraryExW` call.
+        #[allow(unsafe_code)]
+        unsafe {
+            windows::Win32::Foundation::FreeLibrary(module)
+                .map_err(|err| Error::Io(io::Error::from_raw_os_error(err.code().0)))?;
+        }
+
+        result
     }
 
     /// Write this trampoline launcher to a file.
@@ -361,29 +389,44 @@ fn write_resources_with_winapi(path: &Path, resources: &[(&str, &[u8])]) -> Resu
     Ok(())
 }
 
-/// Read a named resource from a parsed PE [`Image`].
-///
-/// Navigates the PE resource directory tree: `RT_RCDATA` → `name` → first language entry.
+/// Safely read a named resource from a loaded PE image.
 #[cfg(windows)]
-fn read_resource_from_image(image: &editpe::Image<'_>, name: &str) -> Option<Vec<u8>> {
-    use editpe::ResourceEntryName;
+fn read_resource(handle: windows::Win32::Foundation::HMODULE, name: &str) -> Option<Vec<u8>> {
+    use windows::Win32::System::LibraryLoader::{
+        FindResourceW, LoadResource, LockResource, SizeofResource,
+    };
 
-    let resource_directory = image.resource_directory()?;
-    let root = resource_directory.root();
+    let name_wide = name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
 
-    let rcdata_entry = root.get(ResourceEntryName::ID(RT_RCDATA))?;
-    let rcdata_table = rcdata_entry.as_table()?;
+    // SAFETY: `name_wide` is null-terminated, `handle` is valid, and the resource pointer is
+    // checked before reading the number of bytes reported by `SizeofResource`.
+    #[allow(unsafe_code)]
+    unsafe {
+        let resource = FindResourceW(
+            Some(handle),
+            windows::core::PCWSTR(name_wide.as_ptr()),
+            windows::core::PCWSTR(RT_RCDATA as usize as *const u16),
+        );
+        if resource.is_invalid() {
+            return None;
+        }
 
-    let name_entry = rcdata_table.get(ResourceEntryName::from_string(name))?;
-    let language_table = name_entry.as_table()?;
+        let size = SizeofResource(Some(handle), resource);
+        if size == 0 {
+            return Some(Vec::new());
+        }
 
-    // Get the first language entry (typically ID(0) for neutral).
-    let entries = language_table.entries();
-    let first_language = entries.first()?;
-    let language_entry = language_table.get(*first_language)?;
-    let data = language_entry.as_data()?;
+        let data = LoadResource(Some(handle), resource).ok()?;
+        let pointer = LockResource(data).cast::<u8>();
+        if pointer.is_null() {
+            return None;
+        }
 
-    Some(data.data().to_vec())
+        Some(std::slice::from_raw_parts(pointer, size as usize).to_vec())
+    }
 }
 
 /// Construct a Windows script launcher.
@@ -662,6 +705,17 @@ if __name__ == "__main__":
             .success();
 
         println!("Signed binary: {}", bin_path.as_ref().display());
+    }
+
+    #[test]
+    fn malformed_trampoline_is_not_recognized() -> Result<()> {
+        let temp_dir = assert_fs::TempDir::new()?;
+        let launcher_path = temp_dir.child("malformed.exe");
+        fs_err::write(launcher_path.path(), b"MZ")?;
+
+        assert!(Launcher::try_from_path(launcher_path.path())?.is_none());
+
+        Ok(())
     }
 
     #[test]

--- a/crates/uv-trampoline-builder/src/resource_tests.rs
+++ b/crates/uv-trampoline-builder/src/resource_tests.rs
@@ -34,6 +34,7 @@ fn write_native_resources(
         .iter()
         .map(|(name, data)| {
             Ok((
+                *name,
                 name.encode_utf16()
                     .chain(std::iter::once(0))
                     .collect::<Vec<_>>(),
@@ -47,20 +48,24 @@ fn write_native_resources(
     // every update, and the update handle is closed on both success and failure.
     #[allow(unsafe_code)]
     unsafe {
-        let handle = BeginUpdateResourceW(PCWSTR(path_wide.as_ptr()), false)?;
-        let result = resources.iter().try_for_each(|(name, data, size)| {
-            UpdateResourceW(
-                handle,
-                PCWSTR(RT_RCDATA as usize as *const u16),
-                PCWSTR(name.as_ptr()),
-                0,
-                Some(data.as_ptr().cast()),
-                *size,
-            )
-        });
+        let handle = BeginUpdateResourceW(PCWSTR(path_wide.as_ptr()), false)
+            .context("BeginUpdateResourceW failed")?;
+        let result = resources
+            .iter()
+            .try_for_each(|(name, name_wide, data, size)| {
+                UpdateResourceW(
+                    handle,
+                    PCWSTR(RT_RCDATA as usize as *const u16),
+                    PCWSTR(name_wide.as_ptr()),
+                    0,
+                    Some(data.as_ptr().cast()),
+                    *size,
+                )
+                .with_context(|| format!("UpdateResourceW failed for {name} ({size} bytes)"))
+            });
         let finish = EndUpdateResourceW(handle, result.is_err());
         result?;
-        finish?;
+        finish.context("EndUpdateResourceW failed")?;
     }
 
     Ok(fs_err::read(path)?)
@@ -185,13 +190,15 @@ fn resources_match_native_windows_updates() -> Result<()> {
                 .context("Missing PE resource table")?
                 .size,
         )?;
-        let mut sizes = vec![0, 1, 65_535, 65_536, 65_537];
+        let mut sizes = vec![1, 65_535, 65_536, 65_537];
         for alignment in [file_alignment, section_alignment] {
             // Account for the resource tables and existing resources so the complete directory
             // crosses the boundary, not just the script payload.
             let boundary = alignment - resource_overhead % alignment;
             sizes.extend([boundary - 1, boundary, boundary + 1]);
         }
+        // UpdateResourceW rejects empty resources, which are covered separately below.
+        sizes.retain(|size| *size > 0);
         sizes.sort_unstable();
         sizes.dedup();
 
@@ -231,6 +238,27 @@ fn resources_match_native_windows_updates() -> Result<()> {
             assert_eq!(edited.script_data.as_deref(), Some(payload.as_slice()));
         }
     }
+
+    Ok(())
+}
+
+#[test]
+fn empty_script_resource_is_preserved() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let path = temp_dir.child("empty.exe");
+    let resources: &[(&str, &[u8])] = &[
+        (RESOURCE_TRAMPOLINE_KIND, &[1]),
+        (RESOURCE_PYTHON_PATH, b"C:/Python312/python.exe"),
+        (RESOURCE_SCRIPT_DATA, &[]),
+    ];
+    fs_err::write(
+        path.path(),
+        write_resources(get_launcher_bin(false)?, resources)?,
+    )?;
+
+    let launcher = Launcher::try_from_path(path.path())?
+        .context("Launcher with an empty script resource was not recognized")?;
+    assert_eq!(launcher.script_data, Some(Vec::new()));
 
     Ok(())
 }

--- a/crates/uv-trampoline-builder/src/resource_tests.rs
+++ b/crates/uv-trampoline-builder/src/resource_tests.rs
@@ -1,0 +1,269 @@
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use assert_cmd::prelude::OutputAssertExt;
+use assert_fs::prelude::PathChild;
+use editpe::{Image, ResourceEntry, ResourceEntryName};
+use fs_err::File;
+use goblin::pe::PE;
+use windows::Win32::System::LibraryLoader::{
+    BeginUpdateResourceW, EndUpdateResourceW, UpdateResourceW,
+};
+use windows::core::PCWSTR;
+
+use super::{
+    Launcher, LauncherKind, RESOURCE_PYTHON_PATH, RESOURCE_SCRIPT_DATA, RESOURCE_TRAMPOLINE_KIND,
+    RT_RCDATA, get_launcher_bin, windows_script_launcher, write_resources,
+};
+
+/// Use the Windows resource editor as an independent reference for resource readback.
+fn write_native_resources(
+    path: &Path,
+    launcher: &[u8],
+    resources: &[(&str, &[u8])],
+) -> Result<Vec<u8>> {
+    fs_err::write(path, launcher)?;
+    let path_wide = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let resources = resources
+        .iter()
+        .map(|(name, data)| {
+            Ok((
+                name.encode_utf16()
+                    .chain(std::iter::once(0))
+                    .collect::<Vec<_>>(),
+                *data,
+                u32::try_from(data.len())?,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // SAFETY: The path and resource names are null-terminated, the data slices remain live for
+    // every update, and the update handle is closed on both success and failure.
+    #[allow(unsafe_code)]
+    unsafe {
+        let handle = BeginUpdateResourceW(PCWSTR(path_wide.as_ptr()), false)?;
+        let result = resources.iter().try_for_each(|(name, data, size)| {
+            UpdateResourceW(
+                handle,
+                PCWSTR(RT_RCDATA as usize as *const u16),
+                PCWSTR(name.as_ptr()),
+                0,
+                Some(data.as_ptr().cast()),
+                *size,
+            )
+        });
+        let finish = EndUpdateResourceW(handle, result.is_err());
+        result?;
+        finish?;
+    }
+
+    Ok(fs_err::read(path)?)
+}
+
+fn assert_pe_layout(original: &[u8], output: &[u8]) -> Result<()> {
+    let original = PE::parse(original)?;
+    let output = PE::parse(output)?;
+    let original_header = original
+        .header
+        .optional_header
+        .context("Missing original PE optional header")?;
+    let output_header = output
+        .header
+        .optional_header
+        .context("Missing updated PE optional header")?;
+
+    assert_eq!(
+        original.header.coff_header.machine,
+        output.header.coff_header.machine
+    );
+    assert_eq!(
+        original_header.standard_fields.base_of_data,
+        output_header.standard_fields.base_of_data,
+    );
+    assert_eq!(
+        original_header.standard_fields.address_of_entry_point,
+        output_header.standard_fields.address_of_entry_point,
+    );
+    assert_eq!(
+        original_header.windows_fields.image_base,
+        output_header.windows_fields.image_base,
+    );
+    assert_eq!(
+        original_header.windows_fields.subsystem,
+        output_header.windows_fields.subsystem,
+    );
+
+    let alignment = output_header.windows_fields.section_alignment;
+    let size = u64::from(output_header.windows_fields.size_of_image);
+    assert_eq!(size % u64::from(alignment), 0);
+    for section in &output.sections {
+        let end = u64::from(section.virtual_address)
+            + u64::from(section.virtual_size.max(section.size_of_raw_data));
+        assert!(end <= size, "Section extends past SizeOfImage");
+    }
+
+    Ok(())
+}
+
+fn assert_other_resources_unchanged(
+    original: &[u8],
+    output: &[u8],
+    updated_names: &[&str],
+) -> Result<()> {
+    let original = Image::parse(original)?;
+    let output = Image::parse(output)?;
+    let Some(original_resources) = original.resource_directory() else {
+        return Ok(());
+    };
+    let output_resources = output
+        .resource_directory()
+        .context("Missing updated resource directory")?;
+
+    for resource_type in original_resources.root().entries() {
+        if resource_type == &ResourceEntryName::ID(RT_RCDATA) {
+            let original_table = original_resources
+                .root()
+                .get(resource_type)
+                .and_then(ResourceEntry::as_table)
+                .context("Invalid original RCDATA table")?;
+            let output_table = output_resources
+                .root()
+                .get(resource_type)
+                .and_then(ResourceEntry::as_table)
+                .context("Invalid updated RCDATA table")?;
+            for name in original_table.entries() {
+                if updated_names
+                    .iter()
+                    .any(|updated| name == &ResourceEntryName::from_string(updated))
+                {
+                    continue;
+                }
+                assert_eq!(original_table.get(name), output_table.get(name));
+            }
+        } else {
+            assert_eq!(
+                original_resources.root().get(resource_type),
+                output_resources.root().get(resource_type),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn resources_match_native_windows_updates() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+
+    for is_gui in [false, true] {
+        let launcher = get_launcher_bin(is_gui)?;
+        let header = PE::parse(launcher)?
+            .header
+            .optional_header
+            .context("Missing PE optional header")?;
+        let file_alignment = usize::try_from(header.windows_fields.file_alignment)?;
+        let section_alignment = usize::try_from(header.windows_fields.section_alignment)?;
+        let mut sizes = vec![0, 1, 65_535, 65_536, 65_537];
+        for alignment in [file_alignment, section_alignment] {
+            sizes.extend([alignment - 1, alignment, alignment + 1]);
+        }
+        sizes.sort_unstable();
+        sizes.dedup();
+
+        for size in sizes {
+            let native_path = temp_dir.child(format!("native-{is_gui}-{size}.exe"));
+            let edited_path = temp_dir.child(format!("edited-{is_gui}-{size}.exe"));
+            let payload = vec![0x5a; size];
+            let resources: &[(&str, &[u8])] = &[
+                (RESOURCE_TRAMPOLINE_KIND, &[1]),
+                (RESOURCE_PYTHON_PATH, b"C:/Python312/python.exe"),
+                (RESOURCE_SCRIPT_DATA, &payload),
+            ];
+            let native = write_native_resources(native_path.path(), launcher, resources)?;
+            let edited = write_resources(launcher, resources)?;
+            fs_err::write(edited_path.path(), &edited)?;
+
+            assert_pe_layout(launcher, &native)?;
+            assert_pe_layout(launcher, &edited)?;
+            assert_other_resources_unchanged(
+                launcher,
+                &edited,
+                &[
+                    RESOURCE_TRAMPOLINE_KIND,
+                    RESOURCE_PYTHON_PATH,
+                    RESOURCE_SCRIPT_DATA,
+                ],
+            )?;
+
+            let native = Launcher::try_from_path(native_path.path())?
+                .context("Windows-generated launcher was not recognized")?;
+            let edited = Launcher::try_from_path(edited_path.path())?
+                .context("editpe-generated launcher was not recognized")?;
+            assert_eq!(native.kind, LauncherKind::Script);
+            assert_eq!(edited.kind, native.kind);
+            assert_eq!(edited.python_path, native.python_path);
+            assert_eq!(native.script_data.as_deref(), Some(payload.as_slice()));
+            assert_eq!(edited.script_data.as_deref(), Some(payload.as_slice()));
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn large_script_survives_launcher_rewrites() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let original_path = temp_dir.child("original.exe");
+    let rewritten_path = temp_dir.child("rewritten.exe");
+    let repeated_path = temp_dir.child("repeated.exe");
+    let original_python = Path::new(r"C:\old Python\π\python.exe");
+    let python = which::which("python")?;
+
+    let script = format!(
+        "{}print('large trampoline')\n",
+        "# Padding keeps the stored ZIP larger than 64 KiB.\n".repeat(2_000),
+    );
+    let original = windows_script_launcher(&script, false, original_python)?;
+    fs_err::write(original_path.path(), &original)?;
+    let launcher = Launcher::try_from_path(original_path.path())?
+        .context("Original launcher was not recognized")?;
+    assert_eq!(launcher.python_path, original_python);
+    let script_data = launcher
+        .script_data
+        .clone()
+        .context("Missing original script data")?;
+    assert!(script_data.len() > 65_536);
+
+    {
+        let mut file = File::create(rewritten_path.path())?;
+        launcher
+            .with_python_path(python.clone())
+            .write_to_file(&mut file, false)?;
+    }
+    let launcher = Launcher::try_from_path(rewritten_path.path())?
+        .context("Rewritten launcher was not recognized")?;
+    assert_eq!(launcher.python_path, python);
+    assert_eq!(
+        launcher.script_data.as_deref(),
+        Some(script_data.as_slice())
+    );
+    {
+        let mut file = File::create(repeated_path.path())?;
+        launcher.write_to_file(&mut file, false)?;
+    }
+
+    for path in [rewritten_path.path(), repeated_path.path()] {
+        Command::new(path)
+            .assert()
+            .success()
+            .stdout("large trampoline\r\n");
+    }
+
+    Ok(())
+}

--- a/crates/uv-trampoline-builder/src/resource_tests.rs
+++ b/crates/uv-trampoline-builder/src/resource_tests.rs
@@ -169,9 +169,28 @@ fn resources_match_native_windows_updates() -> Result<()> {
             .context("Missing PE optional header")?;
         let file_alignment = usize::try_from(header.windows_fields.file_alignment)?;
         let section_alignment = usize::try_from(header.windows_fields.section_alignment)?;
+        let empty_resources: &[(&str, &[u8])] = &[
+            (RESOURCE_TRAMPOLINE_KIND, &[1]),
+            (RESOURCE_PYTHON_PATH, b"C:/Python312/python.exe"),
+            (RESOURCE_SCRIPT_DATA, &[]),
+        ];
+        let empty = write_resources(launcher, empty_resources)?;
+        let resource_overhead = usize::try_from(
+            PE::parse(&empty)?
+                .header
+                .optional_header
+                .context("Missing updated PE optional header")?
+                .data_directories
+                .get_resource_table()
+                .context("Missing PE resource table")?
+                .size,
+        )?;
         let mut sizes = vec![0, 1, 65_535, 65_536, 65_537];
         for alignment in [file_alignment, section_alignment] {
-            sizes.extend([alignment - 1, alignment, alignment + 1]);
+            // Account for the resource tables and existing resources so the complete directory
+            // crosses the boundary, not just the script payload.
+            let boundary = alignment - resource_overhead % alignment;
+            sizes.extend([boundary - 1, boundary, boundary + 1]);
         }
         sizes.sort_unstable();
         sizes.dedup();

--- a/test/integration/windows-nanoserver.ps1
+++ b/test/integration/windows-nanoserver.ps1
@@ -3,9 +3,9 @@ $ErrorActionPreference = "Stop"
 # Test that uv can install packages with entrypoints on Windows NanoServer.
 #
 # Windows NanoServer does not support the `BeginUpdateResourceW`,
-# `UpdateResourceW`, and `EndUpdateResourceW` APIs that are used to embed
-# metadata in trampoline executables. uv must fall back to the legacy
-# trampoline format on this platform.
+# `UpdateResourceW`, and `EndUpdateResourceW` APIs. uv uses the `editpe`
+# crate to directly manipulate PE resources instead of these syscalls,
+# which allows trampoline creation to work on this platform.
 #
 # See: https://github.com/astral-sh/uv/issues/18663
 

--- a/test/integration/windows-nanoserver.ps1
+++ b/test/integration/windows-nanoserver.ps1
@@ -28,4 +28,8 @@ if ($LASTEXITCODE -ne 0) { throw "uv init failed" }
 uv --directory C:\test-project add pytest
 if ($LASTEXITCODE -ne 0) { throw "uv add pytest failed" }
 
-Write-Host "Successfully installed package with entrypoints on Windows NanoServer"
+# Verify the generated trampoline can execute on NanoServer.
+& C:\test-project\.venv\Scripts\pytest.exe --version
+if ($LASTEXITCODE -ne 0) { throw "pytest entrypoint failed" }
+
+Write-Host "Successfully installed and ran an entrypoint on Windows NanoServer"

--- a/test/integration/windows-nanoserver.ps1
+++ b/test/integration/windows-nanoserver.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = "Stop"
+
+# Test that uv can install packages with entrypoints on Windows NanoServer.
+#
+# Windows NanoServer does not support the `BeginUpdateResourceW`,
+# `UpdateResourceW`, and `EndUpdateResourceW` APIs. uv uses the `editpe`
+# crate to directly manipulate PE resources instead of these syscalls,
+# which allows trampoline creation to work on this platform.
+#
+# See: https://github.com/astral-sh/uv/issues/18663
+
+Write-Host "Testing uv on Windows NanoServer"
+
+# Add the mounted binary directory to PATH
+$env:PATH = "C:\uv;" + $env:PATH
+
+# Verify uv is available
+uv --version
+if ($LASTEXITCODE -ne 0) { throw "uv --version failed" }
+
+# Create a temporary project
+uv init C:\test-project
+if ($LASTEXITCODE -ne 0) { throw "uv init failed" }
+
+# Install a package that has console_scripts entry points.
+# `pytest` is a pure-Python package that registers a `pytest` console script,
+# which exercises the trampoline creation code path.
+uv --directory C:\test-project add pytest
+if ($LASTEXITCODE -ne 0) { throw "uv add pytest failed" }
+
+Write-Host "Successfully installed package with entrypoints on Windows NanoServer"


### PR DESCRIPTION
Windows trampoline resource updates currently depend on Win32 APIs that are unavailable on NanoServer and can contend with antivirus software while reopening temporary executables. Use upstream `editpe` 0.2.4 to edit PE resources in memory across all supported Windows architectures, and restore the NanoServer integration test.

Closes astral-sh/uv#18663.
Closes astral-sh/uv#20955.