### PR TITLE
Require all direct URL hash algorithms to match

### DIFF
--- a/crates/uv-distribution-types/src/hash.rs
+++ b/crates/uv-distribution-types/src/hash.rs
@@ -6,9 +6,13 @@ pub enum HashPolicy<'a> {
     None,
     /// Hashes should be generated (specifically, a SHA-256 hash), but not validated.
     Generate(HashGeneration),
-    /// Hashes should be validated against a pre-defined list of hashes. If necessary, hashes should
-    /// be generated so as to ensure that the archive is valid.
-    Validate(&'a [HashDigest]),
+    /// Hashes should be validated against a pre-defined list of hashes, and any matching digest is
+    /// sufficient. If necessary, hashes should be generated so as to ensure that the archive is
+    /// valid.
+    Any(&'a [HashDigest]),
+    /// Hashes should be validated against a pre-defined list of hashes, and every digest must
+    /// match. If necessary, hashes should be generated so as to ensure that the archive is valid.
+    All(&'a [HashDigest]),
 }
 
 impl HashPolicy<'_> {
@@ -17,9 +21,9 @@ impl HashPolicy<'_> {
         matches!(self, Self::None)
     }
 
-    /// Returns `true` if the hash policy is `Validate`.
-    pub fn is_validate(&self) -> bool {
-        matches!(self, Self::Validate(_))
+    /// Returns `true` if the hash policy is `Any` or `All`.
+    pub fn requires_validation(&self) -> bool {
+        matches!(self, Self::Any(_) | Self::All(_))
     }
 
     /// Returns `true` if the hash policy indicates that hashes should be generated.
@@ -29,7 +33,8 @@ impl HashPolicy<'_> {
             Self::Generate(HashGeneration::All) => {
                 dist.file().is_none_or(|file| file.hashes.is_empty())
             }
-            Self::Validate(_) => false,
+            Self::Any(_) => false,
+            Self::All(_) => false,
             Self::None => false,
         }
     }
