### PR TITLE
Drop whoami dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,28 +3027,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
- "objc2-core-foundation",
-]
 
 [[package]]
 name = "oid-registry"
@@ -5888,7 +5870,6 @@ dependencies = [
  "uv-workspace",
  "walkdir",
  "which",
- "whoami",
  "windows",
  "wiremock",
  "zip",
@@ -7563,15 +7544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
-dependencies = [
- "wasi 0.14.7+wasi-0.2.4",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7734,19 +7706,6 @@ checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
  "regex",
-]
-
-[[package]]
-name = "whoami"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
-dependencies = [
- "libc",
- "libredox",
- "objc2-system-configuration",
- "wasite",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,6 @@ test-log = { version = "0.2.16", features = [
   "trace",
 ], default-features = false }
 tokio-rustls = { version = "0.26.2", default-features = false }
-whoami = { version = "2.0.0" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -152,7 +152,6 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
-whoami = { workspace = true }
 wiremock = { workspace = true }
 zip = { workspace = true }
 

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -1373,7 +1373,7 @@ fn reduce_ssh_key_file_permissions(key_file: &Path) -> Result<()> {
         Command::new("icacls")
             .arg(key_file)
             .arg("/grant:r")
-            .arg(format!("{}:R", whoami::username()?))
+            .arg(format!("{}:R", std::env::var("USERNAME")?))
             .assert()
             .success();
     }


### PR DESCRIPTION
## Summary

We were only using this crate in one place, in a Windows-specific test helper where accessing `%USERNAME%` should work just as well.

(This isn't super critical, but it reduces our dependency footprint slightly.)

## Test Plan

The existing tests should continue to pass with this change.