### PR TITLE
Add support for `'3.7.*' == python_full_version`-style markers

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -1850,6 +1850,16 @@ mod tests {
     }
 
     #[test]
+    fn wildcard_version_marker_on_rhs() {
+        let requirement =
+            Requirement::<Url>::from_str("pytest; '3.7.*' == python_full_version").unwrap();
+        assert_eq!(
+            requirement.to_string(),
+            "pytest ; python_full_version == '3.7.*'"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "non-pep508-extensions")]
     fn path_with_fragment() {
         let requirements = if cfg!(windows) {

--- a/crates/uv-pep508/src/marker/parse.rs
+++ b/crates/uv-pep508/src/marker/parse.rs
@@ -487,9 +487,8 @@ fn parse_inverted_version_expr(
     // Invert the operator to normalize the expression order.
     let marker_operator = marker_operator.invert();
 
-    // Not star allowed here, `'3.*' == python_version` is not a valid PEP 440 comparison.
-    let version = match value.parse::<Version>() {
-        Ok(version) => version,
+    let pattern = match value.parse::<VersionPattern>() {
+        Ok(pattern) => pattern,
         Err(err) => {
             reporter.report(
                 MarkerWarningKind::Pep440Error,
@@ -508,14 +507,15 @@ fn parse_inverted_version_expr(
             MarkerWarningKind::Pep440Error,
             format!(
                 "Expected PEP 440 version operator to compare {key} with `{version}`,
-                    found `{marker_operator}`, will be ignored"
+                    found `{marker_operator}`, will be ignored",
+                version = pattern.version()
             ),
         );
 
         return None;
     };
 
-    let specifier = match VersionSpecifier::from_version(operator, version) {
+    let specifier = match VersionSpecifier::from_pattern(operator, pattern) {
         Ok(specifier) => specifier,
         Err(err) => {
             reporter.report(

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -2304,11 +2304,15 @@ mod test {
             .evaluate(&env37, &[]);
         assert!(!result);
 
-        // Meaningless expressions are ignored, so this is always true.
-        let result = MarkerTree::from_str("'3.*' == python_version")
+        let result = MarkerTree::from_str("'3.7.*' == python_version")
             .unwrap()
             .evaluate(&env37, &[]);
         assert!(result);
+
+        let result = MarkerTree::from_str("'3.8.*' == python_version")
+            .unwrap()
+            .evaluate(&env37, &[]);
+        assert!(!result);
     }
 
     #[test]
@@ -2393,6 +2397,18 @@ mod test {
             .unwrap()
             .to_string(),
             "python_full_version == '3.7.*' and 'nt' in os_name",
+        );
+    }
+
+    #[test]
+    fn test_marker_expression_inverted_wildcard() {
+        assert_eq!(
+            MarkerTree::from_str(r"'3.7.*' == python_full_version")
+                .unwrap()
+                .contents()
+                .unwrap()
+                .to_string(),
+            "python_full_version == '3.7.*'",
         );
     }
 


### PR DESCRIPTION
## Summary

There's a comment here that suggests these aren't valid per PEP 440, but I think these _are_ valid?

See: https://github.com/pypa/packaging/pull/1126.
