### PR TITLE
Allow `scripts/build-trampolines.sh` to try podman when it's available

### DIFF
--- a/crates/uv-trampoline/Dockerfile
+++ b/crates/uv-trampoline/Dockerfile
@@ -12,7 +12,7 @@ ARG CARGO_XWIN_VERSION=0.21.4
 ARG XWIN_SDK_VERSION=10.0.22621
 ARG XWIN_CRT_VERSION=14.44.17.14
 
-FROM ubuntu:26.04@sha256:4095ef613201918336b5d7d00be15d8b09c72ddb77c80bca249c255887a64d87 AS base
+FROM docker.io/ubuntu:26.04@sha256:4095ef613201918336b5d7d00be15d8b09c72ddb77c80bca249c255887a64d87 AS base
 
 ARG RUST_NIGHTLY
 ARG UBUNTU_SNAPSHOT
@@ -62,6 +62,6 @@ RUN cargo xwin cache xwin \
 
 FROM base
 
-COPY --chmod=a+rwX --from=xwin-cache ${HOME}/xwin-cache ${HOME}/xwin-cache
-RUN chmod a+w ${HOME}/xwin-cache
+COPY --from=xwin-cache ${HOME}/xwin-cache ${HOME}/xwin-cache
+RUN chmod a+rwX ${HOME}/xwin-cache
 COPY --from=xwin-cache ${CARGO_HOME}/bin/cargo-xwin ${CARGO_HOME}/bin/cargo-xwin

--- a/scripts/build-trampolines.sh
+++ b/scripts/build-trampolines.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+if ! command -v docker >/dev/null 2>&1 && command -v podman >/dev/null 2>&1; then
+    docker() { podman "$@"; }
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TRAMPOLINE_DIR="$REPO_ROOT/crates/uv-trampoline"


### PR DESCRIPTION
## Summary

Opportunistically use `podman` instead of `docker` when `docker` is not available but `podman` is.

This required a few small compatibility adjustments to the `Dockerfile`.

## Test Plan

Manually tested locally...