### PR TITLE
Add `allow-bypass` option to `exclude-newer` for allowing direct pinned dependencies

### DIFF
--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -81,6 +81,7 @@ pub enum ExcludeNewerChange {
     GlobalAdded(ExcludeNewerValue),
     GlobalRemoved,
     Package(ExcludeNewerPackageChange),
+    AllowBypassChanged,
 }
 
 impl ExcludeNewerChange {
@@ -88,7 +89,7 @@ impl ExcludeNewerChange {
     pub fn is_relative_timestamp_change(&self) -> bool {
         match self {
             Self::GlobalChanged(change) => change.is_relative_timestamp_change(),
-            Self::GlobalAdded(_) | Self::GlobalRemoved => false,
+            Self::GlobalAdded(_) | Self::GlobalRemoved | Self::AllowBypassChanged => false,
             Self::Package(change) => change.is_relative_timestamp_change(),
         }
     }
@@ -106,6 +107,9 @@ impl std::fmt::Display for ExcludeNewerChange {
             Self::GlobalRemoved => write!(f, "removal of global exclude newer"),
             Self::Package(change) => {
                 write!(f, "{change}")
+            }
+            Self::AllowBypassChanged => {
+                write!(f, "change of exclude newer allow-bypass setting")
             }
         }
     }
@@ -150,6 +154,7 @@ impl std::fmt::Display for ExcludeNewerPackageChange {
         }
     }
 }
+
 /// A timestamp that excludes files newer than it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExcludeNewerValue {
@@ -865,9 +870,17 @@ impl ExcludeNewer {
             (Some(_), None) => return Some(ExcludeNewerChange::GlobalRemoved),
             (None, None) => (),
         }
-        self.package
+        if let Some(change) = self
+            .package
             .compare(&other.package)
             .map(ExcludeNewerChange::Package)
+        {
+            return Some(change);
+        }
+        if self.allow_bypass != other.allow_bypass {
+            return Some(ExcludeNewerChange::AllowBypassChanged);
+        }
+        None
     }
 }
 

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -10,6 +10,23 @@ use serde::Deserialize;
 use serde::de::value::MapAccessDeserializer;
 use uv_normalize::PackageName;
 
+/// A bypass mode that allows certain packages to skip the `exclude-newer` filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ExcludeNewerBypass {
+    /// Bypass `exclude-newer` for direct dependencies that are pinned with `==`.
+    DirectPinned,
+}
+
+impl std::fmt::Display for ExcludeNewerBypass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DirectPinned => write!(f, "direct-pinned"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExcludeNewerValueChange {
     /// A relative span changed to a new value
@@ -140,6 +157,8 @@ pub struct ExcludeNewerValue {
     timestamp: Timestamp,
     /// The span used to derive the [`Timestamp`], if any.
     span: Option<ExcludeNewerSpan>,
+    /// Bypass modes parsed from the table form, to be propagated to [`ExcludeNewer`].
+    allow_bypass: Vec<ExcludeNewerBypass>,
 }
 
 impl ExcludeNewerValue {
@@ -224,11 +243,14 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
         D: serde::Deserializer<'de>,
     {
         // Support both a simple string ("2024-03-11T00:00:00Z") and a table
-        // ({ timestamp = "2024-03-11T00:00:00Z", span = "P2W" })
+        // ({ timestamp = "2024-03-11T00:00:00Z", span = "P2W", allow-bypass = ["direct-pinned"] })
         #[derive(serde::Deserialize)]
+        #[serde(rename_all = "kebab-case")]
         struct TableForm {
             timestamp: Timestamp,
             span: Option<ExcludeNewerSpan>,
+            #[serde(default)]
+            allow_bypass: Vec<ExcludeNewerBypass>,
         }
 
         #[derive(serde::Deserialize)]
@@ -240,7 +262,11 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
 
         match Helper::deserialize(deserializer)? {
             Helper::String(s) => Self::from_str(&s).map_err(serde::de::Error::custom),
-            Helper::Table(table) => Ok(Self::new(table.timestamp, table.span)),
+            Helper::Table(table) => {
+                let mut value = Self::new(table.timestamp, table.span);
+                value.allow_bypass = table.allow_bypass;
+                Ok(value)
+            }
         }
     }
 }
@@ -261,9 +287,18 @@ impl ExcludeNewerValue {
         self.span.as_ref()
     }
 
+    /// Return the bypass modes parsed from the table form.
+    pub fn allow_bypass(&self) -> &[ExcludeNewerBypass] {
+        &self.allow_bypass
+    }
+
     /// Create a new [`ExcludeNewerValue`].
     pub fn new(timestamp: Timestamp, span: Option<ExcludeNewerSpan>) -> Self {
-        Self { timestamp, span }
+        Self {
+            timestamp,
+            span,
+            allow_bypass: Vec::new(),
+        }
     }
 }
 
@@ -272,6 +307,7 @@ impl From<Timestamp> for ExcludeNewerValue {
         Self {
             timestamp,
             span: None,
+            allow_bypass: Vec::new(),
         }
     }
 }
