### PR TITLE
feat: support GitHub Enterprise gist URLs in remote script resolution

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1654,7 +1654,11 @@ impl ParsedRunCommand {
 
         let gist_url;
         // If it's a Gist URL, use the GitHub API to get the raw URL.
-        if response.url().host_str() == Some("gist.github.com") {
+        let is_gist = {
+            let url = response.url();
+            url.host_str() == Some("gist.github.com") || url.path().starts_with("/gists/")
+        };
+        if is_gist {
             gist_url =
                 resolve_gist_url(DisplaySafeUrl::ref_cast(response.url()), client_builder).await?;
             url = &gist_url;
@@ -1967,7 +1971,12 @@ async fn resolve_gist_url(
         .ok_or_else(|| anyhow!("Invalid Gist URL format"))?;
 
     // Build the API URL.
-    let api_url = format!("https://api.github.com/gists/{gist_id}");
+    let api_url = if url.host_str() == Some("gist.github.com") {
+        format!("https://api.github.com/gists/{gist_id}")
+    } else {
+        let host = url.host_str().unwrap_or("github.com");
+        format!("https://{host}/api/v3/gists/{gist_id}")
+    };
 
     let client = client_builder.build()?;
 


### PR DESCRIPTION
## Summary

Extends gist URL detection and resolution to support GitHub Enterprise Server instances, in addition to `gist.github.com`.

Previously, `uv run` would only detect gist URLs from `gist.github.com`. This change also detects gist URLs from GitHub Enterprise instances, where the URL path starts with `/gists/`.

For GHE instances, the API endpoint is constructed as `https://{host}/api/v3/gists/{gist_id}` instead of `https://api.github.com/gists/{gist_id}`, following the same pattern as the `gh` CLI.

Closes #15109

## Test Plan

- Manual testing with a GHE gist URL (e.g., `uv run https://github.example.com/gists/abc123`)
- Existing gist URL tests continue to work for `gist.github.com`