### PR TITLE
fix(trampoline): don't set PYTHONHOME for venv trampolines

### DIFF
--- a/crates/uv-trampoline/src/bounce.rs
+++ b/crates/uv-trampoline/src/bounce.rs
@@ -158,7 +158,19 @@ fn make_child_cmdline() -> CString {
                 // whether `PYTHONHOME` was set by uv. This allows us to:
                 // - Override inherited `PYTHONHOME` from parent Python processes
                 // - Preserve user-defined `PYTHONHOME` values
-                if !is_virtualenv(python_exe.as_path()) {
+                //
+                // We must check both `executable_name` (the trampoline itself,
+                // which may live inside a virtual environment's `Scripts`
+                // directory and target the base interpreter via the
+                // `python_path` resource) and `python_exe` (the resolved target
+                // interpreter). Otherwise, virtual environments built on top of
+                // managed interpreters would incorrectly receive `PYTHONHOME`
+                // pointing at the base installation, which then leaks into
+                // child processes and can shadow stdlib from a different Python
+                // (see https://github.com/astral-sh/uv/issues/19080).
+                if !is_virtualenv(executable_name.as_path())
+                    && !is_virtualenv(python_exe.as_path())
+                {
                     let python_home = std::env::var(EnvVars::PYTHONHOME).ok();
                     let marker = std::env::var(EnvVars::UV_INTERNAL__PYTHONHOME).ok();
 

--- a/crates/uv-trampoline/src/bounce.rs
+++ b/crates/uv-trampoline/src/bounce.rs
@@ -168,8 +168,7 @@ fn make_child_cmdline() -> CString {
                 // pointing at the base installation, which then leaks into
                 // child processes and can shadow stdlib from a different Python
                 // (see https://github.com/astral-sh/uv/issues/19080).
-                if !is_virtualenv(executable_name.as_path())
-                    && !is_virtualenv(python_exe.as_path())
+                if !is_virtualenv(executable_name.as_path()) && !is_virtualenv(python_exe.as_path())
                 {
                     let python_home = std::env::var(EnvVars::PYTHONHOME).ok();
                     let marker = std::env::var(EnvVars::UV_INTERNAL__PYTHONHOME).ok();


### PR DESCRIPTION
Closes #19080

<!-- Drafted by an agent run; please review carefully before merging. -->

## Repo
astral-sh/uv

## Issue
https://github.com/astral-sh/uv/issues/19080

## Root cause
The Windows trampoline in `crates/uv-trampoline/src/bounce.rs` decides whether to
set `PYTHONHOME` by calling `is_virtualenv(python_exe)`. For a venv trampoline,
`python_exe` resolves to the *base* managed interpreter (e.g.
`~\AppData\Roaming\uv\python\cpython-3.13-...\python.exe`), which is not itself
a virtualenv. So even when the user invokes `.venv\Scripts\python` (which IS a
venv trampoline), `PYTHONHOME` is set to the base install. That env var then
leaks to child processes (e.g. cibuildwheel running a different Python),
shadowing the wrong stdlib and producing
`AttributeError: module '_thread' has no attribute 'start_joinable_thread'`.

## Fix
Also check `is_virtualenv(executable_name)` — the trampoline's own path — before
deciding to set `PYTHONHOME`. A venv trampoline lives in `<venv>\Scripts\` next
to a `<venv>\pyvenv.cfg`, so this correctly suppresses `PYTHONHOME` for venv
trampolines while preserving the original junction-handling behavior for
non-venv managed interpreters.

## Regression test
None added. The trampoline crate (`crates/uv-trampoline`) is excluded from the
workspace, builds only as a Windows binary with `panic-immediate-abort` /
`#![no_main]`, and has no existing unit-test surface. The patch is a
two-line guard change adjacent to the existing `is_virtualenv(python_exe)`
check and follows the same pattern.

## Risk
low

## Verification
skipped: build requires Windows MSVC toolchain (cross-check on macOS fails on
`rust-src` for the nightly toolchain). The change is a localized predicate
extension reusing the existing `is_virtualenv` helper.
