### PR TITLE
docs: deduplicate editable install instructions

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -544,11 +544,19 @@ requires-dist = ["torch", "einops"]
 
 ## Editable mode
 
-By default, the project will be installed in editable mode, such that changes to the source code are
-immediately reflected in the environment. `uv sync` and `uv run` both accept a `--no-editable` flag,
-which instructs uv to install the project in non-editable mode. `--no-editable` is intended for
-deployment use-cases, such as building a Docker container, in which the project should be included
-in the deployed environment without a dependency on the originating source code.
+By default, the project (and any other [workspace members](./workspaces.md)) is installed in
+editable mode during [syncing](./sync.md), such that changes to the source code are immediately
+reflected in the environment without re-syncing.
+
+`uv sync` and `uv run` both accept a `--no-editable` flag, which instructs uv to install the project
+in non-editable mode. `--no-editable` is intended for deployment use-cases, such as building a
+Docker container, in which the project should be included in the deployed environment without a
+dependency on the originating source code.
+
+!!! note
+
+    If the project does not define a build system, it will not be installed. See the
+    [build systems](#build-systems) documentation for details.
 
 ## Conflicting dependencies
 

--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -78,16 +78,11 @@ versions of dependencies.
 
 ### Editable installation
 
-When the environment is synced, uv will install the project (and other workspace members) as
-_editable_ packages, such that re-syncing is not necessary for changes to be reflected in the
-environment.
+By default, the project and other workspace members are installed as editable packages, so changes
+to the source code are reflected in the environment without re-syncing. Use the `--no-editable`
+option to opt-out.
 
-To opt-out of this behavior, use the `--no-editable` option.
-
-!!! note
-
-    If the project does not define a build system, it will not be installed.
-    See the [build systems](./config.md#build-systems) documentation for details.
+See the [editable mode](./config.md#editable-mode) documentation for details.
 
 ### Handling of extraneous packages
 


### PR DESCRIPTION
The "Editable mode" section in config.md and "Editable installation" in sync.md overlapped and each was missing a detail the other had. Move the full explanation to config.md and shorten sync.md to a link, matching how optional and dev dependencies are handled on that page.

Closes #15409.