### PR TITLE
fix: use GET probe for wheel range support

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -243,33 +243,9 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
+            .get_cacheable(req, cache_entry, cache_control, async |resp| {
                 let payload = response_callback(resp).await?;
-                Ok((SerdeCacheable { inner: payload }, None))
-            })
-            .await?;
-        Ok(payload)
-    }
-
-    /// Make a cached request with a custom response transformation and an
-    /// optional cache policy override while using serde to (de)serialize
-    /// cached responses.
-    #[instrument(skip_all)]
-    pub async fn get_serde_with_cache_policy<
-        Payload: Serialize + DeserializeOwned + Send + 'static,
-        CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
-    >(
-        &self,
-        req: Request,
-        cache_entry: &CacheEntry,
-        cache_control: CacheControl,
-        response_callback: Callback,
-    ) -> Result<Payload, CachedClientError<CallBackError>> {
-        let payload = self
-            .get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
-                let (payload, cache_policy) = response_callback(resp).await?;
-                Ok((SerdeCacheable { inner: payload }, cache_policy))
+                Ok(SerdeCacheable { inner: payload })
             })
             .await?;
         Ok(payload)
@@ -292,24 +268,6 @@ impl CachedClient {
         Payload: Cacheable,
         CallBackError: std::error::Error + 'static,
         Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
-    >(
-        &self,
-        req: Request,
-        cache_entry: &CacheEntry,
-        cache_control: CacheControl,
-        response_callback: Callback,
-    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
-        self.get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
-            let payload = response_callback(resp).await?;
-            Ok((payload, None))
-        })
-        .await
-    }
-
-    async fn get_cacheable_with_policy_override<
-        Payload: Cacheable,
-        CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
     >(
         &self,
         req: Request,
@@ -342,7 +300,7 @@ impl CachedClient {
                         "Broken fresh cache entry (for payload) at {}, removing: {err}",
                         cache_entry.path().display()
                     );
-                    self.resend_and_heal_cache_with_policy_override(
+                    self.resend_and_heal_cache(
                         fresh_req,
                         cache_entry,
                         cache_control.clone(),
@@ -368,7 +326,7 @@ impl CachedClient {
                                  (for payload) at {}, removing: {err}",
                                 cache_entry.path().display()
                             );
-                            self.resend_and_heal_cache_with_policy_override(
+                            self.resend_and_heal_cache(
                                 fresh_req,
                                 cache_entry,
                                 cache_control.clone(),
@@ -392,7 +350,7 @@ impl CachedClient {
                         "Server returned unusable 304 for: {}",
                         DisplaySafeUrl::from_url(fresh_req.url().clone())
                     );
-                    self.resend_and_heal_cache_with_policy_override(
+                    self.resend_and_heal_cache(
                         fresh_req,
                         cache_entry,
                         cache_control,
@@ -400,7 +358,7 @@ impl CachedClient {
                     )
                     .await
                 } else {
-                    self.run_response_callback_with_policy_override(
+                    self.run_response_callback(
                         cache_entry,
                         cache_policy,
                         start,
@@ -438,10 +396,10 @@ impl CachedClient {
         Ok(payload)
     }
 
-    async fn resend_and_heal_cache_with_policy_override<
+    async fn resend_and_heal_cache<
         Payload: Cacheable,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFnOnce(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
+        Callback: AsyncFnOnce(Response) -> Result<Payload, CallBackError>,
     >(
         &self,
         req: Request,
@@ -452,7 +410,7 @@ impl CachedClient {
         let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
         let start = Instant::now();
         let (response, cache_policy) = self.fresh_request(req, cache_control).await?;
-        self.run_response_callback_with_policy_override(
+        self.run_response_callback(
             cache_entry,
             cache_policy,
             start,
@@ -474,31 +432,6 @@ impl CachedClient {
         response: Response,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
-        self.run_response_callback_with_policy_override(
-            cache_entry,
-            cache_policy,
-            start,
-            response,
-            async |response| {
-                let payload = response_callback(response).await?;
-                Ok((payload, None))
-            },
-        )
-        .await
-    }
-
-    async fn run_response_callback_with_policy_override<
-        Payload: Cacheable,
-        CallBackError: std::error::Error + 'static,
-        Callback: AsyncFnOnce(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
-    >(
-        &self,
-        cache_entry: &CacheEntry,
-        cache_policy: Option<Box<CachePolicy>>,
-        start: Instant,
-        response: Response,
-        response_callback: Callback,
-    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let new_cache = info_span!("new_cache", file = %cache_entry.path().display());
         // Capture retries from the retry middleware
         let retries = response
@@ -506,7 +439,7 @@ impl CachedClient {
             .get::<reqwest_retry::RetryCount>()
             .map(|retries| retries.value())
             .unwrap_or_default();
-        let (data, cache_policy_override) = response_callback(response)
+        let data = response_callback(response)
             .boxed_local()
             .await
             .map_err(|err| CachedClientError::Callback {
@@ -514,7 +447,6 @@ impl CachedClient {
                 err,
                 duration: start.elapsed(),
             })?;
-        let cache_policy = cache_policy_override.map(Box::new).or(cache_policy);
         let Some(cache_policy) = cache_policy else {
             return Ok(data.into_target());
         };
@@ -735,43 +667,10 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_retry_and_policy_override(
-                req,
-                cache_entry,
-                cache_control,
-                async |resp| {
-                    let payload = response_callback(resp).await?;
-                    Ok((SerdeCacheable { inner: payload }, None))
-                },
-            )
-            .await?;
-        Ok(payload)
-    }
-
-    /// Perform a [`CachedClient::get_serde`] request with a default retry
-    /// strategy and an optional cache policy override.
-    #[instrument(skip_all)]
-    pub async fn get_serde_with_retry_and_cache_policy<
-        Payload: Serialize + DeserializeOwned + Send + 'static,
-        CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
-    >(
-        &self,
-        req: Request,
-        cache_entry: &CacheEntry,
-        cache_control: CacheControl,
-        response_callback: Callback,
-    ) -> Result<Payload, CachedClientError<CallBackError>> {
-        let payload = self
-            .get_cacheable_with_retry_and_policy_override(
-                req,
-                cache_entry,
-                cache_control,
-                async |resp| {
-                    let (payload, cache_policy) = response_callback(resp).await?;
-                    Ok((SerdeCacheable { inner: payload }, cache_policy))
-                },
-            )
+            .get_cacheable_with_retry(req, cache_entry, cache_control, async |resp| {
+                let payload = response_callback(resp).await?;
+                Ok(SerdeCacheable { inner: payload })
+            })
             .await?;
         Ok(payload)
     }
@@ -791,35 +690,11 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
-        self.get_cacheable_with_retry_and_policy_override(
-            req,
-            cache_entry,
-            cache_control,
-            async |resp| {
-                let payload = response_callback(resp).await?;
-                Ok((payload, None))
-            },
-        )
-        .await
-    }
-
-    #[instrument(skip_all)]
-    pub async fn get_cacheable_with_retry_and_policy_override<
-        Payload: Cacheable,
-        CallBackError: std::error::Error + 'static,
-        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
-    >(
-        &self,
-        req: Request,
-        cache_entry: &CacheEntry,
-        cache_control: CacheControl,
-        response_callback: Callback,
-    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let mut retry_state = RetryState::start(self.uncached().retry_policy(), req.url().clone());
         loop {
             let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
             let result = self
-                .get_cacheable_with_policy_override(
+                .get_cacheable(
                     fresh_req,
                     cache_entry,
                     cache_control.clone(),
@@ -1029,7 +904,7 @@ impl DataWithCachePolicy {
     ///
     /// If there was a problem converting the given cache policy to its
     /// serialized representation, then this routine will return an error.
-    fn serialize(cache_policy: &CachePolicy, data: &[u8]) -> Result<Vec<u8>, Error> {
+    pub(crate) fn serialize(cache_policy: &CachePolicy, data: &[u8]) -> Result<Vec<u8>, Error> {
         let mut buf = vec![];
         Self::serialize_to_writer(cache_policy, data, &mut buf)?;
         Ok(buf)

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -243,9 +243,33 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable(req, cache_entry, cache_control, async |resp| {
+            .get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
                 let payload = response_callback(resp).await?;
-                Ok(SerdeCacheable { inner: payload })
+                Ok((SerdeCacheable { inner: payload }, None))
+            })
+            .await?;
+        Ok(payload)
+    }
+
+    /// Make a cached request with a custom response transformation and an
+    /// optional cache policy override while using serde to (de)serialize
+    /// cached responses.
+    #[instrument(skip_all)]
+    pub async fn get_serde_with_cache_policy<
+        Payload: Serialize + DeserializeOwned + Send + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload, CachedClientError<CallBackError>> {
+        let payload = self
+            .get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
+                let (payload, cache_policy) = response_callback(resp).await?;
+                Ok((SerdeCacheable { inner: payload }, cache_policy))
             })
             .await?;
         Ok(payload)
@@ -268,6 +292,24 @@ impl CachedClient {
         Payload: Cacheable,
         CallBackError: std::error::Error + 'static,
         Callback: AsyncFn(Response) -> Result<Payload, CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
+        self.get_cacheable_with_policy_override(req, cache_entry, cache_control, async |resp| {
+            let payload = response_callback(resp).await?;
+            Ok((payload, None))
+        })
+        .await
+    }
+
+    async fn get_cacheable_with_policy_override<
+        Payload: Cacheable,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
     >(
         &self,
         req: Request,
@@ -300,7 +342,7 @@ impl CachedClient {
                         "Broken fresh cache entry (for payload) at {}, removing: {err}",
                         cache_entry.path().display()
                     );
-                    self.resend_and_heal_cache(
+                    self.resend_and_heal_cache_with_policy_override(
                         fresh_req,
                         cache_entry,
                         cache_control.clone(),
@@ -326,7 +368,7 @@ impl CachedClient {
                                  (for payload) at {}, removing: {err}",
                                 cache_entry.path().display()
                             );
-                            self.resend_and_heal_cache(
+                            self.resend_and_heal_cache_with_policy_override(
                                 fresh_req,
                                 cache_entry,
                                 cache_control.clone(),
@@ -350,7 +392,7 @@ impl CachedClient {
                         "Server returned unusable 304 for: {}",
                         DisplaySafeUrl::from_url(fresh_req.url().clone())
                     );
-                    self.resend_and_heal_cache(
+                    self.resend_and_heal_cache_with_policy_override(
                         fresh_req,
                         cache_entry,
                         cache_control,
@@ -358,7 +400,7 @@ impl CachedClient {
                     )
                     .await
                 } else {
-                    self.run_response_callback(
+                    self.run_response_callback_with_policy_override(
                         cache_entry,
                         cache_policy,
                         start,
@@ -396,10 +438,10 @@ impl CachedClient {
         Ok(payload)
     }
 
-    async fn resend_and_heal_cache<
+    async fn resend_and_heal_cache_with_policy_override<
         Payload: Cacheable,
         CallBackError: std::error::Error + 'static,
-        Callback: AsyncFnOnce(Response) -> Result<Payload, CallBackError>,
+        Callback: AsyncFnOnce(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
     >(
         &self,
         req: Request,
@@ -410,7 +452,7 @@ impl CachedClient {
         let _ = fs_err::tokio::remove_file(&cache_entry.path()).await;
         let start = Instant::now();
         let (response, cache_policy) = self.fresh_request(req, cache_control).await?;
-        self.run_response_callback(
+        self.run_response_callback_with_policy_override(
             cache_entry,
             cache_policy,
             start,
@@ -432,6 +474,31 @@ impl CachedClient {
         response: Response,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
+        self.run_response_callback_with_policy_override(
+            cache_entry,
+            cache_policy,
+            start,
+            response,
+            async |response| {
+                let payload = response_callback(response).await?;
+                Ok((payload, None))
+            },
+        )
+        .await
+    }
+
+    async fn run_response_callback_with_policy_override<
+        Payload: Cacheable,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFnOnce(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
+    >(
+        &self,
+        cache_entry: &CacheEntry,
+        cache_policy: Option<Box<CachePolicy>>,
+        start: Instant,
+        response: Response,
+        response_callback: Callback,
+    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let new_cache = info_span!("new_cache", file = %cache_entry.path().display());
         // Capture retries from the retry middleware
         let retries = response
@@ -439,7 +506,7 @@ impl CachedClient {
             .get::<reqwest_retry::RetryCount>()
             .map(|retries| retries.value())
             .unwrap_or_default();
-        let data = response_callback(response)
+        let (data, cache_policy_override) = response_callback(response)
             .boxed_local()
             .await
             .map_err(|err| CachedClientError::Callback {
@@ -447,6 +514,7 @@ impl CachedClient {
                 err,
                 duration: start.elapsed(),
             })?;
+        let cache_policy = cache_policy_override.map(Box::new).or(cache_policy);
         let Some(cache_policy) = cache_policy else {
             return Ok(data.into_target());
         };
@@ -667,10 +735,43 @@ impl CachedClient {
         response_callback: Callback,
     ) -> Result<Payload, CachedClientError<CallBackError>> {
         let payload = self
-            .get_cacheable_with_retry(req, cache_entry, cache_control, async |resp| {
-                let payload = response_callback(resp).await?;
-                Ok(SerdeCacheable { inner: payload })
-            })
+            .get_cacheable_with_retry_and_policy_override(
+                req,
+                cache_entry,
+                cache_control,
+                async |resp| {
+                    let payload = response_callback(resp).await?;
+                    Ok((SerdeCacheable { inner: payload }, None))
+                },
+            )
+            .await?;
+        Ok(payload)
+    }
+
+    /// Perform a [`CachedClient::get_serde`] request with a default retry
+    /// strategy and an optional cache policy override.
+    #[instrument(skip_all)]
+    pub async fn get_serde_with_retry_and_cache_policy<
+        Payload: Serialize + DeserializeOwned + Send + 'static,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload, CachedClientError<CallBackError>> {
+        let payload = self
+            .get_cacheable_with_retry_and_policy_override(
+                req,
+                cache_entry,
+                cache_control,
+                async |resp| {
+                    let (payload, cache_policy) = response_callback(resp).await?;
+                    Ok((SerdeCacheable { inner: payload }, cache_policy))
+                },
+            )
             .await?;
         Ok(payload)
     }
@@ -690,11 +791,35 @@ impl CachedClient {
         cache_control: CacheControl,
         response_callback: Callback,
     ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
+        self.get_cacheable_with_retry_and_policy_override(
+            req,
+            cache_entry,
+            cache_control,
+            async |resp| {
+                let payload = response_callback(resp).await?;
+                Ok((payload, None))
+            },
+        )
+        .await
+    }
+
+    #[instrument(skip_all)]
+    pub async fn get_cacheable_with_retry_and_policy_override<
+        Payload: Cacheable,
+        CallBackError: std::error::Error + 'static,
+        Callback: AsyncFn(Response) -> Result<(Payload, Option<CachePolicy>), CallBackError>,
+    >(
+        &self,
+        req: Request,
+        cache_entry: &CacheEntry,
+        cache_control: CacheControl,
+        response_callback: Callback,
+    ) -> Result<Payload::Target, CachedClientError<CallBackError>> {
         let mut retry_state = RetryState::start(self.uncached().retry_policy(), req.url().clone());
         loop {
             let fresh_req = req.try_clone().expect("HTTP request must be cloneable");
             let result = self
-                .get_cacheable(
+                .get_cacheable_with_policy_override(
                     fresh_req,
                     cache_entry,
                     cache_control.clone(),

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -138,6 +138,7 @@ actually need to make an HTTP request).
 use std::time::{Duration, SystemTime};
 
 use http::header::HeaderValue;
+use http::{HeaderMap, StatusCode};
 
 use crate::rkyvutil::OwnedArchive;
 
@@ -222,6 +223,22 @@ impl CachePolicyBuilder {
             config: self.config,
             request: self.request,
             response: Response::from(response),
+            vary,
+        }
+    }
+
+    /// Return a new policy given explicit response parts.
+    ///
+    /// This is used for caches that store derived data rather than the origin
+    /// response body itself, where the originating response shape (for example
+    /// `206 Partial Content`) should not dictate whether the derived cache
+    /// entry is reusable.
+    pub(crate) fn build_with_parts(self, status: StatusCode, headers: &HeaderMap) -> CachePolicy {
+        let vary = Vary::from_request_response_headers(&self.request_headers, headers);
+        CachePolicy {
+            config: self.config,
+            request: self.request,
+            response: Response::from_parts(status, headers),
             vary,
         }
     }
@@ -1138,6 +1155,16 @@ impl<'a> From<&'a reqwest::Response> for Response {
         Self {
             status: from.status().as_u16(),
             headers: ResponseHeaders::from(from.headers()),
+            unix_timestamp: unix_timestamp(SystemTime::now()),
+        }
+    }
+}
+
+impl Response {
+    fn from_parts(status: StatusCode, headers: &HeaderMap) -> Self {
+        Self {
+            status: status.as_u16(),
+            headers: ResponseHeaders::from(headers),
             unix_timestamp: unix_timestamp(SystemTime::now()),
         }
     }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1206,18 +1206,20 @@ impl RegistryClient {
                             .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
 
                         let metadata_for_cache = metadata.clone();
-                        if let Err(err) = self
-                            .cached_client()
-                            .skip_cache_with_retry(
-                                req,
-                                &cache_entry,
-                                cache_control.clone(),
-                                move |_response| {
-                                    let metadata_for_cache = metadata_for_cache.clone();
-                                    async move { Ok::<ResolutionMetadata, Error>(metadata_for_cache) }
-                                },
-                            )
-                            .await
+                        if let Err(err) =
+                            self.cached_client()
+                                .skip_cache_with_retry(
+                                    req,
+                                    &cache_entry,
+                                    cache_control.clone(),
+                                    move |_response| {
+                                        let metadata_for_cache = metadata_for_cache.clone();
+                                        async move {
+                                            Ok::<ResolutionMetadata, Error>(metadata_for_cache)
+                                        }
+                                    },
+                                )
+                                .await
                         {
                             warn!(
                                 "Failed to cache wheel metadata for {filename} after a successful \

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -41,6 +41,7 @@ use crate::base_client::{BaseClientBuilder, ClientBuildError, ExtraMiddleware, R
 use crate::cached_client::CacheControl;
 use crate::flat_index::FlatIndexEntry;
 use crate::html::SimpleDetailHTML;
+use crate::httpcache::CachePolicyBuilder;
 use crate::remote_metadata::wheel_metadata_from_remote_zip;
 use crate::rkyvutil::OwnedArchive;
 use crate::{
@@ -1181,55 +1182,27 @@ impl RegistryClient {
                 .instrument(info_span!("read_metadata_range_request", wheel = %filename))
             };
 
+            let req_for_cache_policy = req
+                .try_clone()
+                .expect("wheel metadata request must be cloneable");
             let result = self
                 .cached_client()
-                .skip_cache_with_retry(
+                .get_serde_with_retry_and_cache_policy(
                     req,
                     &cache_entry,
                     cache_control.clone(),
-                    read_metadata_range_request,
+                    async move |response| -> Result<(_, Option<_>), Error> {
+                        let cache_policy = CachePolicyBuilder::new(&req_for_cache_policy)
+                            .build_with_parts(StatusCode::OK, response.headers());
+                        let metadata = read_metadata_range_request(response).await?;
+                        Ok((metadata, Some(cache_policy)))
+                    },
                 )
                 .await
                 .map_err(crate::Error::from);
 
             match result {
-                Ok(metadata) => {
-                    if matches!(self.connectivity, Connectivity::Online) {
-                        let req = self
-                            .uncached_client(url)
-                            .head(Url::from(url.clone()))
-                            .header(
-                                "accept-encoding",
-                                reqwest::header::HeaderValue::from_static("identity"),
-                            )
-                            .build()
-                            .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
-
-                        let metadata_for_cache = metadata.clone();
-                        if let Err(err) =
-                            self.cached_client()
-                                .skip_cache_with_retry(
-                                    req,
-                                    &cache_entry,
-                                    cache_control.clone(),
-                                    move |_response| {
-                                        let metadata_for_cache = metadata_for_cache.clone();
-                                        async move {
-                                            Ok::<ResolutionMetadata, Error>(metadata_for_cache)
-                                        }
-                                    },
-                                )
-                                .await
-                        {
-                            warn!(
-                                "Failed to cache wheel metadata for {filename} after a successful \
-                                 range probe: {err}"
-                            );
-                        }
-                    }
-
-                    return Ok(metadata);
-                }
+                Ok(metadata) => return Ok(metadata),
                 Err(err) => {
                     if err.is_http_range_requests_unsupported(url, index) {
                         // The range request version failed. Fall back to streaming the file to search

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1126,7 +1126,11 @@ impl RegistryClient {
         if index.is_none_or(|index| capabilities.supports_range_requests(index)) {
             let req = self
                 .uncached_client(url)
-                .head(Url::from(url.clone()))
+                .get(Url::from(url.clone()))
+                .header(
+                    reqwest::header::RANGE,
+                    reqwest::header::HeaderValue::from_static("bytes=0-0"),
+                )
                 .header(
                     "accept-encoding",
                     http::HeaderValue::from_static("identity"),
@@ -1134,7 +1138,7 @@ impl RegistryClient {
                 .build()
                 .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
 
-            // Copy authorization headers from the HEAD request to subsequent requests
+            // Copy authorization headers from the initial range probe to subsequent requests.
             let mut headers = HeaderMap::default();
             if let Some(authorization) = req.headers().get("authorization") {
                 headers.append("authorization", authorization.clone());
@@ -1155,7 +1159,7 @@ impl RegistryClient {
             // fetch the file from the remote zip.
             let read_metadata_range_request = |response: Response| {
                 async {
-                    let mut reader = AsyncHttpRangeReader::from_head_response(
+                    let mut reader = AsyncHttpRangeReader::from_range_response(
                         self.uncached_client(url).clone(),
                         response,
                         Url::from(url.clone()),

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1183,7 +1183,7 @@ impl RegistryClient {
 
             let result = self
                 .cached_client()
-                .get_serde_with_retry(
+                .skip_cache_with_retry(
                     req,
                     &cache_entry,
                     cache_control.clone(),
@@ -1193,7 +1193,41 @@ impl RegistryClient {
                 .map_err(crate::Error::from);
 
             match result {
-                Ok(metadata) => return Ok(metadata),
+                Ok(metadata) => {
+                    if matches!(self.connectivity, Connectivity::Online) {
+                        let req = self
+                            .uncached_client(url)
+                            .head(Url::from(url.clone()))
+                            .header(
+                                "accept-encoding",
+                                reqwest::header::HeaderValue::from_static("identity"),
+                            )
+                            .build()
+                            .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
+
+                        let metadata_for_cache = metadata.clone();
+                        if let Err(err) = self
+                            .cached_client()
+                            .skip_cache_with_retry(
+                                req,
+                                &cache_entry,
+                                cache_control.clone(),
+                                move |_response| {
+                                    let metadata_for_cache = metadata_for_cache.clone();
+                                    async move { Ok::<ResolutionMetadata, Error>(metadata_for_cache) }
+                                },
+                            )
+                            .await
+                        {
+                            warn!(
+                                "Failed to cache wheel metadata for {filename} after a successful \
+                                 range probe: {err}"
+                            );
+                        }
+                    }
+
+                    return Ok(metadata);
+                }
                 Err(err) => {
                     if err.is_http_range_requests_unsupported(url, index) {
                         // The range request version failed. Fall back to streaming the file to search

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -24,6 +24,7 @@ use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
     IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, IndexUrls, Name,
 };
+use uv_fs::write_atomic;
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
@@ -1185,17 +1186,28 @@ impl RegistryClient {
             let req_for_cache_policy = req
                 .try_clone()
                 .expect("wheel metadata request must be cloneable");
+            let cache_entry_for_write = cache_entry.clone();
             let result = self
                 .cached_client()
-                .get_serde_with_retry_and_cache_policy(
+                .get_serde_with_retry(
                     req,
                     &cache_entry,
                     cache_control.clone(),
-                    async move |response| -> Result<(_, Option<_>), Error> {
+                    async move |response| -> Result<ResolutionMetadata, Error> {
                         let cache_policy = CachePolicyBuilder::new(&req_for_cache_policy)
                             .build_with_parts(StatusCode::OK, response.headers());
                         let metadata = read_metadata_range_request(response).await?;
-                        Ok((metadata, Some(cache_policy)))
+                        let metadata_bytes =
+                            rmp_serde::to_vec(&metadata).map_err(ErrorKind::Encode)?;
+                        fs_err::tokio::create_dir_all(cache_entry_for_write.dir())
+                            .await
+                            .map_err(ErrorKind::CacheWrite)?;
+                        let cache_bytes =
+                            crate::DataWithCachePolicy::serialize(&cache_policy, &metadata_bytes)?;
+                        write_atomic(cache_entry_for_write.path(), cache_bytes)
+                            .await
+                            .map_err(ErrorKind::CacheWrite)?;
+                        Ok(metadata)
                     },
                 )
                 .await

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -6,7 +6,7 @@ use assert_fs::fixture::{ChildPath, FileWriteStr, PathChild};
 use bytes::Bytes;
 use http::StatusCode;
 use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, StreamBody};
+use http_body_util::{BodyExt, Full, StreamBody};
 use hyper::body::Frame;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
@@ -123,6 +123,80 @@ fn connection_reset(_request: &wiremock::Request) -> io::Error {
     io::Error::new(io::ErrorKind::ConnectionReset, "Connection reset by peer")
 }
 
+async fn range_probe_response(
+    req: hyper::Request<hyper::body::Incoming>,
+    wheel: Bytes,
+) -> Result<hyper::Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    const WHEEL_PATH: &str = "/packages/validation-1.0.0-py3-none-any.whl";
+
+    if req.uri().path() != WHEEL_PATH {
+        return Ok(hyper::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Full::new(Bytes::new()).boxed())
+            .unwrap());
+    }
+
+    let len = wheel.len() as u64;
+
+    if req.method() == hyper::Method::HEAD {
+        return Ok(hyper::Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Length", len)
+            .header("Content-Type", "application/octet-stream")
+            .body(Full::new(Bytes::new()).boxed())
+            .unwrap());
+    }
+
+    if req.method() != hyper::Method::GET {
+        return Ok(hyper::Response::builder()
+            .status(StatusCode::METHOD_NOT_ALLOWED)
+            .body(Full::new(Bytes::new()).boxed())
+            .unwrap());
+    }
+
+    let range = req
+        .headers()
+        .get(hyper::header::RANGE)
+        .and_then(|value| value.to_str().ok());
+
+    let Some(range) = range.and_then(|value| value.strip_prefix("bytes=")) else {
+        return Ok(hyper::Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Length", len)
+            .header("Content-Type", "application/octet-stream")
+            .body(Full::new(wheel).boxed())
+            .unwrap());
+    };
+
+    let (start, end) = if let Some(suffix) = range.strip_prefix('-') {
+        let suffix: u64 = suffix.parse().unwrap();
+        let start = len.saturating_sub(suffix.min(len));
+        (start, len.saturating_sub(1))
+    } else {
+        let (start, end) = range.split_once('-').unwrap();
+        let start: u64 = start.parse().unwrap();
+        let end = if end.is_empty() {
+            len.saturating_sub(1)
+        } else {
+            end.parse().unwrap()
+        };
+        (start, end.min(len.saturating_sub(1)))
+    };
+
+    let start = start.min(len.saturating_sub(1));
+    let end = end.max(start).min(len.saturating_sub(1));
+    let body = wheel.slice(start as usize..=end as usize);
+
+    Ok(hyper::Response::builder()
+        .status(StatusCode::PARTIAL_CONTENT)
+        .header("Accept-Ranges", "bytes")
+        .header("Content-Type", "application/octet-stream")
+        .header("Content-Length", body.len())
+        .header("Content-Range", format!("bytes {start}-{end}/{len}"))
+        .body(Full::new(body).boxed())
+        .unwrap())
+}
+
 /// Returns true if the mock server has received any requests.
 async fn has_received_requests(server: &MockServer) -> bool {
     !server.received_requests().await.unwrap().is_empty()
@@ -221,6 +295,51 @@ fn read_timeout_server() -> (String, impl Drop) {
                                 hyper_util::rt::TokioExecutor::new(),
                             )
                             .serve_connection(io, service_fn(time_out_response))
+                            .await;
+                        });
+                    }
+                } => {}
+                _ = shutdown_rx => {}
+            }
+        });
+    });
+
+    (server, shutdown_tx)
+}
+
+fn wheel_range_probe_server() -> (String, impl Drop) {
+    const WHEEL: &[u8] =
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../test/links/validation-1.0.0-py3-none-any.whl"
+        ));
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let server = format!("http://{}", listener.local_addr().unwrap());
+    let wheel = Bytes::from_static(WHEEL);
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async move {
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            tokio::select! {
+                _ = async {
+                    loop {
+                        let (stream, _) = listener.accept().await.unwrap();
+                        let io = TokioIo::new(stream);
+                        let wheel = wheel.clone();
+
+                        tokio::spawn(async move {
+                           let _ = hyper_util::server::conn::auto::Builder::new(
+                                hyper_util::rt::TokioExecutor::new(),
+                            )
+                            .serve_connection(io, service_fn(move |req| range_probe_response(req, wheel.clone())))
                             .await;
                         });
                     }
@@ -686,6 +805,27 @@ async fn rfc9457_problem_details_license_violation() {
       ├─▶ Failed to fetch: `http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl`
       ├─▶ Server message: License Compliance Issue, This package version has a license that violates organizational policy.
       ╰─▶ HTTP status client error (403 Forbidden) for url (http://[LOCALHOST]/packages/tqdm-4.67.1-py3-none-any.whl)
+    ");
+}
+
+#[tokio::test]
+async fn direct_wheel_metadata_uses_get_probe_when_head_is_inconclusive() {
+    let context = uv_test::test_context!("3.12");
+    let (_server_drop_guard, server) = wheel_range_probe_server();
+    let wheel_url = format!("{server}/packages/validation-1.0.0-py3-none-any.whl");
+
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg(format!("validation @ {wheel_url}")), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + validation==1.0.0 (from http://[LOCALHOST]/packages/validation-1.0.0-py3-none-any.whl)
     ");
 }
 

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -811,7 +811,7 @@ async fn rfc9457_problem_details_license_violation() {
 #[tokio::test]
 async fn direct_wheel_metadata_uses_get_probe_when_head_is_inconclusive() {
     let context = uv_test::test_context!("3.12");
-    let (_server_drop_guard, server) = wheel_range_probe_server();
+    let (server, _server_drop_guard) = wheel_range_probe_server();
     let wheel_url = format!("{server}/packages/validation-1.0.0-py3-none-any.whl");
 
     uv_snapshot!(context.filters(), context

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -308,11 +308,10 @@ fn read_timeout_server() -> (String, impl Drop) {
 }
 
 fn wheel_range_probe_server() -> (String, impl Drop) {
-    const WHEEL: &[u8] =
-        include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../test/links/validation-1.0.0-py3-none-any.whl"
-        ));
+    const WHEEL: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../test/links/validation-1.0.0-py3-none-any.whl"
+    ));
 
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::future;
 use std::io;
 use std::time::{Duration, Instant};
 
@@ -123,7 +124,7 @@ fn connection_reset(_request: &wiremock::Request) -> io::Error {
     io::Error::new(io::ErrorKind::ConnectionReset, "Connection reset by peer")
 }
 
-async fn range_probe_response(
+fn range_probe_response(
     req: hyper::Request<hyper::body::Incoming>,
     wheel: Bytes,
 ) -> Result<hyper::Response<BoxBody<Bytes, Infallible>>, Infallible> {
@@ -185,7 +186,9 @@ async fn range_probe_response(
 
     let start = start.min(len.saturating_sub(1));
     let end = end.max(start).min(len.saturating_sub(1));
-    let body = wheel.slice(start as usize..=end as usize);
+    let start = usize::try_from(start).unwrap();
+    let end = usize::try_from(end).unwrap();
+    let body = wheel.slice(start..=end);
 
     Ok(hyper::Response::builder()
         .status(StatusCode::PARTIAL_CONTENT)
@@ -338,7 +341,12 @@ fn wheel_range_probe_server() -> (String, impl Drop) {
                            let _ = hyper_util::server::conn::auto::Builder::new(
                                 hyper_util::rt::TokioExecutor::new(),
                             )
-                            .serve_connection(io, service_fn(move |req| range_probe_response(req, wheel.clone())))
+                            .serve_connection(
+                                io,
+                                service_fn(move |req| {
+                                    future::ready(range_probe_response(req, wheel.clone()))
+                                }),
+                            )
                             .await;
                         });
                     }

--- a/crates/uv/tests/it/network.rs
+++ b/crates/uv/tests/it/network.rs
@@ -127,46 +127,47 @@ fn connection_reset(_request: &wiremock::Request) -> io::Error {
 fn range_probe_response(
     req: hyper::Request<hyper::body::Incoming>,
     wheel: Bytes,
-) -> Result<hyper::Response<BoxBody<Bytes, Infallible>>, Infallible> {
+) -> hyper::Response<BoxBody<Bytes, Infallible>> {
     const WHEEL_PATH: &str = "/packages/validation-1.0.0-py3-none-any.whl";
+    let (parts, _body) = req.into_parts();
 
-    if req.uri().path() != WHEEL_PATH {
-        return Ok(hyper::Response::builder()
+    if parts.uri.path() != WHEEL_PATH {
+        return hyper::Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(Full::new(Bytes::new()).boxed())
-            .unwrap());
+            .unwrap();
     }
 
     let len = wheel.len() as u64;
 
-    if req.method() == hyper::Method::HEAD {
-        return Ok(hyper::Response::builder()
+    if parts.method == hyper::Method::HEAD {
+        return hyper::Response::builder()
             .status(StatusCode::OK)
             .header("Content-Length", len)
             .header("Content-Type", "application/octet-stream")
             .body(Full::new(Bytes::new()).boxed())
-            .unwrap());
+            .unwrap();
     }
 
-    if req.method() != hyper::Method::GET {
-        return Ok(hyper::Response::builder()
+    if parts.method != hyper::Method::GET {
+        return hyper::Response::builder()
             .status(StatusCode::METHOD_NOT_ALLOWED)
             .body(Full::new(Bytes::new()).boxed())
-            .unwrap());
+            .unwrap();
     }
 
-    let range = req
-        .headers()
+    let range = parts
+        .headers
         .get(hyper::header::RANGE)
         .and_then(|value| value.to_str().ok());
 
     let Some(range) = range.and_then(|value| value.strip_prefix("bytes=")) else {
-        return Ok(hyper::Response::builder()
+        return hyper::Response::builder()
             .status(StatusCode::OK)
             .header("Content-Length", len)
             .header("Content-Type", "application/octet-stream")
             .body(Full::new(wheel).boxed())
-            .unwrap());
+            .unwrap();
     };
 
     let (start, end) = if let Some(suffix) = range.strip_prefix('-') {
@@ -190,14 +191,14 @@ fn range_probe_response(
     let end = usize::try_from(end).unwrap();
     let body = wheel.slice(start..=end);
 
-    Ok(hyper::Response::builder()
+    hyper::Response::builder()
         .status(StatusCode::PARTIAL_CONTENT)
         .header("Accept-Ranges", "bytes")
         .header("Content-Type", "application/octet-stream")
         .header("Content-Length", body.len())
         .header("Content-Range", format!("bytes {start}-{end}/{len}"))
         .body(Full::new(body).boxed())
-        .unwrap())
+        .unwrap()
 }
 
 /// Returns true if the mock server has received any requests.
@@ -344,7 +345,10 @@ fn wheel_range_probe_server() -> (String, impl Drop) {
                             .serve_connection(
                                 io,
                                 service_fn(move |req| {
-                                    future::ready(range_probe_response(req, wheel.clone()))
+                                    future::ready(Ok::<_, Infallible>(range_probe_response(
+                                        req,
+                                        wheel.clone(),
+                                    )))
                                 }),
                             )
                             .await;


### PR DESCRIPTION
## Summary
This changes the wheel metadata fallback path to probe range support with a tiny `GET Range: bytes=0-0` request instead of relying on a `HEAD` preflight.

The motivating case is a private Python index flow discussed in #18998, where the canonical wheel URL redirects to a download endpoint that serves ranged `GET`s correctly, but the `HEAD` response on the canonical URL does not expose a usable range capability signal. In that situation, `uv` currently logs `Range requests not supported ...; streaming wheel` and falls back to downloading the full wheel even though byte-range reads actually work.

This PR keeps the existing range-based metadata extraction path, but changes the capability probe so it exercises the HTTP method that range semantics are actually defined for. It also keeps the existing offline direct-URL behavior by persisting the parsed wheel metadata cache entry directly in the wheel-metadata path, instead of widening `CachedClient` with a new generic cache-policy override API.

## Why this change
- RFC 9110 defines range handling for `GET`, not `HEAD`.
- `Accept-Ranges` is advisory, not a hard prerequisite for sending a ranged request.
- Some registries and download flows are compatible with ranged `GET` while being a poor or misleading source of truth for range capability on `HEAD`.
- The wheel metadata cache stores derived metadata, not the raw `206` response body, so it is cleaner to normalize and persist that cache entry in the caller that derives it.

Using `GET Range: bytes=0-0` avoids those false negatives while adding only a one-byte response body.

## Changes
- replace the wheel metadata range preflight with `GET Range: bytes=0-0`
- initialize the async range reader from the ranged response instead of a `HEAD` response
- normalize and persist the derived wheel metadata cache entry in `RegistryClient` so offline direct URL resolution continues to work
- add a regression test for a server that omits `Accept-Ranges` on `HEAD` but serves ranged `GET`s correctly

## Related
- Closes #18998