@@ -731,20 +767,33 @@ pub struct ExcludeNewer {
     /// Per-package timestamps that override the global timestamp.
     #[serde(default, skip_serializing_if = "FxHashMap::is_empty")]
     pub package: ExcludeNewerPackage,
+    /// Bypass modes that allow certain packages to skip the `exclude-newer` filter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_bypass: Vec<ExcludeNewerBypass>,
 }
 
 impl ExcludeNewer {
     /// Create a new exclude newer configuration with just a global timestamp.
     pub fn global(global: ExcludeNewerValue) -> Self {
+        let allow_bypass = global.allow_bypass.clone();
         Self {
             global: Some(global),
             package: ExcludeNewerPackage::default(),
+            allow_bypass,
         }
     }
 
     /// Create a new exclude newer configuration.
     pub fn new(global: Option<ExcludeNewerValue>, package: ExcludeNewerPackage) -> Self {
-        Self { global, package }
+        let allow_bypass = global
+            .as_ref()
+            .map(|g| g.allow_bypass.clone())
+            .unwrap_or_default();
+        Self {
+            global,
+            package,
+            allow_bypass,
+        }
     }
 
     /// Create from CLI arguments.
@@ -753,8 +802,22 @@ impl ExcludeNewer {
         package: Vec<ExcludeNewerPackageEntry>,
     ) -> Self {
         let package: ExcludeNewerPackage = package.into_iter().collect();
+        let allow_bypass = global
+            .as_ref()
+            .map(|g| g.allow_bypass.clone())
+            .unwrap_or_default();
 
-        Self { global, package }
+        Self {
+            global,
+            package,
+            allow_bypass,
+        }
+    }
+
+    /// Returns whether the `direct-pinned` bypass is enabled.
+    pub fn allows_direct_pinned_bypass(&self) -> bool {
+        self.allow_bypass
+            .contains(&ExcludeNewerBypass::DirectPinned)
     }
 
     /// Returns the exclude-newer value for a specific package, returning `Some(value)` if the
@@ -772,6 +835,21 @@ impl ExcludeNewer {
     /// Returns true if this has any configuration (global or per-package).
     pub fn is_empty(&self) -> bool {
         self.global.is_none() && self.package.is_empty()
+    }
+
+    /// Disable `exclude-newer` for any direct dependency that is pinned with `==`,
+    /// by adding a [`PackageExcludeNewer::Disabled`] entry to the per-package map.
+    ///
+    /// This is a no-op if `allow-bypass` does not contain `direct-pinned`.
+    pub fn apply_direct_pinned_bypass(&mut self, direct_pinned_packages: &[PackageName]) {
+        if !self.allows_direct_pinned_bypass() {
+            return;
+        }
+        for name in direct_pinned_packages {
+            self.package
+                .entry(name.clone())
+                .or_insert(PackageExcludeNewer::Disabled);
+        }
     }
 
     pub fn compare(&self, other: &Self) -> Option<ExcludeNewerChange> {

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -1,9 +1,9 @@
 pub use dependency_mode::DependencyMode;
 pub use error::{ErrorTree, NoSolutionError, NoSolutionHeader, ResolveError, SentinelRange};
 pub use exclude_newer::{
-    ExcludeNewer, ExcludeNewerChange, ExcludeNewerPackage, ExcludeNewerPackageChange,
-    ExcludeNewerPackageEntry, ExcludeNewerValue, ExcludeNewerValueChange, PackageExcludeNewer,
-    PackageExcludeNewerChange,
+    ExcludeNewer, ExcludeNewerBypass, ExcludeNewerChange, ExcludeNewerPackage,
+    ExcludeNewerPackageChange, ExcludeNewerPackageEntry, ExcludeNewerValue,
+    ExcludeNewerValueChange, PackageExcludeNewer, PackageExcludeNewerChange,
 };
 pub use exclusions::Exclusions;
 pub use flat_index::{FlatDistributions, FlatIndex};

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -54,7 +54,7 @@ use uv_small_str::SmallString;
 use uv_types::{BuildContext, HashStrategy};
 use uv_workspace::{Editability, WorkspaceMember};
 
-use crate::exclude_newer::ExcludeNewerSpan;
+use crate::exclude_newer::{ExcludeNewerBypass, ExcludeNewerSpan};
 use crate::fork_strategy::ForkStrategy;
 pub(crate) use crate::lock::export::PylockTomlPackage;
 pub use crate::lock::export::RequirementsTxtExport;
@@ -1197,6 +1197,15 @@ impl Lock {
                         }
                     }
                     options_table.insert("exclude-newer-package", Item::Table(package_table));
+                }
+
+                // Serialize allow-bypass as an array
+                if !exclude_newer.allow_bypass.is_empty() {
+                    let mut bypass_array = toml_edit::Array::new();
+                    for b in &exclude_newer.allow_bypass {
+                        bypass_array.push(b.to_string());
+                    }
+                    options_table.insert("exclude-newer-allow-bypass", value(bypass_array));
                 }
             }
 
