### PR TITLE
Allow some modification of global preview state

### DIFF
--- a/crates/uv-build/src/main.rs
+++ b/crates/uv-build/src/main.rs
@@ -63,8 +63,10 @@ fn main() -> Result<()> {
     } else if preview.any_enabled() {
         debug!("The following preview features are enabled: {preview}");
     }
-    uv_preview::init(preview)
+    uv_preview::set(preview)
         .expect("Global preview features should not have been initialised already");
+    // Errors returned by finalize are self-describing, but should also be impossible.
+    uv_preview::finalize().unwrap();
 
     match command.as_str() {
         "build-sdist" => {

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -48,9 +48,10 @@ pub enum PreviewError {
 ///
 /// This should be called once at startup with the resolved preview settings.
 pub fn set(preview: Preview) -> Result<(), PreviewError> {
-    match PREVIEW.get_or_init(|| {
+    let mode = PREVIEW.get_or_init(|| {
         PreviewMode::Normal(Mutex::new(PreviewState::Provisional(Preview::default())))
-    }) {
+    });
+    match mode {
         PreviewMode::Normal(mutex) => {
             // Calling `set` in a test context is already disallowed, so a panic if
             // the mutex is poisoned is fine.

--- a/crates/uv-preview/src/lib.rs
+++ b/crates/uv-preview/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::{
     fmt::{Debug, Display, Formatter},
     ops::BitOr,
@@ -9,11 +9,17 @@ use enumflags2::{BitFlags, bitflags};
 use thiserror::Error;
 use uv_warnings::warn_user_once;
 
+/// Indicates if the preview state has been finalized yet or not.
+enum PreviewState {
+    Provisional(Preview),
+    Final(Preview),
+}
+
 /// Indicates how the preview was initialised, to distinguish between normal
 /// code and unit tests.
 enum PreviewMode {
     /// Initialised by a call to [`init`].
-    Normal(Preview),
+    Normal(Mutex<PreviewState>),
     /// Initialised by a call to [`test::with_features`].
     #[cfg(feature = "testing")]
     Test(std::sync::RwLock<Option<Preview>>),
@@ -21,19 +27,70 @@ enum PreviewMode {
 
 static PREVIEW: OnceLock<PreviewMode> = OnceLock::new();
 
-/// Error returned when [`init`] is called more than once.
+/// Error type for global preview state initialization related errors
 #[derive(Debug, Error)]
-#[error("The preview configuration has already been initialized")]
-pub struct InitError;
+pub enum PreviewError {
+    /// Returned when [`set`] or [`finalize`] are called on a finalized state.
+    #[error("The preview configuration has already been finalized")]
+    AlreadyFinalized,
+
+    /// Returned when [`finalize`] is called on an uninitialized state.
+    #[error("The preview configuration has not been initialized yet")]
+    NotInitialized,
+
+    /// Returned when [`set`] or [`finalize`] are called on a test state.
+    #[cfg(feature = "testing")]
+    #[error("The preview configuration is in test mode and {}::{} cannot be used", module_path!(), .0)]
+    InTest(&'static str),
+}
 
 /// Initialize the global preview configuration.
 ///
 /// This should be called once at startup with the resolved preview settings.
-pub fn init(preview: Preview) -> Result<(), InitError> {
-    PREVIEW
-        .set(PreviewMode::Normal(preview))
-        .map_err(|_| InitError)
+pub fn set(preview: Preview) -> Result<(), PreviewError> {
+    match PREVIEW.get_or_init(|| {
+        PreviewMode::Normal(Mutex::new(PreviewState::Provisional(Preview::default())))
+    }) {
+        PreviewMode::Normal(mutex) => {
+            // Calling `set` in a test context is already disallowed, so a panic if
+            // the mutex is poisoned is fine.
+            let mut state = mutex.lock().unwrap();
+            match &*state {
+                PreviewState::Provisional(_) => {
+                    *state = PreviewState::Provisional(preview);
+                    Ok(())
+                }
+                PreviewState::Final(_) => Err(PreviewError::AlreadyFinalized),
+            }
+        }
+        #[cfg(feature = "testing")]
+        PreviewMode::Test(_) => Err(PreviewError::InTest("set")),
+    }
 }
+
+pub fn finalize() -> Result<(), PreviewError> {
+    match PREVIEW.get().ok_or(PreviewError::NotInitialized)? {
+        PreviewMode::Normal(mutex) => {
+            // Calling `set` in a test context is already disallowed, so a panic if
+            // the mutex is poisoned is fine.
+            let mut state = mutex.lock().unwrap();
+            match &*state {
+                PreviewState::Provisional(preview) => {
+                    *state = PreviewState::Final(*preview);
+                    Ok(())
+                }
+                PreviewState::Final(_) => Err(PreviewError::AlreadyFinalized),
+            }
+        }
+        #[cfg(feature = "testing")]
+        PreviewMode::Test(_) => Err(PreviewError::InTest("finalize")),
+    }
+}
+
+/// Error returned when [`finalize`] is called on an uninitialized state.
+#[derive(Debug, Error)]
+#[error("The preview configuration has already been finalized")]
+pub struct SetError;
 
 /// Get the current global preview configuration.
 ///
@@ -43,7 +100,10 @@ pub fn init(preview: Preview) -> Result<(), InitError> {
 /// current thread does not hold a [`test::with_features`] guard.
 pub fn get() -> Preview {
     match PREVIEW.get() {
-        Some(PreviewMode::Normal(preview)) => *preview,
+        Some(PreviewMode::Normal(mutex)) => match *mutex.lock().unwrap() {
+            PreviewState::Provisional(preview) => preview,
+            PreviewState::Final(preview) => preview,
+        },
         #[cfg(feature = "testing")]
         Some(PreviewMode::Test(rwlock)) => {
             assert!(

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -114,6 +114,9 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         &cli.top_level.global_args.preview_features,
     );
 
+    // Make the early preview flags globally available.
+    uv_preview::set(early_preview)?;
+
     // Determine the project directory.
     //
     // If `--project` points to a `pyproject.toml` file, resolve to its parent directory,
@@ -427,8 +430,9 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     // Resolve the cache settings.
     let cache_settings = CacheSettings::resolve(*cli.top_level.cache_args, filesystem.as_ref());
 
-    // Set the global preview configuration.
-    uv_preview::init(globals.preview)?;
+    // Set and finalize the global preview configuration.
+    uv_preview::set(globals.preview)?;
+    uv_preview::finalize()?;
 
     // Enforce the required version.
     if let Some(required_version) = globals.required_version.as_ref() {


### PR DESCRIPTION
## Summary

Some preview flags are set early. Meaning the preview state can change early on in uv's lifecycle. This means that the global preview must accommodate for this scenario.

This PR implements that by having the normal preview state have two initialisation stages.

`set` replaces `init` and allows unbounded new values of `preview` to be applied to the state as long as it is not finalized.

Once `finalize` is called, the state becomes locked and further calls to `set` result in an error.

## Test Plan

Existing test coverage.
