### PR TITLE
Don't hush `uv sync` changes with just `--quiet`

### DIFF
--- a/crates/uv/src/commands/pip/loggers.rs
+++ b/crates/uv/src/commands/pip/loggers.rs
@@ -211,7 +211,7 @@ impl InstallLogger for DefaultInstallLogger {
             match event.kind {
                 ChangeEventKind::Added => {
                     writeln!(
-                        printer.stderr(),
+                        printer.stderr_important(),
                         " {} {}{}",
                         "+".green(),
                         event.dist.name().bold(),
@@ -220,7 +220,7 @@ impl InstallLogger for DefaultInstallLogger {
                 }
                 ChangeEventKind::Removed => {
                     writeln!(
-                        printer.stderr(),
+                        printer.stderr_important(),
                         " {} {}{}",
                         "-".red(),
                         event.dist.name().bold(),
@@ -229,7 +229,7 @@ impl InstallLogger for DefaultInstallLogger {
                 }
                 ChangeEventKind::Reinstalled => {
                     writeln!(
-                        printer.stderr(),
+                        printer.stderr_important(),
                         " {} {}{}",
                         "~".yellow(),
                         event.dist.name().bold(),
@@ -395,7 +395,7 @@ impl InstallLogger for UpgradeInstallLogger {
                         .collect::<Vec<_>>()
                         .join(", ");
                     writeln!(
-                        printer.stderr(),
+                        printer.stderr_important(),
                         "{} {} {}",
                         "Reinstalled".yellow().bold(),
                         &self.target,
@@ -413,7 +413,7 @@ impl InstallLogger for UpgradeInstallLogger {
                         .collect::<Vec<_>>()
                         .join(", ");
                     writeln!(
-                        printer.stderr(),
+                        printer.stderr_important(),
                         "{} {} {} -> {}",
                         "Updated".green().bold(),
                         &self.target,
@@ -429,7 +429,7 @@ impl InstallLogger for UpgradeInstallLogger {
                     .collect::<Vec<_>>()
                     .join(", ");
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{} {} {}",
                     "Removed".red().bold(),
                     &self.target,
@@ -443,7 +443,7 @@ impl InstallLogger for UpgradeInstallLogger {
                     .collect::<Vec<_>>()
                     .join(", ");
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{} {} {}",
                     "Added".green().bold(),
                     &self.target,
@@ -452,7 +452,7 @@ impl InstallLogger for UpgradeInstallLogger {
             }
             (None, None) => {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{} {} {}",
                     "Modified".dimmed(),
                     &self.target.dimmed().bold(),

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -53,7 +53,6 @@ impl Printer {
     }
 
     /// Return the [`Stderr`] for this printer.
-    #[allow(dead_code)] // Only used with the optional self-update feature.
     pub(crate) fn stderr_important(self) -> Stderr {
         match self {
             Self::Silent => Stderr::Disabled,

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -44,6 +44,57 @@ fn sync() -> Result<()> {
     Ok(())
 }
 
+/// `-q` should suppress timing output but retain the per-package change lines, so users can still
+/// see what was modified. `-qq` should suppress all output. See
+/// <https://github.com/astral-sh/uv/issues/19050>.
+#[test]
+fn sync_quiet() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    // `-q` should show the change lines but hide timing output.
+    uv_snapshot!(context.filters(), context.sync().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+     + iniconfig==2.0.0
+    ");
+
+    // A subsequent `-q` sync with no changes should produce no output.
+    uv_snapshot!(context.filters(), context.sync().arg("-q"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    // Reset, then verify `-qq` suppresses all output even when there are changes.
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(context.filters(), context.sync().arg("-qq"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn locked() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

The idea here is to suppress the timing information with `--quiet`, but retain the subjectively more important difference render on stderr. The user can then fully suppress the stderr with `-qq` for full silence.

To do this, I've reused `stderr_important` (which was previously only used on some gated functionality).

Note: I'm kind of low-confidence on doing this; I think my _approach_ is right but I think this would be establishing a new precedent in the packaging subcommands.

Fixes #19050.

## Test Plan

Added a `uv sync` integration test demonstrating `-q` and `-qq`.