### PR TITLE
Don't drop blake2b hashes

### DIFF
--- a/crates/uv-pypi-types/src/simple_json.rs
+++ b/crates/uv-pypi-types/src/simple_json.rs
@@ -649,7 +649,8 @@ impl From<Hashes> for HashDigests {
             usize::from(value.sha512.is_some())
                 + usize::from(value.sha384.is_some())
                 + usize::from(value.sha256.is_some())
-                + usize::from(value.md5.is_some()),
+                + usize::from(value.md5.is_some())
+                + usize::from(value.blake2b.is_some()),
         );
         if let Some(sha512) = value.sha512 {
             digests.push(HashDigest {
@@ -673,6 +674,12 @@ impl From<Hashes> for HashDigests {
             digests.push(HashDigest {
                 algorithm: HashAlgorithm::Md5,
                 digest: md5,
+            });
+        }
+        if let Some(blake2b) = value.blake2b {
+            digests.push(HashDigest {
+                algorithm: HashAlgorithm::Blake2b,
+                digest: blake2b,
             });
         }
         Self::from(digests)


### PR DESCRIPTION
An oversight from adding blake2b hashes.