@@ -2345,6 +2354,8 @@ struct ExcludeNewerWire {
     exclude_newer_span: Option<ExcludeNewerSpan>,
     #[serde(default, skip_serializing_if = "ExcludeNewerPackage::is_empty")]
     exclude_newer_package: ExcludeNewerPackage,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    exclude_newer_allow_bypass: Vec<ExcludeNewerBypass>,
 }
 
 impl From<ExcludeNewerWire> for ExcludeNewer {
@@ -2354,6 +2365,7 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
                 .exclude_newer
                 .map(|timestamp| ExcludeNewerValue::new(timestamp, wire.exclude_newer_span)),
             package: wire.exclude_newer_package,
+            allow_bypass: wire.exclude_newer_allow_bypass,
         }
     }
 }
@@ -2368,6 +2380,7 @@ impl From<ExcludeNewer> for ExcludeNewerWire {
             exclude_newer: timestamp,
             exclude_newer_span: span,
             exclude_newer_package: exclude_newer.package,
+            exclude_newer_allow_bypass: exclude_newer.allow_bypass,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -25,19 +25,19 @@ use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
     BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
     IncompatibleSource, IncompatibleWheel, IndexCapabilities, IndexLocations, IndexMetadata,
-    IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement, ResolvedDist,
-    ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
+    IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement,
+    RequirementSource, ResolvedDist, ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
 };
 use uv_git::GitResolver;
 use uv_normalize::{ExtraName, GroupName, PackageName};
