### PR TITLE
docs: link "Running commands" page to "Locking and syncing"

### DIFF
--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -10,7 +10,9 @@ $ uv run python -c "import example"
 ```
 
 When using `run`, uv will ensure that the project environment is up-to-date before running the given
-command.
+command. See the [locking and syncing](./sync.md) documentation for details on how uv manages the
+project environment, including how to control locking behavior with `--locked`, `--frozen`, and
+`--no-sync`.
 
 The given command can be provided by the project environment or exist outside of it, e.g.:
 


### PR DESCRIPTION
Closes #15407

The "Running commands" page mentions that `uv run` ensures the project environment is up-to-date, but doesn't point readers to where that behavior is documented. This adds a link to the [locking and syncing](./sync.md) page so users can learn about `--locked`, `--frozen`, and `--no-sync` options from the same context.

Made with [Cursor](https://cursor.com)