### PR TITLE
Only show the version number in `uv self version --short`

### DIFF
--- a/crates/uv-cli/src/version.rs
+++ b/crates/uv-cli/src/version.rs
@@ -56,6 +56,13 @@ impl ProjectVersionInfo {
     }
 }
 
+impl SelfVersionInfo {
+    /// Returns just the version string (e.g., "0.5.1"), without commit info or target triple.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
 impl fmt::Display for SelfVersionInfo {
     /// Formatted version information: "<version>[+<commits>] ([<commit> <date> ]<target>)"
     ///

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -50,7 +50,7 @@ pub(crate) fn self_version(
     match output_format {
         VersionFormat::Text => {
             if short {
-                writeln!(printer.stdout(), "{}", version_info.cyan())?;
+                writeln!(printer.stdout(), "{}", version_info.version().cyan())?;
             } else {
                 writeln!(printer.stdout(), "uv {}", version_info.cyan())?;
             }

--- a/crates/uv/tests/it/version.rs
+++ b/crates/uv/tests/it/version.rs
@@ -2289,17 +2289,14 @@ fn self_version_short() -> Result<()> {
     let filters = context
         .filters()
         .into_iter()
-        .chain([(
-            r"\d+\.\d+\.\d+(-alpha\.\d+)?(\+\d+)?( \(.*\))?",
-            r"[VERSION] ([COMMIT] DATE)",
-        )])
+        .chain([(r"\d+\.\d+\.\d+(-alpha\.\d+)?(\+\d+)?", r"[VERSION]")])
         .collect::<Vec<_>>();
     uv_snapshot!(filters, context.self_version()
         .arg("--short"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    [VERSION] ([COMMIT] DATE)
+    [VERSION]
 
     ----- stderr -----
     ");


### PR DESCRIPTION
Simplify the `--short` output format for `uv self version` to display only the version string (e.g., "0.5.1") without commit info or target triple.

See https://github.com/astral-sh/uv/pull/18520#issuecomment-4237301352