### PR TITLE
Log out without `--username` if username is unambiguous

### DIFF
--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -10,7 +10,7 @@ pub use pyx::{
 };
 pub use realm::{Realm, RealmRef};
 pub use service::{Service, ServiceParseError};
-pub use store::{AuthBackend, AuthScheme, TextCredentialStore, TomlCredentialError};
+pub use store::{AuthBackend, AuthScheme, LookupError, TextCredentialStore, TomlCredentialError};
 
 mod access_token;
 mod cache;

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
@@ -333,14 +334,14 @@ impl TextCredentialStore {
         Ok(())
     }
 
-    /// Get credentials for a given URL and username.
+    /// Get the credential entry for a given URL and username.
     ///
     /// The most specific URL prefix match in the same [`Realm`] is returned, if any.
-    pub fn get_credentials(
+    pub fn get_credential_entry(
         &self,
         url: &DisplaySafeUrl,
         username: Option<&str>,
-    ) -> Result<Option<&Credentials>, LookupError> {
+    ) -> Result<Option<(Cow<'_, Service>, &Credentials)>, LookupError> {
         let request_realm = Realm::from(url);
 
         // Perform an exact lookup first
@@ -351,7 +352,7 @@ impl TextCredentialStore {
                 url_service.clone(),
                 Username::from(username.map(str::to_string)),
             )) {
-                return Ok(Some(credential));
+                return Ok(Some((Cow::Owned(url_service), credential)));
             }
         }
 
@@ -388,11 +389,24 @@ impl TextCredentialStore {
         }
 
         // Return the most specific match
