### PR TITLE
docs: link dynamic metadata to cache guidance

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -335,6 +335,9 @@ static metadata. If static metadata is unavailable, uv is required to build the 
 dependency resolution phase; as such, uv cannot determine the version of the build dependency that
 would ultimately be installed in the project environment.
 
+For guidance on tracking dynamic metadata changes in the cache, see
+[Dynamic metadata](../cache.md#dynamic-metadata).
+
 In other words, if `flash-attn` did not declare static metadata, uv would not be able to determine
 the version of `torch` that would be installed in the project environment, since it would need to
 build `flash-attn` prior to resolving the `torch` version.


### PR DESCRIPTION
## Summary
- link the project configuration docs to the cache guide's dynamic-metadata section
- make the cache-key guidance easier to discover from the `match-runtime` documentation

## Problem
The project configuration page explains how dynamic metadata affects `match-runtime`, but it does not point readers to the cache guidance that explains how to track those dynamic inputs.

## Changes
- add a short cross-reference in `docs/concepts/projects/config.md`
- link readers directly to the cache guide's dynamic-metadata section

## Validation
- `git diff --check`

Closes #15413
