### PR TITLE
Track newly-activated extras when determining conflicts

### DIFF
--- a/crates/uv-resolver/src/lock/installable.rs
+++ b/crates/uv-resolver/src/lock/installable.rs
@@ -16,8 +16,21 @@ use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_platform_tags::Tags;
 use uv_pypi_types::ResolverMarkerEnvironment;
 
-use crate::lock::{HashedDist, LockErrorKind, Package, TagPolicy};
+use crate::lock::{Dependency, HashedDist, LockErrorKind, Package, TagPolicy};
 use crate::{Lock, LockError};
+
+fn newly_activated_extras<'lock>(
+    dep: &'lock Dependency,
+    activated_extras: &[(&'lock PackageName, &'lock ExtraName)],
+) -> Vec<(&'lock PackageName, &'lock ExtraName)> {
+    dep.extra
+        .iter()
+        .filter_map(|extra| {
+            let key = (&dep.package_id.name, extra);
+            (!activated_extras.contains(&key)).then_some(key)
+        })
+        .collect()
+}
 
 pub trait Installable<'lock> {
     /// Return the root install path.
@@ -143,10 +156,14 @@ pub trait Installable<'lock> {
                 })
                 .flatten()
             {
+                let additional_activated_extras = newly_activated_extras(dep, &activated_extras);
                 if !dep.complexified_marker.evaluate(
                     marker_env,
                     activated_projects.iter().copied(),
-                    activated_extras.iter().copied(),
+                    activated_extras
+                        .iter()
+                        .chain(additional_activated_extras.iter())
+                        .copied(),
                     activated_groups.iter().copied(),
                 ) {
                     continue;
@@ -370,13 +387,8 @@ pub trait Installable<'lock> {
                     Either::Right(package.dependencies.iter())
                 };
                 for dep in deps {
-                    let mut additional_activated_extras = vec![];
-                    for extra in &dep.extra {
-                        let key = (&dep.package_id.name, extra);
-                        if !activated_extras_set.contains(&key) {
-                            additional_activated_extras.push(key);
-                        }
-                    }
+                    let additional_activated_extras =
+                        newly_activated_extras(dep, &activated_extras);
                     if !dep.complexified_marker.evaluate(
                         marker_env,
                         activated_projects.iter().copied(),

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -4964,6 +4964,80 @@ fn sync_group_self() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for: <https://github.com/astral-sh/uv/issues/14645>
+#[test]
+fn sync_workspace_member_group_self_conflicting_extra() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["member"]
+        "#,
+    )?;
+
+    let member = context.temp_dir.child("member");
+    member.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "member"
+        version = "0.0.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        cpu = ["idna>=3"]
+        gpu = []
+
+        [dependency-groups]
+        ci = ["member[cpu]"]
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+
+        [tool.uv]
+        package = true
+        conflicts = [
+          [
+            { extra = "cpu" },
+            { extra = "gpu" },
+          ],
+        ]
+        "#,
+    )?;
+    member
+        .child("src")
+        .child("member")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .sync()
+            .arg("--package")
+            .arg("member")
+            .arg("--group")
+            .arg("ci"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + idna==3.6
+     + member==0.0.0 (from file://[TEMP_DIR]/member)
+    "
+    );
+
+    context.assert_command("import idna").success();
+
+    Ok(())
+}
+
 #[test]
 fn sync_non_existent_extra() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

When evaluating a dependency like `member[cpu]`, we now treat `cpu` as active for that dependency’s own conflict marker check.

Closes https://github.com/astral-sh/uv/issues/14645.
