### PR TITLE
Fix two bugs in `uv audit`

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -873,6 +873,11 @@ impl Lock {
                 if seen.insert((&package.id, None)) {
                     queue.push_back((package, None));
                 }
+                for extra in &*requirement.extras {
+                    if seen.insert((&package.id, Some(extra))) {
+                        queue.push_back((package, Some(extra)));
+                    }
+                }
             }
         }
 
@@ -890,6 +895,11 @@ impl Lock {
                 {
                     if seen.insert((&package.id, None)) {
                         queue.push_back((package, None));
+                    }
+                    for extra in &*requirement.extras {
+                        if seen.insert((&package.id, Some(extra))) {
+                            queue.push_back((package, Some(extra)));
+                        }
                     }
                 }
             }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -370,10 +370,10 @@ impl<'env> LockOperation<'env> {
             LockMode::Locked(interpreter, lock_source) => {
                 // Read the existing lockfile.
                 let lock_filename = target.lock_filename();
-                let existing = target
-                    .read()
-                    .await?
-                    .ok_or(ProjectError::MissingLockfile(lock_source.into(), lock_filename))?;
+                let existing = target.read().await?.ok_or(ProjectError::MissingLockfile(
+                    lock_source.into(),
+                    lock_filename,
+                ))?;
 
                 // Perform the lock operation, but don't write the lockfile to disk.
                 let result = Box::pin(do_lock(

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -348,10 +348,11 @@ impl<'env> LockOperation<'env> {
         match self.mode {
             LockMode::Frozen(source) => {
                 // Read the existing lockfile, but don't attempt to lock the project.
+                let lock_filename = target.lock_filename();
                 let existing = target
                     .read()
                     .await?
-                    .ok_or(ProjectError::MissingLockfile(source))?;
+                    .ok_or(ProjectError::MissingLockfile(source, lock_filename))?;
 
                 // Check if the discovered workspace members match the locked workspace members.
                 if let LockTarget::Workspace(workspace) = target {
@@ -368,10 +369,11 @@ impl<'env> LockOperation<'env> {
             }
             LockMode::Locked(interpreter, lock_source) => {
                 // Read the existing lockfile.
+                let lock_filename = target.lock_filename();
                 let existing = target
                     .read()
                     .await?
-                    .ok_or(ProjectError::MissingLockfile(lock_source.into()))?;
+                    .ok_or(ProjectError::MissingLockfile(lock_source.into(), lock_filename))?;
 
                 // Perform the lock operation, but don't write the lockfile to disk.
                 let result = Box::pin(do_lock(

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -268,17 +268,7 @@ impl<'lock> LockTarget<'lock> {
 
     /// Return the filename of the lockfile, for use in user-facing messages.
     pub(crate) fn lock_filename(self) -> PathBuf {
-        match self {
-            Self::Workspace(_) => PathBuf::from("uv.lock"),
-            Self::Script(script) => {
-                let mut file_name = match script.path.file_name() {
-                    Some(f) => f.to_os_string(),
-                    None => panic!("Script path has no file name"),
-                };
-                file_name.push(".lock");
-                PathBuf::from(file_name)
-            }
-        }
+        PathBuf::from(self.lock_path().file_name().unwrap())
     }
 
     /// Return the path to the lockfile.

--- a/crates/uv/src/commands/project/lock_target.rs
+++ b/crates/uv/src/commands/project/lock_target.rs
@@ -266,6 +266,21 @@ impl<'lock> LockTarget<'lock> {
         }
     }
 
+    /// Return the filename of the lockfile, for use in user-facing messages.
+    pub(crate) fn lock_filename(self) -> PathBuf {
+        match self {
+            Self::Workspace(_) => PathBuf::from("uv.lock"),
+            Self::Script(script) => {
+                let mut file_name = match script.path.file_name() {
+                    Some(f) => f.to_os_string(),
+                    None => panic!("Script path has no file name"),
+                };
+                file_name.push(".lock");
+                PathBuf::from(file_name)
+            }
+        }
+    }
+
     /// Return the path to the lockfile.
     pub(crate) fn lock_path(self) -> PathBuf {
         match self {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -139,9 +139,9 @@ pub(crate) enum ProjectError {
     LockMismatch(Option<Box<Lock>>, Box<Lock>, LockCheckSource),
 
     #[error(
-        "Unable to find lockfile at `uv.lock`, but {0} was provided. To create a lockfile, run `uv lock` or `uv sync` without the flag."
+        "Unable to find lockfile at `{1}`, but {0} was provided. To create a lockfile, run `uv lock` or `uv sync` without the flag."
     )]
-    MissingLockfile(MissingLockfileSource),
+    MissingLockfile(MissingLockfileSource, PathBuf),
 
     #[error(
         "The lockfile at `uv.lock` needs to be updated, but `--frozen` was provided: Missing workspace member `{0}`. To update the lockfile, run `uv lock`."

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -304,6 +304,10 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             | ProjectCommand::Export(uv_cli::ExportArgs {
                 script: Some(script),
                 ..
+            })
+            | ProjectCommand::Audit(uv_cli::AuditArgs {
+                script: Some(script),
+                ..
             }) => match Pep723Script::read(script).await {
                 Ok(Some(script)) => Some(Pep723Item::Script(script)),
                 Ok(None) => {

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -1289,3 +1289,420 @@ async fn audit_ignore_mixed_matched_unmatched() {
     Found no known vulnerabilities and no adverse project statuses in 1 package
     ");
 }
+
+/// Audit a PEP 723 script with a single dependency and no vulnerabilities.
+#[tokio::test]
+async fn audit_script_no_vulnerabilities() {
+    let context = uv_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig==2.0.0",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = [{ name = "iniconfig", specifier = "==2.0.0" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T12:52:09.585Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beebd3ce04b132a8bf3491/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T12:52:07.538Z" },
+        ]
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}
+
+/// Audit a PEP 723 script and find a vulnerability.
+#[tokio::test]
+async fn audit_script_vulnerability_found() {
+    let context = uv_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig==2.0.0",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = [{ name = "iniconfig", specifier = "==2.0.0" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T12:52:09.585Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beebd3ce04b132a8bf3491/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T12:52:07.538Z" },
+        ]
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2023-0001"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2023-0001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2023-0001",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A test vulnerability in iniconfig",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {"fixed": "2.1.0"}
+                    ]
+                }]
+            }],
+            "references": [{
+                "type": "ADVISORY",
+                "url": "https://example.com/advisory/PYSEC-2023-0001"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - PYSEC-2023-0001: A test vulnerability in iniconfig
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://example.com/advisory/PYSEC-2023-0001
+
+
+    ----- stderr -----
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
+/// Audit a PEP 723 script with no dependencies.
+#[tokio::test]
+async fn audit_script_no_dependencies() {
+    let context = uv_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = []
+        # ///
+        print("hello")
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = []
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found no known vulnerabilities and no adverse project statuses in 0 packages
+    ");
+}
+
+/// Audit a PEP 723 script with --frozen but no lockfile should error.
+#[tokio::test]
+async fn audit_script_frozen_missing_lockfile() {
+    let context = uv_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig==2.0.0",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    // No lockfile written — --frozen should fail.
+    let server = MockServer::start().await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unable to find lockfile at `script.py.lock`, but `--frozen` was provided. To create a lockfile, run `uv lock` or `uv sync` without the flag.
+    ");
+}
+
+/// Audit a PEP 723 script with multiple dependencies.
+#[tokio::test]
+async fn audit_script_multiple_dependencies() {
+    let context = uv_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig==2.0.0",
+        #   "typing-extensions==4.10.0",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = [
+            { name = "iniconfig", specifier = "==2.0.0" },
+            { name = "typing-extensions", specifier = "==4.10.0" },
+        ]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T12:52:09.585Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beebd3ce04b132a8bf3491/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T12:52:07.538Z" },
+        ]
+
+        [[package]]
+        name = "typing-extensions"
+        version = "4.10.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8f4940a02f85f2b05e6e22cf5fd8a7c1d3b5e0b/typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb", size = 77558, upload-time = "2024-02-24T00:10:00.000Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926, upload-time = "2024-02-24T00:09:57.000Z" },
+        ]
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}, {"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found no known vulnerabilities and no adverse project statuses in 2 packages
+    ");
+}
+
+/// Audit a PEP 723 script where a requirement specifies extras. Dependencies reachable only
+/// through those extras must be included in the audit.
+#[tokio::test]
+async fn audit_script_extras() {
+    let context = uv_test::test_context!("3.12");
+
+    // A PEP 723 script that depends on `iniconfig[test]`.
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig[test]",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    // Write a synthetic lockfile where `iniconfig` has an optional dependency
+    // `typing-extensions` under the `test` extra.
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = [{ name = "iniconfig", extras = ["test"] }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T12:52:09.585Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beebd3ce04b132a8bf3491/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T12:52:07.538Z" },
+        ]
+
+        [package.optional-dependencies]
+        test = [
+            { name = "typing-extensions" },
+        ]
+
+        [[package]]
+        name = "typing-extensions"
+        version = "4.10.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8f4940a02f85f2b05e6e22cf5fd8a7c1d3b5e0b/typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb", size = 77558, upload-time = "2024-02-24T00:10:00.000Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926, upload-time = "2024-02-24T00:09:57.000Z" },
+        ]
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+
+    // Both iniconfig and typing-extensions should be queried (2 packages).
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}, {"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    // With --frozen, the synthetic lockfile is used directly.
+    // typing-extensions (reachable only via the `test` extra) should be audited.
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found no known vulnerabilities and no adverse project statuses in 2 packages
+    ");
+}


### PR DESCRIPTION
## Summary

This fixes two (unrelated) bugs in `uv audit`:

1. We now correctly handle `--script` in general, including producing an appropriate error message when the user requests `uv audit --script ... --frozen` without a lockfile being present. Doing this required adapting `MissingLockfile` slightly to ensure we can return an appropriate lockfile name rather than just the generic `uv.lock`.
2. We now correctly collect extras on requirements/dep groups when performing the `packages_for_audit` BFS. This was an oversight in my original traversal.

## Test Plan

Added integration tests for both of these.