### PR TITLE
Allow `exclude-newer` to be missing from the lockfile when `exclude-newer-span` is present

### DIFF
--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -127,18 +127,9 @@ impl ExcludeNewerValue {
     /// Returns `self` unchanged if there is no span (i.e., the timestamp is absolute).
     #[must_use]
     pub fn recompute(self) -> Self {
-        let Self::Relative { span, timestamp } = self else {
-            return self;
-        };
-
-        let now = current_time();
-        let Ok(cutoff) = now.checked_sub(span.0.abs()) else {
-            return Self::Relative { timestamp, span };
-        };
-
-        Self::Relative {
-            timestamp: cutoff.into(),
-            span,
+        match self {
+            Self::Absolute(_) => self,
+            Self::Relative { span, .. } => Self::from_span(span),
         }
     }
 }

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -60,46 +60,66 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerSpan {
     }
 }
 
+/// An exclude-newer cutoff value: either an absolute timestamp or a relative span with a
+/// computed timestamp.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ExcludeNewerValue {
-    timestamp: Option<Timestamp>,
-    span: Option<ExcludeNewerSpan>,
+pub enum ExcludeNewerValue {
+    /// An absolute timestamp (no relative span).
+    Absolute(Timestamp),
+    /// A relative span with a computed timestamp.
+    Relative {
+        timestamp: Timestamp,
+        span: ExcludeNewerSpan,
+    },
 }
 
 impl ExcludeNewerValue {
-    pub fn into_parts(self) -> (Option<Timestamp>, Option<ExcludeNewerSpan>) {
-        (self.timestamp, self.span)
+    /// Split into the stored timestamp and optional span for wire serialization.
+    pub fn into_parts(self) -> (Timestamp, Option<ExcludeNewerSpan>) {
+        match self {
+            Self::Absolute(timestamp) => (timestamp, None),
+            Self::Relative { timestamp, span } => (timestamp, Some(span)),
+        }
     }
 
     /// Return the [`Timestamp`] in milliseconds.
-    pub fn timestamp_millis(&self) -> Option<i64> {
-        self.timestamp.map(Timestamp::as_millisecond)
+    pub fn timestamp_millis(&self) -> i64 {
+        self.timestamp().as_millisecond()
     }
 
     /// Return the [`Timestamp`].
-    pub fn timestamp(&self) -> Option<Timestamp> {
-        self.timestamp
+    pub fn timestamp(&self) -> Timestamp {
+        match self {
+            Self::Absolute(timestamp) | Self::Relative { timestamp, .. } => *timestamp,
+        }
     }
 
     /// Return the [`ExcludeNewerSpan`] used to construct the [`Timestamp`], if any.
     pub fn span(&self) -> Option<&ExcludeNewerSpan> {
-        self.span.as_ref()
-    }
-
-    /// Create a new [`ExcludeNewerValue`].
-    pub fn new(timestamp: Option<Timestamp>, span: Option<ExcludeNewerSpan>) -> Self {
-        Self { timestamp, span }
-    }
-
-    /// Create a new [`ExcludeNewerValue`] with only a span and no timestamp.
-    ///
-    /// This represents a lockfile entry where the timestamp was stripped but the span was
-    /// preserved.
-    pub fn span_only(span: ExcludeNewerSpan) -> Self {
-        Self {
-            timestamp: None,
-            span: Some(span),
+        match self {
+            Self::Absolute(_) => None,
+            Self::Relative { span, .. } => Some(span),
         }
+    }
+
+    /// Create a new [`ExcludeNewerValue`] from a timestamp and optional span.
+    pub fn new(timestamp: Timestamp, span: Option<ExcludeNewerSpan>) -> Self {
+        match span {
+            Some(span) => Self::Relative { timestamp, span },
+            None => Self::Absolute(timestamp),
+        }
+    }
+
+    /// Create a new [`ExcludeNewerValue`] from a span, computing the timestamp relative to
+    /// the current time.
+    ///
+    /// This is used when a lockfile has a span but the timestamp was stripped.
+    pub fn from_span(span: ExcludeNewerSpan) -> Self {
+        let now = current_time();
+        let timestamp = now
+            .checked_sub(span.0.abs())
+            .map_or(now.timestamp(), |cutoff| cutoff.timestamp());
+        Self::Relative { timestamp, span }
     }
 
     /// If this value was derived from a relative span, recompute the timestamp relative to now.
@@ -107,30 +127,31 @@ impl ExcludeNewerValue {
     /// Returns `self` unchanged if there is no span (i.e., the timestamp is absolute).
     #[must_use]
     pub fn recompute(self) -> Self {
-        let Some(span) = self.span else {
+        let Self::Relative { span, timestamp } = self else {
             return self;
         };
 
-        let now = if let Ok(test_time) = std::env::var("UV_TEST_CURRENT_TIMESTAMP") {
-            test_time
-                .parse::<Timestamp>()
-                .expect("UV_TEST_CURRENT_TIMESTAMP must be a valid RFC 3339 timestamp")
-                .to_zoned(TimeZone::UTC)
-        } else {
-            Timestamp::now().to_zoned(TimeZone::UTC)
-        };
-
+        let now = current_time();
         let Ok(cutoff) = now.checked_sub(span.0.abs()) else {
-            return Self {
-                timestamp: self.timestamp,
-                span: Some(span),
-            };
+            return Self::Relative { timestamp, span };
         };
 
-        Self {
-            timestamp: Some(cutoff.into()),
-            span: Some(span),
+        Self::Relative {
+            timestamp: cutoff.into(),
+            span,
         }
+    }
+}
+
+/// Return the current time, respecting the `UV_TEST_CURRENT_TIMESTAMP` override.
+fn current_time() -> jiff::Zoned {
+    if let Ok(test_time) = std::env::var("UV_TEST_CURRENT_TIMESTAMP") {
+        test_time
+            .parse::<Timestamp>()
+            .expect("UV_TEST_CURRENT_TIMESTAMP must be a valid RFC 3339 timestamp")
+            .to_zoned(TimeZone::UTC)
+    } else {
+        Timestamp::now().to_zoned(TimeZone::UTC)
     }
 }
 
@@ -139,11 +160,7 @@ impl serde::Serialize for ExcludeNewerValue {
     where
         S: serde::Serializer,
     {
-        if let Some(timestamp) = &self.timestamp {
-            timestamp.serialize(serializer)
-        } else {
-            serializer.serialize_none()
-        }
+        self.timestamp().serialize(serializer)
     }
 }
 
@@ -154,7 +171,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
     {
         #[derive(serde::Deserialize)]
         struct TableForm {
-            timestamp: Option<Timestamp>,
+            timestamp: Timestamp,
             span: Option<ExcludeNewerSpan>,
         }
 
@@ -174,10 +191,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
 
 impl From<Timestamp> for ExcludeNewerValue {
     fn from(timestamp: Timestamp) -> Self {
-        Self {
-            timestamp: Some(timestamp),
-            span: None,
-        }
+        Self::Absolute(timestamp)
     }
 }
 
@@ -228,7 +242,7 @@ impl FromStr for ExcludeNewerValue {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         if let Ok(timestamp) = input.parse::<Timestamp>() {
-            return Ok(Self::new(Some(timestamp), None));
+            return Ok(Self::new(timestamp, None));
         }
 
         let date_err = match input.parse::<jiff::civil::Date>() {
@@ -242,7 +256,7 @@ impl FromStr for ExcludeNewerValue {
                             "`{input}` parsed to date `{date}`, but could not be converted to a timestamp: {err}",
                         )
                     })?;
-                return Ok(Self::new(Some(timestamp), None));
+                return Ok(Self::new(timestamp, None));
             }
             Err(err) => err,
         };
@@ -284,7 +298,7 @@ impl FromStr for ExcludeNewerValue {
                 let cutoff = now.checked_sub(span.abs()).map_err(|err| {
                     format!("Duration `{input}` is too large to subtract from current time: {err}")
                 })?;
-                return Ok(Self::new(Some(cutoff.into()), Some(ExcludeNewerSpan(span))));
+                return Ok(Self::new(cutoff.into(), Some(ExcludeNewerSpan(span))));
             }
             Err(err) => err,
         };
@@ -295,13 +309,7 @@ impl FromStr for ExcludeNewerValue {
 
 impl std::fmt::Display for ExcludeNewerValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(timestamp) = &self.timestamp {
-            timestamp.fmt(f)
-        } else if let Some(span) = &self.span {
-            write!(f, "<{span}>")
-        } else {
-            write!(f, "<none>")
-        }
+        self.timestamp().fmt(f)
     }
 }
 

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -66,7 +66,8 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerSpan {
 pub enum ExcludeNewerValue {
     /// An absolute timestamp (no relative span).
     Absolute(Timestamp),
-    /// A relative span with a computed timestamp.
+    /// A relative span with a computed timestamp. The timestamp is computed once at creation
+    /// time so that a single consistent value is used throughout a resolution.
     Relative {
         timestamp: Timestamp,
         span: ExcludeNewerSpan,
@@ -110,10 +111,8 @@ impl ExcludeNewerValue {
         }
     }
 
-    /// Create a new [`ExcludeNewerValue`] from a span, computing the timestamp relative to
-    /// the current time.
-    ///
-    /// This is used when a lockfile has a span but the timestamp was stripped.
+    /// Create a [`Relative`](Self::Relative) value from a span, computing the timestamp
+    /// relative to the current time.
     pub fn from_span(span: ExcludeNewerSpan) -> Self {
         let now = current_time();
         let timestamp = now
@@ -122,7 +121,7 @@ impl ExcludeNewerValue {
         Self::Relative { timestamp, span }
     }
 
-    /// If this value was derived from a relative span, recompute the timestamp relative to now.
+    /// If this value has a relative span, recompute the timestamp relative to now.
     ///
     /// Returns `self` unchanged if there is no span (i.e., the timestamp is absolute).
     #[must_use]

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -60,75 +60,57 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerSpan {
     }
 }
 
-/// An exclude-newer cutoff value: either an absolute timestamp or a relative span with a
-/// computed timestamp.
+/// An exclude-newer cutoff value: either an absolute timestamp or a relative span.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ExcludeNewerValue {
     /// An absolute timestamp (no relative span).
     Absolute(Timestamp),
-    /// A relative span with a computed timestamp. The timestamp is computed once at creation
-    /// time so that a single consistent value is used throughout a resolution.
-    Relative {
-        timestamp: Timestamp,
-        span: ExcludeNewerSpan,
-    },
+    /// A relative span whose effective timestamp is computed on demand from the current time.
+    Relative(ExcludeNewerSpan),
 }
 
 impl ExcludeNewerValue {
-    /// Split into the stored timestamp and optional span for wire serialization.
+    /// Split into a timestamp and optional span for wire serialization.
+    ///
+    /// For [`Relative`](Self::Relative) values, the timestamp is a placeholder — the span is
+    /// the source of truth.
     pub fn into_parts(self) -> (Timestamp, Option<ExcludeNewerSpan>) {
         match self {
             Self::Absolute(timestamp) => (timestamp, None),
-            Self::Relative { timestamp, span } => (timestamp, Some(span)),
+            Self::Relative(span) => (Timestamp::UNIX_EPOCH, Some(span)),
         }
     }
 
-    /// Return the [`Timestamp`] in milliseconds.
-    pub fn timestamp_millis(&self) -> i64 {
-        self.timestamp().as_millisecond()
-    }
-
-    /// Return the [`Timestamp`].
+    /// Return the effective [`Timestamp`].
+    ///
+    /// For [`Relative`](Self::Relative) values this is computed from the span and the current
+    /// time on each call.
     pub fn timestamp(&self) -> Timestamp {
         match self {
-            Self::Absolute(timestamp) | Self::Relative { timestamp, .. } => *timestamp,
+            Self::Absolute(timestamp) => *timestamp,
+            Self::Relative(span) => {
+                let now = current_time();
+                now.checked_sub(span.0.abs())
+                    .map_or(now.timestamp(), |cutoff| cutoff.timestamp())
+            }
         }
     }
 
-    /// Return the [`ExcludeNewerSpan`] used to construct the [`Timestamp`], if any.
+    /// Return the [`ExcludeNewerSpan`], if any.
     pub fn span(&self) -> Option<&ExcludeNewerSpan> {
         match self {
             Self::Absolute(_) => None,
-            Self::Relative { span, .. } => Some(span),
+            Self::Relative(span) => Some(span),
         }
     }
 
     /// Create a new [`ExcludeNewerValue`] from a timestamp and optional span.
+    ///
+    /// When a span is provided the timestamp is ignored — the span is the source of truth.
     pub fn new(timestamp: Timestamp, span: Option<ExcludeNewerSpan>) -> Self {
         match span {
-            Some(span) => Self::Relative { timestamp, span },
+            Some(span) => Self::Relative(span),
             None => Self::Absolute(timestamp),
-        }
-    }
-
-    /// Create a [`Relative`](Self::Relative) value from a span, computing the timestamp
-    /// relative to the current time.
-    pub fn from_span(span: ExcludeNewerSpan) -> Self {
-        let now = current_time();
-        let timestamp = now
-            .checked_sub(span.0.abs())
-            .map_or(now.timestamp(), |cutoff| cutoff.timestamp());
-        Self::Relative { timestamp, span }
-    }
-
-    /// If this value has a relative span, recompute the timestamp relative to now.
-    ///
-    /// Returns `self` unchanged if there is no span (i.e., the timestamp is absolute).
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        match self {
-            Self::Absolute(_) => self,
-            Self::Relative { span, .. } => Self::from_span(span),
         }
     }
 }
@@ -285,10 +267,10 @@ impl FromStr for ExcludeNewerValue {
                     ));
                 }
 
-                let cutoff = now.checked_sub(span.abs()).map_err(|err| {
+                now.checked_sub(span.abs()).map_err(|err| {
                     format!("Duration `{input}` is too large to subtract from current time: {err}")
                 })?;
-                return Ok(Self::new(cutoff.into(), Some(ExcludeNewerSpan(span))));
+                return Ok(Self::Relative(ExcludeNewerSpan(span)));
             }
             Err(err) => err,
         };

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -70,16 +70,9 @@ pub enum ExcludeNewerValue {
 }
 
 impl ExcludeNewerValue {
-    /// Split into a timestamp and optional span for wire serialization.
-    ///
-    /// For [`Relative`](Self::Relative) values, the timestamp is a placeholder — the span is
-    /// the source of truth.
-    pub fn into_parts(self) -> (Timestamp, Option<ExcludeNewerSpan>) {
-        match self {
-            Self::Absolute(timestamp) => (timestamp, None),
-            Self::Relative(span) => (Timestamp::UNIX_EPOCH, Some(span)),
-        }
-    }
+    /// A placeholder absolute timestamp (Unix epoch) used when serializing a [`Relative`](Self::Relative)
+    /// value to a wire format that requires a timestamp field.
+    pub const PLACEHOLDER: Self = Self::Absolute(Timestamp::UNIX_EPOCH);
 
     /// Return the effective [`Timestamp`].
     ///

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -62,22 +62,22 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerSpan {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExcludeNewerValue {
-    timestamp: Timestamp,
+    timestamp: Option<Timestamp>,
     span: Option<ExcludeNewerSpan>,
 }
 
 impl ExcludeNewerValue {
-    pub fn into_parts(self) -> (Timestamp, Option<ExcludeNewerSpan>) {
+    pub fn into_parts(self) -> (Option<Timestamp>, Option<ExcludeNewerSpan>) {
         (self.timestamp, self.span)
     }
 
     /// Return the [`Timestamp`] in milliseconds.
-    pub fn timestamp_millis(&self) -> i64 {
-        self.timestamp.as_millisecond()
+    pub fn timestamp_millis(&self) -> Option<i64> {
+        self.timestamp.map(Timestamp::as_millisecond)
     }
 
     /// Return the [`Timestamp`].
-    pub fn timestamp(&self) -> Timestamp {
+    pub fn timestamp(&self) -> Option<Timestamp> {
         self.timestamp
     }
 
@@ -87,8 +87,19 @@ impl ExcludeNewerValue {
     }
 
     /// Create a new [`ExcludeNewerValue`].
-    pub fn new(timestamp: Timestamp, span: Option<ExcludeNewerSpan>) -> Self {
+    pub fn new(timestamp: Option<Timestamp>, span: Option<ExcludeNewerSpan>) -> Self {
         Self { timestamp, span }
+    }
+
+    /// Create a new [`ExcludeNewerValue`] with only a span and no timestamp.
+    ///
+    /// This represents a lockfile entry where the timestamp was stripped but the span was
+    /// preserved.
+    pub fn span_only(span: ExcludeNewerSpan) -> Self {
+        Self {
+            timestamp: None,
+            span: Some(span),
+        }
     }
 
     /// If this value was derived from a relative span, recompute the timestamp relative to now.
@@ -117,7 +128,7 @@ impl ExcludeNewerValue {
         };
 
         Self {
-            timestamp: cutoff.into(),
+            timestamp: Some(cutoff.into()),
             span: Some(span),
         }
     }
@@ -128,7 +139,11 @@ impl serde::Serialize for ExcludeNewerValue {
     where
         S: serde::Serializer,
     {
-        self.timestamp.serialize(serializer)
+        if let Some(timestamp) = &self.timestamp {
+            timestamp.serialize(serializer)
+        } else {
+            serializer.serialize_none()
+        }
     }
 }
 
@@ -139,7 +154,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
     {
         #[derive(serde::Deserialize)]
         struct TableForm {
-            timestamp: Timestamp,
+            timestamp: Option<Timestamp>,
             span: Option<ExcludeNewerSpan>,
         }
 
@@ -160,7 +175,7 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
 impl From<Timestamp> for ExcludeNewerValue {
     fn from(timestamp: Timestamp) -> Self {
         Self {
-            timestamp,
+            timestamp: Some(timestamp),
             span: None,
         }
     }
@@ -213,7 +228,7 @@ impl FromStr for ExcludeNewerValue {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         if let Ok(timestamp) = input.parse::<Timestamp>() {
-            return Ok(Self::new(timestamp, None));
+            return Ok(Self::new(Some(timestamp), None));
         }
 
         let date_err = match input.parse::<jiff::civil::Date>() {
@@ -227,7 +242,7 @@ impl FromStr for ExcludeNewerValue {
                             "`{input}` parsed to date `{date}`, but could not be converted to a timestamp: {err}",
                         )
                     })?;
-                return Ok(Self::new(timestamp, None));
+                return Ok(Self::new(Some(timestamp), None));
             }
             Err(err) => err,
         };
@@ -269,7 +284,7 @@ impl FromStr for ExcludeNewerValue {
                 let cutoff = now.checked_sub(span.abs()).map_err(|err| {
                     format!("Duration `{input}` is too large to subtract from current time: {err}")
                 })?;
-                return Ok(Self::new(cutoff.into(), Some(ExcludeNewerSpan(span))));
+                return Ok(Self::new(Some(cutoff.into()), Some(ExcludeNewerSpan(span))));
             }
             Err(err) => err,
         };
@@ -280,7 +295,13 @@ impl FromStr for ExcludeNewerValue {
 
 impl std::fmt::Display for ExcludeNewerValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.timestamp.fmt(f)
+        if let Some(timestamp) = &self.timestamp {
+            timestamp.fmt(f)
+        } else if let Some(span) = &self.span {
+            write!(f, "<{span}>")
+        } else {
+            write!(f, "<none>")
+        }
     }
 }
 

--- a/crates/uv-distribution-types/src/exclude_newer.rs
+++ b/crates/uv-distribution-types/src/exclude_newer.rs
@@ -61,65 +61,61 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerSpan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ExcludeNewerValue {
-    timestamp: Timestamp,
-    span: Option<ExcludeNewerSpan>,
+pub enum ExcludeNewerValue {
+    /// An absolute timestamp.
+    Absolute(Timestamp),
+    /// A span used to compute a timestamp relative to the current time.
+    Relative(ExcludeNewerSpan),
 }
 
 impl ExcludeNewerValue {
-    pub fn into_parts(self) -> (Timestamp, Option<ExcludeNewerSpan>) {
-        (self.timestamp, self.span)
-    }
+    /// A placeholder timestamp used when serializing a [`Relative`](Self::Relative)
+    /// value to a wire format that requires a timestamp field.
+    pub const PLACEHOLDER: &'static str = "0001-01-01T00:00:00Z";
 
-    /// Return the [`Timestamp`] in milliseconds.
-    pub fn timestamp_millis(&self) -> i64 {
-        self.timestamp.as_millisecond()
-    }
-
-    /// Return the [`Timestamp`].
-    pub fn timestamp(&self) -> Timestamp {
-        self.timestamp
-    }
-
-    /// Return the [`ExcludeNewerSpan`] used to construct the [`Timestamp`], if any.
-    pub fn span(&self) -> Option<&ExcludeNewerSpan> {
-        self.span.as_ref()
-    }
-
-    /// Create a new [`ExcludeNewerValue`].
-    pub fn new(timestamp: Timestamp, span: Option<ExcludeNewerSpan>) -> Self {
-        Self { timestamp, span }
-    }
-
-    /// If this value was derived from a relative span, recompute the timestamp relative to now.
+    /// Return the effective [`Timestamp`].
     ///
-    /// Returns `self` unchanged if there is no span (i.e., the timestamp is absolute).
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        let Some(span) = self.span else {
-            return self;
-        };
-
-        let now = if let Ok(test_time) = std::env::var("UV_TEST_CURRENT_TIMESTAMP") {
-            test_time
-                .parse::<Timestamp>()
-                .expect("UV_TEST_CURRENT_TIMESTAMP must be a valid RFC 3339 timestamp")
-                .to_zoned(TimeZone::UTC)
-        } else {
-            Timestamp::now().to_zoned(TimeZone::UTC)
-        };
-
-        let Ok(cutoff) = now.checked_sub(span.0.abs()) else {
-            return Self {
-                timestamp: self.timestamp,
-                span: Some(span),
-            };
-        };
-
-        Self {
-            timestamp: cutoff.into(),
-            span: Some(span),
+    /// For [`Relative`](Self::Relative) values this is computed from the span and the current
+    /// time on each call.
+    pub fn timestamp(&self) -> Timestamp {
+        match self {
+            Self::Absolute(timestamp) => *timestamp,
+            Self::Relative(span) => {
+                let now = current_time();
+                now.checked_sub(span.0.abs())
+                    .map_or(now.timestamp(), |cutoff| cutoff.timestamp())
+            }
         }
+    }
+
+    /// Return the [`ExcludeNewerSpan`], if any.
+    pub fn span(&self) -> Option<&ExcludeNewerSpan> {
+        match self {
+            Self::Absolute(_) => None,
+            Self::Relative(span) => Some(span),
+        }
+    }
+
+    /// Create a new [`ExcludeNewerValue`] from an absolute timestamp.
+    pub fn absolute(timestamp: Timestamp) -> Self {
+        Self::Absolute(timestamp)
+    }
+
+    /// Create a new [`ExcludeNewerValue`] from a relative span.
+    pub fn relative(span: ExcludeNewerSpan) -> Self {
+        Self::Relative(span)
+    }
+}
+
+/// Return the current time, respecting the `UV_TEST_CURRENT_TIMESTAMP` override.
+fn current_time() -> jiff::Zoned {
+    if let Ok(test_time) = std::env::var("UV_TEST_CURRENT_TIMESTAMP") {
+        test_time
+            .parse::<Timestamp>()
+            .expect("UV_TEST_CURRENT_TIMESTAMP must be a valid RFC 3339 timestamp")
+            .to_zoned(TimeZone::UTC)
+    } else {
+        Timestamp::now().to_zoned(TimeZone::UTC)
     }
 }
 
@@ -128,7 +124,7 @@ impl serde::Serialize for ExcludeNewerValue {
     where
         S: serde::Serializer,
     {
-        self.timestamp.serialize(serializer)
+        self.timestamp().serialize(serializer)
     }
 }
 
@@ -152,17 +148,23 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewerValue {
 
         match Helper::deserialize(deserializer)? {
             Helper::String(s) => Self::from_str(&s).map_err(serde::de::Error::custom),
-            Helper::Table(table) => Ok(Self::new(table.timestamp, table.span)),
+            Helper::Table(table) => Ok(match table.span {
+                Some(span) => Self::relative(span),
+                None => Self::absolute(table.timestamp),
+            }),
         }
     }
 }
 
 impl From<Timestamp> for ExcludeNewerValue {
     fn from(timestamp: Timestamp) -> Self {
-        Self {
-            timestamp,
-            span: None,
-        }
+        Self::Absolute(timestamp)
+    }
+}
+
+impl From<ExcludeNewerSpan> for ExcludeNewerValue {
+    fn from(span: ExcludeNewerSpan) -> Self {
+        Self::Relative(span)
     }
 }
 
@@ -213,7 +215,7 @@ impl FromStr for ExcludeNewerValue {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         if let Ok(timestamp) = input.parse::<Timestamp>() {
-            return Ok(Self::new(timestamp, None));
+            return Ok(Self::absolute(timestamp));
         }
 
         let date_err = match input.parse::<jiff::civil::Date>() {
@@ -227,7 +229,7 @@ impl FromStr for ExcludeNewerValue {
                             "`{input}` parsed to date `{date}`, but could not be converted to a timestamp: {err}",
                         )
                     })?;
-                return Ok(Self::new(timestamp, None));
+                return Ok(Self::absolute(timestamp));
             }
             Err(err) => err,
         };
@@ -266,10 +268,10 @@ impl FromStr for ExcludeNewerValue {
                     ));
                 }
 
-                let cutoff = now.checked_sub(span.abs()).map_err(|err| {
+                now.checked_sub(span.abs()).map_err(|err| {
                     format!("Duration `{input}` is too large to subtract from current time: {err}")
                 })?;
-                return Ok(Self::new(cutoff.into(), Some(ExcludeNewerSpan(span))));
+                return Ok(Self::relative(ExcludeNewerSpan(span)));
             }
             Err(err) => err,
         };
@@ -280,7 +282,7 @@ impl FromStr for ExcludeNewerValue {
 
 impl std::fmt::Display for ExcludeNewerValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.timestamp.fmt(f)
+        self.timestamp().fmt(f)
     }
 }
 

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -470,57 +470,54 @@ impl ExcludeNewer {
         Self { global, package }
     }
 
-    /// Returns the exclude-newer value for a specific package, returning `Some(value)` if the
-    /// package has a package-specific setting or falls back to the global value if set, or `None`
-    /// if exclude-newer is explicitly disabled for the package (set to `false`) or if no
-    /// exclude-newer is configured.
-    pub fn exclude_newer_package(&self, package_name: &PackageName) -> Option<ExcludeNewerValue> {
+    /// Returns the effective exclude-newer timestamp for a specific package, falling back to the
+    /// global value if no package-specific setting exists.
+    pub fn exclude_newer_package(&self, package_name: &PackageName) -> Option<Timestamp> {
         match self.package.get(package_name) {
-            Some(ExcludeNewerOverride::Enabled(timestamp)) => Some(timestamp.as_ref().clone()),
+            Some(ExcludeNewerOverride::Enabled(value)) => Some(value.timestamp()),
             Some(ExcludeNewerOverride::Disabled) => None,
-            None => self.global.clone(),
+            None => self.global.as_ref().map(ExcludeNewerValue::timestamp),
         }
     }
 
-    /// Returns the effective exclude-newer value for a package resolved from a specific index.
+    /// Returns the effective exclude-newer timestamp for a package resolved from a specific index.
     pub fn exclude_newer_package_for_index(
         &self,
         package_name: &PackageName,
         index: Option<&ExcludeNewerOverride>,
-    ) -> Option<ExcludeNewerValue> {
+    ) -> Option<Timestamp> {
         self.exclude_newer_package_for_index_with_source(package_name, index)
-            .map(|(exclude_newer, _)| exclude_newer)
+            .map(|(timestamp, _)| timestamp)
     }
 
-    /// Returns the effective exclude-newer value and its source for a package resolved from a
+    /// Returns the effective exclude-newer timestamp and its source for a package resolved from a
     /// specific index.
     pub(crate) fn exclude_newer_package_for_index_with_source(
         &self,
         package_name: &PackageName,
         index: Option<&ExcludeNewerOverride>,
-    ) -> Option<(ExcludeNewerValue, EffectiveExcludeNewerSource)> {
+    ) -> Option<(Timestamp, EffectiveExcludeNewerSource)> {
         match self.package.get(package_name) {
-            Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
-                timestamp.as_ref().clone(),
-                EffectiveExcludeNewerSource::Package,
-            )),
+            Some(ExcludeNewerOverride::Enabled(value)) => {
+                Some((value.timestamp(), EffectiveExcludeNewerSource::Package))
+            }
             Some(ExcludeNewerOverride::Disabled) => None,
             None => match index {
                 Some(ExcludeNewerOverride::Disabled) => {
                     Self::warn_index_exclude_newer_preview();
                     None
                 }
-                Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
+                Some(ExcludeNewerOverride::Enabled(value)) => Some((
                     {
                         Self::warn_index_exclude_newer_preview();
-                        ExcludeNewerValue::from(timestamp.timestamp())
+                        value.timestamp()
                     },
                     EffectiveExcludeNewerSource::Index,
                 )),
                 None => self
                     .global
-                    .clone()
-                    .map(|timestamp| (timestamp, EffectiveExcludeNewerSource::Global)),
+                    .as_ref()
+                    .map(|value| (value.timestamp(), EffectiveExcludeNewerSource::Global)),
             },
         }
     }

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -31,9 +31,9 @@ pub enum ExcludeNewerValueChange {
     /// A relative span was removed
     SpanRemoved,
     /// A relative span is present and the timestamp changed
-    RelativeTimestampChanged(Option<Timestamp>, Option<Timestamp>, ExcludeNewerSpan),
+    RelativeTimestampChanged(Timestamp, Timestamp, ExcludeNewerSpan),
     /// The timestamp changed and a relative span is not present
-    AbsoluteTimestampChanged(Option<Timestamp>, Option<Timestamp>),
+    AbsoluteTimestampChanged(Timestamp, Timestamp),
 }
 
 impl ExcludeNewerValueChange {
@@ -55,16 +55,12 @@ impl std::fmt::Display for ExcludeNewerValueChange {
                 write!(f, "removal of exclude newer span")
             }
             Self::RelativeTimestampChanged(old, new, span) => {
-                let old = old.map_or_else(|| "<none>".to_string(), |t| t.to_string());
-                let new = new.map_or_else(|| "<none>".to_string(), |t| t.to_string());
                 write!(
                     f,
                     "change of calculated ({span}) exclude newer timestamp from `{old}` to `{new}`"
                 )
             }
             Self::AbsoluteTimestampChanged(old, new) => {
-                let old = old.map_or_else(|| "<none>".to_string(), |t| t.to_string());
-                let new = new.map_or_else(|| "<none>".to_string(), |t| t.to_string());
                 write!(
                     f,
                     "change of exclude newer timestamp from `{old}` to `{new}`"
@@ -181,15 +177,13 @@ impl serde::Serialize for ExcludeNewerValueWithSpanRef<'_> {
     where
         S: serde::Serializer,
     {
-        if let (Some(timestamp), Some(span)) = (self.0.timestamp(), self.0.span()) {
+        if let Some(span) = self.0.span() {
             let mut map = serializer.serialize_map(Some(2))?;
-            map.serialize_entry("timestamp", &timestamp)?;
+            map.serialize_entry("timestamp", &self.0.timestamp())?;
             map.serialize_entry("span", span)?;
             map.end()
-        } else if let Some(timestamp) = self.0.timestamp() {
-            timestamp.serialize(serializer)
         } else {
-            serializer.serialize_none()
+            self.0.timestamp().serialize(serializer)
         }
     }
 }
@@ -516,15 +510,13 @@ impl ExcludeNewer {
                     Self::warn_index_exclude_newer_preview();
                     None
                 }
-                Some(ExcludeNewerOverride::Enabled(timestamp)) => {
-                    Self::warn_index_exclude_newer_preview();
-                    timestamp.timestamp().map(|ts| {
-                        (
-                            ExcludeNewerValue::from(ts),
-                            EffectiveExcludeNewerSource::Index,
-                        )
-                    })
-                }
+                Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
+                    {
+                        Self::warn_index_exclude_newer_preview();
+                        ExcludeNewerValue::from(timestamp.timestamp())
+                    },
+                    EffectiveExcludeNewerSource::Index,
+                )),
                 None => self
                     .global
                     .clone()

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -348,25 +348,6 @@ impl ExcludeNewerPackage {
         self.0.is_empty()
     }
 
-    /// Recompute all relative span timestamps relative to the current time.
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        Self(
-            self.0
-                .into_iter()
-                .map(|(name, setting)| {
-                    let setting = match setting {
-                        ExcludeNewerOverride::Disabled => ExcludeNewerOverride::Disabled,
-                        ExcludeNewerOverride::Enabled(value) => {
-                            ExcludeNewerOverride::Enabled(Box::new((*value).recompute()))
-                        }
-                    };
-                    (name, setting)
-                })
-                .collect(),
-        )
-    }
-
     pub fn compare(&self, other: &Self) -> Option<ExcludeNewerPackageChange> {
         for (package, setting) in self {
             match (setting, other.get(package)) {
@@ -525,17 +506,6 @@ impl ExcludeNewer {
     /// Returns true if this has any configuration (global or per-package).
     pub fn is_empty(&self) -> bool {
         self.global.is_none() && self.package.is_empty()
-    }
-
-    /// Recompute all relative span timestamps relative to the current time.
-    ///
-    /// For values with an absolute timestamp (no span), the timestamp is unchanged.
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        Self {
-            global: self.global.map(ExcludeNewerValue::recompute),
-            package: self.package.recompute(),
-        }
     }
 
     pub fn compare(&self, other: &Self) -> Option<ExcludeNewerChange> {

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -31,9 +31,9 @@ pub enum ExcludeNewerValueChange {
     /// A relative span was removed
     SpanRemoved,
     /// A relative span is present and the timestamp changed
-    RelativeTimestampChanged(Timestamp, Timestamp, ExcludeNewerSpan),
+    RelativeTimestampChanged(Option<Timestamp>, Option<Timestamp>, ExcludeNewerSpan),
     /// The timestamp changed and a relative span is not present
-    AbsoluteTimestampChanged(Timestamp, Timestamp),
+    AbsoluteTimestampChanged(Option<Timestamp>, Option<Timestamp>),
 }
 
 impl ExcludeNewerValueChange {
@@ -55,12 +55,16 @@ impl std::fmt::Display for ExcludeNewerValueChange {
                 write!(f, "removal of exclude newer span")
             }
             Self::RelativeTimestampChanged(old, new, span) => {
+                let old = old.map_or_else(|| "<none>".to_string(), |t| t.to_string());
+                let new = new.map_or_else(|| "<none>".to_string(), |t| t.to_string());
                 write!(
                     f,
                     "change of calculated ({span}) exclude newer timestamp from `{old}` to `{new}`"
                 )
             }
             Self::AbsoluteTimestampChanged(old, new) => {
+                let old = old.map_or_else(|| "<none>".to_string(), |t| t.to_string());
+                let new = new.map_or_else(|| "<none>".to_string(), |t| t.to_string());
                 write!(
                     f,
                     "change of exclude newer timestamp from `{old}` to `{new}`"
@@ -177,13 +181,15 @@ impl serde::Serialize for ExcludeNewerValueWithSpanRef<'_> {
     where
         S: serde::Serializer,
     {
-        if let Some(span) = self.0.span() {
+        if let (Some(timestamp), Some(span)) = (self.0.timestamp(), self.0.span()) {
             let mut map = serializer.serialize_map(Some(2))?;
-            map.serialize_entry("timestamp", &self.0.timestamp())?;
+            map.serialize_entry("timestamp", &timestamp)?;
             map.serialize_entry("span", span)?;
             map.end()
+        } else if let Some(timestamp) = self.0.timestamp() {
+            timestamp.serialize(serializer)
         } else {
-            self.0.timestamp().serialize(serializer)
+            serializer.serialize_none()
         }
     }
 }
@@ -510,13 +516,15 @@ impl ExcludeNewer {
                     Self::warn_index_exclude_newer_preview();
                     None
                 }
-                Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
-                    {
-                        Self::warn_index_exclude_newer_preview();
-                        ExcludeNewerValue::from(timestamp.timestamp())
-                    },
-                    EffectiveExcludeNewerSource::Index,
-                )),
+                Some(ExcludeNewerOverride::Enabled(timestamp)) => {
+                    Self::warn_index_exclude_newer_preview();
+                    timestamp.timestamp().map(|ts| {
+                        (
+                            ExcludeNewerValue::from(ts),
+                            EffectiveExcludeNewerSource::Index,
+                        )
+                    })
+                }
                 None => self
                     .global
                     .clone()

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -348,25 +348,6 @@ impl ExcludeNewerPackage {
         self.0.is_empty()
     }
 
-    /// Recompute all relative span timestamps relative to the current time.
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        Self(
-            self.0
-                .into_iter()
-                .map(|(name, setting)| {
-                    let setting = match setting {
-                        ExcludeNewerOverride::Disabled => ExcludeNewerOverride::Disabled,
-                        ExcludeNewerOverride::Enabled(value) => {
-                            ExcludeNewerOverride::Enabled(Box::new((*value).recompute()))
-                        }
-                    };
-                    (name, setting)
-                })
-                .collect(),
-        )
-    }
-
     pub fn compare(&self, other: &Self) -> Option<ExcludeNewerPackageChange> {
         for (package, setting) in self {
             match (setting, other.get(package)) {
@@ -470,57 +451,54 @@ impl ExcludeNewer {
         Self { global, package }
     }
 
-    /// Returns the exclude-newer value for a specific package, returning `Some(value)` if the
-    /// package has a package-specific setting or falls back to the global value if set, or `None`
-    /// if exclude-newer is explicitly disabled for the package (set to `false`) or if no
-    /// exclude-newer is configured.
-    pub fn exclude_newer_package(&self, package_name: &PackageName) -> Option<ExcludeNewerValue> {
+    /// Returns the effective exclude-newer timestamp for a specific package, falling back to the
+    /// global value if no package-specific setting exists.
+    pub fn exclude_newer_package(&self, package_name: &PackageName) -> Option<Timestamp> {
         match self.package.get(package_name) {
-            Some(ExcludeNewerOverride::Enabled(timestamp)) => Some(timestamp.as_ref().clone()),
+            Some(ExcludeNewerOverride::Enabled(value)) => Some(value.timestamp()),
             Some(ExcludeNewerOverride::Disabled) => None,
-            None => self.global.clone(),
+            None => self.global.as_ref().map(ExcludeNewerValue::timestamp),
         }
     }
 
-    /// Returns the effective exclude-newer value for a package resolved from a specific index.
+    /// Returns the effective exclude-newer timestamp for a package resolved from a specific index.
     pub fn exclude_newer_package_for_index(
         &self,
         package_name: &PackageName,
         index: Option<&ExcludeNewerOverride>,
-    ) -> Option<ExcludeNewerValue> {
+    ) -> Option<Timestamp> {
         self.exclude_newer_package_for_index_with_source(package_name, index)
-            .map(|(exclude_newer, _)| exclude_newer)
+            .map(|(timestamp, _)| timestamp)
     }
 
-    /// Returns the effective exclude-newer value and its source for a package resolved from a
+    /// Returns the effective exclude-newer timestamp and its source for a package resolved from a
     /// specific index.
     pub(crate) fn exclude_newer_package_for_index_with_source(
         &self,
         package_name: &PackageName,
         index: Option<&ExcludeNewerOverride>,
-    ) -> Option<(ExcludeNewerValue, EffectiveExcludeNewerSource)> {
+    ) -> Option<(Timestamp, EffectiveExcludeNewerSource)> {
         match self.package.get(package_name) {
-            Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
-                timestamp.as_ref().clone(),
-                EffectiveExcludeNewerSource::Package,
-            )),
+            Some(ExcludeNewerOverride::Enabled(value)) => {
+                Some((value.timestamp(), EffectiveExcludeNewerSource::Package))
+            }
             Some(ExcludeNewerOverride::Disabled) => None,
             None => match index {
                 Some(ExcludeNewerOverride::Disabled) => {
                     Self::warn_index_exclude_newer_preview();
                     None
                 }
-                Some(ExcludeNewerOverride::Enabled(timestamp)) => Some((
+                Some(ExcludeNewerOverride::Enabled(value)) => Some((
                     {
                         Self::warn_index_exclude_newer_preview();
-                        ExcludeNewerValue::from(timestamp.timestamp())
+                        value.timestamp()
                     },
                     EffectiveExcludeNewerSource::Index,
                 )),
                 None => self
                     .global
-                    .clone()
-                    .map(|timestamp| (timestamp, EffectiveExcludeNewerSource::Global)),
+                    .as_ref()
+                    .map(|value| (value.timestamp(), EffectiveExcludeNewerSource::Global)),
             },
         }
     }
@@ -528,17 +506,6 @@ impl ExcludeNewer {
     /// Returns true if this has any configuration (global or per-package).
     pub fn is_empty(&self) -> bool {
         self.global.is_none() && self.package.is_empty()
-    }
-
-    /// Recompute all relative span timestamps relative to the current time.
-    ///
-    /// For values with an absolute timestamp (no span), the timestamp is unchanged.
-    #[must_use]
-    pub fn recompute(self) -> Self {
-        Self {
-            global: self.global.map(ExcludeNewerValue::recompute),
-            package: self.package.recompute(),
-        }
     }
 
     pub fn compare(&self, other: &Self) -> Option<ExcludeNewerChange> {

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1174,12 +1174,13 @@ impl Lock {
                     for (name, setting) in &exclude_newer.package {
                         match setting {
                             ExcludeNewerOverride::Enabled(exclude_newer_value) => {
-                                if let (Some(timestamp), Some(span)) =
-                                    (exclude_newer_value.timestamp(), exclude_newer_value.span())
-                                {
+                                if let Some(span) = exclude_newer_value.span() {
                                     // Serialize as inline table with timestamp and span
                                     let mut inline = toml_edit::InlineTable::new();
-                                    inline.insert("timestamp", timestamp.to_string().into());
+                                    inline.insert(
+                                        "timestamp",
+                                        exclude_newer_value.timestamp().to_string().into(),
+                                    );
                                     inline.insert("span", span.to_string().into());
                                     package_table.insert(name.as_ref(), Item::Value(inline.into()));
                                 } else {
@@ -2350,12 +2351,12 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
     fn from(wire: ExcludeNewerWire) -> Self {
         Self {
             global: match (wire.exclude_newer, wire.exclude_newer_span) {
-                (Some(timestamp), span) => Some(ExcludeNewerValue::new(Some(timestamp), span)),
-                // The lockfile has a span but the timestamp was stripped. Preserve the span
-                // so comparison logic can match it against the current config and treat the
-                // missing timestamp as a relative timestamp change (which doesn't invalidate
-                // the lockfile).
-                (None, Some(span)) => Some(ExcludeNewerValue::span_only(span)),
+                (Some(timestamp), span) => Some(ExcludeNewerValue::new(timestamp, span)),
+                // The lockfile has a span but the timestamp was stripped. Compute a
+                // timestamp from the span so comparison logic can match it against the
+                // current config and treat the difference as a relative timestamp change
+                // (which doesn't invalidate the lockfile).
+                (None, Some(span)) => Some(ExcludeNewerValue::from_span(span)),
                 (None, None) => None,
             },
             package: wire.exclude_newer_package,
@@ -2368,7 +2369,7 @@ impl From<ExcludeNewer> for ExcludeNewerWire {
         let (timestamp, span) = exclude_newer
             .global
             .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(t, s)| (t, s));
+            .map_or((None, None), |(t, s)| (Some(t), s));
         Self {
             exclude_newer: timestamp,
             exclude_newer_span: span,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2352,11 +2352,7 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
         Self {
             global: match (wire.exclude_newer, wire.exclude_newer_span) {
                 (Some(timestamp), span) => Some(ExcludeNewerValue::new(timestamp, span)),
-                // The lockfile has a span but the timestamp was stripped. Compute a
-                // timestamp from the span so comparison logic can match it against the
-                // current config and treat the difference as a relative timestamp change
-                // (which doesn't invalidate the lockfile).
-                (None, Some(span)) => Some(ExcludeNewerValue::from_span(span)),
+                (None, Some(span)) => Some(ExcludeNewerValue::Relative(span)),
                 (None, None) => None,
             },
             package: wire.exclude_newer_package,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1174,13 +1174,12 @@ impl Lock {
                     for (name, setting) in &exclude_newer.package {
                         match setting {
                             ExcludeNewerOverride::Enabled(exclude_newer_value) => {
-                                if let Some(span) = exclude_newer_value.span() {
+                                if let (Some(timestamp), Some(span)) =
+                                    (exclude_newer_value.timestamp(), exclude_newer_value.span())
+                                {
                                     // Serialize as inline table with timestamp and span
                                     let mut inline = toml_edit::InlineTable::new();
-                                    inline.insert(
-                                        "timestamp",
-                                        exclude_newer_value.timestamp().to_string().into(),
-                                    );
+                                    inline.insert("timestamp", timestamp.to_string().into());
                                     inline.insert("span", span.to_string().into());
                                     package_table.insert(name.as_ref(), Item::Value(inline.into()));
                                 } else {
@@ -2351,14 +2350,12 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
     fn from(wire: ExcludeNewerWire) -> Self {
         Self {
             global: match (wire.exclude_newer, wire.exclude_newer_span) {
-                (Some(timestamp), span) => Some(ExcludeNewerValue::new(timestamp, span)),
-                // The lockfile has a span but the timestamp was stripped. Use a placeholder
-                // so comparison logic can match the span against the current config and
-                // treat this as a relative timestamp change (which doesn't invalidate the
-                // lockfile).
-                (None, Some(span)) => {
-                    Some(ExcludeNewerValue::new(Timestamp::UNIX_EPOCH, Some(span)))
-                }
+                (Some(timestamp), span) => Some(ExcludeNewerValue::new(Some(timestamp), span)),
+                // The lockfile has a span but the timestamp was stripped. Preserve the span
+                // so comparison logic can match it against the current config and treat the
+                // missing timestamp as a relative timestamp change (which doesn't invalidate
+                // the lockfile).
+                (None, Some(span)) => Some(ExcludeNewerValue::span_only(span)),
                 (None, None) => None,
             },
             package: wire.exclude_newer_package,
@@ -2371,7 +2368,7 @@ impl From<ExcludeNewer> for ExcludeNewerWire {
         let (timestamp, span) = exclude_newer
             .global
             .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(t, s)| (Some(t), s));
+            .map_or((None, None), |(t, s)| (t, s));
         Self {
             exclude_newer: timestamp,
             exclude_newer_span: span,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2350,9 +2350,17 @@ struct ExcludeNewerWire {
 impl From<ExcludeNewerWire> for ExcludeNewer {
     fn from(wire: ExcludeNewerWire) -> Self {
         Self {
-            global: wire
-                .exclude_newer
-                .map(|timestamp| ExcludeNewerValue::new(timestamp, wire.exclude_newer_span)),
+            global: match (wire.exclude_newer, wire.exclude_newer_span) {
+                (Some(timestamp), span) => Some(ExcludeNewerValue::new(timestamp, span)),
+                // The lockfile has a span but the timestamp was stripped. Use a placeholder
+                // so comparison logic can match the span against the current config and
+                // treat this as a relative timestamp change (which doesn't invalidate the
+                // lockfile).
+                (None, Some(span)) => {
+                    Some(ExcludeNewerValue::new(Timestamp::UNIX_EPOCH, Some(span)))
+                }
+                (None, None) => None,
+            },
             package: wire.exclude_newer_package,
         }
     }

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2362,10 +2362,11 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
 
 impl From<ExcludeNewer> for ExcludeNewerWire {
     fn from(exclude_newer: ExcludeNewer) -> Self {
-        let (timestamp, span) = exclude_newer
-            .global
-            .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(t, s)| (Some(t), s));
+        let (timestamp, span) = match exclude_newer.global {
+            Some(ExcludeNewerValue::Absolute(timestamp)) => (Some(timestamp), None),
+            Some(ExcludeNewerValue::Relative(span)) => (Some(Timestamp::UNIX_EPOCH), Some(span)),
+            None => (None, None),
+        };
         Self {
             exclude_newer: timestamp,
             exclude_newer_span: span,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2358,10 +2358,12 @@ struct ExcludeNewerWire {
 impl From<ExcludeNewerWire> for ExcludeNewer {
     fn from(wire: ExcludeNewerWire) -> Self {
         let global = match (wire.exclude_newer, wire.exclude_newer_span) {
-            (Some(_), Some(span)) => Some(ExcludeNewerValue::relative(span)),
             (Some(timestamp), None) => Some(ExcludeNewerValue::absolute(timestamp)),
-            // Preserve span-only lockfile entries. Relative values compute their timestamp on
-            // demand, so a missing serialized timestamp should not invalidate the lockfile.
+            // We're phasing out writing a timestamp when spans are used. uv writes a dummy
+            // timestamp for backwards compatibility that we can ignore on deserialization.
+            (Some(_), Some(span)) => Some(ExcludeNewerValue::relative(span)),
+            // A future version of uv will remove the timestamp entirely, so for forwards
+            // compatibility we ignore a missing value.
             (None, Some(span)) => Some(ExcludeNewerValue::relative(span)),
             (None, None) => None,
         };

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1165,7 +1165,7 @@ impl Lock {
                         // When a relative span is present, write a no-op timestamp to avoid
                         // merge conflicts in the lockfile. In a future version of uv, we'll drop
                         // this field entirely but it's retained for backwards compatibility for now.
-                        let mut noop = value("0001-01-01T00:00:00Z");
+                        let mut noop = value(ExcludeNewerValue::PLACEHOLDER);
                         if let Item::Value(ref mut v) = noop {
                             v.decor_mut().set_suffix(" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.");
                         }
@@ -2358,8 +2358,11 @@ struct ExcludeNewerWire {
 impl From<ExcludeNewerWire> for ExcludeNewer {
     fn from(wire: ExcludeNewerWire) -> Self {
         let global = match (wire.exclude_newer, wire.exclude_newer_span) {
-            (Some(timestamp), span) => Some(ExcludeNewerValue::new(timestamp, span)),
-            (None, Some(span)) => Some(ExcludeNewerValue::new(Timestamp::UNIX_EPOCH, Some(span))),
+            (Some(_), Some(span)) => Some(ExcludeNewerValue::relative(span)),
+            (Some(timestamp), None) => Some(ExcludeNewerValue::absolute(timestamp)),
+            // Preserve span-only lockfile entries. Relative values compute their timestamp on
+            // demand, so a missing serialized timestamp should not invalidate the lockfile.
+            (None, Some(span)) => Some(ExcludeNewerValue::relative(span)),
             (None, None) => None,
         };
         Self {
@@ -2371,10 +2374,11 @@ impl From<ExcludeNewerWire> for ExcludeNewer {
 
 impl From<ExcludeNewer> for ExcludeNewerWire {
     fn from(exclude_newer: ExcludeNewer) -> Self {
-        let (timestamp, span) = exclude_newer
-            .global
-            .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(t, s)| (Some(t), s));
+        let (timestamp, span) = match exclude_newer.global {
+            Some(ExcludeNewerValue::Absolute(timestamp)) => (Some(timestamp), None),
+            Some(ExcludeNewerValue::Relative(span)) => (None, Some(span)),
+            None => (None, None),
+        };
         Self {
             exclude_newer: timestamp,
             exclude_newer_span: span,
@@ -2557,12 +2561,16 @@ impl TryFrom<LockWire> for Lock {
             .map(|simplified_marker| simplified_marker.into_marker(&wire.requires_python))
             .map(UniversalMarker::from_combined)
             .collect();
+        let mut options = wire.options;
+        if options.exclude_newer.exclude_newer_span.is_some() {
+            options.exclude_newer.exclude_newer = None;
+        }
         let lock = Self::new(
             wire.version,
             wire.revision.unwrap_or(0),
             packages,
             wire.requires_python,
-            wire.options,
+            options,
             wire.manifest,
             wire.conflicts.unwrap_or_else(Conflicts::empty),
             supported_environments,

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -4,6 +4,7 @@ use std::ops::Bound;
 
 use indexmap::IndexSet;
 use itertools::Itertools;
+use jiff::Timestamp;
 use owo_colors::OwoColorize;
 use pubgrub::{DerivationTree, Derived, External, Map, Range, ReportFormatter, Term};
 use rustc_hash::FxHashMap;
@@ -30,9 +31,7 @@ use crate::resolver::{
     MetadataUnavailable, UnavailableErrorChain, UnavailablePackage, UnavailableReason,
     UnavailableVersion,
 };
-use crate::{
-    ExcludeNewerValue, Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionsResponse,
-};
+use crate::{Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionsResponse};
 
 #[derive(Debug)]
 pub(crate) struct PubGrubReportFormatter<'a> {
@@ -1393,7 +1392,7 @@ pub(crate) enum PubGrubHint {
         package: PackageName,
         source: EffectiveExcludeNewerSource,
         // excluded from `PartialEq` and `Hash`
-        exclude_newer: ExcludeNewerValue,
+        exclude_newer: Timestamp,
         // excluded from `PartialEq` and `Hash`
         matching_version: Option<ExcludeNewerVersionDetail>,
     },

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2771,9 +2771,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_none_or(|upload_time| {
-                                        exclude_newer
-                                            .timestamp_millis()
-                                            .is_some_and(|cutoff| upload_time >= cutoff)
+                                        upload_time >= exclude_newer.timestamp_millis()
                                     })
                                 })
                             };
@@ -2796,9 +2794,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_some_and(|upload_time| {
-                                        exclude_newer
-                                            .timestamp_millis()
-                                            .is_some_and(|cutoff| upload_time >= cutoff)
+                                        upload_time >= exclude_newer.timestamp_millis()
                                     })
                                 })
                             };

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2771,7 +2771,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_none_or(|upload_time| {
-                                        upload_time >= exclude_newer.timestamp_millis()
+                                        exclude_newer
+                                            .timestamp_millis()
+                                            .is_some_and(|cutoff| upload_time >= cutoff)
                                     })
                                 })
                             };
@@ -2794,7 +2796,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_some_and(|upload_time| {
-                                        upload_time >= exclude_newer.timestamp_millis()
+                                        exclude_newer
+                                            .timestamp_millis()
+                                            .is_some_and(|cutoff| upload_time >= cutoff)
                                     })
                                 })
                             };

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -23,10 +23,10 @@ use tracing::{Level, debug, info, instrument, trace, warn};
 use uv_configuration::{Constraints, Excludes, Overrides};
 use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_distribution_types::{
-    BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, ExcludeNewerValue, Identifier,
-    IncompatibleDist, IncompatibleSource, IncompatibleWheel, IndexCapabilities, IndexLocations,
-    IndexMetadata, IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement,
-    ResolvedDist, ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
+    BuiltDist, CompatibleDist, DerivationChain, Dist, DistErrorKind, Identifier, IncompatibleDist,
+    IncompatibleSource, IncompatibleWheel, IndexCapabilities, IndexLocations, IndexMetadata,
+    IndexUrl, InstalledDist, Name, PythonRequirementKind, RemoteSource, Requirement, ResolvedDist,
+    ResolvedDistRef, SourceDist, VersionOrUrlRef, implied_markers,
 };
 use uv_git::GitResolver;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -2725,7 +2725,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         let mut included_versions = FxHashMap::default();
         let mut available_versions = FxHashMap::default();
 
-        let available_version_cutoff: Option<ExcludeNewerValue> =
+        let available_version_cutoff: Option<jiff::Timestamp> =
             std::env::var(EnvVars::UV_TEST_AVAILABLE_VERSION_CUTOFF)
                 .ok()
                 .and_then(|s| s.parse().ok());
@@ -2771,7 +2771,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_none_or(|upload_time| {
-                                        upload_time >= exclude_newer.timestamp_millis()
+                                        upload_time >= exclude_newer.as_millisecond()
                                     })
                                 })
                             };
@@ -2794,7 +2794,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 };
                                 prioritized_dist.files().all(|file| {
                                     file.upload_time_utc_ms.is_some_and(|upload_time| {
-                                        upload_time >= exclude_newer.timestamp_millis()
+                                        upload_time >= exclude_newer.as_millisecond()
                                     })
                                 })
                             };

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -154,7 +154,7 @@ impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
         &self,
         package_name: &PackageName,
         index: &uv_distribution_types::IndexUrl,
-    ) -> Option<crate::ExcludeNewerValue> {
+    ) -> Option<jiff::Timestamp> {
         self.exclude_newer.exclude_newer_package_for_index(
             package_name,
             self.index_locations.exclude_newer_for(index),

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -3,6 +3,7 @@ use std::collections::btree_map::{BTreeMap, Entry};
 use std::ops::RangeBounds;
 use std::sync::OnceLock;
 
+use jiff::Timestamp;
 use pubgrub::Ranges;
 use rustc_hash::FxHashMap;
 use tracing::{instrument, trace};
@@ -23,7 +24,7 @@ use uv_types::HashStrategy;
 use uv_warnings::warn_user_once;
 
 use crate::flat_index::FlatDistributions;
-use crate::{ExcludeNewerValue, yanks::AllowedYanks};
+use crate::yanks::AllowedYanks;
 
 /// A map from versions to distributions.
 #[derive(Debug)]
@@ -51,7 +52,7 @@ impl VersionMap {
         requires_python: &RequiresPython,
         allowed_yanks: &AllowedYanks,
         hasher: &HashStrategy,
-        exclude_newer: Option<ExcludeNewerValue>,
+        exclude_newer: Option<Timestamp>,
         flat_index: Option<FlatDistributions>,
         build_options: &BuildOptions,
     ) -> Self {
@@ -189,7 +190,7 @@ impl VersionMap {
     }
 
     /// Return the effective `exclude-newer` cutoff for this version map, if any.
-    pub(crate) fn exclude_newer(&self) -> Option<&ExcludeNewerValue> {
+    pub(crate) fn exclude_newer(&self) -> Option<&Timestamp> {
         match &self.inner {
             VersionMapInner::Eager(_) => None,
             VersionMapInner::Lazy(lazy) => lazy.exclude_newer.as_ref(),
@@ -398,7 +399,7 @@ struct VersionMapLazy {
     /// in the current environment.
     tags: Option<Tags>,
     /// Whether files newer than this timestamp should be excluded or not.
-    exclude_newer: Option<ExcludeNewerValue>,
+    exclude_newer: Option<Timestamp>,
     /// Which yanked versions are allowed
     allowed_yanks: AllowedYanks,
     /// The hashes of allowed distributions.
@@ -455,7 +456,7 @@ impl VersionMapLazy {
                 // upload time information.
                 let (excluded, upload_time) = if let Some(exclude_newer) = &self.exclude_newer {
                     match file.upload_time_utc_ms.as_ref() {
-                        Some(&upload_time) if upload_time >= exclude_newer.timestamp_millis() => {
+                        Some(&upload_time) if upload_time >= exclude_newer.as_millisecond() => {
                             trace!(
                                 "Excluding `{}` (uploaded {upload_time}) due to exclude-newer ({exclude_newer})",
                                 file.filename

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -455,11 +455,7 @@ impl VersionMapLazy {
                 // upload time information.
                 let (excluded, upload_time) = if let Some(exclude_newer) = &self.exclude_newer {
                     match file.upload_time_utc_ms.as_ref() {
-                        Some(&upload_time)
-                            if exclude_newer
-                                .timestamp_millis()
-                                .is_some_and(|cutoff| upload_time >= cutoff) =>
-                        {
+                        Some(&upload_time) if upload_time >= exclude_newer.timestamp_millis() => {
                             trace!(
                                 "Excluding `{}` (uploaded {upload_time}) due to exclude-newer ({exclude_newer})",
                                 file.filename

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -455,7 +455,11 @@ impl VersionMapLazy {
                 // upload time information.
                 let (excluded, upload_time) = if let Some(exclude_newer) = &self.exclude_newer {
                     match file.upload_time_utc_ms.as_ref() {
-                        Some(&upload_time) if upload_time >= exclude_newer.timestamp_millis() => {
+                        Some(&upload_time)
+                            if exclude_newer
+                                .timestamp_millis()
+                                .is_some_and(|cutoff| upload_time >= cutoff) =>
+                        {
                             trace!(
                                 "Excluding `{}` (uploaded {upload_time}) due to exclude-newer ({exclude_newer})",
                                 file.filename

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -2256,9 +2256,6 @@ impl From<ToolOptionsWire> for ToolOptions {
         let exclude_newer = value.exclude_newer.map(|exclude_newer| {
             if exclude_newer.span().is_none() {
                 ExcludeNewerValue::new(exclude_newer.timestamp(), value.exclude_newer_span)
-            } else if exclude_newer.timestamp().is_none() && value.exclude_newer_span.is_some() {
-                // The wire format has a span stored separately; merge it in
-                ExcludeNewerValue::new(None, value.exclude_newer_span)
             } else {
                 exclude_newer
             }
@@ -2302,7 +2299,7 @@ impl From<ToolOptions> for ToolOptionsWire {
             .exclude_newer
             .map(ExcludeNewerValue::into_parts)
             .map_or((None, None), |(timestamp, span)| {
-                (timestamp.map(ExcludeNewerValue::from), span)
+                (Some(ExcludeNewerValue::from(timestamp)), span)
             });
 
         Self {

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -525,25 +525,6 @@ pub struct ResolverInstallerOptions {
     pub no_binary_package: Option<Vec<PackageName>>,
 }
 
-impl ResolverInstallerOptions {
-    /// Recompute any relative exclude-newer values against the current time.
-    #[must_use]
-    pub fn recompute_exclude_newer(mut self) -> Self {
-        let exclude_newer = ExcludeNewer::new(
-            self.exclude_newer.take(),
-            self.exclude_newer_package.take().unwrap_or_default(),
-        )
-        .recompute();
-        self.exclude_newer = exclude_newer.global;
-        self.exclude_newer_package = if exclude_newer.package.is_empty() {
-            None
-        } else {
-            Some(exclude_newer.package)
-        };
-        self
-    }
-}
-
 impl From<ResolverInstallerSchema> for ResolverInstallerOptions {
     fn from(value: ResolverInstallerSchema) -> Self {
         let ResolverInstallerSchema {

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -2256,6 +2256,9 @@ impl From<ToolOptionsWire> for ToolOptions {
         let exclude_newer = value.exclude_newer.map(|exclude_newer| {
             if exclude_newer.span().is_none() {
                 ExcludeNewerValue::new(exclude_newer.timestamp(), value.exclude_newer_span)
+            } else if exclude_newer.timestamp().is_none() && value.exclude_newer_span.is_some() {
+                // The wire format has a span stored separately; merge it in
+                ExcludeNewerValue::new(None, value.exclude_newer_span)
             } else {
                 exclude_newer
             }
@@ -2299,7 +2302,7 @@ impl From<ToolOptions> for ToolOptionsWire {
             .exclude_newer
             .map(ExcludeNewerValue::into_parts)
             .map_or((None, None), |(timestamp, span)| {
-                (Some(ExcludeNewerValue::from(timestamp)), span)
+                (timestamp.map(ExcludeNewerValue::from), span)
             });
 
         Self {

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -2276,12 +2276,14 @@ impl From<ToolOptionsWire> for ToolOptions {
 
 impl From<ToolOptions> for ToolOptionsWire {
     fn from(value: ToolOptions) -> Self {
-        let (exclude_newer, exclude_newer_span) = value
-            .exclude_newer
-            .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(timestamp, span)| {
-                (Some(ExcludeNewerValue::from(timestamp)), span)
-            });
+        let (exclude_newer, exclude_newer_span) = match &value.exclude_newer {
+            Some(value @ ExcludeNewerValue::Absolute(_)) => (Some(value.clone()), None),
+            Some(value @ ExcludeNewerValue::Relative(span)) => (
+                Some(ExcludeNewerValue::Absolute(value.timestamp())),
+                Some(*span),
+            ),
+            None => (None, None),
+        };
 
         Self {
             index: value.index,

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -525,25 +525,6 @@ pub struct ResolverInstallerOptions {
     pub no_binary_package: Option<Vec<PackageName>>,
 }
 
-impl ResolverInstallerOptions {
-    /// Recompute any relative exclude-newer values against the current time.
-    #[must_use]
-    pub fn recompute_exclude_newer(mut self) -> Self {
-        let exclude_newer = ExcludeNewer::new(
-            self.exclude_newer.take(),
-            self.exclude_newer_package.take().unwrap_or_default(),
-        )
-        .recompute();
-        self.exclude_newer = exclude_newer.global;
-        self.exclude_newer_package = if exclude_newer.package.is_empty() {
-            None
-        } else {
-            Some(exclude_newer.package)
-        };
-        self
-    }
-}
-
 impl From<ResolverInstallerSchema> for ResolverInstallerOptions {
     fn from(value: ResolverInstallerSchema) -> Self {
         let ResolverInstallerSchema {
@@ -2254,8 +2235,10 @@ impl From<ResolverInstallerOptions> for ToolOptions {
 impl From<ToolOptionsWire> for ToolOptions {
     fn from(value: ToolOptionsWire) -> Self {
         let exclude_newer = value.exclude_newer.map(|exclude_newer| {
-            if exclude_newer.span().is_none() {
-                ExcludeNewerValue::new(exclude_newer.timestamp(), value.exclude_newer_span)
+            if let Some(span) = value.exclude_newer_span
+                && exclude_newer.span().is_none()
+            {
+                ExcludeNewerValue::relative(span)
             } else {
                 exclude_newer
             }
@@ -2295,12 +2278,14 @@ impl From<ToolOptionsWire> for ToolOptions {
 
 impl From<ToolOptions> for ToolOptionsWire {
     fn from(value: ToolOptions) -> Self {
-        let (exclude_newer, exclude_newer_span) = value
-            .exclude_newer
-            .map(ExcludeNewerValue::into_parts)
-            .map_or((None, None), |(timestamp, span)| {
-                (Some(ExcludeNewerValue::from(timestamp)), span)
-            });
+        let (exclude_newer, exclude_newer_span) = match &value.exclude_newer {
+            Some(value @ ExcludeNewerValue::Absolute(_)) => (Some(value.clone()), None),
+            Some(value @ ExcludeNewerValue::Relative(span)) => (
+                Some(ExcludeNewerValue::absolute(value.timestamp())),
+                Some(*span),
+            ),
+            None => (None, None),
+        };
 
         Self {
             index: value.index,

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -86,9 +86,7 @@ impl LatestClient<'_> {
                     if let Some(exclude_newer) = &exclude_newer {
                         match file.upload_time_utc_ms.as_ref() {
                             Some(&upload_time)
-                                if exclude_newer
-                                    .timestamp_millis()
-                                    .is_some_and(|cutoff| upload_time >= cutoff) =>
+                                if upload_time >= exclude_newer.timestamp_millis() =>
                             {
                                 continue;
                             }

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -86,7 +86,9 @@ impl LatestClient<'_> {
                     if let Some(exclude_newer) = &exclude_newer {
                         match file.upload_time_utc_ms.as_ref() {
                             Some(&upload_time)
-                                if upload_time >= exclude_newer.timestamp_millis() =>
+                                if exclude_newer
+                                    .timestamp_millis()
+                                    .is_some_and(|cutoff| upload_time >= cutoff) =>
                             {
                                 continue;
                             }

--- a/crates/uv/src/commands/pip/latest.rs
+++ b/crates/uv/src/commands/pip/latest.rs
@@ -31,7 +31,7 @@ impl LatestClient<'_> {
         &self,
         package: &PackageName,
         index: &IndexUrl,
-    ) -> Option<uv_resolver::ExcludeNewerValue> {
+    ) -> Option<jiff::Timestamp> {
         self.exclude_newer
             .exclude_newer_package_for_index(package, self.index_locations.exclude_newer_for(index))
     }
@@ -85,9 +85,7 @@ impl LatestClient<'_> {
                     // Skip distributions uploaded after the cutoff.
                     if let Some(exclude_newer) = &exclude_newer {
                         match file.upload_time_utc_ms.as_ref() {
-                            Some(&upload_time)
-                                if upload_time >= exclude_newer.timestamp_millis() =>
-                            {
+                            Some(&upload_time) if upload_time >= exclude_newer.as_millisecond() => {
                                 continue;
                             }
                             None => {

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -229,10 +229,7 @@ pub(crate) async fn tree(
             .build()?;
             let download_concurrency = concurrency.downloads_semaphore.clone();
 
-            // Recompute the exclude-newer timestamps from relative spans so that
-            // `--outdated` judges outdatedness relative to the current moment,
-            // not the time the lock was originally generated.
-            let exclude_newer = lock.exclude_newer().recompute();
+            let exclude_newer = lock.exclude_newer();
 
             // Initialize the client to fetch the latest version of each package.
             let client = LatestClient {

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -130,13 +130,9 @@ pub(crate) async fn list(
                 let filesystem = filesystem.clone();
                 async move {
                     let capabilities = IndexCapabilities::default();
-                    let settings = ResolverInstallerSettings::from(
-                        args.combine(
-                            ResolverInstallerOptions::from(tool.options().clone())
-                                .recompute_exclude_newer()
-                                .combine(filesystem),
-                        ),
-                    );
+                    let settings = ResolverInstallerSettings::from(args.combine(
+                        ResolverInstallerOptions::from(tool.options().clone()).combine(filesystem),
+                    ));
                     let interpreter = tool_env.environment().interpreter();
 
                     let client = RegistryClientBuilder::new(

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -319,7 +319,6 @@ async fn upgrade_tool(
     // Resolve the appropriate settings, preferring: CLI > receipt > user.
     let options = args.clone().combine(
         ResolverInstallerOptions::from(existing_tool_receipt.options().clone())
-            .recompute_exclude_newer()
             .combine(filesystem.clone()),
     );
     let settings = ResolverInstallerSettings::from(options.clone());

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2546,7 +2546,7 @@ impl FormatSettings {
             diff,
             extra_args,
             version,
-            exclude_newer: exclude_newer.map(|v| v.timestamp()),
+            exclude_newer: exclude_newer.and_then(|v| v.timestamp()),
             no_project,
             show_version,
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -2546,7 +2546,7 @@ impl FormatSettings {
             diff,
             extra_args,
             version,
-            exclude_newer: exclude_newer.and_then(|v| v.timestamp()),
+            exclude_newer: exclude_newer.map(|v| v.timestamp()),
             no_project,
             show_version,
         }

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1263,8 +1263,9 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     let lock = lock.replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "");
     context.temp_dir.child("uv.lock").write_str(&lock)?;
 
-    // The lockfile now has no exclude-newer, but `pyproject.toml` still configures one,
-    // so the resolver detects "addition of global exclude newer" and re-resolves.
+    // The lockfile now has no exclude-newer timestamp, but the span is still present.
+    // Since the span matches the `pyproject.toml` configuration, the lockfile is still
+    // treated as valid — the missing timestamp alone does not trigger re-resolution.
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
@@ -1274,41 +1275,8 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolving despite existing lockfile due to addition of global exclude newer 2024-04-10T00:00:00Z
     Resolved 2 packages in [TIME]
     ");
-
-    // The lockfile should have exclude-newer restored.
-    let lock = context.read("uv.lock");
-    assert_snapshot!(lock, @r#"
-    version = 1
-    revision = 3
-    requires-python = ">=3.12"
-
-    [options]
-    exclude-newer = "2024-04-10T00:00:00Z"
-    exclude-newer-span = "P3W"
-
-    [[package]]
-    name = "idna"
-    version = "3.6"
-    source = { registry = "https://pypi.org/simple" }
-    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
-    wheels = [
-        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
-    ]
-
-    [[package]]
-    name = "project"
-    version = "0.1.0"
-    source = { virtual = "." }
-    dependencies = [
-        { name = "idna" },
-    ]
-
-    [package.metadata]
-    requires-dist = [{ name = "idna" }]
-    "#);
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -480,7 +480,7 @@ fn lock_exclude_newer_package_relative() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    // And the `exclude-newer-package` timestamp value in the lockfile should be changed
+    // The `exclude-newer-package` span is unchanged; the timestamp is a placeholder
     let lock = context.read("uv.lock");
     assert_snapshot!(lock, @r#"
     version = 1
@@ -490,7 +490,7 @@ fn lock_exclude_newer_package_relative() -> Result<()> {
     [options]
 
     [options.exclude-newer-package]
-    idna = { timestamp = "2024-05-18T00:00:00Z", span = "P2W" }
+    idna = { timestamp = "2024-04-17T00:00:00Z", span = "P2W" }
 
     [[package]]
     name = "idna"

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1198,19 +1198,8 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
     Ok(())
 }
 
-/// Test that manually removing the exclude-newer timestamp from the lockfile triggers a
-/// re-resolution.
-///
-/// When a lockfile has `exclude-newer` (timestamp) and `exclude-newer-span` set and the
-/// timestamp is manually removed, the span alone is not enough to constitute a global
-/// exclude-newer value, so the next `uv lock` should detect this as an addition of global
-/// exclude-newer and trigger a fresh resolution.
-///
-/// Uses idna which has releases at:
-/// - 3.6: 2023-11-25
-/// - 3.7: 2024-04-11
 #[test]
-fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
+fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
@@ -1226,7 +1215,6 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
         "#,
     )?;
 
-    // 3 weeks before 2024-05-01 is 2024-04-10, which is before idna 3.7 (released 2024-04-11).
     let current_timestamp = "2024-05-01T00:00:00Z";
     uv_snapshot!(context.filters(), context
         .lock()

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1198,8 +1198,17 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
     Ok(())
 }
 
+/// Test that manually removing exclude-newer from the lockfile triggers a re-resolution.
+///
+/// When a lockfile has `exclude-newer` and `exclude-newer-span` set and these are manually
+/// removed, the next `uv lock` with a relative `--exclude-newer` should detect this as an
+/// addition of global exclude-newer and trigger a fresh resolution.
+///
+/// Uses idna which has releases at:
+/// - 3.6: 2023-11-25
+/// - 3.7: 2024-04-11
 #[test]
-fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
+fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
@@ -1209,17 +1218,17 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = ["idna"]
-
-        [tool.uv]
-        exclude-newer = "3 weeks"
         "#,
     )?;
 
+    // 3 weeks before 2024-05-01 is 2024-04-10, which is before idna 3.7 (released 2024-04-11).
     let current_timestamp = "2024-05-01T00:00:00Z";
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @"
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp)
+        .arg("--exclude-newer")
+        .arg("3 weeks"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1229,46 +1238,35 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     ");
 
     let lock = context.read("uv.lock");
-    assert_snapshot!(lock, @r#"
-    version = 1
-    revision = 3
-    requires-python = ">=3.12"
+    // Verify the lockfile has exclude-newer fields
+    assert!(
+        lock.contains("exclude-newer = \"2024-04-10T00:00:00Z\""),
+        "Expected exclude-newer timestamp in lockfile"
+    );
+    assert!(
+        lock.contains("exclude-newer-span = \"P3W\""),
+        "Expected exclude-newer-span in lockfile"
+    );
+    assert!(
+        lock.contains("version = \"3.6\""),
+        "Expected idna 3.6 in lockfile"
+    );
 
-    [options]
-    exclude-newer = "2024-04-10T00:00:00Z"
-    exclude-newer-span = "P3W"
-
-    [[package]]
-    name = "idna"
-    version = "3.6"
-    source = { registry = "https://pypi.org/simple" }
-    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
-    wheels = [
-        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
-    ]
-
-    [[package]]
-    name = "project"
-    version = "0.1.0"
-    source = { virtual = "." }
-    dependencies = [
-        { name = "idna" },
-    ]
-
-    [package.metadata]
-    requires-dist = [{ name = "idna" }]
-    "#);
-
-    // Manually remove the exclude-newer timestamp from the lockfile, leaving the span.
-    let lock = lock.replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "");
+    // Manually remove exclude-newer from the lockfile by stripping the lines
+    let lock = lock
+        .replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "")
+        .replace("exclude-newer-span = \"P3W\"\n", "");
     context.temp_dir.child("uv.lock").write_str(&lock)?;
 
-    // The lockfile now has no exclude-newer, but `pyproject.toml` still configures one,
-    // so the resolver detects "addition of global exclude newer" and re-resolves.
+    // Running with the same --exclude-newer should detect the removal and re-resolve.
+    // The lockfile now has no exclude-newer, but the CLI provides one, so it's treated as
+    // "addition of global exclude newer".
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @"
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp)
+        .arg("--exclude-newer")
+        .arg("3 weeks"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1278,7 +1276,7 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    // The lockfile should have exclude-newer restored.
+    // The lockfile should have exclude-newer restored
     let lock = context.read("uv.lock");
     assert_snapshot!(lock, @r#"
     version = 1
@@ -1309,6 +1307,38 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     [package.metadata]
     requires-dist = [{ name = "idna" }]
     "#);
+
+    // Also test: remove exclude-newer and run WITHOUT --exclude-newer.
+    // This should be a no-op since neither lockfile nor CLI has exclude-newer.
+    let lock = context.read("uv.lock");
+    let lock = lock
+        .replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "")
+        .replace("exclude-newer-span = \"P3W\"\n", "");
+    context.temp_dir.child("uv.lock").write_str(&lock)?;
+
+    uv_snapshot!(context.filters(), context
+        .lock()
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    // Without exclude-newer, the lockfile should not have it and idna should stay at 3.6
+    // (no upgrade unless --upgrade is passed)
+    let lock = context.read("uv.lock");
+    assert!(
+        !lock.contains("exclude-newer"),
+        "Expected no exclude-newer in lockfile"
+    );
+    assert!(
+        lock.contains("version = \"3.6\""),
+        "Expected idna 3.6 to remain stable without --upgrade"
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1201,8 +1201,8 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
 /// Test that manually removing exclude-newer from the lockfile triggers a re-resolution.
 ///
 /// When a lockfile has `exclude-newer` and `exclude-newer-span` set and these are manually
-/// removed, the next `uv lock` with a relative `--exclude-newer` should detect this as an
-/// addition of global exclude-newer and trigger a fresh resolution.
+/// removed, the next `uv lock` should detect this as an addition of global exclude-newer
+/// and trigger a fresh resolution.
 ///
 /// Uses idna which has releases at:
 /// - 3.6: 2023-11-25
@@ -1218,6 +1218,9 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = ["idna"]
+
+        [tool.uv]
+        exclude-newer = "3 weeks"
         "#,
     )?;
 
@@ -1226,9 +1229,7 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp)
-        .arg("--exclude-newer")
-        .arg("3 weeks"), @"
+        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1237,46 +1238,6 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    let lock = context.read("uv.lock");
-    // Verify the lockfile has exclude-newer fields
-    assert!(
-        lock.contains("exclude-newer = \"2024-04-10T00:00:00Z\""),
-        "Expected exclude-newer timestamp in lockfile"
-    );
-    assert!(
-        lock.contains("exclude-newer-span = \"P3W\""),
-        "Expected exclude-newer-span in lockfile"
-    );
-    assert!(
-        lock.contains("version = \"3.6\""),
-        "Expected idna 3.6 in lockfile"
-    );
-
-    // Manually remove exclude-newer from the lockfile by stripping the lines
-    let lock = lock
-        .replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "")
-        .replace("exclude-newer-span = \"P3W\"\n", "");
-    context.temp_dir.child("uv.lock").write_str(&lock)?;
-
-    // Running with the same --exclude-newer should detect the removal and re-resolve.
-    // The lockfile now has no exclude-newer, but the CLI provides one, so it's treated as
-    // "addition of global exclude newer".
-    uv_snapshot!(context.filters(), context
-        .lock()
-        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
-        .env(EnvVars::UV_TEST_CURRENT_TIMESTAMP, current_timestamp)
-        .arg("--exclude-newer")
-        .arg("3 weeks"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolving despite existing lockfile due to addition of global exclude newer 2024-04-10T00:00:00Z
-    Resolved 2 packages in [TIME]
-    ");
-
-    // The lockfile should have exclude-newer restored
     let lock = context.read("uv.lock");
     assert_snapshot!(lock, @r#"
     version = 1
@@ -1308,14 +1269,14 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     requires-dist = [{ name = "idna" }]
     "#);
 
-    // Also test: remove exclude-newer and run WITHOUT --exclude-newer.
-    // This should be a no-op since neither lockfile nor CLI has exclude-newer.
-    let lock = context.read("uv.lock");
+    // Manually remove exclude-newer from the lockfile by stripping the lines.
     let lock = lock
         .replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "")
         .replace("exclude-newer-span = \"P3W\"\n", "");
     context.temp_dir.child("uv.lock").write_str(&lock)?;
 
+    // The lockfile now has no exclude-newer, but `pyproject.toml` still configures one,
+    // so the resolver detects "addition of global exclude newer" and re-resolves.
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)
@@ -1325,20 +1286,41 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Resolving despite existing lockfile due to addition of global exclude newer 2024-04-10T00:00:00Z
     Resolved 2 packages in [TIME]
     ");
 
-    // Without exclude-newer, the lockfile should not have it and idna should stay at 3.6
-    // (no upgrade unless --upgrade is passed)
+    // The lockfile should have exclude-newer restored.
     let lock = context.read("uv.lock");
-    assert!(
-        !lock.contains("exclude-newer"),
-        "Expected no exclude-newer in lockfile"
-    );
-    assert!(
-        lock.contains("version = \"3.6\""),
-        "Expected idna 3.6 to remain stable without --upgrade"
-    );
+    assert_snapshot!(lock, @r#"
+    version = 1
+    revision = 3
+    requires-python = ">=3.12"
+
+    [options]
+    exclude-newer = "2024-04-10T00:00:00Z"
+    exclude-newer-span = "P3W"
+
+    [[package]]
+    name = "idna"
+    version = "3.6"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
+    ]
+
+    [[package]]
+    name = "project"
+    version = "0.1.0"
+    source = { virtual = "." }
+    dependencies = [
+        { name = "idna" },
+    ]
+
+    [package.metadata]
+    requires-dist = [{ name = "idna" }]
+    "#);
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -1198,11 +1198,13 @@ fn lock_exclude_newer_relative_values() -> Result<()> {
     Ok(())
 }
 
-/// Test that manually removing exclude-newer from the lockfile triggers a re-resolution.
+/// Test that manually removing the exclude-newer timestamp from the lockfile triggers a
+/// re-resolution.
 ///
-/// When a lockfile has `exclude-newer` and `exclude-newer-span` set and these are manually
-/// removed, the next `uv lock` should detect this as an addition of global exclude-newer
-/// and trigger a fresh resolution.
+/// When a lockfile has `exclude-newer` (timestamp) and `exclude-newer-span` set and the
+/// timestamp is manually removed, the span alone is not enough to constitute a global
+/// exclude-newer value, so the next `uv lock` should detect this as an addition of global
+/// exclude-newer and trigger a fresh resolution.
 ///
 /// Uses idna which has releases at:
 /// - 3.6: 2023-11-25
@@ -1269,10 +1271,8 @@ fn lock_exclude_newer_relative_remove_from_lockfile() -> Result<()> {
     requires-dist = [{ name = "idna" }]
     "#);
 
-    // Manually remove exclude-newer from the lockfile by stripping the lines.
-    let lock = lock
-        .replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "")
-        .replace("exclude-newer-span = \"P3W\"\n", "");
+    // Manually remove the exclude-newer timestamp from the lockfile, leaving the span.
+    let lock = lock.replace("exclude-newer = \"2024-04-10T00:00:00Z\"\n", "");
     context.temp_dir.child("uv.lock").write_str(&lock)?;
 
     // The lockfile now has no exclude-newer, but `pyproject.toml` still configures one,

--- a/crates/uv/tests/it/lock_exclude_newer_relative.rs
+++ b/crates/uv/tests/it/lock_exclude_newer_relative.rs
@@ -482,7 +482,7 @@ fn lock_exclude_newer_package_relative() -> Result<()> {
     Resolved 2 packages in [TIME]
     ");
 
-    // And the `exclude-newer-package` timestamp value in the lockfile should be changed
+    // The `exclude-newer-package` span is unchanged; the timestamp is a placeholder
     let lock = context.read("uv.lock");
     assert_snapshot!(lock, @r#"
     version = 1
@@ -492,7 +492,7 @@ fn lock_exclude_newer_package_relative() -> Result<()> {
     [options]
 
     [options.exclude-newer-package]
-    idna = { timestamp = "2024-05-18T00:00:00Z", span = "P2W" }
+    idna = { timestamp = "2024-04-17T00:00:00Z", span = "P2W" }
 
     [[package]]
     name = "idna"
@@ -1265,8 +1265,9 @@ fn lock_exclude_newer_relative_no_timestamp_in_lockfile() -> Result<()> {
     let lock = lock.replace("exclude-newer = \"0001-01-01T00:00:00Z\" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.\n", "");
     context.temp_dir.child("uv.lock").write_str(&lock)?;
 
-    // The lockfile now has no exclude-newer, but `pyproject.toml` still configures one,
-    // so the resolver detects "addition of global exclude newer" and re-resolves.
+    // The lockfile now has no exclude-newer timestamp, but the span is still present.
+    // Since the span matches the `pyproject.toml` configuration, the lockfile is still
+    // treated as valid — the missing timestamp alone does not trigger re-resolution.
     uv_snapshot!(context.filters(), context
         .lock()
         .env_remove(EnvVars::UV_EXCLUDE_NEWER)


### PR DESCRIPTION
Following #19022 this is an incremental step towards removing `exclude-newer` timestamps from lockfiles. We don't remove it here, but we ensure from this version onward, uv will not behave poorly when the value is missing. This includes substantial refactoring to better represent the desired end state in our exclude-newer types.