### PR TITLE
fix: respect --output-format json for OutdatedEnvironment error

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, LazyLock};
 
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
+use serde::Serialize;
+use uv_cli::SyncFormat;
 use version_ranges::Ranges;
 
 use uv_distribution_types::{
@@ -38,6 +40,8 @@ pub(crate) struct OperationDiagnostic {
     pub(crate) system_certs: bool,
     /// The context to display to the user upon resolution failure.
     pub(crate) context: Option<&'static str>,
+    // The output format to use for error messages.
+    pub(crate) output_format: SyncFormat,
 }
 
 impl OperationDiagnostic {
@@ -64,6 +68,15 @@ impl OperationDiagnostic {
     pub(crate) fn with_context(self, context: &'static str) -> Self {
         Self {
             context: Some(context),
+            ..self
+        }
+    }
+
+    /// Set the output format to use for error messages.
+    #[must_use]
+    pub(crate) fn with_output_format(self, output_format: SyncFormat) -> Self {
+        Self {
+            output_format,
             ..self
         }
     }
@@ -137,7 +150,23 @@ impl OperationDiagnostic {
                 None
             }
             pip::operations::Error::OutdatedEnvironment => {
-                anstream::eprintln!("{}", err);
+                match self.output_format {
+                    SyncFormat::Json => {
+                        #[derive(Serialize)]
+                        struct OutdatedEnvironmentError {
+                            error: String,
+                            message: String,
+                        }
+                        let error = OutdatedEnvironmentError {
+                            error: "OutdatedEnvironment".to_string(),
+                            message: err.to_string(),
+                        };
+                        anstream::eprintln!("{}", serde_json::to_string(&error).unwrap());
+                    }
+                    SyncFormat::Text => {
+                        anstream::eprintln!("{}", err);
+                    }
+                }
                 None
             }
             err => Some(err),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -303,11 +303,11 @@ pub(crate) async fn sync(
                     }
                     return Ok(ExitStatus::Success);
                 }
-                // TODO(zanieb): We should respect `--output-format json` for the error case
                 Err(ProjectError::Operation(err)) => {
                     return diagnostics::OperationDiagnostic::with_system_certs(
                         client_builder.system_certs(),
                     )
+                    .with_output_format(output_format)
                     .report(err)
                     .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
                 }
@@ -357,6 +357,7 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
+            .with_output_format(output_format)
             .report(err)
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }
@@ -435,6 +436,7 @@ pub(crate) async fn sync(
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),
             )
+            .with_output_format(output_format)
             .report(err)
             .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
         }


### PR DESCRIPTION
## Summary

When using `uv sync --output-format json --check`, if the environment is outdated, the error was always printed in text format instead of JSON format.

## Changes

- Added `output_format` field to `OperationDiagnostic`
- Added `with_output_format()` method to set the output format
- Updated `OutdatedEnvironment` error handling to respect `output_format`
- Removed the TODO comment that mentioned this issue

## Testing

The fix ensures that when `--output-format=json` is used with `--check`, the `OutdatedEnvironment` error is output as JSON:

```json
{"error":"OutdatedEnvironment","message":"The environment is outdated; run `uv sync` to update the environment"}
```

Instead of plain text.

Fixes #18744