### PR TITLE
Report error cleanly instead of panicking on TLS certificate error

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -70,7 +70,9 @@ fn setup(manifest: Manifest, universal: bool) -> impl Fn() {
     let interpreter = PythonEnvironment::from_root("../../.venv", &cache)
         .unwrap()
         .into_interpreter();
-    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache.clone()).build();
+    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache.clone())
+        .build()
+        .expect("failed to build registry client");
 
     // Prime the cache: First run for performance the network operation, the second run primes
     // reading from the cache from the first run. If they are already primed, we only lose ~1s for
@@ -92,7 +94,8 @@ fn setup(manifest: Manifest, universal: bool) -> impl Fn() {
         BaseClientBuilder::default().connectivity(Connectivity::Offline),
         cache.clone(),
     )
-    .build();
+    .build()
+    .expect("failed to build registry client");
 
     move || {
         runtime

--- a/crates/uv-bin-install/src/lib.rs
+++ b/crates/uv-bin-install/src/lib.rs
@@ -916,7 +916,7 @@ mod tests {
         let platform_name = platform.as_cargo_dist_triple();
         let client_builder = BaseClientBuilder::default().retries(0);
         let retry_policy = client_builder.retry_policy();
-        let client = client_builder.build();
+        let client = client_builder.build().expect("failed to build base client");
 
         fetch_with_url_fallback(urls, retry_policy, "manifest for `uv`", |url| {
             fetch_and_find_matching_version(
@@ -1042,7 +1042,9 @@ mod tests {
         });
 
         let url = DisplaySafeUrl::parse(&format!("http://{addr}/ruff.tar.gz")).unwrap();
-        let client = BaseClientBuilder::default().build();
+        let client = BaseClientBuilder::default()
+            .build()
+            .expect("failed to build base client");
         let response = client
             .for_host(&url)
             .get(Url::from(url.clone()))

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -380,7 +380,7 @@ impl<'a> BaseClientBuilder<'a> {
         retry_policy(self.retries, self.no_retry_delay)
     }
 
-    pub fn build(&self) -> BaseClient {
+    pub fn build(&self) -> reqwest::Result<BaseClient> {
         if let Some(name) = self.client_name {
             debug!(
                 "Using request connect timeout of {}s and read timeout of {}s for {} client",
@@ -400,7 +400,7 @@ impl<'a> BaseClientBuilder<'a> {
         let (raw_client, raw_dangerous_client) = match &self.custom_client {
             Some(client) => (client.clone(), client.clone()),
             None => {
-                self.create_secure_and_insecure_clients(self.read_timeout, self.connect_timeout)
+                self.create_secure_and_insecure_clients(self.read_timeout, self.connect_timeout)?
             }
         };
 
@@ -416,7 +416,7 @@ impl<'a> BaseClientBuilder<'a> {
             cross_origin_credentials_policy: self.cross_origin_credential_policy,
         };
 
-        BaseClient {
+        Ok(BaseClient {
             connectivity: self.connectivity,
             allow_insecure_host: self.allow_insecure_host.clone(),
             retries: self.retries,
@@ -428,7 +428,7 @@ impl<'a> BaseClientBuilder<'a> {
             read_timeout: self.read_timeout,
             connect_timeout: self.connect_timeout,
             credentials_cache: self.credentials_cache.clone(),
-        }
+        })
     }
 
     /// Share the underlying client between two different middleware configurations.
@@ -464,7 +464,7 @@ impl<'a> BaseClientBuilder<'a> {
         &self,
         read_timeout: Duration,
         connect_timeout: Duration,
-    ) -> (Client, Client) {
+    ) -> reqwest::Result<(Client, Client)> {
         // Create user agent.
         let mut user_agent_string = format!("uv/{}", version());
 
@@ -485,7 +485,7 @@ impl<'a> BaseClientBuilder<'a> {
             custom_certs.clone(),
             Security::Secure,
             self.redirect_policy,
-        );
+        )?;
 
         // Create an insecure client that accepts invalid certificates.
         let raw_dangerous_client = self.create_client(
@@ -495,9 +495,9 @@ impl<'a> BaseClientBuilder<'a> {
             custom_certs,
             Security::Insecure,
             self.redirect_policy,
-        );
+        )?;
 
-        (raw_client, raw_dangerous_client)
+        Ok((raw_client, raw_dangerous_client))
     }
 
     fn create_client(
@@ -508,7 +508,7 @@ impl<'a> BaseClientBuilder<'a> {
         custom_certs: Option<Vec<Certificate>>,
         security: Security,
         redirect_policy: RedirectPolicy,
-    ) -> Client {
+    ) -> reqwest::Result<Client> {
         // Configure the builder.
         let client_builder = ClientBuilder::new()
             .http1_title_case_headers()
@@ -574,11 +574,7 @@ impl<'a> BaseClientBuilder<'a> {
             client_builder = client_builder.proxy(proxy);
         }
 
-        let client_builder = client_builder;
-
-        client_builder
-            .build()
-            .expect("Failed to build HTTP client.")
+        client_builder.build()
     }
 
     fn apply_middleware(&self, client: Client) -> ClientWithMiddleware {

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -163,7 +163,7 @@ impl<'a> RegistryClientBuilder<'a> {
         }
     }
 
-    pub fn build(mut self) -> RegistryClient {
+    pub fn build(mut self) -> reqwest::Result<RegistryClient> {
         self.cache_index_credentials();
         let index_urls = self.index_locations.index_urls();
 
@@ -173,7 +173,7 @@ impl<'a> RegistryClientBuilder<'a> {
             .indexes(Indexes::from(&self.index_locations))
             .redirect(RedirectPolicy::RetriggerMiddleware);
 
-        let client = builder.build();
+        let client = builder.build()?;
 
         let read_timeout = client.read_timeout();
         let connectivity = client.connectivity();
@@ -181,7 +181,7 @@ impl<'a> RegistryClientBuilder<'a> {
         // Wrap in the cache middleware.
         let client = CachedClient::new(client);
 
-        RegistryClient {
+        Ok(RegistryClient {
             index_urls,
             index_strategy: self.index_strategy,
             torch_backend: self.torch_backend,
@@ -191,7 +191,7 @@ impl<'a> RegistryClientBuilder<'a> {
             read_timeout,
             flat_indexes: Arc::default(),
             pyx_token_store: PyxTokenStore::from_settings().ok(),
-        }
+        })
     }
 
     /// Share the underlying client between two different middleware configurations.
@@ -1693,7 +1693,8 @@ mod tests {
         let cache = Cache::temp()?;
         let registry_client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache)
             .allow_cross_origin_credentials()
-            .build();
+            .build()
+            .expect("failed to build registry client");
         let client = registry_client.cached_client().uncached();
 
         assert_eq!(
@@ -1753,7 +1754,8 @@ mod tests {
         let cache = Cache::temp()?;
         let registry_client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache)
             .allow_cross_origin_credentials()
-            .build();
+            .build()
+            .expect("failed to build registry client");
         let client = registry_client.cached_client().uncached();
 
         let mut url = redirect_server_url.clone();
@@ -1801,7 +1803,8 @@ mod tests {
         let cache = Cache::temp()?;
         let registry_client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache)
             .allow_cross_origin_credentials()
-            .build();
+            .build()
+            .expect("failed to build registry client");
         let client = registry_client.cached_client().uncached();
 
         let redirect_server_url = DisplaySafeUrl::parse(&redirect_server.uri())?.join("foo/")?;

--- a/crates/uv-client/tests/it/http_util.rs
+++ b/crates/uv-client/tests/it/http_util.rs
@@ -13,8 +13,8 @@ use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
 use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
-    Issuer, KeyPair, KeyUsagePurpose, SanType, date_time_ymd,
+    BasicConstraints, Certificate, CertificateParams, CustomExtension, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, date_time_ymd,
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
@@ -53,7 +53,14 @@ pub(crate) fn test_cert_dir() -> PathBuf {
 ///
 /// Use sparingly as generation of these certs is a very slow operation.
 pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
-    // Generate the CA
+    generate_self_signed_certs_with_ca_custom_extensions(Vec::new())
+}
+
+/// Generates a self-signed root CA, server certificate, and client certificate,
+/// with additional custom extensions on the CA certificate.
+pub(crate) fn generate_self_signed_certs_with_ca_custom_extensions(
+    custom_extensions: Vec<CustomExtension>,
+) -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
     let mut ca_params = CertificateParams::default();
     ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained); // root cert
     ca_params.not_before = date_time_ymd(1975, 1, 1);
@@ -61,6 +68,7 @@ pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSi
     ca_params.key_usages.push(KeyUsagePurpose::DigitalSignature);
     ca_params.key_usages.push(KeyUsagePurpose::KeyCertSign);
     ca_params.key_usages.push(KeyUsagePurpose::CrlSign);
+    ca_params.custom_extensions = custom_extensions;
     ca_params
         .distinguished_name
         .push(DnType::OrganizationName, "Astral Software Inc.");

--- a/crates/uv-client/tests/it/proxy.rs
+++ b/crates/uv-client/tests/it/proxy.rs
@@ -26,7 +26,7 @@ async fn http_proxy() -> Result<()> {
     // Create a client with the proxy.
     let client = BaseClientBuilder::default()
         .http_proxy(Some(proxy_server.uri().parse::<ProxyUrl>()?))
-        .build();
+        .build()?;
 
     // Make a request to the target.
     let response = client
@@ -67,7 +67,7 @@ async fn no_proxy() -> Result<()> {
     let client = BaseClientBuilder::default()
         .http_proxy(Some(proxy_server.uri().parse::<ProxyUrl>()?))
         .no_proxy(Some(vec![target_host]))
-        .build();
+        .build()?;
 
     // Make a request to the target.
     let response = client

--- a/crates/uv-client/tests/it/remote_metadata.rs
+++ b/crates/uv-client/tests/it/remote_metadata.rs
@@ -12,7 +12,7 @@ use uv_redacted::DisplaySafeUrl;
 #[tokio::test]
 async fn remote_metadata_with_and_without_cache() -> Result<()> {
     let cache = Cache::temp()?.init().await?;
-    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache).build();
+    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache).build()?;
 
     // The first run is without cache (the tempdir is empty), the second has the cache from the
     // first run.

--- a/crates/uv-client/tests/it/ssl_certs.rs
+++ b/crates/uv-client/tests/it/ssl_certs.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::Result;
+use rcgen::CustomExtension;
 use temp_env::async_with_vars;
 use tempfile::{NamedTempFile, TempDir};
 use url::Url;
@@ -15,7 +16,8 @@ use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 
 use crate::http_util::{
-    SelfSigned, generate_self_signed_certs_with_ca, start_https_mtls_user_agent_server,
+    SelfSigned, generate_self_signed_certs_with_ca,
+    generate_self_signed_certs_with_ca_custom_extensions, start_https_mtls_user_agent_server,
     start_https_user_agent_server, test_cert_dir,
 };
 
@@ -39,11 +41,28 @@ impl TestCertificate {
     /// Generate a fresh CA, server cert, and client cert, persisting the
     /// relevant PEM files to a temporary directory.
     fn new() -> Result<Self> {
+        let (ca, server, client) = generate_self_signed_certs_with_ca()?;
+        Self::persist(ca, server, &client)
+    }
+
+    /// Generate a fresh certificate set whose CA contains an unsupported
+    /// critical extension.
+    fn new_with_unsupported_critical_ca_extension() -> Result<Self> {
+        let mut unsupported_extension = CustomExtension::from_oid_content(
+            &[1, 2, 3, 4],
+            [vec![0x0c, 0x0b], b"unsupported".to_vec()].concat(),
+        );
+        unsupported_extension.set_criticality(true);
+
+        let (ca, server, client) =
+            generate_self_signed_certs_with_ca_custom_extensions(vec![unsupported_extension])?;
+        Self::persist(ca, server, &client)
+    }
+
+    fn persist(ca: SelfSigned, server: SelfSigned, client: &SelfSigned) -> Result<Self> {
         let cert_dir = test_cert_dir();
         fs_err::create_dir_all(&cert_dir)?;
         let temp_dir = TempDir::new_in(cert_dir)?;
-
-        let (ca, server, client) = generate_self_signed_certs_with_ca()?;
 
         let trust_path = temp_dir.path().join("ca.pem");
         fs_err::write(&trust_path, ca.public.pem())?;
@@ -342,7 +361,9 @@ async fn send_request_to(
     let base = BaseClientBuilder::default()
         .no_retry_delay(true)
         .with_system_certs(system_certs);
-    let client = RegistryClientBuilder::new(base, cache).build();
+    let client = RegistryClientBuilder::new(base, cache)
+        .build()
+        .expect("failed to build registry client");
     client
         .cached_client()
         .uncached()
@@ -429,6 +450,30 @@ async fn test_ssl_cert_file_valid() -> Result<()> {
         .ssl_cert_file(&cert.trust_path)
         .expect_https_connect_succeeds(&cert)
         .await;
+    Ok(())
+}
+
+/// An unsupported critical extension in `SSL_CERT_FILE` returns a builder
+/// error instead of panicking.
+#[tokio::test]
+async fn test_ssl_cert_file_unsupported_critical_extension_returns_error() -> Result<()> {
+    let cert = TestCertificate::new_with_unsupported_critical_ca_extension()?;
+    let test_client = client().ssl_cert_file(&cert.trust_path);
+    let vars = test_client.ssl_vars();
+
+    async_with_vars(vars, async {
+        let err = BaseClientBuilder::default()
+            .build()
+            .expect_err("expected client build to fail");
+
+        assert!(err.is_builder(), "expected builder error, got: {err:?}");
+        assert!(
+            format!("{err:?}").contains("UnsupportedCriticalExtension"),
+            "expected error to mention UnsupportedCriticalExtension, got: {err:?}"
+        );
+    })
+    .await;
+
     Ok(())
 }
 

--- a/crates/uv-client/tests/it/user_agent_version.rs
+++ b/crates/uv-client/tests/it/user_agent_version.rs
@@ -26,7 +26,7 @@ async fn test_user_agent_has_version() -> Result<()> {
 
     // Initialize uv-client
     let cache = Cache::temp()?.init().await?;
-    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache).build();
+    let client = RegistryClientBuilder::new(BaseClientBuilder::default(), cache).build()?;
 
     // Send request to our dummy server
     let url = DisplaySafeUrl::from_str(&format!("http://{addr}"))?;
@@ -86,7 +86,7 @@ async fn test_user_agent_has_subcommand() -> Result<()> {
         BaseClientBuilder::default().subcommand(vec!["foo".to_owned(), "bar".to_owned()]),
         cache,
     )
-    .build();
+    .build()?;
 
     // Send request to our dummy server
     let url = DisplaySafeUrl::from_str(&format!("http://{addr}"))?;
@@ -182,7 +182,7 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
     } else if cfg!(target_os = "macos") {
         builder = builder.platform(&macos);
     }
-    let client = builder.build();
+    let client = builder.build()?;
 
     // Send request to our dummy server
     let url = DisplaySafeUrl::from_str(&format!("http://{addr}"))?;

--- a/crates/uv-dev/src/list_packages.rs
+++ b/crates/uv-dev/src/list_packages.rs
@@ -26,7 +26,7 @@ pub(crate) async fn list_packages(
             .connect_timeout(environment.http_connect_timeout),
         cache,
     )
-    .build();
+    .build()?;
 
     let index_url = IndexUrl::parse(&args.url, None)?;
     let index = client.fetch_simple_index(&index_url).await?;

--- a/crates/uv-dev/src/validate_zip.rs
+++ b/crates/uv-dev/src/validate_zip.rs
@@ -29,7 +29,7 @@ pub(crate) async fn validate_zip(
             .connect_timeout(environment.http_connect_timeout),
         cache,
     )
-    .build();
+    .build()?;
 
     let ParsedUrl::Archive(archive) = ParsedUrl::try_from(args.url.to_url())? else {
         bail!("Only archive URLs are supported");

--- a/crates/uv-dev/src/wheel_metadata.rs
+++ b/crates/uv-dev/src/wheel_metadata.rs
@@ -30,7 +30,7 @@ pub(crate) async fn wheel_metadata(
             .connect_timeout(environment.http_connect_timeout),
         cache,
     )
-    .build();
+    .build()?;
     let capabilities = IndexCapabilities::default();
 
     let filename = WheelFilename::from_str(&args.url.filename()?)?;

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1561,7 +1561,8 @@ mod tests {
             .redirect(RedirectPolicy::NoRedirect)
             .retries(0)
             .auth_integration(AuthIntegration::NoAuthMiddleware)
-            .build();
+            .build()
+            .expect("failed to build base client");
 
         let download_concurrency = Arc::new(Semaphore::new(1));
         let registry = DisplaySafeUrl::parse(&format!("{}/final", &mock_server.uri())).unwrap();
@@ -1934,7 +1935,9 @@ mod tests {
         project_urls: Source, https://github.com/unknown/tqdm
         ");
 
-        let client = BaseClientBuilder::default().build();
+        let client = BaseClientBuilder::default()
+            .build()
+            .expect("failed to build base client");
         let (request, _) = build_upload_request(
             &group,
             &DisplaySafeUrl::parse("https://example.org/upload").unwrap(),
@@ -2095,7 +2098,9 @@ mod tests {
         requires_dist: requests ; extra == 'telegram'
         "#);
 
-        let client = BaseClientBuilder::default().build();
+        let client = BaseClientBuilder::default()
+            .build()
+            .expect("failed to build base client");
         let (request, _) = build_upload_request(
             &group,
             &DisplaySafeUrl::parse("https://example.org/upload").unwrap(),

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -2065,7 +2065,9 @@ mod tests {
             .with_implementation(ImplementationName::CPython)
             .with_build("20240814".to_string());
 
-        let client = uv_client::BaseClientBuilder::default().build();
+        let client = uv_client::BaseClientBuilder::default()
+            .build()
+            .expect("failed to build base client");
         let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
 
         let downloads: Vec<_> = download_list
@@ -2091,7 +2093,9 @@ mod tests {
             .with_implementation(ImplementationName::CPython)
             .with_build("99999999".to_string());
 
-        let client = uv_client::BaseClientBuilder::default().build();
+        let client = uv_client::BaseClientBuilder::default()
+            .build()
+            .expect("failed to build base client");
         let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
 
         // Should find no matching downloads

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -88,7 +88,7 @@ impl PythonInstallation {
         preview: Preview,
     ) -> Result<Self, Error> {
         let retry_policy = client_builder.retry_policy();
-        let client = client_builder.clone().retries(0).build();
+        let client = client_builder.clone().retries(0).build()?;
         let download_list =
             ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
         let downloads_enabled = preference.allows_managed()
@@ -134,7 +134,7 @@ impl PythonInstallation {
         // Python downloads are performing their own retries to catch stream errors, disable the
         // default retries to avoid the middleware performing uncontrolled retries.
         let retry_policy = client_builder.retry_policy();
-        let client = client_builder.clone().retries(0).build();
+        let client = client_builder.clone().retries(0).build()?;
         let download_list =
             ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -87,6 +87,9 @@ pub enum Error {
     #[error(transparent)]
     Download(#[from] downloads::Error),
 
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
     // TODO(zanieb) We might want to ensure this is always wrapped in another type
     #[error(transparent)]
     KeyError(#[from] installation::PythonInstallationKeyError),
@@ -1000,6 +1003,11 @@ mod tests {
     ) -> Result<PythonInstallation, crate::Error> {
         let client_builder = BaseClientBuilder::default();
         let download_list = ManagedPythonDownloadList::new_only_embedded()?;
+        let client = client_builder
+            .clone()
+            .retries(0)
+            .build()
+            .expect("failed to build base client");
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1010,7 +1018,7 @@ mod tests {
                 preference,
                 false,
                 &download_list,
-                &client_builder.clone().retries(0).build(),
+                &client,
                 &client_builder.retry_policy(),
                 cache,
                 None,

--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -289,7 +289,21 @@ impl RequirementsTxt {
                     });
                 }
 
-                let client = client_builder.build();
+                let url = DisplaySafeUrl::parse(&requirements_txt.display().to_string()).map_err(
+                    |err| RequirementsTxtFileError {
+                        file: requirements_txt.to_path_buf(),
+                        error: RequirementsTxtParserError::InvalidUrl(
+                            requirements_txt.display().to_string(),
+                            err,
+                        ),
+                    },
+                )?;
+                let client = client_builder
+                    .build()
+                    .map_err(|err| RequirementsTxtFileError {
+                        file: requirements_txt.to_path_buf(),
+                        error: RequirementsTxtParserError::from_reqwest(url, err),
+                    })?;
                 let content = read_url_to_string(&requirements_txt, client)
                     .await
                     .map_err(|err| RequirementsTxtFileError {

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -782,7 +782,7 @@ async fn read_file(path: &Path, client_builder: &BaseClientBuilder<'_>) -> Resul
         if !cfg!(unix) || matches!(path.try_exists(), Ok(false)) {
             let url = DisplaySafeUrl::parse(&path.to_string_lossy())?;
 
-            let client = client_builder.build();
+            let client = client_builder.build()?;
             let response = client
                 .for_host(&url)
                 .get(Url::from(url.clone()))

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -2359,7 +2359,8 @@ pub async fn download_to_disk(url: &str, path: &Path) {
 
     let client = uv_client::BaseClientBuilder::default()
         .allow_insecure_host(trusted_hosts)
-        .build();
+        .build()
+        .expect("failed to build base client");
     let url = url.parse().unwrap();
     let response = client
         .for_host(&url)

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -89,7 +89,7 @@ async fn credentials_for_url(
         }
         let client = client_builder
             .auth_integration(uv_client::AuthIntegration::NoAuthMiddleware)
-            .build();
+            .build()?;
         let token = pyx_store
             .access_token(
                 client.for_host(pyx_store.api()).raw_client(),

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -42,7 +42,7 @@ pub(crate) async fn login(
 
         let client = client_builder
             .auth_integration(AuthIntegration::NoAuthMiddleware)
-            .build();
+            .build()?;
 
         let access_token = pyx_login_with_browser(&pyx_store, &client, &printer).await?;
         let jwt = PyxJwt::decode(&access_token)?;

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -99,7 +99,7 @@ async fn pyx_logout(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Initialize the client.
-    let client = client_builder.build();
+    let client = client_builder.build()?;
 
     // Retrieve the token store.
     let Some(tokens) = store.read().await? else {

--- a/crates/uv/src/commands/auth/token.rs
+++ b/crates/uv/src/commands/auth/token.rs
@@ -27,7 +27,7 @@ pub(crate) async fn token(
         }
         let client = client_builder
             .auth_integration(AuthIntegration::NoAuthMiddleware)
-            .build();
+            .build()?;
 
         pyx_refresh(&pyx_store, &client, printer).await?;
         return Ok(ExitStatus::Success);

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -61,6 +61,8 @@ enum Error {
     #[error(transparent)]
     FlatIndex(#[from] uv_client::FlatIndexError),
     #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
     BuildPlan(anyhow::Error),
     #[error(transparent)]
     Extract(#[from] uv_extract::Error),
@@ -587,7 +589,7 @@ async fn build_package(
         .keyring(keyring_provider)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let environment;

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -463,7 +463,7 @@ pub(crate) async fn pip_compile(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Read the lockfile, if present.
     let LockedRequirements { preferences, git } =

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -419,7 +419,7 @@ pub(crate) async fn pip_install(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Combine the `--no-binary` and `--no-build` flags from the requirements files.
     let build_options = build_options.combine(no_binary, no_build);
@@ -497,7 +497,7 @@ pub(crate) async fn pip_install(
             if pylock.starts_with("http://") || pylock.starts_with("https://") {
                 // Fetch the `pylock.toml` over HTTP(S).
                 let url = uv_redacted::DisplaySafeUrl::parse(&pylock.to_string_lossy())?;
-                let client = client_builder.build();
+                let client = client_builder.build()?;
                 let response = client
                     .for_host(&url)
                     .get(url::Url::from(url.clone()))

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -117,7 +117,7 @@ pub(crate) async fn pip_list(
         .index_strategy(index_strategy)
         .markers(environment.interpreter().markers())
         .platform(environment.interpreter().platform())
-        .build();
+        .build()?;
         let download_concurrency = concurrency.downloads_semaphore.clone();
 
         // Determine the platform tags.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -321,7 +321,7 @@ pub(crate) async fn pip_sync(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Combine the `--no-binary` and `--no-build` flags from the requirements files.
     let build_options = build_options.combine(no_binary, no_build);

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -101,7 +101,7 @@ pub(crate) async fn pip_tree(
         .index_strategy(index_strategy)
         .markers(environment.interpreter().markers())
         .platform(environment.interpreter().platform())
-        .build();
+        .build()?;
         let download_concurrency = concurrency.downloads_semaphore.clone();
 
         // Determine the platform tags.

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -384,7 +384,7 @@ pub(crate) async fn add(
                 .index_strategy(settings.resolver.index_strategy)
                 .markers(target.interpreter().markers())
                 .platform(target.interpreter().platform())
-                .build();
+                .build()?;
 
             // Determine whether to enable build isolation.
             let environment;

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -198,7 +198,7 @@ pub(crate) async fn audit(
         .iter()
         .map(|(name, version)| Dependency::new((*name).clone(), (*version).clone()))
         .collect();
-    let base_client = client_builder.build();
+    let base_client = client_builder.build()?;
     let all_findings = {
         match service {
             VulnerabilityServiceFormat::Osv => {

--- a/crates/uv/src/commands/project/format.rs
+++ b/crates/uv/src/commands/project/format.rs
@@ -67,7 +67,7 @@ pub(crate) async fn format(
     let retry_policy = client_builder.retry_policy();
     // Python downloads are performing their own retries to catch stream errors, disable the
     // default retries to avoid the middleware from performing uncontrolled retries.
-    let client = client_builder.retries(0).build();
+    let client = client_builder.retries(0).build()?;
 
     // Determine the version to use and get the path to Ruff.
     let reporter = BinaryDownloadReporter::single(printer);

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -701,7 +701,7 @@ async fn do_lock(
         .index_strategy(*index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let environment;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -279,6 +279,9 @@ pub(crate) enum ProjectError {
     Client(#[from] uv_client::Error),
 
     #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+
+    #[error(transparent)]
     Python(#[from] uv_python::Error),
 
     #[error(transparent)]
@@ -1876,7 +1879,8 @@ pub(crate) async fn resolve_names(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()
+        .map_err(std::io::Error::other)?;
 
     // Determine whether to enable build isolation.
     let environment;
@@ -2074,7 +2078,7 @@ pub(crate) async fn resolve_environment(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let environment;
@@ -2250,7 +2254,7 @@ pub(crate) async fn sync_environment(
         .index_strategy(index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let build_isolation = match build_isolation {
@@ -2498,7 +2502,7 @@ pub(crate) async fn update_environment(
         .torch_backend(torch_backend.clone())
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let build_isolation = match build_isolation {

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1620,7 +1620,7 @@ impl ParsedRunCommand {
         mut url: &DisplaySafeUrl,
         client_builder: &BaseClientBuilder<'_>,
     ) -> anyhow::Result<tempfile::NamedTempFile> {
-        let client = client_builder.build();
+        let client = client_builder.build()?;
         let mut response = client
             .for_host(url)
             .get(Url::from(url.clone()))
@@ -1944,7 +1944,7 @@ async fn resolve_gist_url(
     // Build the API URL.
     let api_url = format!("https://api.github.com/gists/{gist_id}");
 
-    let client = client_builder.build();
+    let client = client_builder.build()?;
 
     // Build the request with appropriate headers.
     let api_url_parsed = DisplaySafeUrl::parse(&api_url)?;

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -776,7 +776,7 @@ pub(super) async fn do_sync(
         .index_strategy(index_strategy)
         .markers(venv.interpreter().markers())
         .platform(venv.interpreter().platform())
-        .build();
+        .build()?;
 
     // Determine whether to enable build isolation.
     let build_isolation = match build_isolation {

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -226,7 +226,7 @@ pub(crate) async fn tree(
             )
             .index_locations(index_locations.clone())
             .keyring(*keyring_provider)
-            .build();
+            .build()?;
             let download_concurrency = concurrency.downloads_semaphore.clone();
 
             // Initialize the client to fetch the latest version of each package.

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -142,14 +142,14 @@ pub(crate) async fn publish(
         .read_timeout(environment.http_read_timeout_upload)
         .connect_timeout(environment.http_connect_timeout)
         .client_name("upload")
-        .build();
+        .build()?;
     // For OIDC (trusted publishing), we need retries (GitHub's networking is unreliable)
     // and default timeouts.
     let oidc_client = client_builder
         .clone()
         .auth_integration(AuthIntegration::NoAuthMiddleware)
         .client_name("oidc")
-        .build();
+        .build()?;
     // For S3 uploads, we roll our own retry loop, use upload timeouts, and no auth middleware.
     let s3_client = client_builder
         .clone()
@@ -158,7 +158,7 @@ pub(crate) async fn publish(
         .read_timeout(environment.http_read_timeout_upload)
         .connect_timeout(environment.http_connect_timeout)
         .client_name("s3")
-        .build();
+        .build()?;
 
     let retry_policy = client_builder.retry_policy();
     // We're only checking a single URL and one at a time, so 1 permit is sufficient
@@ -616,7 +616,7 @@ mod tests {
         username: Option<String>,
         password: Option<String>,
     ) -> Result<(DisplaySafeUrl, Credentials)> {
-        let client = BaseClientBuilder::default().build();
+        let client = BaseClientBuilder::default().build()?;
         let token_store = PyxTokenStore::from_settings()?;
         gather_credentials(
             url,

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -78,7 +78,7 @@ pub(crate) async fn find(
     )
     .await?;
 
-    let client = client_builder.clone().retries(0).build();
+    let client = client_builder.clone().retries(0).build()?;
     let download_list = ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
 
     let python = PythonInstallation::find(

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -338,7 +338,7 @@ async fn perform_install(
     let retry_policy = client_builder.retry_policy();
     // Python downloads are performing their own retries to catch stream errors, disable the
     // default retries to avoid the middleware from performing uncontrolled retries.
-    let client = client_builder.retries(0).build();
+    let client = client_builder.retries(0).build()?;
     let download_list =
         ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
     // TODO(zanieb): We use this variable to special-case .python-version files, but it'd be nice to

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -81,7 +81,7 @@ pub(crate) async fn list(
         PythonDownloadRequest::from_request(request.as_ref().unwrap_or(&PythonRequest::Any))
     };
 
-    let client = client_builder.build();
+    let client = client_builder.build()?;
     let download_list =
         ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
     let mut output = BTreeSet::new();

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -96,7 +96,7 @@ pub(crate) async fn pin(
             for pin in file.versions() {
                 writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
                 if let Some(virtual_project) = &virtual_project {
-                    let client = client_builder.clone().retries(0).build();
+                    let client = client_builder.clone().retries(0).build()?;
                     let download_list = ManagedPythonDownloadList::new(
                         &client,
                         install_mirrors.python_downloads_json_url.as_deref(),

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -36,8 +36,9 @@ pub(crate) async fn self_update(
     }
 
     let mut updater = AxoUpdater::new_for("uv");
+    let updater_client = client_builder.build()?;
     updater
-        .set_client(client_builder.build().raw_client().clone())
+        .set_client(updater_client.raw_client().clone())
         .disable_installer_output();
 
     if let Some(ref token) = token {
@@ -113,7 +114,7 @@ pub(crate) async fn self_update(
         debug!("Using official public self-update path");
 
         let retry_policy = client_builder.retry_policy();
-        let client = client_builder.retries(0).build();
+        let client = client_builder.retries(0).build()?;
         let constraints = official_target_version_specifiers(version.as_deref())?;
 
         let resolved = find_matching_version(

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -270,7 +270,7 @@ pub(crate) async fn install(
         .index_strategy(settings.resolver.index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
         // Initialize the capabilities.
         let capabilities = IndexCapabilities::default();

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -141,7 +141,7 @@ pub(crate) async fn list(
                     .index_strategy(settings.resolver.index_strategy)
                     .markers(interpreter.markers())
                     .platform(interpreter.platform())
-                    .build();
+                    .build()?;
 
                     let requires_python = RequiresPython::greater_than_equal_version(
                         interpreter.python_full_version(),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -926,7 +926,7 @@ async fn get_or_create_environment(
         .index_strategy(settings.resolver.index_strategy)
         .markers(interpreter.markers())
         .platform(interpreter.platform())
-        .build();
+        .build()?;
 
         // Initialize the capabilities.
         let capabilities = IndexCapabilities::default();

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -219,7 +219,7 @@ pub(crate) async fn venv(
             .keyring(keyring_provider)
             .markers(interpreter.markers())
             .platform(interpreter.platform())
-            .build();
+            .build()?;
 
         // Resolve the flat indexes from `--find-links`.
         let flat_index = {


### PR DESCRIPTION
See https://github.com/astral-sh/uv/issues/18890

We can load a certificate that is a valid bundle, but on client build we can fail if the certificate is unsupported for various reasons. This propagates the error instead of panicking.