### PR TITLE
Ensure uv invocations of git do not inherit repository location environment variables

### DIFF
--- a/crates/uv-configuration/src/vcs.rs
+++ b/crates/uv-configuration/src/vcs.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use serde::Deserialize;
 use uv_git::GIT;
@@ -39,7 +39,8 @@ impl VersionControlSystem {
                     return Err(VersionControlError::GitNotInstalled);
                 };
 
-                let output = Command::new(git)
+                let output = git
+                    .build_command()
                     .arg("init")
                     .current_dir(path)
                     .stdout(Stdio::piped())

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -59,7 +59,8 @@ pub static GIT: LazyLock<Result<ProcessBuilder, GitError>> = LazyLock::new(|| {
         .env_remove(EnvVars::GIT_WORK_TREE)
         .env_remove(EnvVars::GIT_INDEX_FILE)
         .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
-        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES);
+        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES)
+        .env_remove(EnvVars::GIT_COMMON_DIR);
 
     Ok(cmd)
 });

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -37,12 +37,31 @@ pub enum GitError {
     TransportNotAllowed,
 }
 
-/// A global cache of the result of `which git`.
-pub static GIT: LazyLock<Result<PathBuf, GitError>> = LazyLock::new(|| {
-    which::which("git").map_err(|err| match err {
+/// A global cache of the result of `which git` as a command
+///
+/// Caching the command allows us to avoid needing to remove environment
+/// variables everywhere.
+pub static GIT: LazyLock<Result<ProcessBuilder, GitError>> = LazyLock::new(|| {
+    let path = which::which("git").map_err(|err| match err {
         which::Error::CannotFindBinaryPath => GitError::GitNotFound,
         err => GitError::Other(err),
-    })
+    })?;
+
+    let mut cmd = ProcessBuilder::new(path);
+
+    // Certain git environment variables never make sense to inherit because
+    // they affect what the current command will act on.
+
+    // This can cause problems if for example uv is ran by git (for example, the
+    // `exec` command in `git rebase`), the GIT_DIR is set by git and will point
+    // to the wrong location (this takes precedence over the cwd).
+    cmd.env_remove(EnvVars::GIT_DIR)
+        .env_remove(EnvVars::GIT_WORK_TREE)
+        .env_remove(EnvVars::GIT_INDEX_FILE)
+        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
+        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES);
+
+    Ok(cmd)
 });
 
 /// Strategy when fetching refspecs for a [`GitReference`]
@@ -166,7 +185,8 @@ impl GitRepository {
     /// Opens an existing Git repository at `path`.
     pub(crate) fn open(path: &Path) -> Result<Self> {
         // Make sure there is a Git repository at the specified path.
-        ProcessBuilder::new(GIT.as_ref()?)
+        GIT.as_ref()
+            .cloned()?
             .arg("rev-parse")
             .cwd(path)
             .exec_with_output()?;
@@ -185,7 +205,8 @@ impl GitRepository {
         // opts.external_template(false);
 
         // Initialize the repository.
-        ProcessBuilder::new(GIT.as_ref()?)
+        GIT.as_ref()
+            .cloned()?
             .arg("init")
             .cwd(path)
             .exec_with_output()?;
@@ -197,7 +218,9 @@ impl GitRepository {
 
     /// Parses the object ID of the given `refname`.
     fn rev_parse(&self, refname: &str) -> Result<GitOid> {
-        let result = ProcessBuilder::new(GIT.as_ref()?)
+        let result = GIT
+            .as_ref()
+            .cloned()?
             .arg("rev-parse")
             .arg(refname)
             .cwd(&self.path)
@@ -359,7 +382,9 @@ impl GitDatabase {
 
     /// Get a short OID for a `revision`, usually 7 chars or more if ambiguous.
     pub(crate) fn to_short_id(&self, revision: GitOid) -> Result<String> {
-        let output = ProcessBuilder::new(GIT.as_ref()?)
+        let output = GIT
+            .as_ref()
+            .cloned()?
             .arg("rev-parse")
             .arg("--short")
             .arg(revision.as_str())
@@ -416,7 +441,9 @@ impl GitCheckout {
         // Perform a local clone of the repository, which will attempt to use
         // hardlinks to set up the repository. This should speed up the clone operation
         // quite a bit if it works.
-        let res = ProcessBuilder::new(GIT.as_ref()?)
+        let res = GIT
+            .as_ref()
+            .cloned()?
             .arg("clone")
             .arg("--local")
             // Make sure to pass the local file path and not a file://... url. If given a url,
@@ -429,7 +456,8 @@ impl GitCheckout {
         if let Err(e) = res {
             debug!("Cloning git repo with --local failed, retrying without hardlinks: {e}");
 
-            ProcessBuilder::new(GIT.as_ref()?)
+            GIT.as_ref()
+                .cloned()?
                 .arg("clone")
                 .arg("--no-hardlinks")
                 .arg(database.repo.path.simplified_display().to_string())
@@ -490,7 +518,8 @@ impl GitCheckout {
         debug!("Reset {} to {}", self.repo.path.display(), self.revision);
 
         // Perform the hard reset.
-        ProcessBuilder::new(GIT.as_ref()?)
+        GIT.as_ref()
+            .cloned()?
             .arg("reset")
             .arg("--hard")
             .arg(self.revision.as_str())
@@ -499,7 +528,8 @@ impl GitCheckout {
             .exec_with_output()?;
 
         // Update submodules (`git submodule update --recursive`).
-        ProcessBuilder::new(GIT.as_ref()?)
+        GIT.as_ref()
+            .cloned()?
             .arg("submodule")
             .arg("update")
             .arg("--recursive")
@@ -690,7 +720,7 @@ fn fetch_with_cli(
     disable_ssl: bool,
     offline: bool,
 ) -> Result<()> {
-    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
+    let mut cmd = GIT.as_ref().cloned()?;
     // Disable interactive prompts in the terminal, as they'll be erased by the progress bar
     // animation and the process will "hang". Interactive prompts via the GUI like `SSH_ASKPASS`
     // are still usable.
@@ -712,17 +742,6 @@ fn fetch_with_cli(
         .arg("--update-head-ok") // see discussion in #2078
         .arg(url.as_str())
         .args(refspecs)
-        // If cargo is run by git (for example, the `exec` command in `git
-        // rebase`), the GIT_DIR is set by git and will point to the wrong
-        // location (this takes precedence over the cwd). Make sure this is
-        // unset so git will look at cwd for the repo.
-        .env_remove(EnvVars::GIT_DIR)
-        // The reset of these may not be necessary, but I'm including them
-        // just to be extra paranoid and avoid any issues.
-        .env_remove(EnvVars::GIT_WORK_TREE)
-        .env_remove(EnvVars::GIT_INDEX_FILE)
-        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
-        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES)
         .cwd(&repo.path);
 
     // We capture the output to avoid streaming it to the user's console during clones.
@@ -754,7 +773,7 @@ pub static GIT_LFS: LazyLock<Result<ProcessBuilder>> = LazyLock::new(|| {
         return Err(anyhow!("Git LFS extension has been forcefully disabled."));
     }
 
-    let mut cmd = ProcessBuilder::new(GIT.as_ref()?);
+    let mut cmd = GIT.as_ref()?.clone();
     cmd.arg("lfs");
 
     // Run a simple command to verify LFS is installed
@@ -786,12 +805,6 @@ fn fetch_lfs(
     cmd.arg("fetch")
         .arg(url.as_str())
         .arg(revision.as_str())
-        // These variables are unset for the same reason as in `fetch_with_cli`.
-        .env_remove(EnvVars::GIT_DIR)
-        .env_remove(EnvVars::GIT_WORK_TREE)
-        .env_remove(EnvVars::GIT_INDEX_FILE)
-        .env_remove(EnvVars::GIT_OBJECT_DIRECTORY)
-        .env_remove(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES)
         // We should not support requesting LFS artifacts with skip smudge being set.
         // While this may not be necessary, it's added to avoid any potential future issues.
         .env_remove(EnvVars::GIT_LFS_SKIP_SMUDGE)

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -927,6 +927,12 @@ impl EnvVars {
     #[attr_added_in("0.4.29")]
     pub const GIT_CEILING_DIRECTORIES: &'static str = "GIT_CEILING_DIRECTORIES";
 
+    /// Cleared for uv's git invocations to ensure git behaves correctly in
+    /// spite of an odd environment.
+    #[attr_hidden]
+    #[attr_added_in("next release")]
+    pub const GIT_COMMON_DIR: &'static str = "GIT_COMMON_DIR";
+
     /// Indicates that the current process is running in GitHub Actions.
     ///
     /// `uv publish` may attempt trusted publishing flows when set

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 use std::iter;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -1299,7 +1299,8 @@ fn detect_git_repository(path: &Path) -> GitDiscoveryResult {
     let Ok(git) = GIT.as_ref() else {
         return GitDiscoveryResult::NoGit;
     };
-    let Ok(output) = Command::new(git)
+    let Ok(output) = git
+        .build_command()
         .arg("rev-parse")
         .arg("--is-inside-work-tree")
         .env(EnvVars::LC_ALL, "C")
@@ -1402,7 +1403,8 @@ fn get_author_from_git(path: &Path) -> Result<Author> {
     let mut name = None;
     let mut email = None;
 
-    let output = Command::new(git)
+    let output = git
+        .build_command()
         .arg("config")
         .arg("--get")
         .arg("user.name")
@@ -1414,7 +1416,8 @@ fn get_author_from_git(path: &Path) -> Result<Author> {
         name = Some(String::from_utf8_lossy(&output.stdout).trim().to_string());
     }
 
-    let output = Command::new(git)
+    let output = git
+        .build_command()
         .arg("config")
         .arg("--get")
         .arg("user.email")

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -11512,6 +11512,36 @@ fn pip_install_no_sources_package() -> Result<()> {
     Ok(())
 }
 
+/// Certain git environment variables should not be forwarded to git
+#[test]
+#[cfg(feature = "test-git")]
+fn install_git_with_git_envs_set() {
+    let context = uv_test::test_context!(DEFAULT_PYTHON_VERSION);
+
+    uv_snapshot!(context.filters(), context
+        .pip_install()
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage")
+        .env(EnvVars::GIT_DIR, "/nonexistent")
+        .env(EnvVars::GIT_COMMON_DIR, "/nonexistent")
+        .env(EnvVars::GIT_WORK_TREE, "/nonexistent")
+        .env(EnvVars::GIT_INDEX_FILE, "/nonexistent")
+        .env(EnvVars::GIT_OBJECT_DIRECTORY, "/nonexistent")
+        .env(EnvVars::GIT_ALTERNATE_OBJECT_DIRECTORIES, "/nonexistent"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    ");
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+}
+
 #[test]
 fn unsupported_git_scheme() {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

These variables can break uv's use of git when set.

Fixes #19008.

Closes #19042.

## Test Plan

Added a test + existing coverage.