### PR TITLE
Remove Ubuntu snapshot pinning from CI workflows

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -14,7 +14,6 @@ env:
   CARGO_TERM_COLOR: always
   PYTHON_VERSION: "3.12"
   RUSTUP_MAX_RETRIES: 10
-  UBUNTU_SNAPSHOT: "20260301T000000Z"
 
 jobs:
   integration-test-nushell:
@@ -199,7 +198,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture armhf
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
-          sudo apt install -y --update --snapshot ${UBUNTU_SNAPSHOT} libc6:armhf libgcc-s1:armhf
+          sudo apt install -y --update libc6:armhf libgcc-s1:armhf
 
       - name: "Prepare binary"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ env:
   CARGO_TERM_COLOR: always
   PYTHON_VERSION: "3.12"
   RUSTUP_MAX_RETRIES: 10
-  UBUNTU_SNAPSHOT: "20260301T000000Z"
 
 jobs:
   # We use the large GitHub actions runners
@@ -54,7 +53,7 @@ jobs:
       - name: "Install secret service"
         run: |
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
-          sudo apt install -y --update --snapshot ${UBUNTU_SNAPSHOT} gnome-keyring
+          sudo apt install -y --update gnome-keyring
 
       - name: "Start gnome-keyring"
         # run gnome-keyring with 'foobar' as password for the login keyring
@@ -64,7 +63,7 @@ jobs:
 
       - name: "Create btrfs filesystem"
         run: |
-          sudo apt install -y --update --snapshot ${UBUNTU_SNAPSHOT} btrfs-progs
+          sudo apt install -y --update btrfs-progs
           truncate -s 1G /tmp/btrfs.img
           mkfs.btrfs /tmp/btrfs.img
           sudo mkdir /btrfs


### PR DESCRIPTION
Reverts https://github.com/astral-sh/uv/pull/19032/changes

Alas, the snapshot server appears to be incredibly unreliable :(