### PR TITLE
Use relative path when creating symlinks in cache.

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -825,16 +825,17 @@ impl Cache {
     /// version. On Unix, we create a symlink to the target directory.
     #[cfg(unix)]
     pub fn create_link(&self, id: &ArchiveId, dst: impl AsRef<Path>) -> io::Result<()> {
-        // Construct the link target.
-        let src = self.archive(id);
         let dst = dst.as_ref();
+        let dst_parent = dst.parent().expect("Cache entry to have parent");
+        // Construct the relative link target.
+        let src = uv_fs::relative_to(self.archive(id), dst_parent)?;
 
         // Attempt to create the symlink directly.
         match fs_err::os::unix::fs::symlink(&src, dst) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 // Create a symlink, using a temporary file to ensure atomicity.
-                let temp_dir = tempfile::tempdir_in(dst.parent().unwrap())?;
+                let temp_dir = tempfile::tempdir_in(dst_parent)?;
                 let temp_file = temp_dir.path().join("link");
                 fs_err::os::unix::fs::symlink(&src, &temp_file)?;
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -826,16 +826,17 @@ impl Cache {
     /// version. On Unix, we create a symlink to the target directory.
     #[cfg(unix)]
     fn create_link(&self, id: &ArchiveId, dst: impl AsRef<Path>) -> io::Result<()> {
-        // Construct the link target.
-        let src = self.archive(id);
         let dst = dst.as_ref();
+        let dst_parent = dst.parent().expect("Cache entry to have parent");
+        // Construct the relative link target.
+        let src = uv_fs::relative_to(self.archive(id), dst_parent)?;
 
         // Attempt to create the symlink directly.
         match fs_err::os::unix::fs::symlink(&src, dst) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 // Create a symlink, using a temporary file to ensure atomicity.
-                let temp_dir = tempfile::tempdir_in(dst.parent().unwrap())?;
+                let temp_dir = tempfile::tempdir_in(dst_parent)?;
                 let temp_file = temp_dir.path().join("link");
                 fs_err::os::unix::fs::symlink(&src, &temp_file)?;
 


### PR DESCRIPTION
## Summary

**Problem**

On non-Windows platforms, a symlink is used to reference the archive within the cache, but the link uses an absolute path even though it always references a path within the same cache directory.

As a result, unlike the Windows platform which uses a regular file containing a reference ID to the archive the cache directory itself is neither relocatable nor shareable across different environments, such as between multiple containers for development.

Related to #2908.

**Solution**

Use a relative path when creating the symlink.

**Considerations**

- Adopting the Windows approach on other platforms was also considered.

    While this would break compatibility with existing cache directories, it would avoid the concern described below.

- Possibility of destination path relocation.

    While it is unlikely happening, a symlink created with a relative path cannot itself be relocated independently of its target.