### PR TITLE
Fix Python variant tagging in the Windows registry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,7 @@ jobs:
           cargo nextest run \
             --cargo-profile fast-build \
             --no-default-features \
-            --features test-python,test-pypi,test-python-managed,native-auth,windows-native \
+            --features test-python,test-pypi,test-python-managed,test-windows-registry,native-auth,windows-native \
             --workspace \
             --profile ci-windows \
             --partition hash:${{ matrix.partition }}/3

--- a/crates/uv-python/src/windows_registry.rs
+++ b/crates/uv-python/src/windows_registry.rs
@@ -200,7 +200,18 @@ fn write_registry_entry(
 }
 
 fn registry_python_tag(key: &PythonInstallationKey) -> String {
-    format!("{}{}", key.implementation().pretty(), key.version())
+    // Include the variant's executable suffix (e.g., "t" for freethreaded) in the
+    // registry tag so that GIL and freethreaded installations of the same version
+    // get distinct registry entries. This suffix can be empty.
+    //
+    // See: https://github.com/astral-sh/uv/issues/18795
+    let variant_suffix = key.variant().executable_suffix();
+    format!(
+        "{}{}{}",
+        key.implementation().pretty(),
+        key.version(),
+        variant_suffix,
+    )
 }
 
 /// Remove requested Python entries from the Windows Registry (PEP 514).

