### PR TITLE
docs: link the run page to locking and syncing

### DIFF
--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -12,9 +12,11 @@ $ uv run python -c "import example"
 When using `run`, uv will ensure that the project environment is up-to-date before running the given
 command.
 
-See [locking and syncing](./sync.md) for details on when uv refreshes the lockfile and project
-environment, and the [projects guide](../../guides/projects.md#running-commands) for a task-focused
-overview of `uv run`.
+!!! note
+
+    See [locking and syncing](./sync.md) for details on when uv refreshes the lockfile and
+    project environment, and the [projects guide](../../guides/projects.md#running-commands) for
+    a task-focused overview of `uv run`.
 
 The given command can be provided by the project environment or exist outside of it, e.g.:
 


### PR DESCRIPTION
## Summary
- link the project `uv run` concept page to the locking and syncing page
- point readers to the projects guide for a task-oriented overview of `uv run`

## Problem
The "Running commands" concept page explains that `uv run` keeps the environment up to date, but it does not point readers to the documentation that explains that locking and syncing behavior in more detail.

## Changes
- add a short follow-up sentence after the automatic sync explanation in `docs/concepts/projects/run.md`
- link to the locking and syncing concept page and the projects guide section for `uv run`

## Validation
- `git diff --check`

Closes #15407
