### PR TITLE
docs: clarify that `uv run python` launches a REPL

### DIFF
--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -22,6 +22,24 @@ $ # Running a `bash` script that requires the project to be available
 $ uv run bash scripts/foo.sh
 ```
 
+## Running the Python interpreter
+
+To start an interactive Python REPL with access to the project's packages, use:
+
+```console
+$ uv run python
+```
+
+This launches the standard Python interpreter in the project environment, which is useful for
+interactively exploring project dependencies and testing code. Any packages defined in the project
+are available to import in the REPL.
+
+You can also use alternative interactive shells, such as `ipython`:
+
+```console
+$ uv run --with ipython ipython
+```
+
 ## Requesting additional dependencies
 
 Additional dependencies or different versions of dependencies can be requested per invocation.

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -33,6 +33,12 @@ Hello world
 
 <!-- TODO(zanieb): Once we have a `python` shim, note you can execute it with `python` here -->
 
+If you need an interactive session, `uv run python` will start a Python REPL:
+
+```console
+$ uv run python
+```
+
 Similarly, if your script depends on a module in the standard library, there's nothing more to do:
 
 ```python title="example.py"


### PR DESCRIPTION
## Summary

- Add a dedicated "Running the Python interpreter" section to `docs/concepts/projects/run.md` explaining that `uv run python` starts an interactive REPL with access to project packages, including an `ipython` example via `--with`
- Add a brief mention in `docs/guides/scripts.md` for discoverability

This places the REPL documentation in its own section rather than interrupting the existing explanation flow, addressing the feedback from prior attempts (#16649, #18475).

Closes #6548

## Test plan

- [x] Verify the docs build correctly with `mkdocs serve` or equivalent
- [x] Confirm the new section renders properly and links are intact
- [x] Review that the placement does not interrupt the existing document flow