### PR TITLE
docs: clarify auth logout username requirement

### DIFF
--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -39,8 +39,11 @@ will not yet be used for Git requests.
 To remove credentials, use the `uv auth logout` command:
 
 ```console
-$ uv auth logout example.com
+$ uv auth logout example.com --username foo
 ```
+
+If the credentials were stored with a username, you should provide that same username when logging
+out. For token-based credentials, you can omit `--username`.
 
 !!! note
 


### PR DESCRIPTION
Fixes confusion reported in #18973.\n\nThe previous docs example showed `uv auth logout example.com`, but for username-based credentials the current behavior requires providing the same `--username` that was used at login.\n\nThis PR updates the example and adds a short clarification distinguishing username-based and token-based credentials.