-        if let Some((_, _, credential)) = best {
-            return Ok(Some(credential));
+        if let Some((_, service, credential)) = best {
+            return Ok(Some((Cow::Borrowed(service), credential)));
         }
 
         Ok(None)
+    }
+
+    /// Get credentials for a given URL and username.
+    ///
+    /// The most specific URL prefix match in the same [`Realm`] is returned, if any.
+    pub fn get_credentials(
+        &self,
+        url: &DisplaySafeUrl,
+        username: Option<&str>,
+    ) -> Result<Option<&Credentials>, LookupError> {
+        Ok(self
+            .get_credential_entry(url, username)?
+            .map(|(.., credential)| credential))
     }
 
     /// Store credentials for a given service.

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -127,7 +127,7 @@ pub enum BearerAuthError {
 #[derive(Debug, Error, PartialEq)]
 pub enum LookupError {
     #[error("Multiple credentials found for URL '{0}', specify which username to use")]
-    AmbiguousUsername(DisplaySafeUrl),
+    AmbiguousUsername(DisplaySafeUrl, Vec<String>),
 }
 
 /// A single credential entry in a TOML credentials file.
@@ -359,6 +359,7 @@ impl TextCredentialStore {
 
         // If that fails, iterate through to find a prefix match
         let mut best: Option<(usize, &Service, &Credentials)> = None;
+        let mut ambiguous_usernames: Vec<String> = Vec::new();
 
         for ((service, stored_username), credential) in &self.credentials {
             let service_realm = Realm::from(service.url().deref());
@@ -384,9 +385,27 @@ impl TextCredentialStore {
             let specificity = service.url().path().len();
             if best.is_none_or(|(best_specificity, _, _)| specificity > best_specificity) {
                 best = Some((specificity, service, credential));
+                ambiguous_usernames.clear();
             } else if best.is_some_and(|(best_specificity, _, _)| specificity == best_specificity) {
-                return Err(LookupError::AmbiguousUsername(url.clone()));
+                if ambiguous_usernames.is_empty()
+                    && let Some((_, _, best_credential)) = best
+                    && let Some(username) = best_credential.username()
+                {
+                    ambiguous_usernames.push(username.to_string());
+                }
+                if let Some(username) = stored_username.as_deref() {
+                    ambiguous_usernames.push(username.to_string());
+                }
             }
+        }
+
+        if !ambiguous_usernames.is_empty() {
+            ambiguous_usernames.sort();
+            ambiguous_usernames.dedup();
+            return Err(LookupError::AmbiguousUsername(
+                url.clone(),
+                ambiguous_usernames,
+            ));
         }
 
         // Return the most specific match
@@ -728,7 +747,13 @@ password = "pass2"
         // When no username is specified, should return an error because there are multiple matches with same specificity
         let result = store.get_credentials(&url, None);
         assert!(result.is_err());
-        assert_eq!(result, Err(LookupError::AmbiguousUsername(url.clone())));
+        assert_eq!(
+            result,
+            Err(LookupError::AmbiguousUsername(
+                url.clone(),
+                vec!["user1".to_string(), "user2".to_string()]
+            ))
+        );
 
         // When a specific username is provided, should return the correct credentials
         let result = store.get_credentials(&url, Some("user1")).unwrap();

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
@@ -334,14 +335,14 @@ impl TextCredentialStore {
         Ok(())
     }
 
-    /// Get credentials for a given URL and username.
+    /// Get the credential entry for a given URL and username.
     ///
     /// The most specific URL prefix match in the same [`Realm`] is returned, if any.
-    pub fn get_credentials(
+    pub fn get_credential_entry(
         &self,
         url: &DisplaySafeUrl,
         username: Option<&str>,
-    ) -> Result<Option<&Credentials>, LookupError> {
+    ) -> Result<Option<(Cow<'_, Service>, &Credentials)>, LookupError> {
         let request_realm = Realm::from(url);
 
         // Perform an exact lookup first
@@ -352,7 +353,7 @@ impl TextCredentialStore {
                 url_service.clone(),
                 Username::from(username.map(str::to_string)),
             )) {
-                return Ok(Some(credential));
+                return Ok(Some((Cow::Owned(url_service), credential)));
             }
         }
 
@@ -389,11 +390,24 @@ impl TextCredentialStore {
         }
 
         // Return the most specific match
-        if let Some((_, _, credential)) = best {
-            return Ok(Some(credential));
+        if let Some((_, service, credential)) = best {
+            return Ok(Some((Cow::Borrowed(service), credential)));
         }
 
         Ok(None)
+    }
+
+    /// Get credentials for a given URL and username.
+    ///
+    /// The most specific URL prefix match in the same [`Realm`] is returned, if any.
+    pub fn get_credentials(
+        &self,
+        url: &DisplaySafeUrl,
+        username: Option<&str>,
+    ) -> Result<Option<&Credentials>, LookupError> {
+        Ok(self
+            .get_credential_entry(url, username)?
+            .map(|(.., credential)| credential))
     }
 
     /// Store credentials for a given service.

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -2,9 +2,10 @@ use std::fmt::Write;
 
 use anyhow::{Context, Result, bail};
 use owo_colors::OwoColorize;
+use url::Url;
 
 use uv_auth::{
-    AuthBackend, Credentials, PyxTokenStore, Service, TextCredentialStore, Username,
+    AuthBackend, Credentials, LookupError, PyxTokenStore, Service, TextCredentialStore, Username,
     is_default_pyx_domain,
 };
 use uv_client::BaseClientBuilder;
@@ -16,7 +17,7 @@ use crate::{commands::ExitStatus, printer::Printer};
 
 /// Logout from a service.
 ///
-/// If no username is provided, defaults to `__token__`.
+/// If no username is provided, uv tries the default token entry first.
 pub(crate) async fn logout(
     service: Service,
     username: Option<String>,
@@ -48,40 +49,85 @@ pub(crate) async fn logout(
                 "Cannot specify a username both via the URL and CLI; found `--username {cli}` and `{url}`"
             );
         }
-        (Some(cli), None) => cli,
-        (None, Some(url)) => url.to_string(),
-        (None, None) => "__token__".to_string(),
+        (Some(cli), None) => Some(cli),
+        (None, Some(url)) => Some(url.to_string()),
+        (None, None) => None,
     };
-    if username.is_empty() {
+    if username.as_ref().is_some_and(String::is_empty) {
         bail!("Username cannot be empty");
     }
 
-    let display_url = if username == "__token__" {
-        url.without_credentials().to_string()
-    } else {
-        format!("{username}@{}", url.without_credentials())
-    };
+    let url_without_credentials = url.without_credentials();
 
     // TODO(zanieb): Consider exhaustively logging out from all backends
-    match backend {
+    let display_url = match backend {
         AuthBackend::System(provider) => {
-            provider
-                .remove(&url, &username)
-                .await
-                .with_context(|| format!("Unable to remove credentials for {display_url}"))?;
+            if let Some(username) = username.as_deref() {
+                let display_url = format_display_url(&url_without_credentials, Some(username));
+                provider
+                    .remove(&url, username)
+                    .await
+                    .with_context(|| format!("Unable to remove credentials for {display_url}"))?;
+                display_url
+            } else if provider.fetch(&url, Some("__token__")).await.is_some() {
+                provider.remove(&url, "__token__").await.with_context(|| {
+                    format!("Unable to remove credentials for {url_without_credentials}")
+                })?;
+                url_without_credentials.to_string()
+            } else {
+                bail!("{}", missing_username_hint(&url_without_credentials));
+            }
         }
         AuthBackend::TextStore(mut store, _lock) => {
-            if store
-                .remove(&service, Username::from(Some(username.clone())))
-                .is_none()
+            let display_url = if let Some(username) = username {
+                let display_url = format_display_url(&url_without_credentials, Some(&username));
+                if store
+                    .remove(&service, Username::from(Some(username)))
+                    .is_none()
+                {
+                    bail!("No matching entry found for {display_url}");
+                }
+                display_url
+            } else if store
+                .remove(&service, Username::from(Some("__token__".to_string())))
+                .is_some()
             {
-                bail!("No matching entry found for {display_url}");
-            }
+                url_without_credentials.to_string()
+            } else {
+                let lookup = store.get_credential_entry(&url, None).map(|entry| {
+                    entry.map(|(matched_service, credentials)| {
+                        (
+                            matched_service.into_owned(),
+                            credentials.username().map(ToString::to_string),
+                        )
+                    })
+                });
+                match lookup {
+                    Ok(Some((matched_service, matched_username))) => {
+                        let display_url = format_display_url(
+                            &url_without_credentials,
+                            matched_username.as_deref(),
+                        );
+                        if store
+                            .remove(&matched_service, Username::from(matched_username))
+                            .is_none()
+                        {
+                            bail!("No matching entry found for {display_url}");
+                        }
+                        display_url
+                    }
+                    Ok(None) => bail!("{}", missing_username_hint(&url_without_credentials)),
+                    Err(LookupError::AmbiguousUsername(..)) => {
+                        bail!("{}", ambiguous_username_hint(&url_without_credentials))
+                    }
+                }
+            };
             store
                 .write(TextCredentialStore::default_file()?, _lock)
                 .with_context(|| "Failed to persist changes to credentials after removal")?;
+            display_url
         }
-    }
+    };
 
     writeln!(
         printer.stderr(),
@@ -90,6 +136,28 @@ pub(crate) async fn logout(
     )?;
 
     Ok(ExitStatus::Success)
+}
+
+/// Format a URL for display, including the username if it's present (and not the default token
+/// entry).
+fn format_display_url(url: &Url, username: Option<&str>) -> String {
+    if let Some(username) = username.filter(|username| *username != "__token__") {
+        format!("{username}@{url}")
+    } else {
+        url.to_string()
+    }
+}
+
+fn missing_username_hint(display_url: &Url) -> String {
+    format!(
+        "No matching entry found for {display_url}. If the credentials were stored with a username, pass `--username` to `uv auth logout`."
+    )
+}
+
+fn ambiguous_username_hint(display_url: &Url) -> String {
+    format!(
+        "Multiple credentials found for {display_url}. Pass `--username` to `uv auth logout` to select which credentials to remove."
+    )
 }
 
 /// Log out via the [`PyxTokenStore`], invalidating the existing tokens.

--- a/crates/uv/src/commands/auth/logout.rs
+++ b/crates/uv/src/commands/auth/logout.rs
@@ -17,7 +17,8 @@ use crate::{commands::ExitStatus, printer::Printer};
 
 /// Logout from a service.
 ///
-/// If no username is provided, uv tries the default token entry first.
+/// If no username is provided, uv removes token credentials first, then username and password
+/// credentials if only one matching entry exists.
 pub(crate) async fn logout(
     service: Service,
     username: Option<String>,
@@ -75,7 +76,10 @@ pub(crate) async fn logout(
                 })?;
                 url_without_credentials.to_string()
             } else {
-                bail!("{}", missing_username_hint(&url_without_credentials));
+                bail!(
+                    "{}",
+                    missing_token_credentials_hint(&url_without_credentials)
+                );
             }
         }
         AuthBackend::TextStore(mut store, _lock) => {
@@ -116,9 +120,12 @@ pub(crate) async fn logout(
                         }
                         display_url
                     }
