### PR TITLE
Elevate configuration errors to `required-version` mismatches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7205,6 +7205,7 @@ dependencies = [
  "uv-macros",
  "uv-normalize",
  "uv-options-metadata",
+ "uv-pep440",
  "uv-pep508",
  "uv-pypi-types",
  "uv-python",
@@ -7212,6 +7213,7 @@ dependencies = [
  "uv-resolver",
  "uv-static",
  "uv-torch",
+ "uv-version",
  "uv-warnings",
  "uv-workspace",
 ]

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -28,6 +28,7 @@ uv-install-wheel = { workspace = true, features = ["schemars", "clap"] }
 uv-macros = { workspace = true }
 uv-normalize = { workspace = true, features = ["schemars"] }
 uv-options-metadata = { workspace = true }
+uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true, features = ["schemars", "clap"] }
@@ -35,6 +36,7 @@ uv-redacted = { workspace = true }
 uv-resolver = { workspace = true, features = ["schemars", "clap"] }
 uv-static = { workspace = true }
 uv-torch = { workspace = true, features = ["schemars", "clap"] }
+uv-version = { workspace = true }
 uv-warnings = { workspace = true }
 uv-workspace = { workspace = true, features = ["schemars", "clap"] }
 

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -1,13 +1,16 @@
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::Duration;
 use tracing::info_span;
 use uv_client::{DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT_UPLOAD};
+use uv_configuration::RequiredVersion;
 use uv_dirs::{system_config_file, user_config_dir};
 use uv_distribution_types::Origin;
 use uv_flags::EnvironmentFlags;
 use uv_fs::Simplified;
+use uv_pep440::Version;
 use uv_static::{EnvVars, InvalidEnvironmentVariable, parse_boolish_environment_variable};
 use uv_warnings::warn_user;
 
