### PR TITLE
fix: support native macOS keyring credential lookup

### DIFF
--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -357,19 +357,32 @@ impl KeyringProvider {
         username: Option<&str>,
     ) -> Option<(String, String)> {
         let prefixed_service = format!("{UV_SERVICE_PREFIX}{service}");
-        let username = username?;
-        let Ok(entry) = uv_keyring::Entry::new(&prefixed_service, username) else {
-            return None;
-        };
-        match entry.get_password().await {
-            Ok(password) => return Some((username.to_string(), password)),
-            Err(uv_keyring::Error::NoEntry) => {
-                debug!("No entry found in system keyring for {service}");
+        if let Some(username) = username {
+            let Ok(entry) = uv_keyring::Entry::new(&prefixed_service, username) else {
+                return None;
+            };
+            match entry.get_password().await {
+                Ok(password) => return Some((username.to_string(), password)),
+                Err(uv_keyring::Error::NoEntry) => {
+                    debug!("No entry found in system keyring for {service}");
+                }
+                Err(err) => {
+                    warn_user_once!(
+                        "Unable to fetch credentials for {service} from system keyring: {err}"
+                    );
+                }
             }
-            Err(err) => {
-                warn_user_once!(
-                    "Unable to fetch credentials for {service} from system keyring: {err}"
-                );
+        } else {
+            match uv_keyring::find_credential_by_service(&prefixed_service).await {
+                Ok(Some(credentials)) => return Some(credentials),
+                Ok(None) => {
+                    debug!("No entry found in system keyring for {service}");
+                }
+                Err(err) => {
+                    warn_user_once!(
+                        "Unable to search credentials for {service} in system keyring: {err}"
+                    );
+                }
             }
         }
         None

--- a/crates/uv-keyring/src/lib.rs
+++ b/crates/uv-keyring/src/lib.rs
@@ -238,6 +238,29 @@ pub fn default_credential_builder() -> Box<CredentialBuilder> {
     credential::nop_credential_builder()
 }
 
+/// Search for a credential by service name only (without knowing the account/username).
+///
+/// Uses platform-specific search APIs to find a matching credential, returning
+/// the first match as an `(account, password)` pair.
+///
+/// Returns `Ok(None)` if no matching credential is found or the platform does not
+/// support username-less search.
+#[cfg_attr(
+    not(all(target_os = "macos", feature = "apple-native")),
+    expect(clippy::unused_async, reason = "async is used on macOS")
+)]
+pub async fn find_credential_by_service(service: &str) -> Result<Option<(String, String)>> {
+    #[cfg(all(target_os = "macos", feature = "apple-native"))]
+    {
+        macos::find_credential_by_service(service).await
+    }
+    #[cfg(not(all(target_os = "macos", feature = "apple-native")))]
+    {
+        let _ = service;
+        Ok(None)
+    }
+}
+
 fn build_default_credential(target: Option<&str>, service: &str, user: &str) -> Result<Entry> {
     static DEFAULT: std::sync::LazyLock<Box<CredentialBuilder>> =
         std::sync::LazyLock::new(default_credential_builder);

--- a/crates/uv-keyring/src/macos.rs
+++ b/crates/uv-keyring/src/macos.rs
@@ -33,6 +33,7 @@ ignores all the others. so clients can't use it to access or update any attribut
 use crate::credential::{Credential, CredentialApi, CredentialBuilder, CredentialBuilderApi};
 use crate::error::{Error as ErrorCode, Result, decode_password};
 use security_framework::base::Error;
+use security_framework::item::{ItemClass, ItemSearchOptions, SearchResult};
 use security_framework::os::macos::keychain::{SecKeychain, SecPreferencesDomain};
 use security_framework::os::macos::passwords::find_generic_password;
 
@@ -331,6 +332,54 @@ pub fn decode_error(err: Error) -> ErrorCode {
     }
 }
 
+/// Search for a generic password credential by service name only (without account).
+///
+/// Uses the modern `SecItemCopyMatching` API to search by service attribute,
+/// returning the first matching credential's (account, password) pair.
+///
+/// Returns `Ok(None)` if no matching credential is found.
+pub(crate) async fn find_credential_by_service(service: &str) -> Result<Option<(String, String)>> {
+    let service = service.to_string();
+    crate::blocking::spawn_blocking(move || {
+        let keychain = get_keychain(MacKeychainDomain::User)?;
+        let results = ItemSearchOptions::new()
+            .keychains(&[keychain])
+            .class(ItemClass::generic_password())
+            .service(&service)
+            .load_attributes(true)
+            .load_data(true)
+            .search();
+
+        let results = match results {
+            Ok(results) => results,
+            Err(err) => {
+                let decoded = decode_error(err);
+                if matches!(decoded, ErrorCode::NoEntry) {
+                    return Ok(None);
+                }
+                return Err(decoded);
+            }
+        };
+
+        for result in &results {
+            if let SearchResult::Dict(_) = result {
+                if let Some(attrs) = result.simplify_dict() {
+                    if let (Some(account), Some(password)) =
+                        (attrs.get("acct"), attrs.get("v_Data"))
+                    {
+                        if !account.is_empty() {
+                            return Ok(Some((account.clone(), password.clone())));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    })
+    .await
+}
+
 #[cfg(feature = "native-auth")]
 #[cfg(not(miri))]
 #[cfg(test)]
@@ -427,6 +476,44 @@ mod tests {
     #[tokio::test]
     async fn test_get_update_attributes() {
         crate::tests::test_noop_get_update_attributes(entry_new).await;
+    }
+
+    #[tokio::test]
+    async fn test_find_credential_by_service_without_account() {
+        let service = generate_random_string();
+        let user = generate_random_string();
+        let password = "test-password-for-search";
+
+        // Store a credential using the normal Entry API
+        let entry = entry_new(&service, &user);
+        entry
+            .set_password(password)
+            .await
+            .expect("Can't set password for search test");
+
+        // Search by service name only (no account) — this is the capability
+        // that was missing, causing native-auth credential lookups to fail
+        // during `uv sync` when the username is not known upfront.
+        let result = super::find_credential_by_service(&service)
+            .await
+            .expect("Search should not error");
+        assert_eq!(
+            result,
+            Some((user.clone(), password.to_string())),
+            "Should find credential by service name alone"
+        );
+
+        // Search for a non-existent service returns None
+        let missing = super::find_credential_by_service("nonexistent-service-name")
+            .await
+            .expect("Search for missing service should not error");
+        assert_eq!(missing, None, "Should return None for missing service");
+
+        // Clean up
+        entry
+            .delete_credential()
+            .await
+            .expect("Couldn't delete after search test");
     }
 
     #[test]


### PR DESCRIPTION
Relates to #12591 and #8810 ([this comment](https://github.com/astral-sh/uv/issues/8810#issuecomment-3254651085)).

## Summary

When `UV_PREVIEW_FEATURES=native-auth` is set, `uv auth login` stores credentials in the macOS Keychain keyed by service name + username. But during `uv sync`, no username is available in the request URL — it's stored inside the keychain entry itself. `fetch_native` returned `None` immediately when `username` was `None`, silently skipping the keychain lookup. Plaintext credential lookup works fine, so the problem is specific to `native-auth` on macOS.

The fix adds `find_credential_by_service` to `uv-keyring`, using the macOS `SecItemCopyMatching` API to search by service name alone (no account/username required), returning the first matching credential. `fetch_native` now falls back to this search when no username is provided.

## Test Plan

New unit test `test_find_credential_by_service_without_account` in `uv-keyring`:

```bash
cargo test -p uv-keyring --features native-auth --lib -- test_find_credential_by_service
```

All existing keyring tests pass:

```bash
cargo test -p uv-auth -- keyring        # 21 passed
cargo test -p uv-keyring --features native-auth --lib  # 22 passed
```

Here below I provide a manual test setup to validate the fix. It can be employed to verify the issue and the resolution even if an alternative approach is preferred.

<details>
<summary>Manual end-to-end reproduction with a local pypiserver</summary>

### 1. Set up a private Python index with basic auth

```bash
pip install pypiserver passlib htpasswd
mkdir -p /tmp/private-pypi/packages && cd /tmp/private-pypi
htpasswd -cb .htpasswd testuser testpass
pip download --no-deps --dest packages/ iniconfig==2.0.0
pypi-server run -p 8099 --authenticate list,update --passwords .htpasswd packages/ &
```

### 2. Create a test project

```bash
mkdir -p /tmp/uv-test-project && cd /tmp/uv-test-project
cat > pyproject.toml << 'EOF'
[project]
name = "test-project"
version = "0.1.0"
requires-python = ">=3.11"
dependencies = ["iniconfig"]

[[tool.uv.index]]
name = "private"
url = "http://localhost:8099/simple/"
default = true
authenticate = "always"
EOF
```

### 3. Reproduce the bug (before fix)

```bash
UV_PREVIEW_FEATURES=native-auth \
  uv auth login http://localhost:8099 --username testuser --password testpass

# FAILS with "Missing credentials"
UV_PREVIEW_FEATURES=native-auth uv sync --no-cache
```

### 4. Verify the fix (after fix)

```bash
rm -f ~/.local/share/uv/credentials/credentials.toml
rm -rf .venv uv.lock

# SUCCEEDS — credentials are fetched from keychain
UV_PREVIEW_FEATURES=native-auth uv sync --no-cache
```

### 5. Verify plaintext credentials still work

```bash
security delete-generic-password -s "uv:http://localhost:8099" 2>/dev/null
rm -rf .venv uv.lock
uv auth login http://localhost:8099 --username testuser --password testpass
uv sync --no-cache
```

### 6. Cleanup

```bash
pkill -f "pypi-server"
security delete-generic-password -s "uv:http://localhost:8099" 2>/dev/null
rm -f ~/.local/share/uv/credentials/credentials.toml
rm -rf /tmp/private-pypi /tmp/uv-test-project
```

</details>

I used Claude Code to diagnose the bug and propose the fix. I reviewed all produced code manually and re-wrote the PR description in my own words, in compliance with the AI policy. Also, I tested the fix on a real-world private Python index. Let me know if something needs to be changed or if I am missing some critical context.