### PR TITLE
docs: add explicit example for opting package out of `--exclude-newer`

### DIFF
--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -729,8 +729,8 @@ The package option also accepts `<package>=false` to opt a package out of the re
 exclude-newer-package = { setuptools = false }
 ```
 
-This is useful to temporarily use a newer version of package or to allow resolving a package from
-an index that does not publish upload times. 
+This is useful to temporarily use a newer version of package or to allow resolving a package from an
+index that does not publish upload times.
 
 Package-specific values will take precedence over global values.
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add the explicit configuration for opting out a package out of `--exclude-newer`. The docs mention this from https://github.com/astral-sh/uv/pull/16854, but the actual pyproject.toml configuration was missing. I found it from https://github.com/astral-sh/uv/issues/12449#issuecomment-4170155721, but this should be in the docs.

## Test Plan

uv run --only-group docs mkdocs serve -f mkdocs.yml