### PR TITLE
replace the RAYON_INITIALIZE `LazyLock` with a local `Once`

### DIFF
--- a/crates/uv-configuration/src/threading.rs
+++ b/crates/uv-configuration/src/threading.rs
@@ -1,6 +1,6 @@
 //! Configure rayon and determine thread stack sizes.
 
-use std::sync::LazyLock;
+use std::sync::Once;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use uv_static::EnvVars;
 
@@ -58,12 +58,15 @@ pub static RAYON_PARALLELISM: AtomicUsize = AtomicUsize::new(0);
 /// Initialize the threadpool lazily. Always call before using rayon the potentially first time.
 ///
 /// The `uv` crate sets [`RAYON_PARALLELISM`] from the user settings, and the extract and install
-/// code initialize the threadpool lazily only if they are actually used by calling
-/// `LazyLock::force(&RAYON_INITIALIZE)`.
-pub static RAYON_INITIALIZE: LazyLock<()> = LazyLock::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(RAYON_PARALLELISM.load(Ordering::Relaxed))
-        .stack_size(min_stack_size())
-        .build_global()
-        .expect("failed to initialize global rayon pool");
-});
+/// code initializes the threadpool lazily only if it is actually used by calling
+/// [`initialize_rayon_once`].
+pub fn initialize_rayon_once() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(RAYON_PARALLELISM.load(Ordering::Relaxed))
+            .stack_size(min_stack_size())
+            .build_global()
+            .expect("failed to initialize global rayon pool");
+    });
+}

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -1,12 +1,12 @@
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use crate::vendor::CloneableSeekableReader;
 use crate::{CompressionMethod, Error, insecure_no_validate, validate_archive_member_name};
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use tracing::warn;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 use uv_warnings::warn_user_once;
 use zip::ZipArchive;
 
@@ -22,7 +22,7 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
     let directories = Mutex::new(FxHashSet::default());
     let skip_validation = insecure_no_validate();
     // Initialize the threadpool with the user settings.
-    LazyLock::force(&RAYON_INITIALIZE);
+    initialize_rayon_once();
     (0..archive.len())
         .into_par_iter()
         .map(|file_number| {

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -1,5 +1,5 @@
 use std::convert;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use anyhow::{Context, Error, Result};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -7,7 +7,7 @@ use tokio::sync::oneshot;
 use tracing::{instrument, warn};
 
 use uv_cache::Cache;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 use uv_distribution_types::CachedDist;
 use uv_install_wheel::{Layout, LinkMode};
 use uv_preview::Preview;
@@ -108,7 +108,7 @@ impl<'a> Installer<'a> {
         let layout = venv.interpreter().layout();
         let relocatable = venv.relocatable();
         // Initialize the threadpool with the user settings.
-        LazyLock::force(&RAYON_INITIALIZE);
+        initialize_rayon_once();
         rayon::spawn(move || {
             let result = install(
                 wheels,
@@ -167,7 +167,7 @@ fn install(
     preview: Preview,
 ) -> Result<Vec<CachedDist>> {
     // Initialize the threadpool with the user settings.
-    LazyLock::force(&RAYON_INITIALIZE);
+    initialize_rayon_once();
     let state = uv_install_wheel::InstallState::new(preview);
     wheels.par_iter().try_for_each(|wheel| {
         uv_install_wheel::install_wheel(


### PR DESCRIPTION
Since we don't actually need this `LazyLock` to contain data, I think using a `Once` is slightly more idiomatic. `LazyLock` contains a `Once` internally, so the actual synchronization that's happening in practice is the same either way. (I ran into this while looking at how we use `LazyLock` across our repos.)