-use uv_pep440::{MIN_VERSION, Version, VersionSpecifiers, release_specifiers_to_ranges};
+use uv_pep440::{MIN_VERSION, Operator, Version, VersionSpecifiers, release_specifiers_to_ranges};
 use uv_pep508::{
     MarkerEnvironment, MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString,
 };
 use uv_platform_tags::{IncompatibleTag, Tags};
 use uv_pypi_types::{ConflictItem, ConflictItemRef, ConflictKindRef, Conflicts, VerbatimParsedUrl};
 use uv_torch::TorchStrategy;
-use uv_types::{BuildContext, HashStrategy, InstalledPackagesProvider};
+use uv_types::{BuildContext, HashStrategy, InstalledPackagesProvider, RequestedRequirements};
 use uv_warnings::warn_user_once;
 
 use crate::candidate_selector::{Candidate, CandidateDist, CandidateSelector};
@@ -177,6 +177,29 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
         installed_packages: InstalledPackages,
         database: DistributionDatabase<'a, Context>,
     ) -> Result<Self, ResolveError> {
+        // Apply the `direct-pinned` bypass: disable `exclude-newer` for direct
+        // dependencies that use the `==` operator.
+        let mut exclude_newer = options.exclude_newer.clone();
+        if exclude_newer.allows_direct_pinned_bypass() {
+            let direct_pinned: Vec<PackageName> = manifest
+                .lookaheads
+                .iter()
+                .filter(|lookahead| lookahead.direct())
+                .flat_map(RequestedRequirements::requirements)
+                .chain(manifest.requirements.iter())
+                .filter(|req| {
+                    if let RequirementSource::Registry { specifier, .. } = &req.source {
+                        specifier.iter().any(|s| *s.operator() == Operator::Equal)
+                    } else {
+                        false
+                    }
+                })
+                .map(|req| req.name.clone())
+                .collect();
+            debug!("Applying direct-pinned bypass for: {:?}", direct_pinned);
+            exclude_newer.apply_direct_pinned_bypass(&direct_pinned);
+        }
+
         let provider = DefaultResolverProvider::new(
             database,
             flat_index,
@@ -184,7 +207,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             python_requirement.target(),
             AllowedYanks::from_manifest(&manifest, &env, options.dependency_mode),
             hasher,
-            options.exclude_newer.clone(),
+            exclude_newer,
             build_context.build_options(),
             build_context.capabilities(),
         );

--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -257,6 +257,10 @@ impl Combine for ExcludeNewer {
             }
         }
 
