### PR TITLE
remove as many `Box::pin` calls as possible

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -734,7 +734,7 @@ pub(crate) async fn add(
     let lock_state = state.fork();
     let sync_state = state;
 
-    match Box::pin(lock_and_sync(
+    match lock_and_sync(
         target,
         &mut toml,
         &edits,
@@ -762,7 +762,7 @@ pub(crate) async fn add(
         cache,
         printer,
         preview,
-    ))
+    )
     .await
     {
         Ok(()) => Ok(ExitStatus::Success),
@@ -1005,28 +1005,26 @@ async fn lock_and_sync(
     printer: Printer,
     preview: Preview,
 ) -> Result<(), ProjectError> {
-    let mut lock = Box::pin(
-        project::lock::LockOperation::new(
-            if let LockCheck::Enabled(lock_check) = lock_check {
-                LockMode::Locked(target.interpreter(), lock_check)
-            } else if dry_run {
-                LockMode::DryRun(target.interpreter())
-            } else {
-                LockMode::Write(target.interpreter())
-            },
-            &settings.resolver,
-            client_builder,
-            &lock_state,
-            Box::new(DefaultResolveLogger),
-            concurrency,
-            cache,
-            &WorkspaceCache::default(),
-            printer,
-            preview,
-        )
-        .with_constraints(constraints)
-        .execute((&target).into()),
+    let mut lock = project::lock::LockOperation::new(
+        if let LockCheck::Enabled(lock_check) = lock_check {
+            LockMode::Locked(target.interpreter(), lock_check)
+        } else if dry_run {
+            LockMode::DryRun(target.interpreter())
+        } else {
+            LockMode::Write(target.interpreter())
+        },
+        &settings.resolver,
+        client_builder,
+        &lock_state,
+        Box::new(DefaultResolveLogger),
+        concurrency,
+        cache,
+        &WorkspaceCache::default(),
+        printer,
+        preview,
     )
+    .with_constraints(constraints)
+    .execute((&target).into())
     .await?
     .into_lock();
 
@@ -1130,27 +1128,25 @@ async fn lock_and_sync(
 
             // If the file was modified, we have to lock again, though the only expected change is
             // the addition of the minimum version specifiers.
-            lock = Box::pin(
-                project::lock::LockOperation::new(
-                    if let LockCheck::Enabled(lock_check) = lock_check {
-                        LockMode::Locked(target.interpreter(), lock_check)
-                    } else if dry_run {
-                        LockMode::DryRun(target.interpreter())
-                    } else {
-                        LockMode::Write(target.interpreter())
-                    },
-                    &settings.resolver,
-                    client_builder,
-                    &lock_state,
-                    Box::new(SummaryResolveLogger),
-                    concurrency,
-                    cache,
-                    &WorkspaceCache::default(),
-                    printer,
-                    preview,
-                )
-                .execute((&target).into()),
+            lock = project::lock::LockOperation::new(
+                if let LockCheck::Enabled(lock_check) = lock_check {
+                    LockMode::Locked(target.interpreter(), lock_check)
+                } else if dry_run {
+                    LockMode::DryRun(target.interpreter())
+                } else {
+                    LockMode::Write(target.interpreter())
+                },
+                &settings.resolver,
+                client_builder,
+                &lock_state,
+                Box::new(SummaryResolveLogger),
+                concurrency,
+                cache,
+                &WorkspaceCache::default(),
+                printer,
+                preview,
             )
+            .execute((&target).into())
             .await?
             .into_lock();
         }

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -159,21 +159,19 @@ pub(crate) async fn audit(
     let state = UniversalState::default();
 
     // Update the lockfile, if necessary.
-    let lock = match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            &cache,
-            &WorkspaceCache::default(),
-            printer,
-            preview,
-        )
-        .execute(target),
+    let lock = match LockOperation::new(
+        mode,
+        &settings,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        &cache,
+        &WorkspaceCache::default(),
+        printer,
+        preview,
     )
+    .execute(target)
     .await
     {
         Ok(result) => result.into_lock(),

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -210,21 +210,19 @@ pub(crate) async fn export(
     let state = UniversalState::default();
 
     // Lock the project.
-    let lock = match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            &workspace_cache,
-            printer,
-            preview,
-        )
-        .execute((&target).into()),
+    let lock = match LockOperation::new(
+        mode,
+        &settings,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        &workspace_cache,
+        printer,
+        preview,
     )
+    .execute((&target).into())
     .await
     {
         Ok(result) => result.into_lock(),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -202,22 +202,20 @@ pub(crate) async fn lock(
     let state = UniversalState::default();
 
     // Perform the lock operation.
-    match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            workspace_cache,
-            printer,
-            preview,
-        )
-        .with_refresh(&refresh)
-        .execute(target),
+    match LockOperation::new(
+        mode,
+        &settings,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        workspace_cache,
+        printer,
+        preview,
     )
+    .with_refresh(&refresh)
+    .execute(target)
     .await
     {
         Ok(lock) => {
@@ -390,7 +388,7 @@ impl<'env> LockOperation<'env> {
                 ))?;
 
                 // Perform the lock operation, but don't write the lockfile to disk.
-                let result = Box::pin(do_lock(
+                let result = do_lock(
                     target,
                     interpreter,
                     Some(existing),
@@ -405,7 +403,7 @@ impl<'env> LockOperation<'env> {
                     self.workspace_cache,
                     self.printer,
                     self.preview,
-                ))
+                )
                 .await?;
 
                 // If the lockfile changed, return an error.
@@ -434,7 +432,7 @@ impl<'env> LockOperation<'env> {
                 };
 
                 // Perform the lock operation.
-                let result = Box::pin(do_lock(
+                let result = do_lock(
                     target,
                     interpreter,
                     existing,
@@ -449,7 +447,7 @@ impl<'env> LockOperation<'env> {
                     self.workspace_cache,
                     self.printer,
                     self.preview,
-                ))
+                )
                 .await?;
 
                 // If the lockfile changed, write it to disk.

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -303,21 +303,19 @@ pub(crate) async fn remove(
     let state = UniversalState::default();
 
     // Lock and sync the environment, if necessary.
-    let lock = match Box::pin(
-        project::lock::LockOperation::new(
-            mode,
-            &settings.resolver,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            &WorkspaceCache::default(),
-            printer,
-            preview,
-        )
-        .execute((&target).into()),
+    let lock = match project::lock::LockOperation::new(
+        mode,
+        &settings.resolver,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        &WorkspaceCache::default(),
+        printer,
+        preview,
     )
+    .execute((&target).into())
     .await
     {
         Ok(result) => result.into_lock(),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -275,25 +275,23 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             };
 
             // Generate a lockfile.
-            let lock = match Box::pin(
-                project::lock::LockOperation::new(
-                    mode,
-                    &settings.resolver,
-                    &client_builder,
-                    &lock_state,
-                    if show_resolution {
-                        Box::new(DefaultResolveLogger)
-                    } else {
-                        Box::new(SummaryResolveLogger)
-                    },
-                    &concurrency,
-                    &cache,
-                    workspace_cache,
-                    printer,
-                    preview,
-                )
-                .execute(target),
+            let lock = match project::lock::LockOperation::new(
+                mode,
+                &settings.resolver,
+                &client_builder,
+                &lock_state,
+                if show_resolution {
+                    Box::new(DefaultResolveLogger)
+                } else {
+                    Box::new(SummaryResolveLogger)
+                },
+                &concurrency,
+                &cache,
+                workspace_cache,
+                printer,
+                preview,
             )
+            .execute(target)
             .await
             {
                 Ok(result) => result.into_lock(),
@@ -785,25 +783,23 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     LockMode::Write(venv.interpreter())
                 };
 
-                let result = match Box::pin(
-                    project::lock::LockOperation::new(
-                        mode,
-                        &settings.resolver,
-                        &client_builder,
-                        &lock_state,
-                        if show_resolution {
-                            Box::new(DefaultResolveLogger)
-                        } else {
-                            Box::new(SummaryResolveLogger)
-                        },
-                        &concurrency,
-                        &cache,
-                        workspace_cache,
-                        printer,
-                        preview,
-                    )
-                    .execute(project.workspace().into()),
+                let result = match project::lock::LockOperation::new(
+                    mode,
+                    &settings.resolver,
+                    &client_builder,
+                    &lock_state,
+                    if show_resolution {
+                        Box::new(DefaultResolveLogger)
+                    } else {
+                        Box::new(SummaryResolveLogger)
+                    },
+                    &concurrency,
+                    &cache,
+                    workspace_cache,
+                    printer,
+                    preview,
                 )
+                .execute(project.workspace().into())
                 .await
                 {
                     Ok(result) => result,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -344,21 +344,19 @@ pub(crate) async fn sync(
         SyncTarget::Script(script) => LockTarget::from(script),
     };
 
-    let outcome = match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings.resolver,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            workspace_cache,
-            printer,
-            preview,
-        )
-        .execute(lock_target),
+    let outcome = match LockOperation::new(
+        mode,
+        &settings.resolver,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        workspace_cache,
+        printer,
+        preview,
     )
+    .execute(lock_target)
     .await
     {
         Ok(result) => Outcome::Success(result),

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -148,21 +148,19 @@ pub(crate) async fn tree(
     let state = UniversalState::default();
 
     // Update the lockfile, if necessary.
-    let lock = match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings,
-            client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            &workspace_cache,
-            printer,
-            preview,
-        )
-        .execute(target),
+    let lock = match LockOperation::new(
+        mode,
+        &settings,
+        client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        &workspace_cache,
+        printer,
+        preview,
     )
+    .execute(target)
     .await
     {
         Ok(result) => result.into_lock(),

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -115,7 +115,7 @@ pub(crate) async fn project_version(
     let is_read_only = value.is_none() && bump.is_empty();
     if let Some(frozen_source) = frozen {
         if is_read_only {
-            return Box::pin(print_frozen_version(
+            return print_frozen_version(
                 project,
                 &name,
                 project_dir,
@@ -135,7 +135,7 @@ pub(crate) async fn project_version(
                 output_format,
                 printer,
                 preview,
-            ))
+            )
             .await;
         }
     }
@@ -335,7 +335,7 @@ pub(crate) async fn project_version(
         ExitStatus::Success
     } else if let Some(new_version) = &new_version {
         let project = update_project(project, new_version, &mut toml, &pyproject_path)?;
-        Box::pin(lock_and_sync(
+        lock_and_sync(
             project,
             project_dir,
             lock_check,
@@ -354,7 +354,7 @@ pub(crate) async fn project_version(
             cache,
             printer,
             preview,
-        ))
+        )
         .await?
     } else {
         debug!("No changes to version; skipping update");
@@ -498,21 +498,19 @@ async fn print_frozen_version(
     let state = UniversalState::default();
 
     // Lock and sync the environment, if necessary.
-    let lock = match Box::pin(
-        project::lock::LockOperation::new(
-            LockMode::Frozen(frozen_source.into()),
-            &settings.resolver,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            concurrency,
-            cache,
-            workspace_cache,
-            printer,
-            preview,
-        )
-        .execute((&target).into()),
+    let lock = match project::lock::LockOperation::new(
+        LockMode::Frozen(frozen_source.into()),
+        &settings.resolver,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        concurrency,
+        cache,
+        workspace_cache,
+        printer,
+        preview,
     )
+    .execute((&target).into())
     .await
     {
         Ok(result) => result.into_lock(),
@@ -647,21 +645,19 @@ async fn lock_and_sync(
     let workspace_cache = WorkspaceCache::default();
 
     // Lock and sync the environment, if necessary.
-    let lock = match Box::pin(
-        project::lock::LockOperation::new(
-            mode,
-            &settings.resolver,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            concurrency,
-            cache,
-            &workspace_cache,
-            printer,
-            preview,
-        )
-        .execute((&target).into()),
+    let lock = match project::lock::LockOperation::new(
+        mode,
+        &settings.resolver,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        concurrency,
+        cache,
+        &workspace_cache,
+        printer,
+        preview,
     )
+    .execute((&target).into())
     .await
     {
         Ok(result) => result.into_lock(),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -286,7 +286,7 @@ pub(crate) async fn run(
     };
 
     // Get or create a compatible environment in which to execute the tool.
-    let result = Box::pin(get_or_create_environment(
+    let result = get_or_create_environment(
         &request,
         with,
         constraints,
@@ -309,7 +309,7 @@ pub(crate) async fn run(
         &workspace_cache,
         printer,
         preview,
-    ))
+    )
     .await;
 
     let explicit_from = from.is_some();

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -123,7 +123,7 @@ pub(crate) async fn upgrade(
     let mut errors = Vec::new();
     for (name, constraints) in &names {
         debug!("Upgrading tool: `{name}`");
-        let result = Box::pin(upgrade_tool(
+        let result = upgrade_tool(
             name,
             constraints,
             interpreter.as_ref(),
@@ -138,7 +138,7 @@ pub(crate) async fn upgrade(
             installer_metadata,
             &concurrency,
             preview,
-        ))
+        )
         .await;
 
         match result {

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -99,22 +99,20 @@ pub(crate) async fn metadata(
     let state = UniversalState::default();
 
     // Perform the lock operation.
-    match Box::pin(
-        LockOperation::new(
-            mode,
-            &settings,
-            &client_builder,
-            &state,
-            Box::new(DefaultResolveLogger),
-            &concurrency,
-            cache,
-            workspace_cache,
-            printer,
-            preview,
-        )
-        .with_refresh(&refresh)
-        .execute(target),
+    match LockOperation::new(
+        mode,
+        &settings,
+        &client_builder,
+        &state,
+        Box::new(DefaultResolveLogger),
+        &concurrency,
+        cache,
+        workspace_cache,
+        printer,
+        preview,
     )
+    .with_refresh(&refresh)
+    .execute(target)
     .await
     {
         Ok(lock) => print_lock_as_metadata(virtual_project.workspace(), &lock.into_lock(), printer),

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -903,7 +903,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     .combine(Refresh::from(args.settings.upgrade.clone())),
             );
 
-            Box::pin(commands::pip_install(
+            commands::pip_install(
                 &requirements,
                 &constraints,
                 &overrides,
@@ -956,7 +956,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.dry_run,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         Commands::Pip(PipNamespace {
@@ -1298,7 +1298,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             .await
         }
         Commands::Project(project) => {
-            Box::pin(run_project(
+            run_project(
                 project,
                 &project_dir,
                 run_command,
@@ -1311,7 +1311,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 cache,
                 &workspace_cache,
                 printer,
-            ))
+            )
             .await
         }
         #[cfg(feature = "self-update")]
@@ -1462,7 +1462,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 }
             };
 
-            Box::pin(commands::tool_run(
+            commands::tool_run(
                 args.command,
                 args.from,
                 &requirements,
@@ -1489,7 +1489,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.env_file,
                 args.no_env_file,
                 globals.preview,
-            ))
+            )
             .await
         }
         Commands::Tool(ToolNamespace {
@@ -1562,7 +1562,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .map(RequirementsSource::from_constraints_txt)
                 .collect::<Result<Vec<_>, _>>()?;
 
-            Box::pin(commands::tool_install(
+            commands::tool_install(
                 args.package,
                 args.editable,
                 args.from,
@@ -1589,7 +1589,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &workspace_cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         Commands::Tool(ToolNamespace {
@@ -1631,7 +1631,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .await?
                 .with_refresh(Refresh::All(Timestamp::now()));
 
-            Box::pin(commands::tool_upgrade(
+            commands::tool_upgrade(
                 args.names,
                 args.python,
                 args.python_platform,
@@ -1647,7 +1647,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &workspace_cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         Commands::Tool(ToolNamespace {
@@ -1938,7 +1938,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                         .combine(Refresh::from(args.settings.upgrade.clone())),
                 );
 
-                Box::pin(commands::metadata(
+                commands::metadata(
                     &project_dir,
                     args.lock_check,
                     args.frozen,
@@ -1956,7 +1956,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     &workspace_cache,
                     printer,
                     globals.preview,
-                ))
+                )
                 .await
             }
             WorkspaceCommand::Dir(args) => {
@@ -2173,7 +2173,7 @@ async fn run_project(
                     .collect::<Result<Vec<_>, _>>()?,
             );
 
-            Box::pin(commands::run(
+            commands::run(
                 project_dir,
                 script,
                 command,
@@ -2207,7 +2207,7 @@ async fn run_project(
                 args.env_file,
                 globals.preview,
                 args.max_recursion_depth,
-            ))
+            )
             .await
         }
         ProjectCommand::Sync(args) => {
@@ -2234,7 +2234,7 @@ async fn run_project(
                 Pep723Item::Remote(..) => unreachable!("`uv lock` does not support remote files"),
             });
 
-            Box::pin(commands::sync(
+            commands::sync(
                 project_dir,
                 args.lock_check,
                 args.frozen,
@@ -2263,7 +2263,7 @@ async fn run_project(
                 printer,
                 globals.preview,
                 args.output_format,
-            ))
+            )
             .await
         }
         ProjectCommand::Lock(args) => {
@@ -2296,7 +2296,7 @@ async fn run_project(
                 .map(ScriptPath::Script)
                 .or(args.script.map(ScriptPath::Path));
 
-            Box::pin(commands::lock(
+            commands::lock(
                 project_dir,
                 args.lock_check,
                 args.frozen,
@@ -2315,7 +2315,7 @@ async fn run_project(
                 workspace_cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         ProjectCommand::Add(args) => {
@@ -2407,7 +2407,7 @@ async fn run_project(
                 .map(RequirementsSource::from_constraints_txt)
                 .collect::<Result<Vec<_>, _>>()?;
 
-            Box::pin(commands::add(
+            commands::add(
                 project_dir,
                 args.lock_check,
                 args.frozen,
@@ -2449,7 +2449,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         ProjectCommand::Remove(args) => {
@@ -2476,7 +2476,7 @@ async fn run_project(
                 Pep723Item::Remote(..) => unreachable!("`uv remove` does not support remote files"),
             });
 
-            Box::pin(commands::remove(
+            commands::remove(
                 project_dir,
                 args.lock_check,
                 args.frozen,
@@ -2498,7 +2498,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         ProjectCommand::Version(args) => {
@@ -2518,7 +2518,7 @@ async fn run_project(
                     .combine(Refresh::from(args.settings.resolver.upgrade.clone())),
             );
 
-            Box::pin(commands::project_version(
+            commands::project_version(
                 args.value,
                 args.bump,
                 args.short,
@@ -2544,7 +2544,7 @@ async fn run_project(
                 workspace_cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         ProjectCommand::Tree(args) => {
@@ -2562,7 +2562,7 @@ async fn run_project(
                 Pep723Item::Remote(..) => unreachable!("`uv tree` does not support remote files"),
             });
 
-            Box::pin(commands::tree(
+            commands::tree(
                 project_dir,
                 args.groups,
                 args.lock_check,
@@ -2589,7 +2589,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
-            ))
+            )
             .await
         }
         ProjectCommand::Export(args) => {
@@ -2648,7 +2648,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache.init().await?;
 
-            Box::pin(commands::format(
+            commands::format(
                 project_dir,
                 args.check,
                 args.diff,
@@ -2661,7 +2661,7 @@ async fn run_project(
                 printer,
                 globals.preview,
                 args.no_project,
-            ))
+            )
             .await
         }
         ProjectCommand::Audit(audit_args) => {
@@ -2678,7 +2678,7 @@ async fn run_project(
                 Pep723Item::Remote(..) => unreachable!("`uv audit` does not support remote files"),
             });
 
-            Box::pin(commands::audit(
+            commands::audit(
                 project_dir,
                 args.extras,
                 args.groups,
@@ -2701,7 +2701,7 @@ async fn run_project(
                 args.service_url,
                 args.ignore,
                 args.ignore_until_fixed,
-            ))
+            )
             .await
         }
     }
@@ -2801,7 +2801,7 @@ where
             .build()
             .expect("Failed building the Runtime");
         // Box the large main future to avoid stack overflows.
-        let result = runtime.block_on(Box::pin(run(cli)));
+        let result = runtime.block_on(run(cli));
         // Avoid waiting for pending tasks to complete.
         //
         // The resolver may have kicked off HTTP requests during resolution that


### PR DESCRIPTION
The remaining uses are in `crates/uv-requirements-txt/src/lib.rs`, where they're necessary because the async fn is recursive.