@@ -123,7 +126,13 @@ impl FilesystemOptions {
                 let options =
                     info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
                         .in_scope(|| toml::from_str::<Options>(&content))
-                        .map_err(|err| Error::UvToml(path.clone(), Box::new(err)))?
+                        .map_err(|err| {
+                            check_uv_toml_required_version(
+                                &path,
+                                &content,
+                                Error::UvToml(path.clone(), Box::new(err)),
+                            )
+                        })?
                         .relative_to(&std::path::absolute(dir)?)?;
 
                 // If the directory also contains a `[tool.uv]` table in a `pyproject.toml` file,
@@ -155,7 +164,9 @@ impl FilesystemOptions {
                 let pyproject =
                     info_span!("toml::from_str filesystem options pyproject.toml", path = %path.display())
                         .in_scope(|| toml::from_str::<PyProjectToml>(&content))
-                        .map_err(|err| Error::PyprojectToml(path.clone(), Box::new(err)))?;
+                        .map_err(|err| {
+                            check_pyproject_required_version(&path, &content, err)
+                        })?;
                 let Some(tool) = pyproject.tool else {
                     tracing::debug!(
                         "Skipping `pyproject.toml` in `{}` (no `[tool]` section)",
@@ -205,7 +216,13 @@ fn read_file(path: &Path) -> Result<Options, Error> {
     let content = fs_err::read_to_string(path)?;
     let options = info_span!("toml::from_str filesystem options uv.toml", path = %path.display())
         .in_scope(|| toml::from_str::<Options>(&content))
-        .map_err(|err| Error::UvToml(path.to_path_buf(), Box::new(err)))?;
+        .map_err(|err| {
+            check_uv_toml_required_version(
+                path,
+                &content,
+                Error::UvToml(path.to_path_buf(), Box::new(err)),
+            )
+        })?;
     let options = if let Some(parent) = std::path::absolute(path)?.parent() {
         options.relative_to(parent)?
     } else {
@@ -214,8 +231,60 @@ fn read_file(path: &Path) -> Result<Options, Error> {
     Ok(options)
 }
 
+/// If `required_version` is set and incompatible with the running uv, return the corresponding
+/// [`Error::RequiredVersion`].
+fn required_version_mismatch(required_version: Option<RequiredVersion>) -> Option<Error> {
+    let required_version = required_version?;
+    let package_version = Version::from_str(uv_version::version())
+        .expect("uv crate version to be a valid PEP 440 version");
+    if required_version.contains(&package_version) {
+        None
+    } else {
+        Some(Error::RequiredVersion {
+            required_version,
+            package_version,
+        })
+    }
+}
+
+/// On a `pyproject.toml` settings parse error, check whether `tool.uv.required-version` should
+/// take precedence over that error.
+fn check_pyproject_required_version(path: &Path, content: &str, source: toml::de::Error) -> Error {
+    let fallback = || Error::PyprojectToml(path.to_path_buf(), Box::new(source));
+    let Ok(pyproject) = info_span!(
+        "toml::from_str filesystem required-version pyproject.toml",
+        path = %path.display()
+    )
+    .in_scope(|| toml::from_str::<PyProjectRequiredVersionToml>(content)) else {
+        return fallback();
+    };
+
+    let required_version = pyproject
+        .tool
+        .and_then(|tool| tool.uv)
+        .and_then(|uv| uv.required_version);
+    required_version_mismatch(required_version).unwrap_or_else(fallback)
+}
+
+/// On a `uv.toml` settings parse or schema error, check whether top-level `required-version`
+/// should take precedence over that error.
+fn check_uv_toml_required_version(path: &Path, content: &str, source: Error) -> Error {
+    let Ok(uv_toml) = info_span!(
+        "toml::from_str filesystem required-version uv.toml",
+        path = %path.display()
+    )
+    .in_scope(|| toml::from_str::<UvRequiredVersionToml>(content)) else {
+        return source;
+    };
+    required_version_mismatch(uv_toml.required_version).unwrap_or(source)
+}
+
 /// Validate that an [`Options`] schema is compatible with `uv.toml`.
 fn validate_uv_toml(path: &Path, options: &Options) -> Result<(), Error> {
+    // A `required-version` mismatch takes precedence over a schema error.
+    if let Some(err) = required_version_mismatch(options.globals.required_version.clone()) {
+        return Err(err);
+    }
     let Options {
         globals: _,
         top_level: _,
@@ -599,6 +668,14 @@ pub enum Error {
     #[error("Failed to parse: `{}`. The `{}` field is not allowed in a `uv.toml` file. `{}` is only applicable in the context of a project, and should be placed in a `pyproject.toml` file instead.", _0.user_display(), _1, _1
     )]
     PyprojectOnlyField(PathBuf, &'static str),
+
+    #[error(
+        "Required uv version `{required_version}` does not match the running version `{package_version}`"
+    )]
+    RequiredVersion {
+        required_version: RequiredVersion,
+        package_version: Version,
+    },
 
     #[error(transparent)]
     InvalidEnvironmentVariable(#[from] InvalidEnvironmentVariable),

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -40,6 +40,32 @@ pub(crate) struct Tools {
     pub(crate) uv: Option<Options>,
 }
 
+/// A `pyproject.toml` with an (optional) `[tool.uv.required-version]`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct PyProjectRequiredVersionToml {
+    pub(crate) tool: Option<RequiredVersionTools>,
+}
+
+/// A `[tool]` section containing only the fields required for `required-version` discovery.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct RequiredVersionTools {
+    pub(crate) uv: Option<RequiredVersionOptions>,
+}
+
+/// The minimal `[tool.uv]` subset required to enforce `required-version` before full parsing.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct RequiredVersionOptions {
+    pub(crate) required_version: Option<RequiredVersion>,
+}
+
+/// A `uv.toml` containing only the fields required for `required-version` discovery.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct UvRequiredVersionToml {
+    pub(crate) required_version: Option<RequiredVersion>,
+}
+
 /// A `[tool.uv]` section.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default, Deserialize, CombineOptions, OptionsMetadata)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -236,23 +236,26 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 "The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--project` argument instead."
             );
         }
-        Some(FilesystemOptions::from_file(config_file)?)
+        Some(FilesystemOptions::from_file(config_file).map_err(map_settings_error)?)
     } else if deprecated_isolated || cli.top_level.no_config {
         None
     } else if matches!(&*cli.command, Commands::Tool(_) | Commands::Self_(_)) {
         // For commands that operate at the user-level, ignore local configuration.
-        FilesystemOptions::user()?.combine(FilesystemOptions::system()?)
+        FilesystemOptions::user()
+            .map_err(map_settings_error)?
+            .combine(FilesystemOptions::system().map_err(map_settings_error)?)
     } else if let Ok(workspace) =
         Workspace::discover(&project_dir, &DiscoveryOptions::default(), &workspace_cache).await
     {
-        let project = FilesystemOptions::find(workspace.install_path())?;
-        let system = FilesystemOptions::system()?;
-        let user = FilesystemOptions::user()?;
+        let project =
+            FilesystemOptions::find(workspace.install_path()).map_err(map_settings_error)?;
+        let system = FilesystemOptions::system().map_err(map_settings_error)?;
+        let user = FilesystemOptions::user().map_err(map_settings_error)?;
         project.combine(user).combine(system)
     } else {
-        let project = FilesystemOptions::find(&project_dir)?;
-        let system = FilesystemOptions::system()?;
-        let user = FilesystemOptions::user()?;
+        let project = FilesystemOptions::find(&project_dir).map_err(map_settings_error)?;
+        let system = FilesystemOptions::system().map_err(map_settings_error)?;
+        let user = FilesystemOptions::user().map_err(map_settings_error)?;
         project.combine(user).combine(system)
     };
 