+        if self.allow_bypass.is_empty() {
+            self.allow_bypass = other.allow_bypass;
+        }
+
         self
     }
 }

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -900,6 +900,11 @@ pub struct ResolverInstallerSchema {
     /// Durations do not respect semantics of the local time zone and are always resolved to a fixed
     /// number of seconds assuming that a day is 24 hours (e.g., DST transitions are ignored).
     /// Calendar units such as months and years are not allowed.
+    ///
+    /// Also accepts a table form with an optional `allow-bypass` key:
+    /// `{ timestamp = "2006-12-02T02:07:43Z", allow-bypass = ["direct-pinned"] }`.
+    /// When `allow-bypass` contains `"direct-pinned"`, direct dependencies that are pinned
+    /// with `==` will bypass the `exclude-newer` filter.
     #[option(
         default = "None",
         value_type = "str",

--- a/crates/uv/tests/it/lock_exclude_newer_allow_bypass.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_allow_bypass.rs
@@ -1,0 +1,186 @@
+use anyhow::Result;
+use assert_fs::fixture::{FileWriteStr, PathChild};
+use insta::assert_snapshot;
+use uv_static::EnvVars;
+
+use uv_test::uv_snapshot;
+
+/// Lock with `exclude-newer` and `allow-bypass = ["direct-pinned"]`.
+///
+/// Uses idna which has releases at:
+/// - 3.6: 2023-11-25
+/// - 3.7: 2024-04-11
+///
+/// When a direct dependency pins `idna==3.7` and `allow-bypass` includes `direct-pinned`,
+/// exclude-newer should be bypassed for that package, allowing 3.7 to be resolved
+/// despite the timestamp cutoff.
+#[test]
+fn lock_exclude_newer_allow_bypass_direct_pinned() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+
+    // Pin idna==3.7 as a direct dependency with `allow-bypass = ["direct-pinned"]`.
+    // The exclude-newer timestamp is set before idna 3.7 was released (2024-04-11),
+    // but the bypass should allow it through.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["idna==3.7"]
+
+        [tool.uv]
+        exclude-newer = { timestamp = "2024-03-01T00:00:00Z", allow-bypass = ["direct-pinned"] }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    // Should resolve to idna 3.7 despite the exclude-newer cutoff of 2024-03-01,
+    // because idna is a direct dependency pinned with `==`.
+    assert_snapshot!(lock, @r#"
+    version = 1
+    revision = 3
+    requires-python = ">=3.12"
+
+    [options]
+    exclude-newer = "2024-03-01T00:00:00Z"
+    exclude-newer-allow-bypass = ["direct-pinned"]
+
+    [[package]]
+    name = "idna"
+    version = "3.7"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc", size = 189575, upload-time = "2024-04-11T03:34:43.276Z" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0", size = 66836, upload-time = "2024-04-11T03:34:41.447Z" },
+    ]
+
+    [[package]]
+    name = "project"
+    version = "0.1.0"
+    source = { virtual = "." }
+    dependencies = [
+        { name = "idna" },
+    ]
+
+    [package.metadata]
+    requires-dist = [{ name = "idna", specifier = "==3.7" }]
+    "#);
+
+    Ok(())
+}
+
+/// Without `allow-bypass`, the same pinned dependency should be excluded.
+#[test]
+fn lock_exclude_newer_no_bypass_direct_pinned() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+
+    // Pin idna==3.7 but without allow-bypass. Should fail because 3.7 is excluded.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["idna==3.7"]
+
+        [tool.uv]
+        exclude-newer = "2024-03-01T00:00:00Z"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because there is no version of idna==3.7 and your project depends on idna==3.7, we can conclude that your project's requirements are unsatisfiable.
+    ");
+
+    Ok(())
+}
+
+/// Non-pinned direct dependencies should still be filtered by exclude-newer,
+/// even when `allow-bypass = ["direct-pinned"]` is set.
+#[test]
+fn lock_exclude_newer_allow_bypass_non_pinned() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+
+    // Use a version range for idna (not ==), so the bypass should NOT apply.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["idna>=3.0"]
+
+        [tool.uv]
+        exclude-newer = { timestamp = "2024-03-01T00:00:00Z", allow-bypass = ["direct-pinned"] }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    // Should resolve to idna 3.6 (the latest version before the cutoff),
+    // NOT 3.7, because `>=3.0` is not an `==` pin.
+    assert_snapshot!(lock, @r#"
+    version = 1
+    revision = 3
+    requires-python = ">=3.12"
+
+    [options]
+    exclude-newer = "2024-03-01T00:00:00Z"
+    exclude-newer-allow-bypass = ["direct-pinned"]
+
+    [[package]]
+    name = "idna"
+    version = "3.6"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
+    ]
+
+    [[package]]
+    name = "project"
+    version = "0.1.0"
+    source = { virtual = "." }
+    dependencies = [
+        { name = "idna" },
+    ]
+
+    [package.metadata]
+    requires-dist = [{ name = "idna", specifier = ">=3.0" }]
+    "#);
+
+    Ok(())
+}

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -54,6 +54,9 @@ mod lock;
 mod lock_conflict;
 
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
+mod lock_exclude_newer_allow_bypass;
+
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod lock_exclude_newer_relative;
 
 mod lock_scenarios;


### PR DESCRIPTION
(not ready for review)