### PR TITLE
Add rust-toolchain.toml to uv-build sdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             [[ -z "$file" ]] && continue
             [[ "$file" =~ \.rs$ ]] && rust_code_changed=1
             [[ "$file" == "Cargo.toml" || "$file" == "Cargo.lock" || "$file" =~ ^crates/.*/Cargo\.toml$ ]] && rust_deps_changed=1
-            [[ "$file" == "rust-toolchain.toml" || "$file" =~ ^\.cargo/ ]] && rust_config_changed=1
+            [[ "$file" == "rust-toolchain.toml" || "$file" == "crates/uv-build/rust-toolchain.toml" || "$file" =~ ^\.cargo/ ]] && rust_config_changed=1
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
             [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1

--- a/crates/uv-build/pyproject.toml
+++ b/crates/uv-build/pyproject.toml
@@ -48,6 +48,7 @@ strip = true
 include = [
   { path = "LICENSE-APACHE", format = "sdist" },
   { path = "LICENSE-MIT", format = "sdist" },
+  { path = "rust-toolchain.toml", format = "sdist" },
 ]
 
 [tool.uv]

--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94.1"


### PR DESCRIPTION
This file was previously missing, causing errors when an older version was preinstalled.

Renovate should also pick up the new file.
