### PR TITLE
Adds --interactive` flag to pass `-i` to python

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3697,6 +3697,12 @@ pub struct RunArgs {
     #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
     pub locked: bool,
 
+    /// Run python interactively after script is run.
+    ///
+    /// Runs python with --interactive flag, which opens an interactive shell after a script is run.
+    #[arg(long)]
+    pub interactive: bool,
+
     /// Run without updating the `uv.lock` file [env: UV_FROZEN=]
     ///
     /// Instead of checking if the lockfile is up-to-date, uses the versions in the lockfile as the

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1429,28 +1429,31 @@ fn can_skip_ephemeral(
 }
 
 #[derive(Debug)]
+pub(crate) struct ExtraPythonArgs(Vec<OsString>);
+
+#[derive(Debug)]
 pub(crate) enum RunCommand {
     /// Execute `python`.
     Python(Vec<OsString>),
     /// Execute a `python` script.
-    PythonScript(PathBuf, Vec<OsString>),
+    PythonScript(PathBuf, Vec<OsString>, ExtraPythonArgs),
     /// Search `sys.path` for the named module and execute its contents as the `__main__` module.
     /// Equivalent to `python -m module`.
-    PythonModule(OsString, Vec<OsString>),
+    PythonModule(OsString, Vec<OsString>, ExtraPythonArgs),
     /// Execute a `pythonw` GUI script.
-    PythonGuiScript(PathBuf, Vec<OsString>),
+    PythonGuiScript(PathBuf, Vec<OsString>, ExtraPythonArgs),
     /// Execute a Python package containing a `__main__.py` file.
     /// If an entrypoint with the target name is installed in the environment, it is preferred.
-    PythonPackage(OsString, PathBuf, Vec<OsString>),
+    PythonPackage(OsString, PathBuf, Vec<OsString>, ExtraPythonArgs),
     /// Execute a Python [zipapp].
     /// [zipapp]: <https://docs.python.org/3/library/zipapp.html>
-    PythonZipapp(PathBuf, Vec<OsString>),
+    PythonZipapp(PathBuf, Vec<OsString>, ExtraPythonArgs),
     /// Execute a `python` script provided via `stdin`.
-    PythonStdin(Vec<u8>, Vec<OsString>),
+    PythonStdin(Vec<u8>, Vec<OsString>, ExtraPythonArgs),
     /// Execute a `pythonw` script provided via `stdin`.
-    PythonGuiStdin(Vec<u8>, Vec<OsString>),
+    PythonGuiStdin(Vec<u8>, Vec<OsString>, ExtraPythonArgs),
     /// Execute a Python script downloaded from a remote URL.
-    PythonRemote(tempfile::NamedTempFile, Vec<OsString>),
+    PythonRemote(tempfile::NamedTempFile, Vec<OsString>, ExtraPythonArgs),
     /// Execute an external command.
     External(OsString, Vec<OsString>),
     /// Execute an empty command (in practice, `python` with no arguments).
@@ -1532,15 +1535,20 @@ impl ParsedRunCommand {
                     Err(Pep723Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => None,
                     Err(err) => return Err(err.into()),
                 };
-
-                Ok((script, RunCommand::PythonRemote(downloaded_script, args)))
+                let py_args = ExtraPythonArgs(vec![]);
+                Ok((
+                    script,
+                    RunCommand::PythonRemote(downloaded_script, args, py_args),
+                ))
             }
         }
     }
 
     /// Determine the [`ParsedRunCommand`] for a given set of arguments.
+    #[expect(clippy::fn_params_excessive_bools)]
     pub(crate) fn from_args(
         command: &ExternalCommand,
+        interactive: bool,
         module: bool,
         script: bool,
         gui_script: bool,
@@ -1550,6 +1558,12 @@ impl ParsedRunCommand {
             return Ok(Self::Ready(RunCommand::Empty));
         };
 
+        let py_args = ExtraPythonArgs(if interactive {
+            vec!["-i".into()]
+        } else {
+            vec![]
+        });
+
         if target.eq_ignore_ascii_case("-") {
             let mut buf = Vec::with_capacity(1024);
             std::io::stdin().read_to_end(&mut buf)?;
@@ -1557,9 +1571,17 @@ impl ParsedRunCommand {
             return if module {
                 Err(anyhow!("Cannot run a Python module from stdin"))
             } else if gui_script {
-                Ok(Self::Ready(RunCommand::PythonGuiStdin(buf, args.to_vec())))
+                Ok(Self::Ready(RunCommand::PythonGuiStdin(
+                    buf,
+                    args.to_vec(),
+                    py_args,
+                )))
             } else {
-                Ok(Self::Ready(RunCommand::PythonStdin(buf, args.to_vec())))
+                Ok(Self::Ready(RunCommand::PythonStdin(
+                    buf,
+                    args.to_vec(),
+                    py_args,
+                )))
             };
         }
 
@@ -1584,16 +1606,19 @@ impl ParsedRunCommand {
             return Ok(Self::Ready(RunCommand::PythonModule(
                 target.clone(),
                 args.to_vec(),
+                py_args,
             )));
         } else if gui_script {
             return Ok(Self::Ready(RunCommand::PythonGuiScript(
                 target.clone().into(),
                 args.to_vec(),
+                py_args,
             )));
         } else if script {
             return Ok(Self::Ready(RunCommand::PythonScript(
                 target.clone().into(),
                 args.to_vec(),
+                py_args,
             )));
         }
 
@@ -1611,6 +1636,7 @@ impl ParsedRunCommand {
             Ok(Self::Ready(RunCommand::PythonScript(
                 target_path,
                 args.to_vec(),
+                py_args,
             )))
         } else if target_path
             .extension()
@@ -1620,17 +1646,20 @@ impl ParsedRunCommand {
             Ok(Self::Ready(RunCommand::PythonGuiScript(
                 target_path,
                 args.to_vec(),
+                py_args,
             )))
         } else if is_dir && target_path.join("__main__.py").is_file() {
             Ok(Self::Ready(RunCommand::PythonPackage(
                 target.clone(),
                 target_path,
                 args.to_vec(),
+                py_args,
             )))
         } else if is_file && is_python_zipapp(&target_path) {
             Ok(Self::Ready(RunCommand::PythonZipapp(
                 target_path,
                 args.to_vec(),
+                py_args,
             )))
         } else {
             Ok(Self::Ready(RunCommand::External(
@@ -1692,7 +1721,7 @@ impl RunCommand {
     /// Read any inline PEP 723 metadata associated with this command target.
     async fn read_pep723_item(&self) -> Result<Option<Pep723Item>, Pep723Error> {
         match self {
-            Self::PythonScript(script, _) | Self::PythonGuiScript(script, _) => {
+            Self::PythonScript(script, _, _) | Self::PythonGuiScript(script, _, _) => {
                 match Pep723Script::read(script).await {
                     Ok(Some(script)) => Ok(Some(Pep723Item::Script(script))),
                     Ok(None) => Ok(None),
@@ -1702,7 +1731,7 @@ impl RunCommand {
                     Err(err) => Err(err),
                 }
             }
-            Self::PythonStdin(contents, _) | Self::PythonGuiStdin(contents, _) => {
+            Self::PythonStdin(contents, _, _) | Self::PythonGuiStdin(contents, _, _) => {
                 Pep723Metadata::parse(contents).map(|metadata| metadata.map(Pep723Item::Stdin))
             }
             Self::Python(_)
@@ -1754,7 +1783,7 @@ impl RunCommand {
                 process.args(args);
                 process
             }
-            Self::PythonPackage(target, path, args) => {
+            Self::PythonPackage(target, path, args, ExtraPythonArgs(py_args)) => {
                 let name = PathBuf::from(target).with_extension(std::env::consts::EXE_EXTENSION);
                 let entrypoint = interpreter.scripts().join(name);
 
@@ -1766,31 +1795,36 @@ impl RunCommand {
                 // Otherwise, invoke `python <module>`
                 } else {
                     let mut process = Command::new(interpreter.sys_executable());
+                    process.args(py_args);
                     process.arg(path);
                     process.args(args);
                     process
                 }
             }
-            Self::PythonScript(target, args) | Self::PythonZipapp(target, args) => {
+            Self::PythonScript(target, args, ExtraPythonArgs(py_args))
+            | Self::PythonZipapp(target, args, ExtraPythonArgs(py_args)) => {
                 let mut process = Command::new(interpreter.sys_executable());
+                process.args(py_args);
                 process.arg(target);
                 process.args(args);
                 process
             }
-            Self::PythonRemote(downloaded_script, args) => {
+            Self::PythonRemote(downloaded_script, args, ExtraPythonArgs(py_args)) => {
                 let mut process = Command::new(interpreter.sys_executable());
+                process.args(py_args);
                 process.arg(downloaded_script.path());
                 process.args(args);
                 process
             }
-            Self::PythonModule(module, args) => {
+            Self::PythonModule(module, args, ExtraPythonArgs(py_args)) => {
                 let mut process = Command::new(interpreter.sys_executable());
+                process.args(py_args);
                 process.arg("-m");
                 process.arg(module);
                 process.args(args);
                 process
             }
-            Self::PythonGuiScript(target, args) => {
+            Self::PythonGuiScript(target, args, ExtraPythonArgs(py_args)) => {
                 let python_executable = interpreter.sys_executable();
 
                 // Use `pythonw.exe` if it exists, otherwise fall back to `python.exe`.
@@ -1805,12 +1839,14 @@ impl RunCommand {
                     .unwrap_or_else(|| python_executable.to_path_buf());
 
                 let mut process = Command::new(&pythonw_executable);
+                process.args(py_args);
                 process.arg(target);
                 process.args(args);
                 process
             }
-            Self::PythonStdin(script, args) => {
+            Self::PythonStdin(script, args, ExtraPythonArgs(py_args)) => {
                 let mut process = Command::new(interpreter.sys_executable());
+                process.args(py_args);
                 process.arg("-c");
 
                 #[cfg(unix)]
@@ -1828,7 +1864,7 @@ impl RunCommand {
 
                 process
             }
-            Self::PythonGuiStdin(script, args) => {
+            Self::PythonGuiStdin(script, args, ExtraPythonArgs(py_args)) => {
                 let python_executable = interpreter.sys_executable();
 
                 // Use `pythonw.exe` if it exists, otherwise fall back to `python.exe`.
@@ -1843,6 +1879,7 @@ impl RunCommand {
                     .unwrap_or_else(|| python_executable.to_path_buf());
 
                 let mut process = Command::new(&pythonw_executable);
+                process.args(py_args);
                 process.arg("-c");
 
                 #[cfg(unix)]
@@ -1876,10 +1913,10 @@ impl RunCommand {
     /// Return the directory containing the script, if any.
     pub(crate) fn script_dir(&self) -> Option<&Path> {
         let parent = match self {
-            Self::PythonScript(target, _)
-            | Self::PythonGuiScript(target, _)
-            | Self::PythonZipapp(target, _) => target.parent(),
-            Self::PythonPackage(_, path, _) => path.parent(),
+            Self::PythonScript(target, _, _)
+            | Self::PythonGuiScript(target, _, _)
+            | Self::PythonZipapp(target, _, _) => target.parent(),
+            Self::PythonPackage(_, path, _, _) => path.parent(),
             Self::Python(_)
             | Self::PythonModule(..)
             | Self::PythonStdin(..)
@@ -1903,30 +1940,42 @@ impl std::fmt::Display for RunCommand {
                 }
                 Ok(())
             }
-            Self::PythonPackage(target, _path, args) => {
+            Self::PythonPackage(target, _path, args, ExtraPythonArgs(_py_args)) => {
                 write!(f, "{}", target.to_string_lossy())?;
                 for arg in args {
                     write!(f, " {}", arg.to_string_lossy())?;
                 }
                 Ok(())
             }
-            Self::PythonScript(target, args) | Self::PythonZipapp(target, args) => {
-                write!(f, "python {}", target.display())?;
+            Self::PythonScript(target, args, ExtraPythonArgs(py_args))
+            | Self::PythonZipapp(target, args, ExtraPythonArgs(py_args)) => {
+                write!(f, "python")?;
+                for arg in py_args {
+                    write!(f, " {}", arg.to_string_lossy())?;
+                }
+                write!(f, " {}", target.display())?;
                 for arg in args {
                     write!(f, " {}", arg.to_string_lossy())?;
                 }
                 Ok(())
             }
-            Self::PythonModule(module, args) => {
-                write!(f, "python -m")?;
-                write!(f, " {}", module.to_string_lossy())?;
+            Self::PythonModule(module, args, ExtraPythonArgs(py_args)) => {
+                write!(f, "python")?;
+                for arg in py_args {
+                    write!(f, " {}", arg.to_string_lossy())?;
+                }
+                write!(f, " -m {}", module.display())?;
                 for arg in args {
                     write!(f, " {}", arg.to_string_lossy())?;
                 }
                 Ok(())
             }
-            Self::PythonGuiScript(target, args) => {
-                write!(f, "pythonw {}", target.display())?;
+            Self::PythonGuiScript(target, args, ExtraPythonArgs(py_args)) => {
+                write!(f, "pythonw")?;
+                for arg in py_args {
+                    write!(f, " {}", arg.to_string_lossy())?;
+                }
+                write!(f, " {}", target.display())?;
                 for arg in args {
                     write!(f, " {}", arg.to_string_lossy())?;
                 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -94,11 +94,16 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             module,
             script,
             gui_script,
+            interactive,
             ..
         }) = **command
     {
         Some(ParsedRunCommand::from_args(
-            command, module, script, gui_script,
+            command,
+            interactive,
+            module,
+            script,
+            gui_script,
         )?)
     } else {
         None

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -603,6 +603,7 @@ impl RunSettings {
             only_group,
             all_groups,
             module: _,
+            interactive: _,
             only_dev,
             editable,
             no_editable,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Adds feature requested in https://github.com/astral-sh/uv/issues/8064 by adding an `--interactive` flag that passes `-i` to python. 
<!-- What's the purpose of the change? What does it do, and why? -->
Allows uv to run scripts and then drop into an interactive terminal in a unified manner. For scripts, this should be equivalent to `uv run --with-requirements script.py python -i script.py`

## Test Plan

<!-- How was it tested? -->
I haven't added tests yet but I wanted to just get this PR going. I have used it in a shell to make sure it works properly. 