### PR TITLE
feat(cli): read `--python-platform` from `UV_PYTHON_PLATFORM`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1676,7 +1676,7 @@ pub struct PipCompileArgs {
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Perform a universal resolution, attempting to generate a single `requirements.txt` output
@@ -2044,7 +2044,7 @@ pub struct PipSyncArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Validate the Python environment after completing the installation, to detect packages with
@@ -2414,7 +2414,7 @@ pub struct PipInstallArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Do not remove extraneous packages present in the environment.
@@ -2764,7 +2764,7 @@ pub struct PipCheckArgs {
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 }
 
@@ -3807,7 +3807,7 @@ pub struct RunArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 }
 
@@ -4132,7 +4132,7 @@ pub struct SyncArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Check if the Python environment is synchronized with the project.
@@ -4774,7 +4774,7 @@ pub struct TreeArgs {
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
-    #[arg(long, conflicts_with = "universal")]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM, conflicts_with = "universal")]
     pub python_platform: Option<TargetTriple>,
 
     /// The Python interpreter to use for locking and filtering.
@@ -5231,7 +5231,7 @@ pub struct AuditArgs {
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Ignore a vulnerability by ID.
@@ -5561,7 +5561,7 @@ pub struct ToolRunArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`, or `auto`)
@@ -5754,7 +5754,7 @@ pub struct ToolInstallArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`, or `auto`)
@@ -5900,7 +5900,7 @@ pub struct ToolUpgradeArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     // The following is equivalent to flattening `ResolverInstallerArgs`, with the `--upgrade`,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -200,6 +200,12 @@ impl EnvVars {
     #[attr_added_in("0.3.2")]
     pub const UV_PYTHON_PREFERENCE: &'static str = "UV_PYTHON_PREFERENCE";
 
+    /// Equivalent to the `--python-platform` argument. Select the target platform used
+    /// when resolving and installing distributions, e.g. `x86_64-unknown-linux-gnu` or
+    /// `aarch64-apple-darwin`.
+    #[attr_added_in("0.12.0")]
+    pub const UV_PYTHON_PLATFORM: &'static str = "UV_PYTHON_PLATFORM";
+
     /// Require use of uv-managed Python versions.
     #[attr_added_in("0.6.8")]
     pub const UV_MANAGED_PYTHON: &'static str = "UV_MANAGED_PYTHON";


### PR DESCRIPTION
## Summary

Adds `UV_PYTHON_PLATFORM` as the environment-variable counterpart of `--python-platform`, wired through clap's `env =` attribute on every command that already accepts the flag.

```rust
#[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
pub python_platform: Option<TargetTriple>,
```

Applied to: `pip compile`, `pip sync`, `pip install`, `pip check`, `run`, `sync`, `tree`, `audit`, `tool run`, `tool install`, `tool upgrade` (every `python_platform: Option<TargetTriple>` site in `uv-cli/src/lib.rs`).

The new constant is registered in `uv-static::EnvVars` so it's picked up by the auto-generated environment-variable reference.

## Why

From the issue: the reporter drives `uv sync` from Pulumi on x86_64 but deploys to aarch64 Lambda, and Pulumi doesn't let them pass CLI flags through. Other platform-related CLI options already have env-var equivalents (`UV_PYTHON`, `UV_PYTHON_PREFERENCE`, `UV_TORCH_BACKEND`, etc.) — this slots `--python-platform` into the same pattern.

Extending to every command that accepts `--python-platform` (not just `sync`) keeps the surface uniform — it would be confusing if `UV_PYTHON_PLATFORM` worked for `uv sync` but not `uv pip install`. Happy to narrow the scope if maintainers prefer.

## Behavior

Clap's `env` attribute preserves the usual precedence: an explicit `--python-platform` on the command line still wins over the env var. Users who don't set `UV_PYTHON_PLATFORM` see no change.

## Test plan

- [x] `cargo check` (workspace) — clean
- [x] `cargo test -p uv-cli` — 11 passed
- [x] `cargo test -p uv-static` — clean
- [x] `cargo dev generate-env-vars-reference` — `docs/reference/environment.md` now contains a `### UV_PYTHON_PLATFORM` entry and subsequent runs report `Up-to-date`

Closes #15241