### PR TITLE
Don't silently ignore directories in source-include

### DIFF
--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -100,7 +100,7 @@ fn source_dist_matcher(
                 let potential_dir = source_tree.join(pattern);
                 if potential_dir.is_dir() {
                     warn_user_once!(
-                        "`source-include` pattern `{pattern}` matches directory `{pattern}` but not its contents. Use `{pattern}/**` to include all files in the directory."
+                        "`source-include` matches directory `{pattern}` but not its contents. Use `{pattern}/**` to include all files in the directory."
                     );
                 }
             }

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -75,7 +75,38 @@ fn source_dist_matcher(
 ) -> Result<(GlobDirFilter, GlobSet), Error> {
     // File and directories to include in the source directory
     let mut include_globs = Vec::new();
-    let mut includes: Vec<String> = settings.source_include;
+    // A trailing slash unambiguously indicates a directory; include its contents recursively.
+    let mut includes: Vec<String> = settings
+        .source_include
+        .into_iter()
+        .map(|pattern| {
+            if let Some(prefix) = pattern.strip_suffix('/') {
+                format!("{prefix}/**")
+            } else {
+                pattern
+            }
+        })
+        .collect();
+
+    // Warn if a pattern without glob metacharacters matches an existing directory but not its
+    // contents.
+    if show_warnings {
+        for pattern in &includes {
+            if !pattern.contains('*')
+                && !pattern.contains('?')
+                && !pattern.contains('[')
+                && !pattern.contains('/')
+            {
+                let potential_dir = source_tree.join(pattern);
+                if potential_dir.is_dir() {
+                    warn_user_once!(
+                        "`source-include` pattern `{pattern}` matches directory `{pattern}` but not its contents. Use `{pattern}/**` to include all files in the directory."
+                    );
+                }
+            }
+        }
+    }
+
     // pyproject.toml is always included.
     includes.push(globset::escape("pyproject.toml"));
 

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -75,22 +75,7 @@ fn source_dist_matcher(
 ) -> Result<(GlobDirFilter, GlobSet), Error> {
     // File and directories to include in the source directory
     let mut include_globs = Vec::new();
-    let mut includes: Vec<String> = settings
-        .source_include
-        .into_iter()
-        .map(|pattern| {
-            // If the pattern is a directory, include all files in that directory.
-            if source_tree.join(&pattern).is_dir() {
-                if pattern.ends_with('/') {
-                    format!("{pattern}**", pattern = globset::escape(&pattern))
-                } else {
-                    format!("{pattern}/**", pattern = globset::escape(&pattern))
-                }
-            } else {
-                pattern
-            }
-        })
-        .collect();
+    let mut includes: Vec<String> = settings.source_include;
 
     // pyproject.toml is always included.
     includes.push(globset::escape("pyproject.toml"));

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -75,37 +75,27 @@ fn source_dist_matcher(
 ) -> Result<(GlobDirFilter, GlobSet), Error> {
     // File and directories to include in the source directory
     let mut include_globs = Vec::new();
-    // A trailing slash unambiguously indicates a directory; include its contents recursively.
+    // If a pattern ends with a trailing slash, or is a literal path that matches an existing
+    // directory, expand it to include the directory's contents recursively.
     let mut includes: Vec<String> = settings
         .source_include
         .into_iter()
         .map(|pattern| {
             if let Some(prefix) = pattern.strip_suffix('/') {
+                // A trailing slash unambiguously indicates a directory.
                 format!("{prefix}/**")
+            } else if !pattern.contains('*') && !pattern.contains('?') && !pattern.contains('[') {
+                // A literal path (no glob metacharacters) that matches an existing directory.
+                if source_tree.join(&pattern).is_dir() {
+                    format!("{pattern}/**")
+                } else {
+                    pattern
+                }
             } else {
                 pattern
             }
         })
         .collect();
-
-    // Warn if a pattern without glob metacharacters matches an existing directory but not its
-    // contents.
-    if show_warnings {
-        for pattern in &includes {
-            if !pattern.contains('*')
-                && !pattern.contains('?')
-                && !pattern.contains('[')
-                && !pattern.contains('/')
-            {
-                let potential_dir = source_tree.join(pattern);
-                if potential_dir.is_dir() {
-                    warn_user_once!(
-                        "`source-include` matches directory `{pattern}` but not its contents. Use `{pattern}/**` to include all files in the directory."
-                    );
-                }
-            }
-        }
-    }
 
     // pyproject.toml is always included.
     includes.push(globset::escape("pyproject.toml"));

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -75,21 +75,16 @@ fn source_dist_matcher(
 ) -> Result<(GlobDirFilter, GlobSet), Error> {
     // File and directories to include in the source directory
     let mut include_globs = Vec::new();
-    // If a pattern ends with a trailing slash, or is a literal path that matches an existing
-    // directory, expand it to include the directory's contents recursively.
     let mut includes: Vec<String> = settings
         .source_include
         .into_iter()
         .map(|pattern| {
-            if let Some(prefix) = pattern.strip_suffix('/') {
-                // A trailing slash unambiguously indicates a directory.
-                format!("{prefix}/**")
-            } else if !pattern.contains('*') && !pattern.contains('?') && !pattern.contains('[') {
-                // A literal path (no glob metacharacters) that matches an existing directory.
-                if source_tree.join(&pattern).is_dir() {
-                    format!("{pattern}/**")
+            // If the pattern is a directory, include all files in that directory.
+            if source_tree.join(&pattern).is_dir() {
+                if pattern.ends_with('/') {
+                    format!("{pattern}**", pattern = globset::escape(&pattern))
                 } else {
-                    pattern
+                    format!("{pattern}/**", pattern = globset::escape(&pattern))
                 }
             } else {
                 pattern

--- a/crates/uv-globfilter/src/glob_dir_filter.rs
+++ b/crates/uv-globfilter/src/glob_dir_filter.rs
@@ -305,4 +305,97 @@ mod tests {
             ]
         );
     }
+
+    /// Test that `**/dir` and `**/dir/` patterns match directories at any depth and include
+    /// their contents.
+    #[test]
+    fn globstar_directory() {
+        let files = [
+            "a/target/file1.txt",
+            "a/target/nested/file2.txt",
+            "b/c/target/file3.txt",
+        ];
+
+        let dir = tempdir().unwrap();
+        for file in files {
+            let path = dir.path().join(file);
+            fs_err::create_dir_all(path.parent().unwrap()).unwrap();
+            fs_err::File::create(path).unwrap();
+        }
+
+        // `**/target` — matches `target` directories at any depth and includes their contents.
+        let patterns = [PortableGlobParser::Uv.parse("**/target").unwrap()];
+        let matcher = GlobDirFilter::from_globs(&patterns).unwrap();
+
+        let walkdir_root = dir.path();
+        let mut matches: Vec<_> = WalkDir::new(walkdir_root)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(|entry| {
+                let relative = entry
+                    .path()
+                    .strip_prefix(walkdir_root)
+                    .expect("walkdir starts with root");
+                matcher.match_directory(relative)
+            })
+            .filter_map(|entry| {
+                let entry = entry.as_ref().unwrap();
+                let relative = entry
+                    .path()
+                    .strip_prefix(walkdir_root)
+                    .expect("walkdir starts with root");
+                if matcher.match_path(relative) {
+                    Some(relative.to_str().unwrap().replace(MAIN_SEPARATOR, "/"))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        matches.sort();
+        assert_eq!(
+            matches,
+            [
+                "",
+                "a",
+                "a/target",
+                "a/target/file1.txt",
+                "a/target/nested",
+                "a/target/nested/file2.txt",
+                "b",
+                "b/c",
+                "b/c/target",
+                "b/c/target/file3.txt",
+            ]
+        );
+
+        // `**/target/` with trailing slash — should behave identically after normalization.
+        let patterns = [PortableGlobParser::Uv.parse("**/target/").unwrap()];
+        let matcher_slash = GlobDirFilter::from_globs(&patterns).unwrap();
+
+        let mut matches_slash: Vec<_> = WalkDir::new(walkdir_root)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(|entry| {
+                let relative = entry
+                    .path()
+                    .strip_prefix(walkdir_root)
+                    .expect("walkdir starts with root");
+                matcher_slash.match_directory(relative)
+            })
+            .filter_map(|entry| {
+                let entry = entry.as_ref().unwrap();
+                let relative = entry
+                    .path()
+                    .strip_prefix(walkdir_root)
+                    .expect("walkdir starts with root");
+                if matcher_slash.match_path(relative) {
+                    Some(relative.to_str().unwrap().replace(MAIN_SEPARATOR, "/"))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        matches_slash.sort();
+        assert_eq!(matches, matches_slash);
+    }
 }

--- a/crates/uv-globfilter/src/glob_dir_filter.rs
+++ b/crates/uv-globfilter/src/glob_dir_filter.rs
@@ -99,8 +99,18 @@ impl GlobDirFilter {
 
         // Paths aren't necessarily UTF-8, which we can gloss over since the globs match bytes only
         // anyway.
+        let separator = u8::try_from(MAIN_SEPARATOR).unwrap();
         let byte_path = path.as_os_str().as_encoded_bytes();
         for b in byte_path {
+            // If we hit a path separator and the state so far is a match, a glob matched a parent
+            // directory of this path. We treat matching a directory as matching everything inside
+            // it, so we can return early.
+            if *b == separator {
+                let eoi_state = dfa.next_eoi_state(state);
+                if !dfa.is_quit_state(eoi_state) && dfa.is_match_state(eoi_state) {
+                    return true;
+                }
+            }
             state = dfa.next_state(state, *b);
         }
         // Say we're looking at a directory `foo/bar`. We want to continue if either `foo/bar` is
@@ -109,7 +119,7 @@ impl GlobDirFilter {
         // We must not call `next_eoi_state` on the slash state, we want to only check if more
         // characters (path components) are allowed, not if we're matching the `$` anchor at the
         // end.
-        let slash_state = dfa.next_state(state, u8::try_from(MAIN_SEPARATOR).unwrap());
+        let slash_state = dfa.next_state(state, separator);
 
         debug_assert!(
             !dfa.is_quit_state(eoi_state) && !dfa.is_quit_state(slash_state),
@@ -137,15 +147,15 @@ mod tests {
     ];
 
     const PATTERNS: [&str; 5] = [
-        // Only sufficient for descending one level
+        // Matches direct children; matched directories include their contents
         "path1/*",
-        // Only sufficient for descending one level
+        // Matches a directory; its contents are included recursively
         "path2/dir2",
-        // Sufficient for descending
+        // Matches a specific file
         "path3/dir3/subdir/a.txt",
-        // Sufficient for descending
+        // Matches everything recursively
         "path4/**/*",
-        // Not sufficient for descending
+        // Matches a directory; its contents are included recursively
         "path5",
     ];
 
@@ -157,7 +167,8 @@ mod tests {
         assert!(matcher.match_directory(&Path::new("path2").join("dir2")));
         assert!(matcher.match_directory(&Path::new("path3").join("dir3")));
         assert!(matcher.match_directory(&Path::new("path4").join("dir4")));
-        assert!(!matcher.match_directory(&Path::new("path5").join("dir5")));
+        // Pattern `path5` matches the directory, so its children are included too.
+        assert!(matcher.match_directory(&Path::new("path5").join("dir5")));
     }
 
     /// Check that we skip directories that can never match.
@@ -202,8 +213,12 @@ mod tests {
                 "",
                 "path1",
                 "path1/dir1",
+                "path1/dir1/subdir",
+                "path1/dir1/subdir/a.txt",
                 "path2",
                 "path2/dir2",
+                "path2/dir2/subdir",
+                "path2/dir2/subdir/a.txt",
                 "path3",
                 "path3/dir3",
                 "path3/dir3/subdir",
@@ -212,7 +227,10 @@ mod tests {
                 "path4/dir4",
                 "path4/dir4/subdir",
                 "path4/dir4/subdir/a.txt",
-                "path5"
+                "path5",
+                "path5/dir5",
+                "path5/dir5/subdir",
+                "path5/dir5/subdir/a.txt",
             ]
         );
     }
@@ -266,8 +284,12 @@ mod tests {
                 "",
                 "path1",
                 "path1/dir1",
+                "path1/dir1/subdir",
+                "path1/dir1/subdir/a.txt",
                 "path2",
                 "path2/dir2",
+                "path2/dir2/subdir",
+                "path2/dir2/subdir/a.txt",
                 "path3",
                 "path3/dir3",
                 "path3/dir3/subdir",
@@ -276,7 +298,10 @@ mod tests {
                 "path4/dir4",
                 "path4/dir4/subdir",
                 "path4/dir4/subdir/a.txt",
-                "path5"
+                "path5",
+                "path5/dir5",
+                "path5/dir5/subdir",
+                "path5/dir5/subdir/a.txt",
             ]
         );
     }

--- a/crates/uv-globfilter/src/portable_glob.rs
+++ b/crates/uv-globfilter/src/portable_glob.rs
@@ -92,8 +92,7 @@ impl PortableGlobParser {
     /// These rules mean that matching the backslash (`\`) is forbidden, which avoid collisions with the windows path separator.
     pub fn parse(&self, glob: &str) -> Result<Glob, PortableGlobError> {
         self.check(glob)?;
-        // A trailing slash is meaningless in a glob — file paths never end with `/` — so
-        // strip it to let `GlobDirFilter` handle the directory-inclusion semantics.
+        // Normalize out any trailing slash; `GlobDirFilter` will handle the directory-inclusion semantics.
         let glob = glob.strip_suffix('/').unwrap_or(glob);
         Ok(GlobBuilder::new(glob)
             .literal_separator(true)

--- a/crates/uv-globfilter/src/portable_glob.rs
+++ b/crates/uv-globfilter/src/portable_glob.rs
@@ -92,6 +92,9 @@ impl PortableGlobParser {
     /// These rules mean that matching the backslash (`\`) is forbidden, which avoid collisions with the windows path separator.
     pub fn parse(&self, glob: &str) -> Result<Glob, PortableGlobError> {
         self.check(glob)?;
+        // A trailing slash is meaningless in a glob — file paths never end with `/` — so
+        // strip it to let `GlobDirFilter` handle the directory-inclusion semantics.
+        let glob = glob.strip_suffix('/').unwrap_or(glob);
         Ok(GlobBuilder::new(glob)
             .literal_separator(true)
             // No need to support Windows-style paths, so the backslash can be used a escape.

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1649,7 +1649,7 @@ fn source_include_bare_directory_warning() -> Result<()> {
 
     ----- stderr -----
     Building source distribution (uv build backend)...
-    warning: `source-include` pattern `tests` matches directory `tests` but not its contents. Use `tests/**` to include all files in the directory.
+    warning: `source-include` matches directory `tests` but not its contents. Use `tests/**` to include all files in the directory.
     Building wheel from source distribution (uv build backend)...
     Successfully built dist/foo-1.0.0.tar.gz
     Successfully built dist/foo-1.0.0-py3-none-any.whl

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1618,8 +1618,61 @@ fn source_include_trailing_slash() -> Result<()> {
 }
 
 #[test]
-fn source_include_bare_directory_warning() -> Result<()> {
+fn source_include_single_file() -> Result<()> {
     let context = uv_test::test_context!("3.12");
+    let sdist_dir = TempDir::new()?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [tool.uv.build-backend]
+        source-include = ["data/build-script.py"]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context.temp_dir.child("src/foo/__init__.py").touch()?;
+    context
+        .temp_dir
+        .child("data/build-script.py")
+        .write_str("print('hello')")?;
+
+    uv_snapshot!(context
+        .build_backend()
+        .arg("build-sdist")
+        .arg(sdist_dir.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    foo-1.0.0.tar.gz
+
+    ----- stderr -----
+    ");
+
+    // Verify the sdist contains the single file.
+    let sdist_reader = BufReader::new(File::open(sdist_dir.path().join("foo-1.0.0.tar.gz"))?);
+    let paths: Vec<String> = tar::Archive::new(GzDecoder::new(sdist_reader))
+        .entries()?
+        .filter_map(|entry| Some(entry.ok()?.path().ok()?.to_string_lossy().into_owned()))
+        .collect();
+    assert!(
+        paths.iter().any(|p| p.contains("data/build-script.py")),
+        "Expected data/build-script.py in sdist, found: {paths:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn source_include_bare_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let sdist_dir = TempDir::new()?;
 
     context
         .temp_dir
@@ -1642,18 +1695,28 @@ fn source_include_bare_directory_warning() -> Result<()> {
         .child("tests/test_example.py")
         .write_str("def test_example(): pass")?;
 
-    uv_snapshot!(context.filters(), context.build(), @"
+    uv_snapshot!(context
+        .build_backend()
+        .arg("build-sdist")
+        .arg(sdist_dir.path()), @"
     success: true
     exit_code: 0
     ----- stdout -----
+    foo-1.0.0.tar.gz
 
     ----- stderr -----
-    Building source distribution (uv build backend)...
-    warning: `source-include` matches directory `tests` but not its contents. Use `tests/**` to include all files in the directory.
-    Building wheel from source distribution (uv build backend)...
-    Successfully built dist/foo-1.0.0.tar.gz
-    Successfully built dist/foo-1.0.0-py3-none-any.whl
     ");
+
+    // Verify the sdist contains the test file.
+    let sdist_reader = BufReader::new(File::open(sdist_dir.path().join("foo-1.0.0.tar.gz"))?);
+    let paths: Vec<String> = tar::Archive::new(GzDecoder::new(sdist_reader))
+        .entries()?
+        .filter_map(|entry| Some(entry.ok()?.path().ok()?.to_string_lossy().into_owned()))
+        .collect();
+    assert!(
+        paths.iter().any(|p| p.contains("tests/test_example.py")),
+        "Expected tests/test_example.py in sdist, found: {paths:?}"
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1565,6 +1565,99 @@ fn tool_uv_build_backend_wrong_build_backend() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn source_include_trailing_slash() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let sdist_dir = TempDir::new()?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [tool.uv.build-backend]
+        source-include = ["tests/"]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context.temp_dir.child("src/foo/__init__.py").touch()?;
+    context
+        .temp_dir
+        .child("tests/test_example.py")
+        .write_str("def test_example(): pass")?;
+
+    uv_snapshot!(context
+        .build_backend()
+        .arg("build-sdist")
+        .arg(sdist_dir.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    foo-1.0.0.tar.gz
+
+    ----- stderr -----
+    ");
+
+    // Verify the sdist contains the test file.
+    let sdist_reader = BufReader::new(File::open(sdist_dir.path().join("foo-1.0.0.tar.gz"))?);
+    let paths: Vec<String> = tar::Archive::new(GzDecoder::new(sdist_reader))
+        .entries()?
+        .filter_map(|entry| Some(entry.ok()?.path().ok()?.to_string_lossy().into_owned()))
+        .collect();
+    assert!(
+        paths.iter().any(|p| p.contains("tests/test_example.py")),
+        "Expected tests/test_example.py in sdist, found: {paths:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn source_include_bare_directory_warning() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [tool.uv.build-backend]
+        source-include = ["tests"]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context.temp_dir.child("src/foo/__init__.py").touch()?;
+    context
+        .temp_dir
+        .child("tests/test_example.py")
+        .write_str("def test_example(): pass")?;
+
+    uv_snapshot!(context.filters(), context.build(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Building source distribution (uv build backend)...
+    warning: `source-include` pattern `tests` matches directory `tests` but not its contents. Use `tests/**` to include all files in the directory.
+    Building wheel from source distribution (uv build backend)...
+    Successfully built dist/foo-1.0.0.tar.gz
+    Successfully built dist/foo-1.0.0-py3-none-any.whl
+    ");
+
+    Ok(())
+}
+
 /// Show a warning when the project uses deprecated `License ::` classifiers.
 #[test]
 fn warn_on_license_classifier() -> Result<()> {


### PR DESCRIPTION
## Summary

WIP.

This is a stab at fixing #16751. The basic observation here is that a user who tries to include something like `tests/` almost certainly means `tests/**`, so we use the same logic as in `source_dist_matcher` and append `**`.

Closes #16751.

## Test Plan

Added two new tests for this: one that ensures we transform `tests/` correct and another that ensures we warn when the user passes `tests` (i.e. without the trailing slash).