### PR TITLE
Review for `--index <name>` support

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6809,12 +6809,12 @@ pub struct IndexArgs {
     /// `--default-index` (which defaults to PyPI). When multiple `--index` flags are provided,
     /// earlier values take priority.
     ///
-    /// Index names can be used to reference indexes defined in the project, workspace, user, or
-    /// system configuration. If a directory exists with the same name as a defined index, the
-    /// directory will be used (with a warning). Use `./` or `../` on Unix or `.\\`, `..\\`, `./` or
-    /// `../` on Windows to disambiguate relative paths from index names. Enable the
-    /// `index-assume-name` preview feature to pick the named index in favour of a directory of the
-    /// same name.
+    /// Indexes defined in the project or configuration files can be referenced by name.
+    ///
+    /// For backwards compatibility, if a directory with the same name as an index exists in the
+    /// working directory, uv will search the directory for packages instead. In the future, uv will
+    /// require disambiguation, e.g., with `./name`, to prefer the local directory. To enable this
+    /// behavior now, enable the `index-assume-name` preview feature.
     //
     // The nested Vec structure (`Vec<Vec<Maybe<IndexArg>>>`) is required for clap's
     // value parsing mechanism, which processes one value at a time, in order to handle

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -671,9 +671,8 @@ impl IndexArg {
         };
 
         let mut index = index.borrow().clone();
-        // A named index selected via `--index <name>` should behave like any
-        // other explicit CLI index, regardless of whether it was marked as a
-        // config-level default.
+        // A named index selected via `--index <name>` should follow precedence
+        // rules of an index provided by the CLI and ignore `default = true`.
         index.default = false;
 
         match strategy {

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -670,8 +670,14 @@ impl IndexArg {
             };
         };
 
+        let mut index = index.borrow().clone();
+        // A named index selected via `--index <name>` should behave like any
+        // other explicit CLI index, regardless of whether it was marked as a
+        // config-level default.
+        index.default = false;
+
         match strategy {
-            IndexArgStrategy::IgnoreDirectory => Ok(index.borrow().clone()),
+            IndexArgStrategy::IgnoreDirectory => Ok(index),
             IndexArgStrategy::PreferDirectory => {
                 // If a directory of the same name exists, treat it as a directory but
                 // warn the user of the impending changes.
@@ -687,7 +693,7 @@ impl IndexArg {
                     );
                     Ok(Index::new(directory).with_origin(Origin::Cli))
                 } else {
-                    Ok(index.borrow().clone())
+                    Ok(index)
                 }
             }
         }

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -542,7 +542,7 @@ pub fn check_for_explicit_indexes(indexes: &[Index]) {
     // Hack to get `write_error_chain` to format things correctly
     #[derive(Debug, Error)]
     #[error(
-        "Explicit index `{0}` cannot be used on the command line. Explicit indexes are only usable when referenced by `[tool.uv.sources]`."
+        "The requested index `{0}` is marked as `explicit` and can only be used in `uv add` or `[tool.uv.sources]`."
     )]
     struct WrapperError(String);
 
@@ -639,36 +639,57 @@ impl IndexArg {
             Self::Unresolved(unresolved) => unresolved,
         };
 
