### PR TITLE
Enforce direct URL hashes for `pyproject.toml` dependencies

### DIFF
--- a/crates/uv-requirements/src/lib.rs
+++ b/crates/uv-requirements/src/lib.rs
@@ -33,6 +33,9 @@ pub enum Error {
     DistributionTypes(#[from] uv_distribution_types::Error),
 
     #[error(transparent)]
+    HashStrategy(#[from] uv_types::HashStrategyError),
+
+    #[error(transparent)]
     WheelFilename(#[from] uv_distribution_filename::WheelFilenameError),
 
     #[error(transparent)]

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -82,10 +82,11 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
     pub async fn resolve(
         self,
         env: &ResolverEnvironment,
-    ) -> Result<Vec<RequestedRequirements>, Error> {
+    ) -> Result<(Vec<RequestedRequirements>, HashStrategy), Error> {
         let mut results = Vec::new();
         let mut futures = FuturesUnordered::new();
         let mut seen = FxHashSet::default();
+        let mut hasher = self.hasher.clone();
 
         // Queue up the initial requirements.
         let mut queue: VecDeque<_> = self
@@ -99,13 +100,14 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
             while let Some(requirement) = queue.pop_front() {
                 if !matches!(requirement.source, RequirementSource::Registry { .. }) {
                     if seen.insert(requirement.clone()) {
-                        futures.push(self.lookahead(requirement));
+                        futures.push(self.lookahead(requirement, hasher.clone()));
                     }
                 }
             }
 
             while let Some(result) = futures.next().await {
                 if let Some(lookahead) = result? {
+                    hasher = hasher.augment_with_requirements(lookahead.requirements().iter())?;
                     for requirement in self
                         .constraints
                         .apply(self.overrides.apply(lookahead.requirements()))
@@ -121,13 +123,14 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
             }
         }
 
-        Ok(results)
+        Ok((results, hasher))
     }
 
     /// Infer the package name for a given "unnamed" requirement.
     async fn lookahead(
         &self,
         requirement: Requirement,
+        hasher: HashStrategy,
     ) -> Result<Option<RequestedRequirements>, Error> {
         trace!("Performing lookahead for {requirement}");
 
@@ -151,7 +154,7 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = self
                     .database
-                    .get_or_build_wheel_metadata(&dist, self.hasher.get(&dist))
+                    .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
                     .await
                     .map_err(|err| Error::from_dist(dist, err))?;
 

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -114,6 +114,32 @@ impl HashStrategy {
         }
     }
 
+    /// Return a [`HashStrategy`] augmented with archive URL hashes discovered in additional
+    /// requirements after the initial command-line parse.
+    pub fn augment_with_requirements<'a>(
+        self,
+        requirements: impl Iterator<Item = &'a Requirement>,
+    ) -> Result<Self, HashStrategyError> {
+        Ok(match self {
+            Self::None => Self::None,
+            Self::Generate(mode) => Self::Generate(mode),
+            Self::Verify(existing) => {
+                if let Some(hashes) = Self::augment_hashes(existing.as_ref(), requirements)? {
+                    Self::Verify(Arc::new(hashes))
+                } else {
+                    Self::Verify(existing)
+                }
+            }
+            Self::Require(existing) => {
+                if let Some(hashes) = Self::augment_hashes(existing.as_ref(), requirements)? {
+                    Self::Require(Arc::new(hashes))
+                } else {
+                    Self::Require(existing)
+                }
+            }
+        })
+    }
+
     /// Generate the required hashes from a set of [`UnresolvedRequirement`] entries.
     ///
     /// When the environment is not given, this treats all marker expressions
@@ -281,6 +307,52 @@ impl HashStrategy {
             HashCheckingMode::Verify => Ok(Self::Verify(Arc::new(hashes))),
             HashCheckingMode::Require => Ok(Self::Require(Arc::new(hashes))),
         }
+    }
+
+    /// Augment an existing set of hashes with archive URL hashes discovered in additional
+    /// requirements.
+    ///
+    /// Archive URL requirements are keyed by a [`VersionId`] so that requirements that refer to
+    /// the same underlying archive but differ only in hash fragments are merged onto the same
+    /// digest set.
+    ///
+    /// Returns `Ok(None)` if no new hashes were added or updated.
+    fn augment_hashes<'a>(
+        existing: &FxHashMap<VersionId, Vec<HashDigest>>,
+        requirements: impl Iterator<Item = &'a Requirement>,
+    ) -> Result<Option<FxHashMap<VersionId, Vec<HashDigest>>>, HashStrategyError> {
+        let mut hashes = None;
+
+        for requirement in requirements {
+            let Some((id, digests)) = Self::requirement_hashes(requirement) else {
+                continue;
+            };
+            let current = hashes.as_ref().unwrap_or(existing);
+            let current_digests = current.get(&id);
+            let mut merged = current_digests.cloned().unwrap_or_default();
+            merge_digests(&mut merged, &digests, requirement)?;
+
+            if current_digests.map(Vec::as_slice) == Some(merged.as_slice()) {
+                continue;
+            }
+
+            hashes
+                .get_or_insert_with(|| existing.clone())
+                .insert(id, merged);
+        }
+
+        Ok(hashes)
+    }
+
+    /// Extract the archive URL hash target and digests for a requirement, if any.
+    fn requirement_hashes(requirement: &Requirement) -> Option<(VersionId, Vec<HashDigest>)> {
+        let mut digests = HashDigests::from(requirement.hashes()?).to_vec();
+        if digests.is_empty() {
+            return None;
+        }
+        digests.sort_unstable();
+        let id = Self::pin(requirement)?;
+        Some((id, digests))
     }
 
     /// Pin a [`Requirement`] to a [`VersionId`], if possible.

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -595,7 +595,7 @@ pub(crate) async fn pip_compile(
     )
     .await
     {
-        Ok(resolution) => resolution,
+        Ok((resolution, _)) => resolution,
         Err(err) => {
             return diagnostics::OperationDiagnostic::with_system_certs(
                 client_builder.system_certs(),

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -574,7 +574,7 @@ pub(crate) async fn pip_install(
             .build();
 
         // Resolve the requirements.
-        let resolution = match operations::resolve(
+        let (resolution, hasher) = match operations::resolve(
             requirements,
             constraints,
             overrides,
@@ -605,7 +605,7 @@ pub(crate) async fn pip_install(
         )
         .await
         {
-            Ok(graph) => Resolution::from(graph),
+            Ok((graph, hasher)) => (Resolution::from(graph), hasher),
             Err(err) => {
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -132,7 +132,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     options: Options,
     logger: Box<dyn ResolveLogger>,
     printer: Printer,
-) -> Result<ResolverOutput, Error> {
+) -> Result<(ResolverOutput, HashStrategy), Error> {
     let start = std::time::Instant::now();
 
     // Resolve the requirements from the provided sources.
@@ -265,6 +265,11 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         requirements
     };
 
+    // Incorporate hashes from requirements discovered while resolving source trees and groups.
+    let mut hasher = hasher
+        .clone()
+        .augment_with_requirements(requirements.iter())?;
+
     // Resolve the overrides from the provided sources.
     let overrides = {
         // Partition the overrides into named and unnamed requirements.
@@ -284,7 +289,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         if !unnamed.is_empty() {
             overrides.extend(
                 NamedRequirementsResolver::new(
-                    hasher,
+                    &hasher,
                     index,
                     DistributionDatabase::new(
                         client,
@@ -315,11 +320,11 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     // Determine any lookahead requirements.
     let lookaheads = match options.dependency_mode {
         DependencyMode::Transitive => {
-            LookaheadResolver::new(
+            let (lookaheads, updated_hasher) = LookaheadResolver::new(
                 &requirements,
                 &constraints,
                 &overrides,
-                hasher,
+                &hasher,
                 index,
                 DistributionDatabase::new(
                     client,
@@ -329,7 +334,9 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             )
             .with_reporter(Arc::new(ResolverReporter::from(printer)))
             .resolve(&resolver_env)
-            .await?
+            .await?;
+            hasher = updated_hasher;
+            lookaheads
         }
         DependencyMode::Direct => Vec::new(),
     };
@@ -370,7 +377,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             tags,
             flat_index,
             index,
-            hasher,
+            &hasher,
             build_dispatch,
             installed_packages,
             DistributionDatabase::new(
@@ -386,7 +393,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
 
     logger.on_complete(resolution.len(), start, printer)?;
 
-    Ok(resolution)
+    Ok((resolution, hasher))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -465,7 +465,7 @@ pub(crate) async fn pip_sync(
             .build_options(build_options.clone())
             .build();
 
-        let resolution = match operations::resolve(
+        let (resolution, hasher) = match operations::resolve(
             requirements,
             constraints,
             overrides,
@@ -496,7 +496,7 @@ pub(crate) async fn pip_sync(
         )
         .await
         {
-            Ok(resolution) => Resolution::from(resolution),
+            Ok((resolution, hasher)) => (Resolution::from(resolution), hasher),
             Err(err) => {
                 return diagnostics::OperationDiagnostic::with_system_certs(
                     client_builder.system_certs(),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -913,7 +913,7 @@ async fn do_lock(
             );
 
             // Resolve the requirements.
-            let resolution = pip::operations::resolve(
+            let (resolution, _) = pip::operations::resolve(
                 ExtrasResolver::new(&hasher, state.index(), database)
                     .with_reporter(Arc::new(ResolverReporter::from(printer)))
                     .resolve(target.members_requirements())

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2199,7 +2199,8 @@ pub(crate) async fn resolve_environment(
         logger,
         printer,
     )
-    .await?)
+    .await?
+    .0)
 }
 
 /// Sync a [`PythonEnvironment`] with a set of resolved requirements.
@@ -2565,7 +2566,7 @@ pub(crate) async fn update_environment(
     );
 
     // Resolve the requirements.
-    let resolution = match pip::operations::resolve(
+    let (resolution, hasher) = match pip::operations::resolve(
         requirements,
         constraints,
         overrides,
@@ -2596,7 +2597,7 @@ pub(crate) async fn update_environment(
     )
     .await
     {
-        Ok(resolution) => Resolution::from(resolution),
+        Ok((resolution, hasher)) => (Resolution::from(resolution), hasher),
         Err(err) => return Err(err.into()),
     };
 

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -10011,6 +10011,138 @@ fn static_metadata_source_tree() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for: <https://github.com/astral-sh/uv/issues/18778>
+#[test]
+fn direct_url_hash_source_tree_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "pylock"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+          "protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520",
+        ]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("pylock")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("."), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+      × Failed to download `protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520`
+      ╰─▶ Hash mismatch for `protobug @ https://files.pythonhosted.org/packages/f2/cc/db26b91cddffbcf0c6df7834fd642578f737fe34197635ae8ea64643a35f/protobug-0.3.0-py3-none-any.whl#sha256=ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520`
+
+          Expected:
+            sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c2026520
+
+          Computed:
+            sha256:ee81583f376bb38e5e7af425d2453e5e8d4b57bfbf45e5dba1a75329c202652e
+      help: `protobug` (v0.3.0) was included because `pylock` (v0.1.0) depends on `protobug`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn direct_url_hash_source_tree_dependency_conflict() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "pylock"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+          "anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha256=cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f",
+          "anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha256=f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a",
+        ]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("pylock")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.pip_install()
+        .arg("."), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Conflicting archive URL hashes for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha256=f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a`: `sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f` conflicts with `sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn direct_url_hash_source_tree_dependency_multiple_hash_algorithms() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "pylock"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+          "anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha256=cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f",
+          "anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha512=f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2",
+        ]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("pylock")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("."), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl#sha512=f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2)
+     + idna==3.6
+     + pylock==0.1.0 (from file://[TEMP_DIR]/)
+     + sniffio==1.3.1
+    "
+    );
+
+    Ok(())
+}
+
 /// Regression test for: <https://github.com/astral-sh/uv/issues/10239#issuecomment-2565663046>
 #[test]
 fn static_metadata_already_installed() -> Result<()> {


### PR DESCRIPTION
## Summary

These requirements are technically "transitive", so we miss them in our initial pass. As such, we need to collect them while we lookahead.

Closes https://github.com/astral-sh/uv/issues/18778.
