### PR TITLE
Support `pip uninstall -y`

### DIFF
--- a/crates/uv-cli/src/compat.rs
+++ b/crates/uv-cli/src/compat.rs
@@ -310,6 +310,40 @@ impl CompatArgs for VenvCompatArgs {
     }
 }
 
+/// Arguments for `pip uninstall` compatibility.
+///
+/// These represent a subset of the `pip uninstall` interface that uv supports by default.
+#[derive(Args)]
+pub struct PipUninstallCompatArgs {
+    /// Don't ask for confirmation of uninstall deletions.
+    ///
+    /// This option is for compatibility with `pip uninstall` and has no effect.
+    #[clap(short, long, hide = true)]
+    yes: bool,
+
+    #[clap(long, hide = true)]
+    disable_pip_version_check: bool,
+}
+
+impl CompatArgs for PipUninstallCompatArgs {
+    /// Validate the arguments passed for `pip uninstall` compatibility.
+    ///
+    /// This method will warn when an argument is passed that has no effect but matches uv's
+    /// behavior. If an argument is passed that does _not_ match uv's behavior, this method will
+    /// return an error.
+    fn validate(&self) -> Result<()> {
+        if self.yes {
+            warn_user!("`--yes` has no effect (uv never asks for confirmation)");
+        }
+
+        if self.disable_pip_version_check {
+            warn_user!("pip's `--disable-pip-version-check` has no effect");
+        }
+
+        Ok(())
+    }
+}
+
 /// Arguments for `pip install` compatibility.
 ///
 /// These represent a subset of the `pip install` interface that uv supports by default.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2551,7 +2551,7 @@ pub struct PipUninstallArgs {
     pub dry_run: bool,
 
     #[command(flatten)]
-    pub compat_args: compat::PipGlobalCompatArgs,
+    pub compat_args: compat::PipUninstallCompatArgs,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -962,6 +962,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Commands::Pip(PipNamespace {
             command: PipCommand::Uninstall(args),
         }) => {
+            args.compat_args.validate()?;
+
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = PipUninstallSettings::resolve(args, filesystem, environment);
             show_settings!(args);

--- a/crates/uv/tests/it/pip_uninstall.rs
+++ b/crates/uv/tests/it/pip_uninstall.rs
@@ -579,3 +579,43 @@ fn uninstall_record_path_traversal() -> Result<()> {
 
     Ok(())
 }
+
+/// `--yes` is accepted for `pip uninstall` compatibility, but emits a warning.
+#[test]
+fn yes_flag() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("--yes")
+        .arg("flask"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `--yes` has no effect (uv never asks for confirmation)
+    warning: Skipping flask as it is not installed
+    warning: No packages to uninstall
+    "
+    );
+}
+
+/// `-y` is accepted for `pip uninstall` compatibility, but emits a warning.
+#[test]
+fn yes_short_flag() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("-y")
+        .arg("flask"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `--yes` has no effect (uv never asks for confirmation)
+    warning: Skipping flask as it is not installed
+    warning: No packages to uninstall
+    "
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #19077. Both `-y` and `--yes` are now accepted (as compat no-ops) to `pip uninstall`.

## Test Plan

Added two integration tests confirming that the flags are no-ops (besides emitting a warning).