### PR TITLE
Fix case-insensitive parsing of `Dynamic` field values in PKG-INFO

### DIFF
--- a/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata_resolver.rs
@@ -79,7 +79,7 @@ impl ResolutionMetadata {
             .collect::<Box<_>>();
         let dynamic = headers
             .get_all_values("Dynamic")
-            .any(|field| field == "Version");
+            .any(|field| field.eq_ignore_ascii_case("Version"));
 
         Ok(Self {
             name,
@@ -112,12 +112,14 @@ impl ResolutionMetadata {
         // If any of the fields we need are marked as dynamic, we can't use the `PKG-INFO` file.
         let mut dynamic = false;
         for field in headers.get_all_values("Dynamic") {
-            match field.as_str() {
-                "Requires-Python" => return Err(MetadataError::DynamicField("Requires-Python")),
-                "Requires-Dist" => return Err(MetadataError::DynamicField("Requires-Dist")),
-                "Provides-Extra" => return Err(MetadataError::DynamicField("Provides-Extra")),
-                "Version" => dynamic = true,
-                _ => (),
+            if field.eq_ignore_ascii_case("Requires-Python") {
+                return Err(MetadataError::DynamicField("Requires-Python"));
+            } else if field.eq_ignore_ascii_case("Requires-Dist") {
+                return Err(MetadataError::DynamicField("Requires-Dist"));
+            } else if field.eq_ignore_ascii_case("Provides-Extra") {
+                return Err(MetadataError::DynamicField("Provides-Extra"));
+            } else if field.eq_ignore_ascii_case("Version") {
+                dynamic = true;
             }
         }
 
@@ -333,6 +335,25 @@ mod tests {
         let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nDynamic: Requires-Dist";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap_err();
         assert!(matches!(meta, MetadataError::DynamicField("Requires-Dist")));
+
+        // Dynamic field values should be matched case-insensitively.
+        let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nDynamic: requires-dist";
+        let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap_err();
+        assert!(matches!(meta, MetadataError::DynamicField("Requires-Dist")));
+
+        let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nDynamic: requires-python";
+        let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap_err();
+        assert!(matches!(
+            meta,
+            MetadataError::DynamicField("Requires-Python")
+        ));
+
+        let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nDynamic: provides-extra";
+        let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap_err();
+        assert!(matches!(
+            meta,
+            MetadataError::DynamicField("Provides-Extra")
+        ));
 
         let s = "Metadata-Version: 2.3\nName: asdf\nVersion: 1.0\nRequires-Dist: foo";
         let meta = ResolutionMetadata::parse_pkg_info(s.as_bytes()).unwrap();


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/18667.

The `Dynamic` field values in `PKG-INFO` metadata were compared case-sensitively (e.g., matching only `Requires-Dist` but not `requires-dist`). Some build backends emit lowercase values, causing uv to silently ignore dynamic markers and read stale static metadata instead of triggering a source build.

This uses `eq_ignore_ascii_case` for `Dynamic` field value comparisons in both `parse_metadata` and `parse_pkg_info`, consistent with how email-style headers should be handled.

## Test Plan

Added integration tests for lowercase `Dynamic` values (`requires-dist`, `requires-python`, `provides-extra`) in `parse_pkg_info`.