### PR TITLE
docs: link "Editable mode" to dynamic metadata cache settings

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -550,6 +550,11 @@ which instructs uv to install the project in non-editable mode. `--no-editable` 
 deployment use-cases, such as building a Docker container, in which the project should be included
 in the deployed environment without a dependency on the originating source code.
 
+By default, uv only rebuilds editable installs when `pyproject.toml`, `setup.py`, or `setup.cfg`
+changes. To control when uv rebuilds a local dependency based on dynamic metadata (e.g., Git commit
+hash or version derived from a file), see
+[Dynamic metadata](../../concepts/cache.md#dynamic-metadata) in the cache documentation.
+
 ## Conflicting dependencies
 
 uv resolves all project dependencies together, including optional dependencies ("extras") and


### PR DESCRIPTION
Closes #15413

The "Configuring projects" page covers editable installs but doesn't mention that uv's cache behavior for local directory dependencies can be customized via `tool.uv.cache-keys`. Users working with dynamic metadata (e.g., `setuptools-scm`, Git-versioned packages) have no way to discover the [Dynamic metadata](../../concepts/cache.md#dynamic-metadata) cache documentation from this page.

This adds a short note at the end of the "Editable mode" section pointing to the cache docs.

Made with [Cursor](https://cursor.com)