@@ -39,7 +44,7 @@ impl HashPolicy<'_> {
         match self {
             Self::None => vec![],
             Self::Generate(_) => vec![HashAlgorithm::Sha256],
-            Self::Validate(hashes) => {
+            Self::Any(hashes) | Self::All(hashes) => {
                 let mut algorithms = hashes.iter().map(HashDigest::algorithm).collect::<Vec<_>>();
                 algorithms.sort();
                 algorithms.dedup();
@@ -53,7 +58,47 @@ impl HashPolicy<'_> {
         match self {
             Self::None => &[],
             Self::Generate(_) => &[],
-            Self::Validate(hashes) => hashes,
+            Self::Any(hashes) | Self::All(hashes) => hashes,
+        }
+    }
+
+    /// Returns `true` if the given hashes satisfy the policy.
+    pub fn matches(&self, hashes: &[HashDigest]) -> bool {
+        match self {
+            Self::None => true,
+            Self::Generate(_) => hashes
+                .iter()
+                .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
+            Self::Any(required) => {
+                !required.is_empty() && hashes.iter().any(|hash| required.contains(hash))
+            }
+            Self::All(required) => {
+                !required.is_empty() && required.iter().all(|hash| hashes.contains(hash))
+            }
+        }
+    }
+
+    /// Returns `true` if the given hashes include the algorithms required by the policy.
+    pub fn has_required_algorithms(&self, hashes: &[HashDigest]) -> bool {
+        match self {
+            Self::None => true,
+            Self::Generate(_) => hashes
+                .iter()
+                .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
+            Self::Any(required) => {
+                !required.is_empty()
+                    && required
+                        .iter()
+                        .map(HashDigest::algorithm)
+                        .any(|algorithm| hashes.iter().any(|hash| hash.algorithm == algorithm))
+            }
+            Self::All(required) => {
+                !required.is_empty()
+                    && required
+                        .iter()
+                        .map(HashDigest::algorithm)
+                        .all(|algorithm| hashes.iter().any(|hash| hash.algorithm == algorithm))
+            }
         }
     }
 }
@@ -74,28 +119,61 @@ pub trait Hashed {
 
     /// Returns `true` if the archive satisfies the given hash policy.
     fn satisfies(&self, hashes: HashPolicy) -> bool {
-        match hashes {
-            HashPolicy::None => true,
-            HashPolicy::Generate(_) => self
-                .hashes()
-                .iter()
-                .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
-            HashPolicy::Validate(hashes) => self.hashes().iter().any(|hash| hashes.contains(hash)),
-        }
+        hashes.matches(self.hashes())
     }
 
-    /// Returns `true` if the archive includes a hash for at least one of the given algorithms.
+    /// Returns `true` if the archive includes the algorithms required by the given hash policy.
     fn has_digests(&self, hashes: HashPolicy) -> bool {
-        match hashes {
-            HashPolicy::None => true,
-            HashPolicy::Generate(_) => self
-                .hashes()
-                .iter()
-                .any(|hash| hash.algorithm == HashAlgorithm::Sha256),
-            HashPolicy::Validate(hashes) => hashes
-                .iter()
-                .map(HashDigest::algorithm)
-                .any(|algorithm| self.hashes().iter().any(|hash| hash.algorithm == algorithm)),
-        }
+        hashes.has_required_algorithms(self.hashes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use uv_pypi_types::HashDigest;
+
+    use super::HashPolicy;
+
+    #[test]
+    fn validate_all_requires_every_digest() {
+        let sha256 = HashDigest::from_str(
+            "sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f",
+        )
+        .unwrap();
+        let sha512 = HashDigest::from_str(
+            "sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2",
+        )
+        .unwrap();
+        let wrong_sha512 = HashDigest::from_str(
+            "sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2",
+        )
+        .unwrap();
+
+        let policy = HashPolicy::All(&[sha256.clone(), sha512.clone()]);
+        assert!(policy.matches(&[sha256.clone(), sha512]));
+        assert!(!policy.matches(std::slice::from_ref(&sha256)));
+        assert!(!policy.matches(&[sha256, wrong_sha512]));
+    }
+
+    #[test]
+    fn validate_any_requires_one_digest() {
+        let sha256 = HashDigest::from_str(
+            "sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f",
+        )
+        .unwrap();
+        let sha512 = HashDigest::from_str(
+            "sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2",
+        )
+        .unwrap();
+        let wrong_sha512 = HashDigest::from_str(
+            "sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2",
+        )
+        .unwrap();
+
+        let policy = HashPolicy::Any(&[sha256.clone(), sha512]);
+        assert!(policy.matches(&[sha256]));
+        assert!(!policy.matches(&[wrong_sha512]));
     }
 }

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -194,7 +194,7 @@ impl<'a> BuiltWheelIndex<'a> {
     /// Return the most compatible [`CachedWheel`] for a given source distribution at a git URL.
     pub fn git(&self, source_dist: &GitSourceDist) -> Option<CachedWheel> {
         // Enforce hash-checking, which isn't supported for Git distributions.
-        if self.hasher.get(source_dist).is_validate() {
+        if self.hasher.get(source_dist).requires_validation() {
             return None;
         }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1173,7 +1173,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         hashes: HashPolicy<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
-        if hashes.is_validate() {
+        if hashes.requires_validation() {
             return Err(Error::HashesNotSupportedSourceTree(source.to_string()));
         }
 
@@ -1277,7 +1277,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
         // Before running the build, check that the hashes match.
-        if hashes.is_validate() {
+        if hashes.requires_validation() {
             return Err(Error::HashesNotSupportedSourceTree(source.to_string()));
         }
 
@@ -1565,7 +1565,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         client: &ManagedClient<'_>,
     ) -> Result<BuiltWheelMetadata, Error> {
         // Before running the build, check that the hashes match.
-        if hashes.is_validate() {
+        if hashes.requires_validation() {
             return Err(Error::HashesNotSupportedGit(source.to_string()));
         }
 
@@ -1697,7 +1697,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         credentials_cache: &CredentialsCache,
     ) -> Result<ArchiveMetadata, Error> {
         // Before running the build, check that the hashes match.
-        if hashes.is_validate() {
+        if hashes.requires_validation() {
             return Err(Error::HashesNotSupportedGit(source.to_string()));
         }
 

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -8,9 +8,8 @@ use uv_client::{FlatIndexEntries, FlatIndexEntry};
 use uv_configuration::BuildOptions;
 use uv_distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use uv_distribution_types::{
-    File, HashComparison, HashPolicy, IncompatibleSource, IncompatibleWheel, IndexUrl,
-    PrioritizedDist, RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility,
-    WheelCompatibility,
+    File, HashComparison, IncompatibleSource, IncompatibleWheel, IndexUrl, PrioritizedDist,
+    RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility, WheelCompatibility,
 };
 use uv_normalize::PackageName;
 use uv_pep440::Version;
@@ -184,12 +183,11 @@ impl FlatDistributions {
         }
 
         // Check if hashes line up
-        let hash = if let HashPolicy::Validate(required) =
-            hasher.get_package(&filename.name, &filename.version)
-        {
+        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if required.iter().any(|hash| hashes.contains(hash)) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -225,12 +223,11 @@ impl FlatDistributions {
         };
 
         // Check if hashes line up.
-        let hash = if let HashPolicy::Validate(required) =
-            hasher.get_package(&filename.name, &filename.version)
-        {
+        let hash_policy = hasher.get_package(&filename.name, &filename.version);
+        let hash = if hash_policy.requires_validation() {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if required.iter().any(|hash| hashes.contains(hash)) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -556,7 +556,7 @@ impl VersionMapLazy {
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hashes.iter().any(|hash| required_hashes.contains(hash)) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched
@@ -620,7 +620,7 @@ impl VersionMapLazy {
         } else {
             if hashes.is_empty() {
                 HashComparison::Missing
-            } else if hashes.iter().any(|hash| required_hashes.contains(hash)) {
+            } else if hash_policy.matches(hashes) {
                 HashComparison::Matched
             } else {
                 HashComparison::Mismatched

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -38,62 +38,57 @@ impl HashStrategy {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
             Self::Verify(hashes) => {
-                if let Some(hashes) = hashes.get(&distribution.version_id()) {
-                    HashPolicy::Validate(hashes.as_slice())
+                let id = distribution.version_id();
+                if let Some(hashes) = hashes.get(&id) {
+                    hash_policy(&id, hashes.as_slice())
                 } else {
                     HashPolicy::None
                 }
             }
-            Self::Require(hashes) => HashPolicy::Validate(
-                hashes
-                    .get(&distribution.version_id())
-                    .map(Vec::as_slice)
-                    .unwrap_or_default(),
-            ),
+            Self::Require(hashes) => {
+                let id = distribution.version_id();
+                hash_policy(&id, hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
+            }
         }
     }
 
     /// Return the [`HashPolicy`] for the given registry-based package.
     pub fn get_package(&self, name: &PackageName, version: &Version) -> HashPolicy<'_> {
+        let id = VersionId::from_registry(name.clone(), version.clone());
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
             Self::Verify(hashes) => {
-                if let Some(hashes) =
-                    hashes.get(&VersionId::from_registry(name.clone(), version.clone()))
-                {
-                    HashPolicy::Validate(hashes.as_slice())
+                if let Some(hashes) = hashes.get(&id) {
+                    HashPolicy::Any(hashes.as_slice())
                 } else {
                     HashPolicy::None
                 }
             }
-            Self::Require(hashes) => HashPolicy::Validate(
-                hashes
-                    .get(&VersionId::from_registry(name.clone(), version.clone()))
-                    .map(Vec::as_slice)
-                    .unwrap_or_default(),
-            ),
+            Self::Require(hashes) => {
+                HashPolicy::Any(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
+            }
         }
     }
 
     /// Return the [`HashPolicy`] for the given direct URL package.
+    ///
+    /// A direct URL identifies a single concrete artifact, so every provided digest must match.
     pub fn get_url(&self, url: &DisplaySafeUrl) -> HashPolicy<'_> {
+        let id = VersionId::from_url(url);
         match self {
             Self::None => HashPolicy::None,
             Self::Generate(mode) => HashPolicy::Generate(*mode),
             Self::Verify(hashes) => {
-                if let Some(hashes) = hashes.get(&VersionId::from_url(url)) {
-                    HashPolicy::Validate(hashes.as_slice())
+                if let Some(hashes) = hashes.get(&id) {
+                    HashPolicy::All(hashes.as_slice())
                 } else {
                     HashPolicy::None
                 }
             }
-            Self::Require(hashes) => HashPolicy::Validate(
-                hashes
-                    .get(&VersionId::from_url(url))
-                    .map(Vec::as_slice)
-                    .unwrap_or_default(),
-            ),
+            Self::Require(hashes) => {
+                HashPolicy::All(hashes.get(&id).map(Vec::as_slice).unwrap_or_default())
+            }
         }
     }
 
@@ -325,6 +320,17 @@ impl HashStrategy {
     }
 }
 
+fn hash_policy<'a>(id: &VersionId, digests: &'a [HashDigest]) -> HashPolicy<'a> {
+    match id {
+        VersionId::NameVersion { .. } => HashPolicy::Any(digests),
+        VersionId::ArchiveUrl { .. }
+        | VersionId::Git { .. }
+        | VersionId::Path { .. }
+        | VersionId::Directory { .. }
+        | VersionId::Unknown { .. } => HashPolicy::All(digests),
+    }
+}
+
 /// Merge repeated hashes for a requirement or constraint into the hash map.
 fn merge_hashes(
     hashes: &mut FxHashMap<VersionId, Vec<HashDigest>>,
@@ -466,10 +472,7 @@ mod tests {
             let RequirementSource::Url { url, .. } = &requirement.source else {
                 panic!("expected direct URL requirement");
             };
-            let HashPolicy::Validate(digests) = hasher.get_url(url) else {
-                panic!("expected hash validation policy");
-            };
-            assert_eq!(digests, expected.as_slice());
+            assert_eq!(hasher.get_url(url), HashPolicy::All(expected.as_slice()));
         }
     }
 }

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -4514,7 +4514,8 @@ fn require_hashes_repeated_hash() -> Result<()> {
     "
     );
 
-    // Use a different hash. The `sha512` is wrong, but the correct `sha256` still allows install.
+    // Use a different hash. The `sha512` is wrong, so validation should fail even though the
+    // `sha256` is still correct.
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt
         .write_str(indoc::indoc! { r"
@@ -4526,16 +4527,22 @@ fn require_hashes_repeated_hash() -> Result<()> {
         .arg("requirements.txt")
         .arg("--require-hashes")
         .arg("--reinstall"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
-    Installed 1 package in [TIME]
-     ~ anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
+      × Failed to download `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+      ╰─▶ Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
+
+          Expected:
+            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+            sha512:e30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
+
+          Computed:
+            sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+            sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
     "
     );
 
@@ -4567,6 +4574,7 @@ fn require_hashes_repeated_hash() -> Result<()> {
 
           Computed:
             sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+            sha512:f30761c1e8725b49c498273b90dba4b05c0fd157811994c806183062cb6647e773364ce45f0e1ff0b10e32fe6d0232ea5ad39476ccf37109d6b49603a09c11c2
     "
     );
 


### PR DESCRIPTION
## Summary

If we're given multiple hashes for a direct URL dependency, we now validate _all_ of them rather than accepting any _one_ correct match.
