### PR TITLE
Share `pylock.toml` reading and resolution in pip commands

### DIFF
--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -87,6 +87,7 @@ mod help;
 pub(crate) mod pip;
 mod project;
 mod publish;
+mod pylock;
 mod python;
 pub(crate) mod reporters;
 #[cfg(feature = "self-update")]

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -1,9 +1,8 @@
 use std::collections::BTreeSet;
 
-use anyhow::Context;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::{Level, debug, enabled, info_span, warn};
+use tracing::{Level, debug, enabled, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -31,8 +30,8 @@ use uv_python::{
 };
 use uv_requirements::{GroupsSpecification, RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
-    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PylockToml,
-    PythonRequirement, ResolutionMode, ResolverEnvironment,
+    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PythonRequirement,
+    ResolutionMode, ResolverEnvironment,
 };
 use uv_settings::PythonInstallMirrors;
 use uv_torch::{TorchMode, TorchSource, TorchStrategy};
@@ -45,6 +44,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::operations::{report_interpreter, report_target_environment};
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
+use crate::commands::pylock::{read_pylock_toml, resolve_pylock_toml};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
@@ -493,44 +493,7 @@ pub(crate) async fn pip_install(
     );
 
     let (resolution, hasher) = if let Some(pylock) = pylock {
-        // Read the `pylock.toml` from disk or URL, and deserialize it from TOML.
-        let (install_path, content) =
-            if pylock.starts_with("http://") || pylock.starts_with("https://") {
-                // Fetch the `pylock.toml` over HTTP(S).
-                let url = uv_redacted::DisplaySafeUrl::parse(&pylock.to_string_lossy())?;
-                let client = client_builder.build()?;
-                let response = client
-                    .for_host(&url)
-                    .get(url::Url::from(url.clone()))
-                    .send()
-                    .await?;
-                response.error_for_status_ref()?;
-                let content = response.text().await?;
-                // Use the current working directory as the install path for remote lock files.
-                let install_path = std::env::current_dir()?;
-                (install_path, content)
-            } else {
-                let install_path = std::path::absolute(&pylock)?;
-                let install_path = install_path.parent().unwrap().to_path_buf();
-                let content = fs_err::tokio::read_to_string(&pylock).await?;
-                (install_path, content)
-            };
-        let lock = info_span!("toml::from_str pip install", path = %pylock.display())
-            .in_scope(|| toml::from_str::<PylockToml>(&content))
-            .with_context(|| {
-                format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
-            })?;
-
-        // Verify that the Python version is compatible with the lock file.
-        if let Some(requires_python) = lock.requires_python.as_ref() {
-            if !requires_python.contains(interpreter.python_version()) {
-                return Err(anyhow::anyhow!(
-                    "The requested interpreter resolved to Python {}, which is incompatible with the `pylock.toml`'s Python requirement: `{}`",
-                    interpreter.python_version(),
-                    requires_python,
-                ));
-            }
-        }
+        let (install_path, lock) = read_pylock_toml(&pylock, &client_builder).await?;
 
         // Convert the extras and groups specifications into a concrete form.
         let extras = extras.with_defaults(DefaultExtras::default());
@@ -549,17 +512,16 @@ pub(crate) async fn pip_install(
             .cloned()
             .collect::<Vec<_>>();
 
-        let resolution = lock.to_resolution(
+        resolve_pylock_toml(
+            lock,
             &install_path,
-            marker_env.markers(),
+            interpreter,
+            python_version.as_ref(),
+            python_platform.as_ref(),
             &extras,
             &groups,
-            &tags,
             &build_options,
-        )?;
-        let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
-
-        (resolution, hasher)
+        )?
     } else {
         // When resolving, don't take any external preferences into account.
         let preferences = Vec::default();

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeSet;
 use std::fmt::Write;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use owo_colors::OwoColorize;
-use tracing::{debug, info_span, warn};
+use tracing::{debug, warn};
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -30,8 +30,8 @@ use uv_python::{
 };
 use uv_requirements::{GroupsSpecification, RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
-    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PylockToml,
-    PythonRequirement, ResolutionMode, ResolverEnvironment,
+    DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PrereleaseMode, PythonRequirement,
+    ResolutionMode, ResolverEnvironment,
 };
 use uv_settings::PythonInstallMirrors;
 use uv_torch::{TorchMode, TorchSource, TorchStrategy};
@@ -44,6 +44,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::operations::{report_interpreter, report_target_environment};
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
+use crate::commands::pylock::{read_pylock_toml, resolve_pylock_toml};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
@@ -403,26 +404,7 @@ pub(crate) async fn pip_sync(
     let site_packages = SitePackages::from_environment(&environment)?;
 
     let (resolution, hasher) = if let Some(pylock) = pylock {
-        // Read the `pylock.toml` from disk, and deserialize it from TOML.
-        let install_path = std::path::absolute(&pylock)?;
-        let install_path = install_path.parent().unwrap();
-        let content = fs_err::tokio::read_to_string(&pylock).await?;
-        let lock = info_span!("toml::from_str pip sync", path = %pylock.display())
-            .in_scope(|| toml::from_str::<PylockToml>(&content))
-            .with_context(|| {
-                format!("Not a valid `pylock.toml` file: {}", pylock.user_display())
-            })?;
-
-        // Verify that the Python version is compatible with the lock file.
-        if let Some(requires_python) = lock.requires_python.as_ref() {
-            if !requires_python.contains(interpreter.python_version()) {
-                return Err(anyhow::anyhow!(
-                    "The requested interpreter resolved to Python {}, which is incompatible with the `pylock.toml`'s Python requirement: `{}`",
-                    interpreter.python_version(),
-                    requires_python,
-                ));
-            }
-        }
+        let (install_path, lock) = read_pylock_toml(&pylock, &client_builder).await?;
 
         // Convert the extras and groups specifications into a concrete form.
         let extras = extras.with_defaults(DefaultExtras::default());
@@ -441,17 +423,16 @@ pub(crate) async fn pip_sync(
             .cloned()
             .collect::<Vec<_>>();
 
-        let resolution = lock.to_resolution(
-            install_path,
-            marker_env.markers(),
+        resolve_pylock_toml(
+            lock,
+            &install_path,
+            interpreter,
+            python_version.as_ref(),
+            python_platform.as_ref(),
             &extras,
             &groups,
-            &tags,
             &build_options,
-        )?;
-        let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
-
-        (resolution, hasher)
+        )?
     } else {
         // When resolving, don't take any external preferences into account.
         let preferences = Vec::default();

--- a/crates/uv/src/commands/pylock.rs
+++ b/crates/uv/src/commands/pylock.rs
@@ -1,0 +1,94 @@
+//! Shared helpers for reading `pylock.toml` (PEP 751) files and deriving a [`Resolution`] and
+//! verifying [`HashStrategy`] from them, used by `uv pip install` and `uv pip sync`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use tracing::info_span;
+
+use uv_client::BaseClientBuilder;
+use uv_configuration::{BuildOptions, HashCheckingMode, TargetTriple};
+use uv_distribution_types::Resolution;
+use uv_fs::Simplified;
+use uv_normalize::{ExtraName, GroupName};
+use uv_python::{Interpreter, PythonVersion};
+use uv_resolver::PylockToml;
+use uv_types::HashStrategy;
+
+use crate::commands::pip::{resolution_markers, resolution_tags};
+
+/// Read a `pylock.toml` from a local path or HTTP(S) URL and parse it.
+///
+/// Returns the `install_path` (used to resolve relative package sources in the lock) alongside
+/// the parsed [`PylockToml`]. For HTTP(S) sources, the current working directory is used as the
+/// install path.
+pub(crate) async fn read_pylock_toml(
+    pylock: &Path,
+    client_builder: &BaseClientBuilder<'_>,
+) -> anyhow::Result<(PathBuf, PylockToml)> {
+    let (install_path, content) = if pylock.starts_with("http://") || pylock.starts_with("https://")
+    {
+        let url = uv_redacted::DisplaySafeUrl::parse(&pylock.to_string_lossy())?;
+        let client = client_builder.build()?;
+        let response = client
+            .for_host(&url)
+            .get(url::Url::from(url.clone()))
+            .send()
+            .await?;
+        response.error_for_status_ref()?;
+        let content = response.text().await?;
+        (std::env::current_dir()?, content)
+    } else {
+        let absolute = std::path::absolute(pylock)?;
+        let install_path = absolute
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(PathBuf::new);
+        let content = fs_err::tokio::read_to_string(pylock).await?;
+        (install_path, content)
+    };
+
+    let lock = info_span!("toml::from_str pylock.toml", path = %pylock.display())
+        .in_scope(|| toml::from_str::<PylockToml>(&content))
+        .with_context(|| format!("Not a valid `pylock.toml` file: {}", pylock.user_display()))?;
+
+    Ok((install_path, lock))
+}
+
+/// Verify Python compatibility and convert a parsed [`PylockToml`] into a [`Resolution`] with a
+/// verifying [`HashStrategy`].
+pub(crate) fn resolve_pylock_toml(
+    lock: PylockToml,
+    install_path: &Path,
+    interpreter: &Interpreter,
+    python_version: Option<&PythonVersion>,
+    python_platform: Option<&TargetTriple>,
+    extras: &[ExtraName],
+    groups: &[GroupName],
+    build_options: &BuildOptions,
+) -> anyhow::Result<(Resolution, HashStrategy)> {
+    if let Some(requires_python) = lock.requires_python.as_ref() {
+        if !requires_python.contains(interpreter.python_version()) {
+            return Err(anyhow::anyhow!(
+                "The requested interpreter resolved to Python {}, which is incompatible with the `pylock.toml`'s Python requirement: `{}`",
+                interpreter.python_version(),
+                requires_python,
+            ));
+        }
+    }
+
+    let tags = resolution_tags(python_version, python_platform, interpreter)?;
+    let marker_env = resolution_markers(python_version, python_platform, interpreter);
+
+    let resolution = lock.to_resolution(
+        install_path,
+        marker_env.markers(),
+        extras,
+        groups,
+        &tags,
+        build_options,
+    )?;
+    let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
+
+    Ok((resolution, hasher))
+}

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -8,6 +8,8 @@ use fs_err as fs;
 use indoc::indoc;
 use predicates::Predicate;
 use url::Url;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_fs::{Simplified, copy_dir_all};
 use uv_static::EnvVars;
@@ -5969,6 +5971,64 @@ fn pep_751() -> Result<()> {
      - idna==3.6
      + iniconfig==2.0.0
      - sniffio==1.3.1
+    "
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn pep_751_remote() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/pylock.toml"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(indoc! {r#"
+            lock-version = "1.0"
+            created-by = "uv"
+            requires-python = ">=3.12"
+
+            [[packages]]
+            name = "anyio"
+            version = "4.3.0"
+            sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", upload-time = 2024-02-19T08:36:28Z, size = 159642, hashes = { sha256 = "f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" } }
+            wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", upload-time = 2024-02-19T08:36:26Z, size = 85584, hashes = { sha256 = "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" } }]
+            dependencies = [
+                { name = "idna" },
+                { name = "sniffio" },
+            ]
+
+            [[packages]]
+            name = "idna"
+            version = "3.6"
+            sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", upload-time = 2023-11-25T15:40:54Z, size = 175426, hashes = { sha256 = "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca" } }
+            wheels = [{ url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", upload-time = 2023-11-25T15:40:52Z, size = 61567, hashes = { sha256 = "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f" } }]
+
+            [[packages]]
+            name = "sniffio"
+            version = "1.3.1"
+            sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", upload-time = 2024-02-25T23:20:04Z, size = 20372, hashes = { sha256 = "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc" } }
+            wheels = [{ url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", upload-time = 2024-02-25T23:20:01Z, size = 10235, hashes = { sha256 = "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2" } }]
+        "#}))
+        .mount(&server)
+        .await;
+
+    let pylock_url = format!("{}/pylock.toml", server.uri());
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg(&pylock_url), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 3 packages in [TIME]
+    Installed 3 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.6
+     + sniffio==1.3.1
     "
     );
 


### PR DESCRIPTION
For some reason, the implementation is duplicated and the `pip sync` one does not support remote files. I think this was an oversight in #17119 since `pip sync` support predated that change (see #12992).

This is precursor refactor to #19117 which would need this utility.