+        let directory = if let Ok(url @ IndexUrl::Path(_)) = IndexUrl::from_str(unresolved.as_ref())
+            && let Ok(path) = url.inner().as_path()
+            && path.is_dir()
+        {
+            Some(url)
+        } else {
+            None
+        };
+
         let Some(index) = indexes
             .into_iter()
             .find(|index| index.borrow().name.as_ref() == Some(&unresolved))
         else {
-            return Err(ResolveIndexArgError(unresolved));
+            return match (strategy, directory) {
+                (IndexArgStrategy::PreferDirectory, Some(directory)) => {
+                    let path_hint = if cfg!(windows) {
+                        format!("`--index .\\{unresolved}`")
+                    } else {
+                        format!("`--index ./{unresolved}`")
+                    };
+                    warn_user_once!(
+                        "`--index {unresolved}` is an ambiguous reference to a local directory. Use {path_hint} instead to disambiguate from an index name. In the future, uv will exit with an error. Use `--preview-features {feature}` to treat this request as an index name reference immediately.",
+                        feature = PreviewFeature::IndexAssumeName
+                    );
+                    Ok(Index::new(directory).with_origin(Origin::Cli))
+                }
+                (IndexArgStrategy::PreferDirectory, None)
+                | (IndexArgStrategy::IgnoreDirectory, _) => Err(ResolveIndexArgError(unresolved)),
+            };
         };
 
         match strategy {
-            IndexArgStrategy::IgnoreDirectory => return Ok(index.borrow().clone()),
-            IndexArgStrategy::PreferDirectory => (),
-        }
-
-        // If a directory of the same name exists, treat it as a directory but
-        // warn the user of the impending changes.
-        if let Ok(url @ IndexUrl::Path(_)) = IndexUrl::from_str(unresolved.as_ref())
-            && let Ok(path) = url.inner().as_path()
-            && path.is_dir()
-        {
-            let path_hint = if cfg!(windows) {
-                format!("`.\\{unresolved}` or `./{unresolved}`")
-            } else {
-                format!("`./{unresolved}`")
-            };
-            warn_user_once!(
-                "Relative paths passed to `--index` should be disambiguated from index names (use {path_hint}). Pass `--preview-features {feature}` to treat this as the named index. In the future, this will become the default.",
-                feature = PreviewFeature::IndexAssumeName
-            );
-            Ok(Index::new(url.clone()).with_origin(Origin::Cli))
-        } else {
-            Ok(index.borrow().clone())
+            IndexArgStrategy::IgnoreDirectory => Ok(index.borrow().clone()),
+            IndexArgStrategy::PreferDirectory => {
+                // If a directory of the same name exists, treat it as a directory but
+                // warn the user of the impending changes.
+                if let Some(directory) = directory {
+                    let path_hint = if cfg!(windows) {
+                        format!("`--index .\\{unresolved}`")
+                    } else {
+                        format!("`--index ./{unresolved}`")
+                    };
+                    warn_user_once!(
+                        "`--index {unresolved}` is an ambiguous reference to both a local directory and named index. Use {path_hint} to prefer the local directory or `--preview-features {feature}` to prefer the named index. A future version of uv will always assume ambiguous references are to named indexes.",
+                        feature = PreviewFeature::IndexAssumeName
+                    );
+                    Ok(Index::new(directory).with_origin(Origin::Cli))
+                } else {
+                    Ok(index.borrow().clone())
+                }
+            }
         }
     }
 }

--- a/crates/uv-distribution-types/src/origin.rs
+++ b/crates/uv-distribution-types/src/origin.rs
@@ -1,5 +1,14 @@
-/// The origin of a piece of configuration.
+/// The origin of a project-level configuration file.
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum ProjectOrigin {
+    /// The setting was provided via a `pyproject.toml` file.
+    PyprojectToml,
+    /// The setting was provided via a `uv.toml` file adjacent to a `pyproject.toml`.
+    UvToml,
+}
+
+/// The origin of a piece of configuration.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Origin {
     /// The setting was provided via the CLI.
     Cli,
