### PR TITLE
fix: use existing git source when adding package by name

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1721,6 +1721,34 @@ impl Source {
                         group: None,
                     }
                 } else {
+                    // If the package has an existing git source, use it
+                    if let Some(sources) = existing_sources {
+                        if let Some(package_sources) = sources.get(name) {
+                            for existing_source in package_sources.iter() {
+                                if let Self::Git {
+                                    git,
+                                    subdirectory,
+                                    marker,
+                                    extra,
+                                    group,
+                                    ..
+                                } = existing_source
+                                {
+                                    return Ok(Some(Self::Git {
+                                        git: git.clone(),
+                                        subdirectory: subdirectory.clone(),
+                                        rev: None,
+                                        tag: None,
+                                        branch: None,
+                                        lfs: GitLfsSetting::default(),
+                                        marker: *marker,
+                                        extra: extra.clone(),
+                                        group: group.clone(),
+                                    }));
+                                }
+                            }
+                        }
+                    }
                     return Ok(None);
                 }
             }


### PR DESCRIPTION
## Summary

When running `uv add <package-name>` for a package that has an existing git source defined in `tool.uv.sources`, uv now recognizes and uses the existing git source instead of treating it as a registry requirement.

This allows updating git dependencies without having to specify the full URL every time:

```
$ uv add tempo-cache-tools  # Now updates the existing git dependency
```

Previously, only the full URL form would trigger an update:
```
$ uv add git+https://www.github.com/Tempo-Organization/tempo-cache-tools  # This worked
$ uv add tempo-cache-tools  # This did NOT update
```

## Fix

In `crates/uv-workspace/src/pyproject.rs`, the `Source::from_requirement` function now checks for existing git sources when the requirement has no explicit URL (registry requirement with no index). Previously, it only checked for existing git sources when the user provided `--branch`, `--tag`, `--rev`, or `--lfs` flags.

## Testing

The existing test `add_update_git_reference_project` demonstrates the behavior when using git flags. The fix extends this to work without git flags.

Fixes #19028