### PR TITLE
Respect discovered hashes from lookahead build dependencies

### DIFF
--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -33,7 +33,6 @@ use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution::BuildRequires;
 use uv_distribution_types::{
     ConfigSettings, ExtraBuildRequirement, ExtraBuildRequires, IndexLocations, Requirement,
-    Resolution,
 };
 use uv_fs::{LockedFile, LockedFileMode};
 use uv_fs::{PythonExt, Simplified};
@@ -42,7 +41,9 @@ use uv_pep440::Version;
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_static::EnvVars;
-use uv_types::{AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, SourceBuildTrait};
+use uv_types::{
+    AnyErrorBuild, BuildContext, BuildIsolation, BuildStack, ResolvedRequirements, SourceBuildTrait,
+};
 use uv_warnings::warn_user_once;
 use uv_workspace::WorkspaceCache;
 
@@ -219,7 +220,7 @@ impl Pep517Backend {
 #[derive(Debug, Clone)]
 pub struct SourceBuildContext {
     /// An in-memory resolution of the default backend's requirements for PEP 517 builds.
-    default_resolution: Arc<Mutex<Option<Resolution>>>,
+    default_resolution: Arc<Mutex<Option<ResolvedRequirements>>>,
     /// A shared semaphore to limit the number of concurrent builds.
     concurrent_build_slots: Arc<Semaphore>,
 }
@@ -522,7 +523,7 @@ impl SourceBuild {
         pep517_backend: &Pep517Backend,
         extra_build_dependencies: Vec<Requirement>,
         build_stack: &BuildStack,
-    ) -> Result<Resolution, Error> {
+    ) -> Result<ResolvedRequirements, Error> {
         Ok(
             if pep517_backend.requirements == DEFAULT_BACKEND.requirements
                 && extra_build_dependencies.is_empty()

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -39,7 +39,7 @@ use uv_resolver::{
 };
 use uv_types::{
     AnyErrorBuild, BuildArena, BuildContext, BuildIsolation, BuildStack, EmptyInstalledPackages,
-    HashStrategy, InFlight, SourceTreeEditablePolicy,
+    HashStrategy, InFlight, ResolvedRequirements, SourceTreeEditablePolicy,
 };
 use uv_workspace::WorkspaceCache;
 
@@ -254,7 +254,7 @@ impl BuildContext for BuildDispatch<'_> {
         &'data self,
         requirements: &'data [Requirement],
         build_stack: &'data BuildStack,
-    ) -> Result<Resolution, BuildDispatchError> {
+    ) -> Result<ResolvedRequirements, BuildDispatchError> {
         let python_requirement = PythonRequirement::from_interpreter(self.interpreter);
         let marker_env = self.interpreter.resolver_marker_environment();
         let resolver_env = ResolverEnvironment::specific(marker_env);
@@ -265,12 +265,17 @@ impl BuildContext for BuildDispatch<'_> {
         // its URL allow-list check. This mirrors what the project resolver does in
         // `uv_requirements::LookaheadResolver` and prevents a `DisallowedUrl` error when one
         // `build-system.requires` entry pulls in another URL dependency.
+        let hasher = self
+            .hasher
+            .clone()
+            .augment_with_requirements(requirements.iter())
+            .map_err(uv_requirements::Error::from)?;
         let overrides = Overrides::default();
-        let (lookaheads, _hasher) = LookaheadResolver::new(
+        let (lookaheads, hasher) = LookaheadResolver::new(
             requirements,
             self.constraints,
             &overrides,
-            self.hasher,
+            &hasher,
             &self.shared_state.index,
             DistributionDatabase::new(
                 self.client,
@@ -302,7 +307,7 @@ impl BuildContext for BuildDispatch<'_> {
             Some(tags),
             self.flat_index,
             &self.shared_state.index,
-            self.hasher,
+            &hasher,
             self,
             EmptyInstalledPackages,
             DistributionDatabase::new(
@@ -321,22 +326,25 @@ impl BuildContext for BuildDispatch<'_> {
                     .join(", ")
             )
         })?);
-        Ok(resolution)
+        Ok(ResolvedRequirements::new(resolution, hasher))
     }
 
     #[instrument(
-        skip(self, resolution, venv),
+        skip(self, requirements, venv),
         fields(
-            resolution = resolution.distributions().map(ToString::to_string).join(", "),
+            resolution = requirements.resolution().distributions().map(ToString::to_string).join(", "),
             venv = ?venv.root()
         )
     )]
     async fn install<'data>(
         &'data self,
