### PR TITLE
fix: bump rustls-webpki 0.103.9 -> 0.103.10 (GHSA-pwjx-qhcg-rvj4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,9 +4300,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Patch Cargo.lock to upgrade rustls-webpki from 0.103.9 to 0.103.10, addressing the security advisory GHSA-pwjx-qhcg-rvj4.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

```
bin/uv (rustbinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────────────────┬───────────────────────────────────────────────────────────┐
│    Library    │    Vulnerability    │ Severity │ Status │ Installed Version │       Fixed Version       │                           Title                           │
├───────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────────────────┼───────────────────────────────────────────────────────────┤
│ rustls-webpki │ GHSA-pwjx-qhcg-rvj4 │ MEDIUM   │ fixed  │ 0.103.9           │ 0.103.10, 0.104.0-alpha.5 │ webpki: CRLs not considered authoritative by Distribution │
│               │                     │          │        │                   │                           │ Point due to faulty matching...                           │
│               │                     │          │        │                   │                           │ https://github.com/advisories/GHSA-pwjx-qhcg-rvj4         │
└───────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────────────────┴───────────────────────────────────────────────────────────┘
```

## Test Plan

<!-- How was it tested? -->
