### PR TITLE
fix: extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/publish-versions.yml
+++ b/.github/workflows/publish-versions.yml
@@ -27,7 +27,9 @@ jobs:
         run: echo "BRANCH_NAME=update-versions-$VERSION-$(date +%s)" >> $GITHUB_ENV
 
       - name: "Clone versions repo"
-        run: git clone https://${{ secrets.ASTRAL_VERSIONS_PAT }}@github.com/astral-sh/versions.git astral-versions
+        run: git clone https://${ASTRAL_VERSIONS_PAT}@github.com/astral-sh/versions.git astral-versions
+        env:
+          ASTRAL_VERSIONS_PAT: ${{ secrets.ASTRAL_VERSIONS_PAT }}
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -941,13 +941,15 @@ jobs:
         run: |
           UV_TEST_AWS_TOKEN=$(aws codeartifact get-authorization-token \
             --domain tests \
-            --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} \
+            --domain-owner ${AWS_ACCOUNT_ID} \
             --region us-east-1 \
             --query authorizationToken \
             --output text)
           echo "::add-mask::$UV_TEST_AWS_TOKEN"
           echo "UV_TEST_AWS_TOKEN=$UV_TEST_AWS_TOKEN" >> $GITHUB_ENV
 
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
       - name: "Authenticate with GCP"
         id: "auth"
         uses: "google-github-actions/auth@fc2174804b84f912b1f6d334e9463f484f1c552d"


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/publish-versions.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/test-integration.yml` | Extracted 1 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-018 | high | `.github/workflows/check-release.yml` | Suspicious Payload Execution Pattern |
| RGS-012 | high | `.github/workflows/ci.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-018 | high | `.github/workflows/release.yml` | Suspicious Payload Execution Pattern |
| RGS-018 | high | `.github/workflows/test-system.yml` | Suspicious Payload Execution Pattern |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.