-        resolution: &'data Resolution,
+        requirements: &'data ResolvedRequirements,
         venv: &'data PythonEnvironment,
         build_stack: &'data BuildStack,
     ) -> Result<Vec<CachedDist>, BuildDispatchError> {
+        let resolution = requirements.resolution();
+        let hasher = requirements.hasher();
+
         debug!(
             "Installing in {} in {}",
             resolution
@@ -362,7 +370,7 @@ impl BuildContext for BuildDispatch<'_> {
             InstallationStrategy::Permissive,
             &Reinstall::default(),
             self.build_options,
-            self.hasher,
+            hasher,
             self.index_locations,
             self.config_settings,
             self.config_settings_package,
@@ -396,7 +404,7 @@ impl BuildContext for BuildDispatch<'_> {
             let preparer = Preparer::new(
                 self.cache,
                 tags,
-                self.hasher,
+                hasher,
                 self.build_options,
                 DistributionDatabase::new(
                     self.client,

--- a/crates/uv-types/src/requirements.rs
+++ b/crates/uv-types/src/requirements.rs
@@ -1,5 +1,33 @@
-use uv_distribution_types::Requirement;
+use uv_distribution_types::{Requirement, Resolution};
 use uv_normalize::ExtraName;
+
+use crate::HashStrategy;
+
+/// A resolved set of requirements, along with the hash policy discovered while resolving them.
+#[derive(Debug, Clone)]
+pub struct ResolvedRequirements {
+    /// The resolved distributions to install.
+    resolution: Resolution,
+    /// The hash policy to apply when installing the resolution.
+    hasher: HashStrategy,
+}
+
+impl ResolvedRequirements {
+    /// Instantiate a [`ResolvedRequirements`] with the given [`Resolution`] and [`HashStrategy`].
+    pub fn new(resolution: Resolution, hasher: HashStrategy) -> Self {
+        Self { resolution, hasher }
+    }
+
+    /// Return the resolved distributions to install.
+    pub fn resolution(&self) -> &Resolution {
+        &self.resolution
+    }
+
+    /// Return the hash policy to apply when installing the resolution.
+    pub fn hasher(&self) -> &HashStrategy {
+        &self.hasher
+    }
+}
 
 /// A set of requirements as requested by a parent requirement.
 ///

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -12,14 +12,14 @@ use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     CachedDist, ConfigSettings, DependencyMetadata, DistributionId, ExtraBuildRequires,
     ExtraBuildVariables, IndexCapabilities, IndexLocations, InstalledDist, IsBuildBackendError,
-    PackageConfigSettings, Requirement, Resolution, SourceDist,
+    PackageConfigSettings, Requirement, SourceDist,
 };
 use uv_git::GitResolver;
 use uv_normalize::PackageName;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_workspace::WorkspaceCache;
 
-use crate::{BuildArena, BuildIsolation};
+use crate::{BuildArena, BuildIsolation, ResolvedRequirements};
 
 /// Controls how source tree requirements influence workspace-member editability during lowering.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
@@ -151,13 +151,13 @@ pub trait BuildContext {
         &'a self,
         requirements: &'a [Requirement],
         build_stack: &'a BuildStack,
-    ) -> impl Future<Output = Result<Resolution, impl IsBuildBackendError>> + 'a;
+    ) -> impl Future<Output = Result<ResolvedRequirements, impl IsBuildBackendError>> + 'a;
 
     /// Install the given set of package versions into the virtual environment. The environment must
     /// use the same base Python as [`BuildContext::interpreter`]
     fn install<'a>(
         &'a self,
-        resolution: &'a Resolution,
+        requirements: &'a ResolvedRequirements,
         venv: &'a PythonEnvironment,
         build_stack: &'a BuildStack,
     ) -> impl Future<Output = Result<Vec<CachedDist>, impl IsBuildBackendError>> + 'a;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -300,12 +300,12 @@ pub(crate) async fn venv(
         //
         // Since the virtual environment is empty, and the set of requirements is trivial (no
         // constraints, no editables, etc.), we can use the build dispatch APIs directly.
-        let resolution = build_dispatch
+        let requirements = build_dispatch
             .resolve(&requirements, &build_stack)
             .await
             .map_err(|err| VenvError::Seed(err.into()))?;
         let installed = build_dispatch
-            .install(&resolution, &venv, &build_stack)
+            .install(&requirements, &venv, &build_stack)
             .await
             .map_err(|err| VenvError::Seed(err.into()))?;
 

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2,12 +2,17 @@ use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use fs_err::File;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
 use std::env::current_dir;
+use url::Url;
 use uv_static::EnvVars;
 use uv_test::{DEFAULT_PYTHON_VERSION, apply_filters, uv_snapshot};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path as url_path},