--- a/crates/uv-python/src/windows_registry.rs
+++ b/crates/uv-python/src/windows_registry.rs
@@ -201,7 +201,7 @@ fn write_registry_entry(
 
 fn registry_python_tag(key: &PythonInstallationKey) -> String {
     // Include the variant's executable suffix (e.g., "t" for freethreaded) in the
-    // registry tag so that GIL and freethreaded installations of the same version
+    // registry tag so that variant (freethreaded, debug, etc.) installations of the same version
     // get distinct registry entries. This suffix can be empty.
     //
     // See: https://github.com/astral-sh/uv/issues/18795

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -184,8 +184,7 @@ test-defaults = [
   "test-python-managed",
   "test-python-eol",
   "test-slow",
-  "test-ecosystem",
-  "test-windows-registry"
+  "test-ecosystem"
 ]
 # Introduces a testing dependency on crates.io.
 test-crates-io = []
@@ -211,6 +210,7 @@ test-slow = []
 test-ecosystem = []
 # Includes test cases that write to the Windows registry. These tests mutate
 # global state (the Windows registry).
+# We don't run these tests by default locally; the CI for Windows enables them.
 test-windows-registry = []
 # Build uvw binary on Windows
 windows-gui-bin = []

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -184,7 +184,8 @@ test-defaults = [
   "test-python-managed",
   "test-python-eol",
   "test-slow",
-  "test-ecosystem"
+  "test-ecosystem",
+  "test-windows-registry"
 ]
 # Introduces a testing dependency on crates.io.
 test-crates-io = []
@@ -208,6 +209,9 @@ test-python-managed = []
 test-slow = []
 # Includes test cases that require ecosystem packages
 test-ecosystem = []
+# Includes test cases that write to the Windows registry. These tests mutate
+# global state (the Windows registry).
+test-windows-registry = []
 # Build uvw binary on Windows
 windows-gui-bin = []
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1226,6 +1226,94 @@ fn python_install_freethreaded() {
     ");
 }
 
+/// Test that installing both GIL and free-threaded variants of the same Python version
+/// doesn't cause managed installation entries to disappear from `uv python list`
+/// on Windows when registry discovery is enabled.
+///
+/// Regression test for <https://github.com/astral-sh/uv/issues/18795>.
+///
+/// IMPORTANT: this test writes to the shared `HKCU` registry. The trailing uninstall is
+/// best-effort cleanup; panics will leak entries. This is fine for now since this is the only
+/// test exercising the registry pathway, but adding more will probably require isolation.
+#[cfg(windows)]
+#[test]
+fn python_install_freethreaded_and_gil_list() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_python_download_cache()
+        .with_filtered_python_install_bin()
+        .with_filtered_python_names()
+        .with_filtered_exe_suffix()
+        .with_collapsed_whitespace();
+
+    // Install both the GIL and free-threaded versions, with registry enabled
+    context
+        .python_install()
+        .arg("3.13")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+    context
+        .python_install()
+        .arg("--preview")
+        .arg("3.13t")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+
+    // List installed versions with registry discovery enabled.
+    // We remove UV_TEST_PYTHON_PATH to enable registry discovery (it's skipped when set),
+    // and use `--managed-python --only-installed` to exclude unrelated system Pythons.
+    //
+    // Both the GIL and freethreaded variants should show entries from:
+    // - The registry (patch-versioned managed directory path)
+    // - The search path (bin trampoline)
+    // - Managed discovery (minor-version junction path)
+    uv_snapshot!(context.filters(), context.python_list()
+        .arg("3.13")
+        .arg("--only-installed")
+        .arg("--managed-python")
+        .env_remove(EnvVars::UV_TEST_PYTHON_PATH)
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.13.[LATEST]-[PLATFORM] managed/cpython-3.13.[LATEST]-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]-[PLATFORM] [BIN]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]-[PLATFORM] managed/cpython-3.13-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context.python_list()
+        .arg("3.13t")
+        .arg("--only-installed")
+        .arg("--managed-python")
+        .env_remove(EnvVars::UV_TEST_PYTHON_PATH)
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] managed/cpython-3.13.[LATEST]+freethreaded-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] [BIN]/python3.13t
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] managed/cpython-3.13+freethreaded-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+
+    ----- stderr -----
+    ");
+
+    // Clean up registry entries
+    context
+        .python_uninstall()
+        .arg("--all")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+}
+
 #[test]
 fn python_upgrade_not_allowed() {
     let context = uv_test::test_context_with_versions!(&[])

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1235,7 +1235,7 @@ fn python_install_freethreaded() {
 /// IMPORTANT: this test writes to the shared `HKCU` registry. The trailing uninstall is
 /// best-effort cleanup; panics will leak entries. This is fine for now since this is the only
 /// test exercising the registry pathway, but adding more will probably require isolation.
-#[cfg(windows)]
+#[cfg(all(windows, feature = "test-windows-registry"))]
 #[test]
 fn python_install_freethreaded_and_gil_list() {
     use assert_cmd::assert::OutputAssertExt;


### PR DESCRIPTION
## Summary

This adds a regression test and fix for #18795. I ran the test and confirmed reproduction before implementing the fix.

The underlying bug here happens only on Windows, and only when exercising the PEP 514 Python installation registration pathway (which the integration tests disable by default, since it involves global mutable state that leaks between tests). The bug itself is just an imprecision in how we compute the "tag" for the Python entry -- we weren't including the variant (the `t` in `3.14t`), so two distinct installs (`3.14` and `3.14t`) would end up with the same registry tag. For an end user, this surfaces as  Python installation entries missing when running `uv python list`.

One thing to note about the test here is that it _does_ exercise the Windows registry pathway, which means that it intentionally bypasses the guardrail around global mutations in the integration tests. This is "fine" in the sense that there are on other tests observing that state at the moment, but I think it's a risk in terms of isolation (in the sense that devs who run our integration tests will actually observe global changes to their Python installations, plus any failure in the test means we won't clean up our global changes). Two options there:

- I could try and harden/isolate the registry mutation pathways a bit more, e.g. we could add `UV_DEV_WINDOWS_REGISTRY_COMPANY_KEY` or something like that to do some more test-level isolation of HKCU writes. This still modifies global state, but at least it'll be more namespaced.
- I could remove the integration test entirely, now that we've confirmed that the fix itself works. This leaves us without coverage, but given that the fix itself is ~2 lines that might be acceptable.

Fixes #18795.

## Test Plan

This PR includes a regression test.