### PR TITLE
Mute `stderr_important` dead code warning

### DIFF
--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -53,6 +53,7 @@ impl Printer {
     }
 
     /// Return the [`Stderr`] for this printer.
+    #[allow(dead_code)] // Only used with the optional self-update feature.
     pub(crate) fn stderr_important(self) -> Stderr {
         match self {
             Self::Silent => Stderr::Disabled,


### PR DESCRIPTION
The warning is recently showing up a lot.