### PR TITLE
Remove powerpc64-unknown-linux-gnu from build targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,7 +27,6 @@ targets = [
     "armv7-unknown-linux-gnueabihf",
     "armv7-unknown-linux-musleabihf",
     "x86_64-apple-darwin",
-    "powerpc64-unknown-linux-gnu",
     "powerpc64le-unknown-linux-gnu",
     "riscv64gc-unknown-linux-gnu",
     "s390x-unknown-linux-gnu",


### PR DESCRIPTION
Removes the `powerpc64-unknown-linux-gnu` target from the list of supported build targets in `dist-workspace.toml`. The `powerpc64le-unknown-linux-gnu` (little-endian) target remains in the configuration.

Closes https://github.com/astral-sh/uv/issues/18798