@@ -8,7 +17,19 @@ pub enum Origin {
     /// The setting was provided via a system-level configuration file.
     System,
     /// The setting was provided via a project-level configuration file.
-    Project,
+    Project(ProjectOrigin),
     /// The setting was provided via a `requirements.txt` file.
     RequirementsTxt,
+}
+
+impl std::fmt::Debug for Origin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cli => f.write_str("Cli"),
+            Self::User => f.write_str("User"),
+            Self::System => f.write_str("System"),
+            Self::Project(_) => f.write_str("Project"),
+            Self::RequirementsTxt => f.write_str("RequirementsTxt"),
+        }
+    }
 }

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -8,7 +8,8 @@ use thiserror::Error;
 use uv_auth::CredentialsCache;
 use uv_distribution_filename::DistExtension;
 use uv_distribution_types::{
-    Index, IndexLocations, IndexMetadata, IndexName, Origin, Requirement, RequirementSource,
+    Index, IndexLocations, IndexMetadata, IndexName, Origin, ProjectOrigin, Requirement,
+    RequirementSource,
 };
 use uv_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -600,8 +601,13 @@ fn missing_index_hint(locations: &IndexLocations, index: &IndexName) -> Option<S
         let source = match idx.origin {
             Some(Origin::User) => "a user-level `uv.toml`",
             Some(Origin::System) => "a system-level `uv.toml`",
-            Some(Origin::Project) => "a project-level `uv.toml`",
-            Some(Origin::Cli | Origin::RequirementsTxt) | None => return None,
+            Some(Origin::Project(ProjectOrigin::UvToml)) => "a project-level `uv.toml`",
+            Some(
+                Origin::Project(ProjectOrigin::PyprojectToml)
+                | Origin::Cli
+                | Origin::RequirementsTxt,
+            )
+            | None => return None,
         };
         Some(format!(
             "Index `{index}` was found in {source}, but indexes \

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tracing::info_span;
 use uv_client::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT_UPLOAD};
 use uv_dirs::{system_config_file, user_config_dir};
-use uv_distribution_types::Origin;
+use uv_distribution_types::{Origin, ProjectOrigin};
 use uv_flags::EnvironmentFlags;
 use uv_fs::Simplified;
 use uv_static::{EnvVars, InvalidEnvironmentVariable, parse_boolish_environment_variable};
@@ -141,7 +141,9 @@ impl FilesystemOptions {
 
                 tracing::debug!("Found workspace configuration at `{}`", path.display());
                 validate_uv_toml(&path, &options)?;
-                return Ok(Some(Self(options.with_origin(Origin::Project))));
+                return Ok(Some(Self(
+                    options.with_origin(Origin::Project(ProjectOrigin::UvToml)),
+                )));
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => return Err(err.into()),
@@ -174,7 +176,9 @@ impl FilesystemOptions {
                 let options = options.relative_to(&std::path::absolute(dir)?)?;
 
                 tracing::debug!("Found workspace configuration at `{}`", path.display());
-                return Ok(Some(Self(options.with_origin(Origin::Project))));
+                return Ok(Some(Self(
+                    options.with_origin(Origin::Project(ProjectOrigin::PyprojectToml)),
+                )));
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => return Err(err.into()),

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -673,14 +673,18 @@ pub(crate) async fn add(
     }
     let indexes = valid_indexes;
 
-    // Add any indexes that were provided on the command-line, in priority order.
+    // Add any non-project indexes from the resolved settings, in priority order.
     if !raw {
         let urls = IndexUrls::from_indexes(indexes);
         let mut indexes = urls.defined_indexes().collect::<Vec<_>>();
         indexes.reverse();
         for index in indexes {
-            if !matches!(index.origin, Some(Origin::Project)) {
-                toml.add_index(index)?;
+            match index.origin {
+                Some(Origin::Project) => {}
+                Some(Origin::Cli | Origin::User | Origin::System | Origin::RequirementsTxt)
+                | None => {
+                    toml.add_index(index)?;
+                }
             }
         }
     }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -497,9 +497,6 @@ pub(crate) async fn add(
         }
     }
 
-    // Store the content prior to any modifications.
-    let snapshot = target.snapshot().await?;
-
     // If the user provides a single, named index, pin all requirements to that index.
     let index = indexes
         .first()
@@ -509,6 +506,21 @@ pub(crate) async fn add(
         .inspect(|index| {
             debug!("Pinning all requirements to index: `{index}`");
         });
+
+    if !raw
+        && let Some(index_name) = index
+        && indexes
+            .first()
+            .is_some_and(|index| matches!(index.origin, Some(Origin::Project)))
+        && !is_declared_in_pyproject(&target, index_name)
+    {
+        bail!(
+            "Index `{index_name}` was found in a project-level `uv.toml`, but `uv add` cannot persist it to `tool.uv.sources`. Define the index in the project's `pyproject.toml` first, or use `--raw`."
+        );
+    }
+
+    // Store the content prior to any modifications.
+    let snapshot = target.snapshot().await?;
 
     // Track modification status, for reverts.
     let mut modified = false;
@@ -776,6 +788,22 @@ pub(crate) async fn add(
                 err => Err(err.into()),
             }
         }
+    }
+}
+
+fn is_declared_in_pyproject(target: &AddTarget, index_name: &IndexName) -> bool {
+    match target {
+        AddTarget::Script(_, _) => true,
+        AddTarget::Project(project, _) => project
+            .pyproject_toml()
+            .tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.index.as_ref())
+            .into_iter()
+            .flatten()
+            .chain(project.workspace().indexes().iter())
+            .any(|index| index.name.as_ref().is_some_and(|name| name == index_name)),
     }
 }
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -497,25 +497,29 @@ pub(crate) async fn add(
         }
     }
 
-    // If the user provides a single, named index, pin all requirements to that index.
-    let index = indexes
+    // `uv add` only pins added requirements to an index when a single named
+    // index was provided. If multiple indexes were provided, or the index is
+    // unnamed, we do not write a `tool.uv.sources` entry.
+    let pinned_index_name = indexes
         .first()
         .as_ref()
         .and_then(|index| index.name.as_ref())
         .filter(|_| indexes.len() == 1)
