### PR TITLE
Catch missing uv build backend compatible version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6048,6 +6048,7 @@ dependencies = [
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
+ "uv-version",
  "uv-warnings",
  "walkdir",
  "zip",

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -24,6 +24,7 @@ uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
+uv-version = { workspace = true }
 uv-warnings = { workspace = true }
 
 base64 = { workspace = true }

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -1861,4 +1861,24 @@ mod tests {
             @"`uv_build>=0.5.0, <0.6` is not a known compatible range"
         );
     }
+
+    #[test]
+    fn update_compatibility_for_breaking_release() {
+        // Handle the case where we made a breaking change to the build backend.
+        // Feel free to update the heuristic if it doesn't suit the current compatibility rules
+        // anymore.
+        if COMPATIBLE_VERSIONS.is_empty() {
+            return;
+        }
+
+        let current_version = Version::from_str(uv_version::version()).unwrap();
+        // Versions are ordered from oldest to latest
+        let last_compatible =
+            Version::from_str(COMPATIBLE_VERSIONS[COMPATIBLE_VERSIONS.len() - 1]).unwrap();
+        if last_compatible.release()[0] != current_version.release()[0]
+            && last_compatible.release()[0] != current_version.release()[1]
+        {
+            panic!("Please update the list of compatible versions for the uv build backend");
+        }
+    }
 }

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -1878,7 +1878,12 @@ mod tests {
         if last_compatible.release()[0] != current_version.release()[0]
             && last_compatible.release()[0] != current_version.release()[1]
         {
-            panic!("Please update the list of compatible versions for the uv build backend");
+            panic!(
+                "Please update the list of compatible versions for the uv build backend: \
+                If there was no breaking change in uv-build, add the last release before the \
+                breaking release to `COMPATIBLE_VERSIONS`, otherwise reset `COMPATIBLE_VERSIONS` \
+                to an empty list"
+            );
         }
     }
 }


### PR DESCRIPTION
The uv build backend itself doesn't know if any particular previous breaking release contained breaking changes for it, so we need to manually update the list. This is easy to forget.

To prevent anyone from missing to update this list, we check for something that looks like a missed release. If it was missed, it will fail test (at latest in CI) on the breaking version change PR. This is meant as oversight prevention, not as a release gate, if it fails inappropriately just remove it.