+};
 use zip::ZipArchive;
 
 #[test]
@@ -1407,6 +1412,111 @@ fn build_sha() -> Result<()> {
         .child("dist")
         .child("project-0.1.0.tar.gz")
         .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn build_transitive_url_build_requirement_hashes() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let filters = context
+        .filters()
+        .into_iter()
+        .chain([(r"\\\.", "")])
+        .collect::<Vec<_>>();
+
+    let ok_wheel = current_dir()?.join("../../test/links/ok-1.0.0-py3-none-any.whl");
+    let validation_wheel =
+        current_dir()?.join("../../test/links/validation-1.0.0-py3-none-any.whl");
+    let server = MockServer::start().await;
+    let ok_wheel_url = Url::parse(&format!("{}/ok-1.0.0-py3-none-any.whl", server.uri()))?;
+    let validation_wheel_url = Url::parse(&format!(
+        "{}/validation-1.0.0-py3-none-any.whl",
+        server.uri()
+    ))?;
+
+    Mock::given(method("GET"))
+        .and(url_path("/ok-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(fs_err::read(ok_wheel)?))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(url_path("/validation-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(fs_err::read(validation_wheel)?))
+        .mount(&server)
+        .await;
+
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["validation @ {validation_wheel_url}#sha256=23ee8bda94d44f5480dccca240b37a4de7c823bc4683d00fd8e5eb85cf056ce6"]
+        build-backend = "backend"
+        backend-path = ["."]
+
+        [[tool.uv.dependency-metadata]]
+        name = "validation"
+        version = "1.0.0"
+        requires-dist = ["ok @ {ok_wheel_url}#sha256=79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f"]
+    "#})?;
+    project.child("backend.py").write_str(indoc! {r#"
+        import pathlib
+        import zipfile
+
+
+        def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+            wheel_name = "project-0.1.0-py3-none-any.whl"
+            wheel_path = pathlib.Path(wheel_directory, wheel_name)
+            records = [
+                ("project/__init__.py", b""),
+                (
+                    "project-0.1.0.dist-info/METADATA",
+                    b"Metadata-Version: 2.1\nName: project\nVersion: 0.1.0\n",
+                ),
+                (
+                    "project-0.1.0.dist-info/WHEEL",
+                    b"Wheel-Version: 1.0\nGenerator: uv-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+                ),
+            ]
+
+            with zipfile.ZipFile(wheel_path, "w") as wheel:
+                for path, contents in records:
+                    wheel.writestr(path, contents)
+                record = "\n".join(f"{path},," for path, _ in records)
+                wheel.writestr(
+                    "project-0.1.0.dist-info/RECORD",
+                    record + "\nproject-0.1.0.dist-info/RECORD,,\n",
+                )
+
+            return wheel_name
+    "#})?;
+    uv_snapshot!(
+        &filters,
+        context
+            .build()
+            .arg("--wheel")
+            .arg("--require-hashes")
+            .current_dir(&project),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel...
+    Successfully built dist/project-0.1.0-py3-none-any.whl
+    "
+    );
+
     project
         .child("dist")
         .child("project-0.1.0-py3-none-any.whl")


### PR DESCRIPTION
## Summary

Small follow-up to https://github.com/astral-sh/uv/pull/19076. If a lookahead URL has its own SHA, we need to include it in the acceptable SHAs for that URL.
