### PR TITLE
Respect dependency-metadata overrides in `uv pip check`

### DIFF
--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -8,9 +8,9 @@ use fs_err as fs;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use uv_distribution_types::{
-    ConfigSettings, Diagnostic, ExtraBuildRequires, ExtraBuildVariables, InstalledDist,
-    InstalledDistKind, Name, NameRequirementSpecification, PackageConfigSettings, Requirement,
-    UnresolvedRequirement, UnresolvedRequirementSpecification,
+    ConfigSettings, DependencyMetadata, Diagnostic, ExtraBuildRequires, ExtraBuildVariables,
+    InstalledDist, InstalledDistKind, Name, NameRequirementSpecification, PackageConfigSettings,
+    Requirement, UnresolvedRequirement, UnresolvedRequirementSpecification,
 };
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
@@ -197,6 +197,26 @@ impl SitePackages {
         markers: &ResolverMarkerEnvironment,
         tags: &Tags,
     ) -> Result<Vec<SitePackagesDiagnostic>> {
+        self.diagnostics_inner(markers, tags, None)
+    }
+
+    /// Validate the installed packages in the virtual environment, using dependency metadata
+    /// overrides when available.
+    pub fn diagnostics_with_dependency_metadata(
+        &self,
+        markers: &ResolverMarkerEnvironment,
+        tags: &Tags,
+        dependency_metadata: &DependencyMetadata,
+    ) -> Result<Vec<SitePackagesDiagnostic>> {
+        self.diagnostics_inner(markers, tags, Some(dependency_metadata))
+    }
+
+    fn diagnostics_inner(
+        &self,
+        markers: &ResolverMarkerEnvironment,
+        tags: &Tags,
+        dependency_metadata: Option<&DependencyMetadata>,
+    ) -> Result<Vec<SitePackagesDiagnostic>> {
         let mut diagnostics = Vec::new();
 
         for (package, indexes) in &self.by_name {
@@ -225,12 +245,19 @@ impl SitePackages {
                 };
 
                 // Determine the dependencies for the given package.
-                let Ok(metadata) = distribution.read_metadata() else {
-                    diagnostics.push(SitePackagesDiagnostic::MetadataUnavailable {
-                        package: package.clone(),
-                        path: distribution.install_path().to_owned(),
-                    });
-                    continue;
+                let metadata = if let Some(metadata) = dependency_metadata.and_then(|metadata| {
+                    metadata.get(distribution.name(), Some(distribution.version()))
+                }) {
+                    metadata
+                } else {
+                    let Ok(metadata) = distribution.read_metadata() else {
+                        diagnostics.push(SitePackagesDiagnostic::MetadataUnavailable {
+                            package: package.clone(),
+                            path: distribution.install_path().to_owned(),
+                        });
+                        continue;
+                    };
+                    metadata.clone()
                 };
 
                 // Verify that the package is compatible with the current Python version.

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
 use uv_configuration::TargetTriple;
-use uv_distribution_types::{Diagnostic, InstalledDist};
+use uv_distribution_types::{DependencyMetadata, Diagnostic, InstalledDist};
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
 use uv_preview::Preview;
 use uv_python::{
@@ -27,6 +27,7 @@ pub(crate) fn pip_check(
     cache: &Cache,
     printer: Printer,
     preview: Preview,
+    dependency_metadata: &DependencyMetadata,
 ) -> Result<ExitStatus> {
     let start = Instant::now();
 
@@ -63,7 +64,7 @@ pub(crate) fn pip_check(
 
     // Run the diagnostics.
     let diagnostics: Vec<SitePackagesDiagnostic> = site_packages
-        .diagnostics(&markers, &tags)?
+        .diagnostics_with_dependency_metadata(&markers, &tags, dependency_metadata)?
         .into_iter()
         .collect();
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1148,6 +1148,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &cache,
                 printer,
                 globals.preview,
+                &args.settings.dependency_metadata,
             )
         }
         Commands::Pip(PipNamespace {

--- a/crates/uv/tests/it/pip_check.rs
+++ b/crates/uv/tests/it/pip_check.rs
@@ -114,6 +114,81 @@ fn check_incompatible_packages() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn check_dependency_metadata_override() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("requests==2.31.0")?;
+
+    uv_snapshot!(context
+        .pip_install()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + certifi==2024.2.2
+     + charset-normalizer==3.3.2
+     + idna==3.6
+     + requests==2.31.0
+     + urllib3==2.2.1
+    "
+    );
+
+    uv_snapshot!(context
+        .pip_uninstall()
+        .arg("idna"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Uninstalled 1 package in [TIME]
+     - idna==3.6
+    "
+    );
+
+    uv_snapshot!(context.pip_check(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Checked 4 packages in [TIME]
+    Found 1 incompatibility
+    The package `requests` requires `idna>=2.5,<4`, but it's not installed
+    "
+    );
+
+    context.temp_dir.child("uv.toml").write_str(
+        r#"
+        dependency-metadata = [
+          { name = "requests", version = "2.31.0", requires-dist = [] },
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.pip_check().arg("--config-file").arg("uv.toml"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Checked 4 packages in [TIME]
+    All installed packages are compatible
+    "
+    );
+
+    Ok(())
+}
+
 // requests 2.31.0 requires idna (<4,>=2.5) and urllib3<3,>=1.21.1
 // this test force-installs idna 2.4 and urllib3 1.20 to trigger a failure
 // with multiple incompatible packages.


### PR DESCRIPTION
## Summary
- teach `uv pip check` to pass config-provided dependency metadata overrides through to the site-packages diagnostic path
- prefer override metadata before falling back to installed wheel metadata when computing incompatibilities
- add an integration regression showing `dependency-metadata` in `uv.toml` suppresses the false incompatibility after `idna` is removed

Fixes #18719.

## Testing
- `cargo test -p uv --test it pip_check::check_dependency_metadata_override`
- `cargo test -p uv --test it pip_check::`
- `cargo fmt --all --check`
- `git diff --check`