@@ -431,38 +434,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     if let Some(required_version) = globals.required_version.as_ref() {
         let package_version = uv_pep440::Version::from_str(uv_version::version())?;
         if !required_version.contains(&package_version) {
-            #[cfg(feature = "self-update")]
-            let hint = {
-                // If the required version range includes a lower bound that's higher than
-                // the current version, suggest `uv self update`.
-                let ranges = release_specifiers_to_ranges(required_version.specifiers().clone());
-
-                if let Some(singleton) = ranges.as_singleton() {
-                    // E.g., `==1.0.0`
-                    format!(
-                        ". Update `uv` by running `{}`.",
-                        format!("uv self update {singleton}").green()
-                    )
-                } else if ranges
-                    .bounding_range()
-                    .iter()
-                    .any(|(lowest, _highest)| match lowest {
-                        Bound::Included(version) => **version > package_version,
-                        Bound::Excluded(version) => **version > package_version,
-                        Bound::Unbounded => false,
-                    })
-                {
-                    // E.g., `>=1.0.0`
-                    format!(". Update `uv` by running `{}`.", "uv self update".cyan())
-                } else {
-                    String::new()
-                }
-            };
-            #[cfg(not(feature = "self-update"))]
-            let hint = "";
-            return Err(anyhow::anyhow!(
-                "Required uv version `{required_version}` does not match the running version `{package_version}`{hint}",
-            ));
+            return Err(required_version_error(required_version, &package_version));
         }
     }
 
@@ -2025,6 +1997,53 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         .await
         .expect("tokio threadpool exited unexpectedly"),
     }
+}
+
+fn map_settings_error(err: uv_settings::Error) -> anyhow::Error {
+    match err {
+        uv_settings::Error::RequiredVersion {
+            required_version,
+            package_version,
+        } => required_version_error(&required_version, &package_version),
+        err => err.into(),
+    }
+}
+
+fn required_version_error(
+    required_version: &uv_configuration::RequiredVersion,
+    package_version: &uv_pep440::Version,
+) -> anyhow::Error {
+    #[cfg(feature = "self-update")]
+    let hint = {
+        // If the required version range includes a lower bound that's higher than the current
+        // version, suggest `uv self update`.
+        let ranges = release_specifiers_to_ranges(required_version.specifiers().clone());
+
+        if let Some(singleton) = ranges.as_singleton() {
+            format!(
+                ". Update `uv` by running `{}`.",
+                format!("uv self update {singleton}").green()
+            )
+        } else if ranges
+            .bounding_range()
+            .iter()
+            .any(|(lowest, _highest)| match lowest {
+                Bound::Included(version) => **version > *package_version,
+                Bound::Excluded(version) => **version > *package_version,
+                Bound::Unbounded => false,
+            })
+        {
+            format!(". Update `uv` by running `{}`.", "uv self update".cyan())
+        } else {
+            String::new()
+        }
+    };
+    #[cfg(not(feature = "self-update"))]
+    let hint = "";
+
+    anyhow!(
+        "Required uv version `{required_version}` does not match the running version `{package_version}`{hint}",
+    )
 }
 
 /// Run a [`ProjectCommand`].

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -251,6 +251,81 @@ fn invalid_pyproject_toml_option_unknown_field() -> Result<()> {
 }
 
 #[test]
+fn pyproject_required_version_preempts_settings_discovery_warning() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((uv_version::version(), "[UV_VERSION]"));
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [tool.uv]
+        required-version = ">=9999"
+        unknown = "field"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("iniconfig"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Required uv version `>=9999` does not match the running version `[UV_VERSION]`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn uv_toml_required_version_preempts_parse_error() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((uv_version::version(), "[UV_VERSION]"));
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(indoc! {r#"
+        required-version = ">=9999"
+        unknown = "field"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("iniconfig"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Required uv version `>=9999` does not match the running version `[UV_VERSION]`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn uv_toml_required_version_preempts_pyproject_only_field() -> Result<()> {
+    let context =
+        uv_test::test_context!("3.12").with_filter((uv_version::version(), "[UV_VERSION]"));
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(indoc! {r#"
+        required-version = ">=9999"
+
+        [sources]
+        iniconfig = { git = "https://example.com/iniconfig" }
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("iniconfig"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Required uv version `>=9999` does not match the running version `[UV_VERSION]`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
 fn invalid_toml_filename() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let test_toml = context.temp_dir.child("test.toml");


### PR DESCRIPTION
## Summary

If we fail to parse a `pyproject.toml` or `uv.toml` due to unsupported settings, we now do a post-validation check to see if we're _not_ running a required version, so that the error message reflects that mismatch.

Closes https://github.com/astral-sh/uv/issues/17609.
