### PR TITLE
Run `LookaheadResolver` when resolving PEP 517 build requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6389,6 +6389,7 @@ dependencies = [
  "uv-preview",
  "uv-pypi-types",
  "uv-python",
+ "uv-requirements",
  "uv-resolver",
  "uv-types",
  "uv-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,12 +1956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -32,6 +32,7 @@ uv-platform-tags = { workspace = true }
 uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
+uv-requirements = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }
 uv-version = { workspace = true }

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -16,7 +16,9 @@ use uv_build_backend::check_direct_build;
 use uv_build_frontend::{SourceBuild, SourceBuildContext};
 use uv_cache::Cache;
 use uv_client::RegistryClient;
-use uv_configuration::{BuildKind, BuildOptions, Constraints, IndexStrategy, NoSources, Reinstall};
+use uv_configuration::{
+    BuildKind, BuildOptions, Constraints, IndexStrategy, NoSources, Overrides, Reinstall,
+};
 use uv_configuration::{BuildOutput, Concurrency};
 use uv_distribution::DistributionDatabase;
 use uv_distribution_filename::DistFilename;
@@ -30,6 +32,7 @@ use uv_installer::{InstallationStrategy, Installer, Plan, Planner, Preparer, Sit
 use uv_preview::Preview;
 use uv_pypi_types::Conflicts;
 use uv_python::{Interpreter, PythonEnvironment};
+use uv_requirements::LookaheadResolver;
 use uv_resolver::{
     ExcludeNewer, FlatIndex, Flexibility, InMemoryIndex, Manifest, OptionsBuilder,
     PythonRequirement, Resolver, ResolverEnvironment,
@@ -59,6 +62,9 @@ pub enum BuildDispatchError {
 
     #[error(transparent)]
     Prepare(#[from] uv_installer::PrepareError),
+
+    #[error(transparent)]
+    Lookahead(#[from] uv_requirements::Error),
 }
 
 impl IsBuildBackendError for BuildDispatchError {
@@ -68,7 +74,8 @@ impl IsBuildBackendError for BuildDispatchError {
             | Self::Resolve(_)
             | Self::Join(_)
             | Self::Anyhow(_)
-            | Self::Prepare(_) => false,
+            | Self::Prepare(_)
+            | Self::Lookahead(_) => false,
             Self::BuildFrontend(err) => err.is_build_backend_error(),
         }
     }
@@ -250,10 +257,37 @@ impl BuildContext for BuildDispatch<'_> {
     ) -> Result<Resolution, BuildDispatchError> {
         let python_requirement = PythonRequirement::from_interpreter(self.interpreter);
         let marker_env = self.interpreter.resolver_marker_environment();
+        let resolver_env = ResolverEnvironment::specific(marker_env);
         let tags = self.interpreter.tags()?;
 
+        // Walk any URL requirements transitively so their sub-URLs (for example, a workspace
+        // member that depends on another workspace member) are known before the resolver runs
+        // its URL allow-list check. This mirrors what the project resolver does in
+        // `uv_requirements::LookaheadResolver` and prevents a `DisallowedUrl` error when one
+        // `build-system.requires` entry pulls in another URL dependency.
+        let overrides = Overrides::default();
+        let (lookaheads, _hasher) = LookaheadResolver::new(
+            requirements,
+            self.constraints,
+            &overrides,
+            self.hasher,
+            &self.shared_state.index,
+            DistributionDatabase::new(
+                self.client,
+                self,
+                self.concurrency.downloads_semaphore.clone(),
+            )
+            .with_build_stack(build_stack),
+        )
+        .resolve(&resolver_env)
+        .await?;
+
+        let manifest = Manifest::simple(requirements.to_vec())
+            .with_constraints(self.constraints.clone())
+            .with_lookaheads(lookaheads);
+
         let resolver = Resolver::new(
-            Manifest::simple(requirements.to_vec()).with_constraints(self.constraints.clone()),
+            manifest,
             OptionsBuilder::new()
                 .exclude_newer(self.exclude_newer.clone())
                 .index_strategy(self.index_strategy)
@@ -261,7 +295,7 @@ impl BuildContext for BuildDispatch<'_> {
                 .flexibility(Flexibility::Fixed)
                 .build(),
             &python_requirement,
-            ResolverEnvironment::specific(marker_env),
+            resolver_env,
             self.interpreter.markers(),
             // Conflicting groups only make sense when doing universal resolution.
             Conflicts::empty(),

--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -98,6 +98,12 @@ impl Manifest {
         self
     }
 
+    #[must_use]
+    pub fn with_lookaheads(mut self, lookaheads: Vec<RequestedRequirements>) -> Self {
+        self.lookaheads = lookaheads;
+        self
+    }
+
     /// Return an iterator over all requirements, constraints, and overrides, in priority order,
     /// such that requirements come first, followed by constraints, followed by overrides.
     ///

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -1078,6 +1078,139 @@ fn build_source_path_ignores_workspace_build_constraint_dependencies() -> Result
     Ok(())
 }
 
+/// A workspace member can use another workspace member as a PEP 517 build dependency, even when
+/// that build dependency itself depends on a third workspace member. Regression test for
+/// <https://github.com/astral-sh/uv/issues/19074>.
+#[test]
+fn build_workspace_transitive_build_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([
+            (r"\\\.", ""),
+            (r"\[my-util\]", "[PKG]"),
+            (r"\[my-backend\]", "[PKG]"),
+            (r"\[my-tool\]", "[PKG]"),
+        ])
+        .collect::<Vec<_>>();
+
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "my-workspace"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [tool.uv]
+        package = false
+
+        [tool.uv.workspace]
+        members = ["my-util", "my-backend", "my-tool"]
+
+        [tool.uv.sources]
+        my-backend = { workspace = true }
+        my-util = { workspace = true }
+        "#,
+    )?;
+    project.child("README.md").touch()?;
+
+    let my_util = project.child("my-util");
+    fs_err::create_dir_all(my_util.path())?;
+    my_util.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "my-util"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    my_util
+        .child("src")
+        .child("my_util")
+        .child("__init__.py")
+        .touch()?;
+    my_util.child("README.md").touch()?;
+
+    let my_backend = project.child("my-backend");
+    fs_err::create_dir_all(my_backend.path())?;
+    my_backend.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "my-backend"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["my-util"]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    my_backend
+        .child("src")
+        .child("my_backend")
+        .child("__init__.py")
+        .touch()?;
+    my_backend.child("README.md").touch()?;
+
+    let my_tool = project.child("my-tool");
+    fs_err::create_dir_all(my_tool.path())?;
+    my_tool.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "my-tool"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["my-backend", "hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    my_tool
+        .child("src")
+        .child("my_tool")
+        .child("__init__.py")
+        .touch()?;
+    my_tool.child("README.md").touch()?;
+
+    uv_snapshot!(
+        &filters,
+        context
+            .build()
+            .arg("--wheel")
+            .arg("--package")
+            .arg("my-tool")
+            .current_dir(&project),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel...
+    Successfully built dist/my_tool-0.1.0-py3-none-any.whl
+    "
+    );
+
+    project
+        .child("dist")
+        .child("my_tool-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    Ok(())
+}
+
 #[test]
 fn build_sha() -> Result<()> {
     let context = uv_test::test_context!(DEFAULT_PYTHON_VERSION);


### PR DESCRIPTION
Build dispatch was constructing its manifest without lookaheads, so the build dependency resolver missed transitive URL dependencies from workspace members referenced via build-system.requires.

Run LookaheadResolver first and pass the result into `Manifest::with_lookaheads`, matching the behavior the project resolver already uses.

Added a regression integration test that fails on main and passes with this change.

Closes #19074!