-        .inspect(|index| {
-            debug!("Pinning all requirements to index: `{index}`");
+        .inspect(|index_name| {
+            debug!("Pinning all requirements to index: `{index_name}`");
         });
 
+    // Raw requirements do not create `tool.uv.sources`, so they do not need a
+    // named index that can be represented in the `pyproject.toml`.
     if !raw
-        && let Some(index_name) = index
+        && let Some(index_name) = pinned_index_name
         && indexes
             .first()
             .is_some_and(|index| matches!(index.origin, Some(Origin::Project)))
         && !is_declared_in_pyproject(&target, index_name)
     {
         bail!(
-            "Index `{index_name}` was found in a project-level `uv.toml`, but `uv add` cannot persist it to `tool.uv.sources`. Define the index in the project's `pyproject.toml` first, or use `--raw`."
+            "Index `{index_name}` was found in a project-level `uv.toml`, but `uv add` can only write `tool.uv.sources` entries for indexes defined in `pyproject.toml`. Move the index definition into `pyproject.toml` or use `--raw`."
         );
     }
 
@@ -645,7 +649,7 @@ pub(crate) async fn add(
         branch.as_deref(),
         lfs,
         &extras_of_dependency,
-        index,
+        pinned_index_name,
         &mut toml,
     )?;
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -23,7 +23,7 @@ use uv_dispatch::BuildDispatch;
 use uv_distribution::{DistributionDatabase, LoweredExtraBuildDependencies};
 use uv_distribution_types::{
     Identifier, Index, IndexName, IndexUrl, IndexUrls, NameRequirementSpecification, Origin,
-    Requirement, RequirementSource, UnresolvedRequirement,
+    ProjectOrigin, Requirement, RequirementSource, UnresolvedRequirement,
 };
 use uv_fs::{LockedFile, LockedFileError, Simplified};
 use uv_git::GIT_STORE;
@@ -513,10 +513,9 @@ pub(crate) async fn add(
     // named index that can be represented in the `pyproject.toml`.
     if !raw
         && let Some(index_name) = pinned_index_name
-        && indexes
-            .first()
-            .is_some_and(|index| matches!(index.origin, Some(Origin::Project)))
-        && !is_declared_in_pyproject(&target, index_name)
+        && indexes.first().is_some_and(|index| {
+            matches!(index.origin, Some(Origin::Project(ProjectOrigin::UvToml)))
+        })
     {
         bail!(
             "Index `{index_name}` was found in a project-level `uv.toml`, but `uv add` can only write `tool.uv.sources` entries for indexes defined in `pyproject.toml`. Move the index definition into `pyproject.toml` or use `--raw`."
@@ -689,14 +688,14 @@ pub(crate) async fn add(
     }
     let indexes = valid_indexes;
 
-    // Add any non-project indexes from the resolved settings, in priority order.
+    // Add any indexes not already declared in `pyproject.toml`, in priority order.
     if !raw {
         let urls = IndexUrls::from_indexes(indexes);
         let mut indexes = urls.defined_indexes().collect::<Vec<_>>();
         indexes.reverse();
         for index in indexes {
             match index.origin {
-                Some(Origin::Project) => {}
+                Some(Origin::Project(ProjectOrigin::PyprojectToml | ProjectOrigin::UvToml)) => {}
                 Some(Origin::Cli | Origin::User | Origin::System | Origin::RequirementsTxt)
                 | None => {
                     toml.add_index(index)?;
@@ -792,22 +791,6 @@ pub(crate) async fn add(
                 err => Err(err.into()),
             }
         }
-    }
-}
-
-fn is_declared_in_pyproject(target: &AddTarget, index_name: &IndexName) -> bool {
-    match target {
-        AddTarget::Script(_, _) => true,
-        AddTarget::Project(project, _) => project
-            .pyproject_toml()
-            .tool
-            .as_ref()
-            .and_then(|tool| tool.uv.as_ref())
-            .and_then(|uv| uv.index.as_ref())
-            .into_iter()
-            .flatten()
-            .chain(project.workspace().indexes().iter())
-            .any(|index| index.name.as_ref().is_some_and(|name| name == index_name)),
     }
 }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -252,14 +252,22 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         // from the workspace member's `pyproject.toml` for named index resolution.
         if let Commands::Project(command) = &*cli.command {
             if let Some(package) = command.package() {
-                package_indexes = workspace.packages().get(package).and_then(|member| {
-                    member
-                        .pyproject_toml()
-                        .tool
-                        .as_ref()
-                        .and_then(|tool| tool.uv.as_ref())
-                        .and_then(|uv| uv.index.clone())
-                });
+                package_indexes = workspace
+                    .packages()
+                    .get(package)
+                    .map(|member| {
+                        member
+                            .pyproject_toml()
+                            .tool
+                            .as_ref()
+                            .and_then(|tool| tool.uv.as_ref())
+                            .and_then(|uv| uv.index.clone())
+                            .into_iter()
+                            .flatten()
+                            .map(|index| index.relative_to(member.root()))
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?;
             }
         }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -50,7 +50,7 @@ use uv_scripts::{Pep723Error, Pep723Item, Pep723Script};
 use uv_settings::{Combine, EnvironmentOptions, FilesystemOptions, Options};
 use uv_static::EnvVars;
 use uv_warnings::{warn_user, warn_user_once};
-use uv_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
+use uv_workspace::{DiscoveryOptions, ProjectWorkspace, Workspace, WorkspaceCache};
 
 use crate::commands::{ExitStatus, ParsedRunCommand, RunCommand, ScriptPath, ToolRunCommand};
 use crate::printer::Printer;
@@ -251,8 +251,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         // Extract the `--package` argument from commands that support it, to load indexes
         // from the workspace member's `pyproject.toml` for named index resolution.
         if let Commands::Project(command) = &*cli.command {
-            if let Some(package) = command.package() {
-                package_indexes = workspace
+            package_indexes = if let Some(package) = command.package() {
+                workspace
                     .packages()
                     .get(package)
                     .map(|member| {
@@ -267,8 +267,31 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                             .map(|index| index.relative_to(member.root()))
                             .collect::<Result<Vec<_>, _>>()
                     })
-                    .transpose()?;
-            }
+                    .transpose()?
+            } else if let Ok(project_workspace) = ProjectWorkspace::discover(
+                &project_dir,
+                &DiscoveryOptions::default(),
+                &workspace_cache,
+            )
+            .await
+            {
+                let member = project_workspace.current_project();
+                member
+                    .pyproject_toml()
+                    .tool
+                    .as_ref()
+                    .and_then(|tool| tool.uv.as_ref())
+                    .and_then(|uv| uv.index.clone())
+                    .map(|indexes| {
+                        indexes
+                            .into_iter()
+                            .map(|index| index.relative_to(member.root()))
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?
+            } else {
+                None
+            };
         }
 
         let project = FilesystemOptions::find(workspace.install_path())?;

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11870,6 +11870,77 @@ fn add_index_by_name_for_workspace_member_with_relative_path() -> Result<()> {
 }
 
 #[test]
+fn add_index_by_name_for_current_workspace_member() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let workspace_toml = context.temp_dir.child("pyproject.toml");
+    workspace_toml.write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["child"]
+    "#})?;
+
+    let child_dir = context.temp_dir.child("child");
+    child_dir.create_dir_all()?;
+    let child_pyproject = child_dir.child("pyproject.toml");
+    child_pyproject.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "./packages"
+    "#})?;
+
+    let packages = child_dir.child("packages");
+    packages.create_dir_all()?;
+
+    let tqdm = packages.child("tqdm");
+    tqdm.create_dir_all()?;
+    let index = tqdm.child("index.html");
+    index.write_str(&formatdoc! {r#"
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta name="pypi:repository-version" content="1.1" />
+          </head>
+          <body>
+            <h1>Links for tqdm</h1>
+            <a
+              href="{}/tqdm-1000.0.0-py3-none-any.whl"
+              data-requires-python=">=3.8"
+            >
+              tqdm-1000.0.0-py3-none-any.whl
+            </a>
+          </body>
+        </html>
+    "#, Url::from_directory_path(context.workspace_root.join("test/links/")).unwrap().as_str()})?;
+
+    uv_snapshot!(context.filters(), context
+        .add()
+        .current_dir(&child_dir)
+        .arg("tqdm")
+        .arg("--index")
+        .arg("local")
+        .arg("--exclude-newer-package")
+        .arg("tqdm=false"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + tqdm==1000.0.0
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn add_index_by_name_no_cross_member_references() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11213,6 +11213,85 @@ fn add_index_with_existing_relative_path_index() -> Result<()> {
     Ok(())
 }
 
+/// Add an index with an existing relative path without disambiguating it.
+#[test]
+fn add_index_with_existing_ambiguous_relative_path_index() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    // Create test-index/ subdirectory and copy our "offline" tqdm wheel there
+    let packages = context.temp_dir.child("test-index");
+    packages.create_dir_all()?;
+
+    let wheel_src = context
+        .workspace_root
+        .join("test/links/ok-1.0.0-py3-none-any.whl");
+    let wheel_dst = packages.child("ok-1.0.0-py3-none-any.whl");
+    fs_err::copy(&wheel_src, &wheel_dst)?;
+
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--index").arg("test-index"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `--index test-index` is an ambiguous reference to a local directory. Use `--index ./test-index` instead to disambiguate from an index name. In the future, uv will exit with an error. Use `--preview-features index-assume-name` to treat this request as an index name reference immediately.
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    Ok(())
+}
+
+/// With preview enabled, require a matching index name for ambiguous values.
+#[test]
+fn add_index_with_existing_ambiguous_relative_path_index_preview() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    // Create test-index/ subdirectory and copy our "offline" tqdm wheel there
+    let packages = context.temp_dir.child("test-index");
+    packages.create_dir_all()?;
+
+    let wheel_src = context
+        .workspace_root
+        .join("test/links/ok-1.0.0-py3-none-any.whl");
+    let wheel_dst = packages.child("ok-1.0.0-py3-none-any.whl");
+    fs_err::copy(&wheel_src, &wheel_dst)?;
+
+    uv_snapshot!(context.add()
+        .arg("iniconfig")
+        .arg("--index").arg("test-index")
+        .arg("--preview-features").arg("index-assume-name"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Could not find an index named `test-index`
+    ");
+
+    Ok(())
+}
+
 /// Add an index with a non-existent relative path.
 #[test]
 fn add_index_with_non_existent_relative_path() -> Result<()> {
@@ -12005,16 +12084,13 @@ async fn add_index_by_name_directory_ambiguity() -> Result<()> {
     proxy_dir.create_dir_all()?;
 
     // Should warn about ambiguity and use the directory (which will fail since it's empty)
-    let mut filters = context.filters();
-    // On Windows the hint includes both `.\\proxy` (normalised to `./proxy`) and `./proxy`.
-    filters.push(("`./proxy` or ", ""));
-    uv_snapshot!(filters, context.add().arg("iniconfig").arg("--index").arg("proxy"), @"
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--index").arg("proxy"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    warning: Relative paths passed to `--index` should be disambiguated from index names (use `./proxy`). Pass `--preview-features index-assume-name` to treat this as the named index. In the future, this will become the default.
+    warning: `--index proxy` is an ambiguous reference to both a local directory and named index. Use `--index ./proxy` to prefer the local directory or `--preview-features index-assume-name` to prefer the named index. A future version of uv will always assume ambiguous references are to named indexes.
     warning: Index directory `file://[TEMP_DIR]/proxy` is empty, skipping
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
@@ -12139,7 +12215,7 @@ fn add_index_by_name_explicit_multiple() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Explicit index `explicit-index` cannot be used on the command line. Explicit indexes are only usable when referenced by `[tool.uv.sources]`.
+    error: The requested index `explicit-index` is marked as `explicit` and can only be used in `uv add` or `[tool.uv.sources]`.
     ");
 
     Ok(())

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11543,7 +11543,7 @@ async fn add_index_by_name_from_project_uv_toml() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Index `test-index` was found in a project-level `uv.toml`, but `uv add` cannot persist it to `tool.uv.sources`. Define the index in the project's `pyproject.toml` first, or use `--raw`.
+    error: Index `test-index` was found in a project-level `uv.toml`, but `uv add` can only write `tool.uv.sources` entries for indexes defined in `pyproject.toml`. Move the index definition into `pyproject.toml` or use `--raw`.
     ");
 
     // Check that the project was left unchanged.

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11824,19 +11824,37 @@ fn add_index_by_name_for_workspace_member_with_relative_path() -> Result<()> {
 
     let packages = child_dir.child("packages");
     packages.create_dir_all()?;
-    let wheel_src = context
-        .workspace_root
-        .join("test/links/ok-1.0.0-py3-none-any.whl");
-    let wheel_dst = packages.child("ok-1.0.0-py3-none-any.whl");
-    fs_err::copy(&wheel_src, &wheel_dst)?;
+
+    let tqdm = packages.child("tqdm");
+    tqdm.create_dir_all()?;
+    let index = tqdm.child("index.html");
+    index.write_str(&formatdoc! {r#"
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta name="pypi:repository-version" content="1.1" />
+          </head>
+          <body>
+            <h1>Links for tqdm</h1>
+            <a
+              href="{}/tqdm-1000.0.0-py3-none-any.whl"
+              data-requires-python=">=3.8"
+            >
+              tqdm-1000.0.0-py3-none-any.whl
+            </a>
+          </body>
+        </html>
+    "#, Url::from_directory_path(context.workspace_root.join("test/links/")).unwrap().as_str()})?;
 
     uv_snapshot!(context.filters(), context
         .add()
         .arg("--package")
         .arg("child")
-        .arg("ok")
+        .arg("tqdm")
         .arg("--index")
-        .arg("local"), @"
+        .arg("local")
+        .arg("--exclude-newer-package")
+        .arg("tqdm=false"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -11845,7 +11863,7 @@ fn add_index_by_name_for_workspace_member_with_relative_path() -> Result<()> {
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
-     + ok==1.0.0
+     + tqdm==1000.0.0
     ");
 
     Ok(())

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11538,19 +11538,15 @@ async fn add_index_by_name_from_project_uv_toml() -> Result<()> {
     })?;
 
     uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--index").arg("test-index"), @r"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + iniconfig==2.0.0
+    error: Index `test-index` was found in a project-level `uv.toml`, but `uv add` cannot persist it to `tool.uv.sources`. Define the index in the project's `pyproject.toml` first, or use `--raw`.
     ");
 
-    // Check that the named index from `uv.toml` was copied into `pyproject.toml` so the source
-    // remains valid on subsequent commands.
+    // Check that the project was left unchanged.
     let pyproject = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
     insta::with_settings!({
         filters => context.filters(),
@@ -11561,16 +11557,7 @@ async fn add_index_by_name_from_project_uv_toml() -> Result<()> {
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = [
-            "iniconfig>=2.0.0",
-        ]
-
-        [[tool.uv.index]]
-        name = "test-index"
-        url = "http://[LOCALHOST]/simple"
-
-        [tool.uv.sources]
-        iniconfig = { index = "test-index" }
+        dependencies = []
         "#
         );
     });

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -11515,6 +11515,70 @@ async fn add_index_by_name() -> Result<()> {
 }
 
 #[tokio::test]
+async fn add_index_by_name_from_project_uv_toml() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(&formatdoc! {r#"
+        [[index]]
+        name = "test-index"
+        url = "{proxy_url}"
+    "#,
+        proxy_url = proxy.url("/simple"),
+    })?;
+
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig").arg("--index").arg("test-index"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    // Check that the named index from `uv.toml` was copied into `pyproject.toml` so the source
+    // remains valid on subsequent commands.
+    let pyproject = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig>=2.0.0",
+        ]
+
+        [[tool.uv.index]]
+        name = "test-index"
+        url = "http://[LOCALHOST]/simple"
+
+        [tool.uv.sources]
+        iniconfig = { index = "test-index" }
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_index_by_name_for_workspace() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let proxy = crate::pypi_proxy::start().await;
@@ -11742,6 +11806,60 @@ async fn add_index_by_name_for_workspace_member() -> Result<()> {
         "#
         );
     });
+
+    Ok(())
+}
+
+#[test]
+fn add_index_by_name_for_workspace_member_with_relative_path() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let workspace_toml = context.temp_dir.child("pyproject.toml");
+    workspace_toml.write_str(indoc! {r#"
+        [tool.uv.workspace]
+        members = ["child"]
+    "#})?;
+
+    let child_dir = context.temp_dir.child("child");
+    child_dir.create_dir_all()?;
+    let child_pyproject = child_dir.child("pyproject.toml");
+    child_pyproject.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [[tool.uv.index]]
+        name = "local"
+        url = "./packages"
+    "#})?;
+
+    let packages = child_dir.child("packages");
+    packages.create_dir_all()?;
+    let wheel_src = context
+        .workspace_root
+        .join("test/links/ok-1.0.0-py3-none-any.whl");
+    let wheel_dst = packages.child("ok-1.0.0-py3-none-any.whl");
+    fs_err::copy(&wheel_src, &wheel_dst)?;
+
+    uv_snapshot!(context.filters(), context
+        .add()
+        .arg("--package")
+        .arg("child")
+        .arg("ok")
+        .arg("--index")
+        .arg("local"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -34620,7 +34620,8 @@ async fn lock_index_by_name() -> Result<()> {
     Ok(())
 }
 
-/// Test that explicit indexes passed via CLI produce an error.
+/// Unlike `uv add` (which allows a single explicit index), `uv lock` errors when an explicit
+/// index is passed via `--index`.
 #[test]
 fn lock_index_by_name_explicit() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -34647,7 +34648,7 @@ fn lock_index_by_name_explicit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Explicit index `explicit` cannot be used on the command line. Explicit indexes are only usable when referenced by `[tool.uv.sources]`.
+    error: The requested index `explicit` is marked as `explicit` and can only be used in `uv add` or `[tool.uv.sources]`.
     ");
 
     Ok(())

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -6956,3 +6956,55 @@ async fn run_index_by_name() -> Result<()> {
 
     Ok(())
 }
+
+/// Run using `--index <name>` for an index marked `default = true`.
+#[tokio::test]
+async fn run_index_by_name_default_selected_on_cli() -> Result<()> {
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [[tool.uv.index]]
+        name = "primary"
+        url = "{server_url}"
+
+        [[tool.uv.index]]
+        name = "example"
+        url = "{proxy_url}"
+        default = true
+        "#,
+        server_url = server.uri(),
+        proxy_url = proxy.url("/simple"),
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg("--index").arg("example").arg("python").arg("-c").arg("import iniconfig; print('ok')"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ok
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    Ok(())
+}

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -55,9 +55,9 @@ index name instead of a URL.
 
 For backwards compatibility, if a directory with the same name as an index exists in the working
 directory, uv will search the directory for packages instead. Names are looked up in the project's
-`pyproject.toml`, then the workspace's `pyproject.toml` (if in a workspace), and finally the
-user's and system's `uv.toml` files. Indexes marked as `explicit = true` cannot be referenced this
-way, since explicit indexes are only usable via `tool.uv.sources`.
+`pyproject.toml`, then the workspace's `pyproject.toml` (if in a workspace), and finally the user's
+and system's `uv.toml` files. Indexes marked as `explicit = true` cannot be referenced this way,
+since explicit indexes are only usable via `tool.uv.sources`.
 
 !!! note
 

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -51,16 +51,19 @@ $ UV_INDEX=pytorch=https://download.pytorch.org/whl/cpu uv lock
 ```
 
 Additionally, `--index` can reference a named index defined in a configuration file by passing the
-index name instead of a URL, as long as there is no local directory with the same name. Names are
-looked up in the project's `pyproject.toml`, then the workspace's `pyproject.toml` (if in a
-workspace), and finally the user's and system's `uv.toml` files. Indexes marked as `explicit = true`
-cannot be referenced this way, since explicit indexes are only usable via `tool.uv.sources`.
+index name instead of a URL.
+
+For backwards compatibility, if a directory with the same name as an index exists in the working
+directory, uv will search the directory for packages instead. Names are looked up in the project's
+`pyproject.toml`, then the workspace's `pyproject.toml` (if in a workspace), and finally the
+user's and system's `uv.toml` files. Indexes marked as `explicit = true` cannot be referenced this
+way, since explicit indexes are only usable via `tool.uv.sources`.
 
 !!! note
 
-    In a future release, if the argument to `--index` is a valid index name, it will always be
-    treated as a name even if a local directory of the same name exists. This behavior is available
-    now in [preview](preview.md).
+    In a future release, uv will require disambiguation (e.g., `./name`) to prefer a local
+    directory over a matching index name. To enable this behavior now, enable the
+    `index-assume-name` preview feature in [preview](preview.md).
 
 ## Pinning a package to an index
 


### PR DESCRIPTION
Review of https://github.com/astral-sh/uv/pull/17455

Addressed my comments there, as well as some edge cases I found:

1. When the `uv.toml` contains an index and `uv add --index name` was used, we would add the `tool.uv.sources` entry but subsequent resolutions would fail because source entries require a co-located index definition. The fix chosen here is to fail instead with a helpful error message.
2. When `--index foo` was used, we would fail immediately if foo was not a known index name. This regressed the existing behavior, where we'd expect `foo` to be a directory. The fix chosen here was to retain the existing behavior and warn that we'd require `./foo` in the future.
3. When `--index name` was used and name referred to an index with `default = true`, we did not toggle the default flag and the index was still considered lowest priority. The resolution chosen here was to move the index priority by unsetting the default flag, such that it would be equivalent to `--index <url>`.
4. When a workspace member defined an index with a relative path, selection of that index by name would result in  computing the path relative to the workspace root instead of the workspace member, breaking resolution. The fix chosen here was to compute the proper path during loading of indexes from workspace members.
5. When using `--index name` with a workspace member as a working directory, we would not load find indexes defined in the workspace member — we'd require `--package member` too. The fix chosen here was to load workspace member indexes for the working directory.