### PR TITLE
Fix crates.io trusted publish workflow name

### DIFF
--- a/scripts/setup-crates-io-publish.py
+++ b/scripts/setup-crates-io-publish.py
@@ -41,7 +41,7 @@ USER_AGENT = "uv-crates-io-publish-setup (github.com/astral-sh/uv)"
 
 REPOSITORY_OWNER = "astral-sh"
 REPOSITORY_NAME = "uv"
-WORKFLOW_FILENAME = "publish-crates.yml"
+WORKFLOW_FILENAME = "release.yml"
 ENVIRONMENT = "release"
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent


### PR DESCRIPTION
This is inverted from PyPI