### PR TITLE
fix(pip): skip empty lines in top_level.txt during egg uninstall

### DIFF
--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -247,6 +247,7 @@ pub fn uninstall_egg(
             Ok(top_level) => top_level
                 .lines()
                 .map(ToString::to_string)
+                .filter(|line| !line.is_empty())
                 .filter(|line| !namespace_packages.contains(line))
                 .collect::<Vec<_>>(),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
## Summary

Fixes #19113

When a package has an empty `top_level.txt` (containing only a newline character), `lines()` produces one empty string `""`. This causes `dist_location.join("")` to return `dist_location` itself, and `remove_dir_all` then deletes the entire site-packages directory.

## Test

Reproducer from the issue: a package installed with older pip that has `.egg-info` metadata and an empty package (where `top_level.txt` contains only a newline).

Before this fix: `uv pip uninstall` removes the entire site-packages directory.
After this fix: the empty line is skipped, and only the egg-info directory is removed.

## Changes

Add `.filter(|line| !line.is_empty())` to the `top_level.txt` parsing in `uninstall_egg()`, before the existing namespace package filter.