### PR TITLE
De-quote `workspace metadata` linehaul data

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1965,7 +1965,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     args.python,
                     args.install_mirrors,
                     args.settings,
-                    client_builder.subcommand(vec!["workspace metadata".to_owned()]),
+                    client_builder.subcommand(vec!["workspace".to_owned(), "metadata".to_owned()]),
                     globals.python_preference,
                     globals.python_downloads,
                     globals.concurrency,


### PR DESCRIPTION
`workspace metadata` was the only subcommand with quotes in the linehaul data, splitting this into an array as we do for `uv pip <…>` subcommands should fix this.