### PR TITLE
Skip macOS AppleDouble sidecar files during .data directory installation

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1299,7 +1299,7 @@ mod test {
         assert!(!is_apple_double(Path::new("_underscore")));
     }
 
-    /// Verify that `move_folder_recorded` skips macOS AppleDouble sidecar files.
+    /// Verify that `move_folder_recorded` skips macOS `AppleDouble` sidecar files.
     ///
     /// On exFAT, macOS creates `._*` sidecar files that are not in the wheel RECORD.
     /// Without filtering, `move_folder_recorded` fails with a RECORD mismatch error.


### PR DESCRIPTION
On exFAT (and FAT32, SMB), macOS creates `._*` AppleDouble sidecar files for every file that carries extended attributes. During `.data` directory installation, `move_folder_recorded()` walks the directory with `WalkDir` and picks up these ghost files that aren't in the wheel's RECORD — then errors out with a RECORD mismatch.

This adds an `is_apple_double` check to skip `._*` entries in both `move_folder_recorded()` and the `install_data()` scripts loop.

Confirmed with `jupyterlab-pygments==0.3.0` on macOS 26 + exFAT — wheel contains zero `._` files but `uv sync` fails because macOS creates them during the copy.

Closes #18790. See also rust-lang/rust#154692.

## Test plan

- `test_is_apple_double`: verifies the helper against various filenames
- `test_move_folder_recorded_skips_apple_double`: creates a `.data` directory with a real file + a `._` sidecar not in RECORD, confirms only the real file is moved
- Manual: `COPYFILE_DISABLE=1 uv sync` with `jupyterlab-pygments` on exFAT now succeeds