### PR TITLE
Fix `build_system.requires` error message

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -1018,8 +1018,8 @@ impl BuildSystem {
                 if !specifier.contains(&uv_version) {
                     // This is allowed to happen when testing prereleases, but we should still warn.
                     warnings.push(format!(
-                        r#"`build_system.requires = ["{uv_requirement}"]` does not contain the
-                        current uv version {uv_version}"#,
+                        "`build_system.requires = [\"{uv_requirement}\"]` does not contain the \
+                        current uv version {uv_version}",
                     ));
                 }
                 Ranges::from(specifier.clone())


### PR DESCRIPTION
## Summary

Fixes a minor formatting problem in an error message.

I wasn't able to reproduce the warning in `uv run` on the lastest version for some reason, which is why I don't have an "after" screenshot for `uv run`. The "before" screenshot is from uv 0.11.3.

**Before:**

<img width="1042" height="115" alt="image" src="https://github.com/user-attachments/assets/4a81aded-44e1-4bac-85dc-acc1effd67fd" />

<img width="917" height="119" alt="image" src="https://github.com/user-attachments/assets/600fa58c-78e8-4b4e-a91f-1bc60546b39e" />

**After:**

<img width="1007" height="104" alt="image" src="https://github.com/user-attachments/assets/42f8b715-ab19-4049-8f2d-2c649b8677e0" />

## Test Plan

Only tested interactively, see above.