-                    Ok(None) => bail!("{}", missing_username_hint(&url_without_credentials)),
-                    Err(LookupError::AmbiguousUsername(..)) => {
-                        bail!("{}", ambiguous_username_hint(&url_without_credentials))
+                    Ok(None) => bail!("{}", missing_credentials_hint(&url_without_credentials)),
+                    Err(LookupError::AmbiguousUsername(_, usernames)) => {
+                        bail!(
+                            "{}",
+                            ambiguous_username_hint(&url_without_credentials, &usernames)
+                        )
                     }
                 }
             };
@@ -148,15 +155,26 @@ fn format_display_url(url: &Url, username: Option<&str>) -> String {
     }
 }
 
-fn missing_username_hint(display_url: &Url) -> String {
+fn missing_credentials_hint(display_url: &Url) -> String {
+    format!("No matching credentials found for {display_url}")
+}
+
+fn missing_token_credentials_hint(display_url: &Url) -> String {
     format!(
-        "No matching entry found for {display_url}. If the credentials were stored with a username, pass `--username` to `uv auth logout`."
+        "No token credentials found for {display_url}. To remove username and password credentials, pass `--username`."
     )
 }
 
-fn ambiguous_username_hint(display_url: &Url) -> String {
+fn ambiguous_username_hint(display_url: &Url, usernames: &[String]) -> String {
+    if usernames.is_empty() {
+        return format!(
+            "Multiple credentials found for {display_url}. Pass `--username` to `uv auth logout` to select which credentials to remove."
+        );
+    }
+
     format!(
-        "Multiple credentials found for {display_url}. Pass `--username` to `uv auth logout` to select which credentials to remove."
+        "Multiple credentials found for {display_url}. Pass `--username` to `uv auth logout` to select which credentials to remove: {}",
+        usernames.join(", ")
     )
 }
 

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -742,8 +742,7 @@ async fn logout_native_auth() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Unable to remove credentials for http://[LOCALHOST]/basic-auth
-      Caused by: No matching entry found in secure storage
+    error: No matching entry found for http://[LOCALHOST]/basic-auth. If the credentials were stored with a username, pass `--username` to `uv auth logout`.
     ");
 
     // Logout before logging in (with a username)
@@ -779,7 +778,6 @@ async fn logout_native_auth() -> Result<()> {
     );
 
     // Logout without a username
-    // TODO(zanieb): Add a hint here if we can?
     uv_snapshot!(context.filters(), context.auth_logout()
         .arg(proxy.url("/basic-auth/simple"))
         .env(EnvVars::UV_PREVIEW_FEATURES, "native-auth"), @r"
@@ -788,8 +786,7 @@ async fn logout_native_auth() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Unable to remove credentials for http://[LOCALHOST]/basic-auth
-      Caused by: No matching entry found in secure storage
+    error: No matching entry found for http://[LOCALHOST]/basic-auth. If the credentials were stored with a username, pass `--username` to `uv auth logout`.
     ");
 
     // Logout with a username
@@ -1605,6 +1602,103 @@ fn logout_text_store_strips_simple_suffix() {
 }
 
 #[test]
+fn logout_text_store_without_username_uses_unique_match() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    context
+        .auth_login()
+        .arg("example.com")
+        .arg("--username")
+        .arg("testuser")
+        .arg("--password")
+        .arg("testpass")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.auth_logout()
+        .arg("example.com"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed credentials for testuser@https://example.com/
+    "
+    );
+
+    uv_snapshot!(context.auth_token()
+        .arg("example.com")
+        .arg("--username")
+        .arg("testuser"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to fetch credentials for testuser@https://example.com/
+    "
+    );
+}
+
+#[test]
+fn logout_text_store_without_username_prefers_token() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    context
+        .auth_login()
+        .arg("https://example.com/simple")
+        .arg("--username")
+        .arg("testuser")
+        .arg("--password")
+        .arg("testpass")
+        .assert()
+        .success();
+
+    context
+        .auth_login()
+        .arg("https://example.com/simple")
+        .arg("--token")
+        .arg("test-token")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.auth_logout()
+        .arg("https://example.com/simple"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed credentials for https://example.com/
+    "
+    );
+
+    uv_snapshot!(context.auth_token()
+        .arg("https://example.com/simple"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to fetch credentials for https://example.com/simple
+    "
+    );
+
+    uv_snapshot!(context.auth_token()
+        .arg("https://example.com/simple")
+        .arg("--username")
+        .arg("testuser"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    testpass
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn token_text_store_strips_simple_suffix() {
     let context = uv_test::test_context_with_versions!(&[]);
 
@@ -1821,7 +1915,56 @@ fn logout_text_store_multiple_usernames() {
     "
     );
 
-    // Try to logout without specifying username (defaults to `__token__`)
+    // With only one matching credential remaining, logout without a username should remove it.
+    uv_snapshot!(context.auth_logout()
+        .arg("https://example.com/simple"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed credentials for user2@https://example.com/
+    "
+    );
+
+    uv_snapshot!(context.auth_token()
+        .arg("https://example.com/simple")
+        .arg("--username")
+        .arg("user2"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to fetch credentials for user2@https://example.com/simple
+    "
+    );
+}
+
+#[test]
+fn logout_text_store_without_username_requires_username_on_ambiguity() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    context
+        .auth_login()
+        .arg("https://example.com/simple")
+        .arg("--username")
+        .arg("user1")
+        .arg("--password")
+        .arg("pass1")
+        .assert()
+        .success();
+
+    context
+        .auth_login()
+        .arg("https://example.com/simple")
+        .arg("--username")
+        .arg("user2")
+        .arg("--password")
+        .arg("pass2")
+        .assert()
+        .success();
+
     uv_snapshot!(context.auth_logout()
         .arg("https://example.com/simple"), @"
     success: false
@@ -1829,7 +1972,7 @@ fn logout_text_store_multiple_usernames() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No matching entry found for https://example.com/
+    error: Multiple credentials found for https://example.com/. Pass `--username` to `uv auth logout` to select which credentials to remove.
     "
     );
 }

--- a/crates/uv/tests/it/auth.rs
+++ b/crates/uv/tests/it/auth.rs
@@ -742,7 +742,7 @@ async fn logout_native_auth() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No matching entry found for http://[LOCALHOST]/basic-auth. If the credentials were stored with a username, pass `--username` to `uv auth logout`.
+    error: No token credentials found for http://[LOCALHOST]/basic-auth. To remove username and password credentials, pass `--username`.
     ");
 
     // Logout before logging in (with a username)
@@ -786,7 +786,7 @@ async fn logout_native_auth() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No matching entry found for http://[LOCALHOST]/basic-auth. If the credentials were stored with a username, pass `--username` to `uv auth logout`.
+    error: No token credentials found for http://[LOCALHOST]/basic-auth. To remove username and password credentials, pass `--username`.
     ");
 
     // Logout with a username
@@ -1972,7 +1972,7 @@ fn logout_text_store_without_username_requires_username_on_ambiguity() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Multiple credentials found for https://example.com/. Pass `--username` to `uv auth logout` to select which credentials to remove.
+    error: Multiple credentials found for https://example.com/. Pass `--username` to `uv auth logout` to select which credentials to remove: user1, user2
     "
     );
 }

--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -62,18 +62,10 @@ For token-based credentials, no username is required:
 $ uv auth logout example.com
 ```
 
-When `--username` is omitted, uv first tries to remove the default token entry for the service, suc
-that means `uv auth logout example.com` works naturally for credentials that were stored with
-`--token`.
-
-For username and password credentials, `--username` should usually be provided. If the default
-plaintext credential store is in use, uv can also remove the only matching credential when the
-choice is unambiguous. If multiple usernames match the same service, uv will ask you to specify
-which one to remove with `--username`.
-
-When the system-native storage backend is enabled with `UV_PREVIEW_FEATURES=native-auth`, uv cannot
-infer an arbitrary username from the service alone, so `--username` is required for
-username/password credentials.
+When `--username` is omitted, uv first tries to remove token credentials for the service. If the
+plaintext credential store is in use, uv can also remove username and password credentials when only
+one set of credentials exists for the service. If multiple usernames match the same service, uv will
+ask you to specify the credentials to remove with `--username`.
 
 !!! note
 

--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -15,6 +15,18 @@ This will prompt for the credentials.
 The credentials can also be provided using the `--username` and `--password` options, or the
 `--token` option for services which use a `__token__` or arbitrary username.
 
+For example, to store username and password credentials:
+
+```console
+$ uv auth login --username foo --password bar example.com
+```
+
+To store a token instead:
+
+```console
+$ uv auth login --token pypi-... example.com
+```
+
 !!! note
 
     We recommend providing the secret via stdin. Use `-` to indicate the value should be read from
@@ -38,9 +50,30 @@ will not yet be used for Git requests.
 
 To remove credentials, use the `uv auth logout` command:
 
+For username and password credentials, provide the username that was used to log in:
+
+```console
+$ uv auth logout --username foo example.com
+```
+
+For token-based credentials, no username is required:
+
 ```console
 $ uv auth logout example.com
 ```
+
+When `--username` is omitted, uv first tries to remove the default token entry for the service, suc
+that means `uv auth logout example.com` works naturally for credentials that were stored with
+`--token`.
+
+For username and password credentials, `--username` should usually be provided. If the default
+plaintext credential store is in use, uv can also remove the only matching credential when the
+choice is unambiguous. If multiple usernames match the same service, uv will ask you to specify
+which one to remove with `--username`.
+
+When the system-native storage backend is enabled with `UV_PREVIEW_FEATURES=native-auth`, uv cannot
+infer an arbitrary username from the service alone, so `--username` is required for
+username/password credentials.
 
 !!! note
 
@@ -51,13 +84,27 @@ $ uv auth logout example.com
 
 To show the credential stored for a given URL, use the `uv auth token` command:
 
+For token-based credentials:
+
 ```console
 $ uv auth token example.com
 ```
 
-If a username was used to log in, it will need to be provided as well, e.g.:
+If a username was used to log in, it must be provided as well:
 
 ```console
+$ uv auth token --username foo example.com
+```
+
+For example, these commands line up with the corresponding login flows:
+
+```console
+$ uv auth login --token pypi-... example.com
+$ uv auth token example.com
+```
+
+```console
+$ uv auth login --username foo --password bar example.com
 $ uv auth token --username foo example.com
 ```
 


### PR DESCRIPTION
## Summary

For now, we can only support this if the user is using the plain-text backend, since the system-native backend is keyed on (service, username).

Closes https://github.com/astral-sh/uv/issues/18973.
