### PR TITLE
Use github-releases for gh-action-pypi-publish Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,6 +63,14 @@
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {
+      // `github-tags` fails to resolve new digests for this action, but its
+      // GitHub releases use the same `v*` tags and are sufficient for updates.
+      // See: https://github.com/astral-sh/uv/issues/15276
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["pypa/gh-action-pypi-publish"],
+      overrideDatasource: "github-releases",
+    },
+    {
       // This package rule disables updates for GitHub runners:
       // we'd only pin them to a specific version
       // if there was a deliberate reason to do so


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->


Fixes #15276.

  Renovate fails to resolve digest updates for `pypa/gh-action-pypi-publish` with the `github-tags` datasource.

  This switches that action to `github-releases` and keeps the workflow SHA-pinned.
