### PR TITLE
Strip GIT_DIR and friends from internal git subprocess calls

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -45,6 +45,22 @@ pub static GIT: LazyLock<Result<PathBuf, GitError>> = LazyLock::new(|| {
     })
 });
 
+/// Creates a [`ProcessBuilder`] for a git command with environment variables
+/// stripped that could cause git to operate on the wrong repository.
+///
+/// For example, `git bisect run uv run …` sets `GIT_DIR` to point at the
+/// bisected repo. Without clearing it, every internal `git` invocation that
+/// uv spawns would operate on that repo rather than on uv's cache directory.
+fn git_cmd() -> Result<ProcessBuilder> {
+    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
+    cmd.env_remove(EnvVars::GIT_DIR)
+        .env_remove(EnvVars::GIT_WORK_TREE)
+        .env_remove(EnvVars::GIT_INDEX_FILE)
+        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
+        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES);
+    Ok(cmd)
+}
+
 /// Strategy when fetching refspecs for a [`GitReference`]
 enum RefspecStrategy {
     /// All refspecs should be fetched, if any fail then the fetch will fail.
@@ -166,10 +182,7 @@ impl GitRepository {
     /// Opens an existing Git repository at `path`.
     pub(crate) fn open(path: &Path) -> Result<Self> {
         // Make sure there is a Git repository at the specified path.
-        ProcessBuilder::new(GIT.as_ref()?)
-            .arg("rev-parse")
-            .cwd(path)
-            .exec_with_output()?;
+        git_cmd()?.arg("rev-parse").cwd(path).exec_with_output()?;
 
         Ok(Self {
             path: path.to_path_buf(),
@@ -185,10 +198,7 @@ impl GitRepository {
         // opts.external_template(false);
 
         // Initialize the repository.
-        ProcessBuilder::new(GIT.as_ref()?)
-            .arg("init")
-            .cwd(path)
-            .exec_with_output()?;
+        git_cmd()?.arg("init").cwd(path).exec_with_output()?;
 
         Ok(Self {
             path: path.to_path_buf(),
@@ -197,7 +207,7 @@ impl GitRepository {
 
     /// Parses the object ID of the given `refname`.
     fn rev_parse(&self, refname: &str) -> Result<GitOid> {
-        let result = ProcessBuilder::new(GIT.as_ref()?)
+        let result = git_cmd()?
             .arg("rev-parse")
             .arg(refname)
             .cwd(&self.path)
@@ -359,7 +369,7 @@ impl GitDatabase {
 
     /// Get a short OID for a `revision`, usually 7 chars or more if ambiguous.
     pub(crate) fn to_short_id(&self, revision: GitOid) -> Result<String> {
-        let output = ProcessBuilder::new(GIT.as_ref()?)
+        let output = git_cmd()?
             .arg("rev-parse")
             .arg("--short")
             .arg(revision.as_str())
@@ -416,7 +426,7 @@ impl GitCheckout {
         // Perform a local clone of the repository, which will attempt to use
         // hardlinks to set up the repository. This should speed up the clone operation
         // quite a bit if it works.
-        let res = ProcessBuilder::new(GIT.as_ref()?)
+        let res = git_cmd()?
             .arg("clone")
             .arg("--local")
             // Make sure to pass the local file path and not a file://... url. If given a url,
@@ -429,7 +439,7 @@ impl GitCheckout {
         if let Err(e) = res {
             debug!("Cloning git repo with --local failed, retrying without hardlinks: {e}");
 
-            ProcessBuilder::new(GIT.as_ref()?)
+            git_cmd()?
                 .arg("clone")
                 .arg("--no-hardlinks")
                 .arg(database.repo.path.simplified_display().to_string())
@@ -490,7 +500,7 @@ impl GitCheckout {
         debug!("Reset {} to {}", self.repo.path.display(), self.revision);
 
         // Perform the hard reset.
-        ProcessBuilder::new(GIT.as_ref()?)
+        git_cmd()?
             .arg("reset")
             .arg("--hard")
             .arg(self.revision.as_str())
@@ -499,7 +509,7 @@ impl GitCheckout {
             .exec_with_output()?;
 
         // Update submodules (`git submodule update --recursive`).
-        ProcessBuilder::new(GIT.as_ref()?)
+        git_cmd()?
             .arg("submodule")
             .arg("update")
             .arg("--recursive")
@@ -690,7 +700,7 @@ fn fetch_with_cli(
     disable_ssl: bool,
     offline: bool,
 ) -> Result<()> {
-    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
+    let mut cmd = git_cmd()?;
     // Disable interactive prompts in the terminal, as they'll be erased by the progress bar
     // animation and the process will "hang". Interactive prompts via the GUI like `SSH_ASKPASS`
     // are still usable.
@@ -712,17 +722,6 @@ fn fetch_with_cli(
         .arg("--update-head-ok") // see discussion in #2078
         .arg(url.as_str())
         .args(refspecs)
-        // If cargo is run by git (for example, the `exec` command in `git
-        // rebase`), the GIT_DIR is set by git and will point to the wrong
-        // location (this takes precedence over the cwd). Make sure this is
-        // unset so git will look at cwd for the repo.
-        .env_remove(EnvVars::GIT_DIR)
-        // The reset of these may not be necessary, but I'm including them
-        // just to be extra paranoid and avoid any issues.
-        .env_remove(EnvVars::GIT_WORK_TREE)
-        .env_remove(EnvVars::GIT_INDEX_FILE)
-        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
-        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES)
         .cwd(&repo.path);
 
     // We capture the output to avoid streaming it to the user's console during clones.
@@ -754,7 +753,7 @@ pub static GIT_LFS: LazyLock<Result<ProcessBuilder>> = LazyLock::new(|| {
         return Err(anyhow!("Git LFS extension has been forcefully disabled."));
     }
 
-    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
+    let mut cmd = git_cmd()?;
     cmd.arg("lfs");
 
     // Run a simple command to verify LFS is installed
@@ -786,12 +785,6 @@ fn fetch_lfs(
     cmd.arg("fetch")
         .arg(url.as_str())
         .arg(revision.as_str())
-        // These variables are unset for the same reason as in `fetch_with_cli`.
-        .env_remove(EnvVars::GIT_DIR)
-        .env_remove(EnvVars::GIT_WORK_TREE)
-        .env_remove(EnvVars::GIT_INDEX_FILE)
-        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
-        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES)
         // We should not support requesting LFS artifacts with skip smudge being set.
         // While this may not be necessary, it's added to avoid any potential future issues.
         .env_remove(EnvVars::GIT_LFS_SKIP_SMUDGE)

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -946,6 +946,43 @@ fn lock_sdist_git_short_rev() -> Result<()> {
     Ok(())
 }
 
+/// Verify that `uv lock` succeeds on a git dependency even when `GIT_DIR` is
+/// set in the environment — as happens when uv is invoked from `git bisect run`.
+/// Regression test for <https://github.com/astral-sh/uv/issues/19008>.
+#[test]
+#[cfg(feature = "test-git")]
+fn lock_sdist_git_with_git_dir_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["uv-public-pypackage"]
+
+        [tool.uv.sources]
+        uv-public-pypackage = { git = "https://github.com/astral-test/uv-public-pypackage", tag = "0.0.1" }
+        "#,
+    )?;
+
+    // `git bisect run` sets GIT_DIR to the bisected repo's .git directory.
+    // Without the fix, this leaks into uv's internal git subprocesses and
+    // causes them to operate on the wrong repository.
+    uv_snapshot!(context.filters(), context.lock().env(EnvVars::GIT_DIR, "/nonexistent"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Lock a requirement from a direct URL to a wheel.
 #[test]
 fn lock_wheel_url() -> Result<()> {


### PR DESCRIPTION
Fixes #19008.

`git bisect run` (and `git rebase --exec`) injects `GIT_DIR` into the
process environment before calling the user's command. When that command
is `uv`, the variable leaks into every `git` subprocess uv spawns,
directing them at the bisected repo instead of uv's own cache.

`fetch_with_cli` and `fetch_lfs` already stripped these five env vars
individually. The other call sites — `open`, `init`, `rev_parse`,
`to_short_id`, both clone variants, `reset`, and `submodule update` —
did not.

## Changes

Introduce a `git_cmd()` helper:

```rust
fn git_cmd() -> Result<ProcessBuilder> {
    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
    cmd.env_remove(EnvVars::GIT_DIR)
        .env_remove(EnvVars::GIT_WORK_TREE)
        .env_remove(EnvVars::GIT_INDEX_FILE)
        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES);
    Ok(cmd)
}
```

All call sites now go through `git_cmd()`. The per-call `env_remove`
chains in `fetch_with_cli` and `fetch_lfs` are removed since the helper
covers them.

## Before / After

**Before:** `GIT_DIR=/bisected-repo/.git uv lock` (with a git dependency) fails — uv's internal `git rev-parse`, `git clone`, etc. hit the wrong repo.

**After:** same command succeeds — `git_cmd()` strips the variable before each subprocess is spawned.

## Test

Added `lock_sdist_git_with_git_dir_env` (behind `#[cfg(feature = "test-git")]`) that runs `uv lock` with `GIT_DIR=/nonexistent` in the environment and expects success.