### PR TITLE
Fix duplicated `eabihf` suffix in ARMv7 platform triples

### DIFF
--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -160,21 +160,20 @@ impl Platform {
 
         let abi = match (&**os, libc) {
             (OperatingSystem::Windows, _) => Some("msvc".to_string()),
-            (OperatingSystem::Linux, Libc::Some(env)) => Some({
-                // Special suffix for ARM with hardware float
-                if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7)) {
-                    let env_str = env.to_string();
-                    // Only append "eabihf" if the environment doesn't already have it
-                    // (e.g., `Gnueabihf` already ends with "eabihf", but `Gnu` doesn't)
-                    if env_str.ends_with("eabihf") {
-                        env_str
-                    } else {
-                        format!("{env}eabihf")
-                    }
-                } else {
-                    env.to_string()
-                }
-            }),
+            // Append the hard-float suffix for ARMv7 only when libc detection
+            // didn't already return one of the explicit `*eabihf` variants.
+            (OperatingSystem::Linux, Libc::Some(env))
+                if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7))
+                    && !matches!(
+                        env,
+                        target_lexicon::Environment::Gnueabihf
+                            | target_lexicon::Environment::Musleabihf
+                            | target_lexicon::Environment::Eabihf
+                    ) =>
+            {
+                Some(format!("{env}eabihf"))
+            }
+            (OperatingSystem::Linux, Libc::Some(env)) => Some(env.to_string()),
             _ => None,
         };
 
@@ -354,6 +353,21 @@ mod tests {
         assert_eq!(
             platform.as_cargo_dist_triple(),
             "armv7-unknown-linux-gnueabihf"
+        );
+    }
+
+    /// Same guarantee as the `Gnueabihf` case: if libc is constructed as `Musleabihf`
+    /// directly, `as_cargo_dist_triple()` must not double the `eabihf` suffix.
+    #[test]
+    fn test_armv7_musleabihf_triple() {
+        let platform = Platform {
+            os: Os::from_str("linux").unwrap(),
+            arch: Arch::from_str("armv7").unwrap(),
+            libc: Libc::Some(target_lexicon::Environment::Musleabihf),
+        };
+        assert_eq!(
+            platform.as_cargo_dist_triple(),
+            "armv7-unknown-linux-musleabihf"
         );
     }
 

--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -163,7 +163,14 @@ impl Platform {
             (OperatingSystem::Linux, Libc::Some(env)) => Some({
                 // Special suffix for ARM with hardware float
                 if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7)) {
-                    format!("{env}eabihf")
+                    let env_str = env.to_string();
+                    // Only append "eabihf" if the environment doesn't already have it
+                    // (e.g., `Gnueabihf` already ends with "eabihf", but `Gnu` doesn't)
+                    if env_str.ends_with("eabihf") {
+                        env_str
+                    } else {
+                        format!("{env}eabihf")
+                    }
                 } else {
                     env.to_string()
                 }
@@ -316,6 +323,38 @@ mod tests {
         assert_eq!(platform.os.to_string(), "linux");
         assert_eq!(platform.arch.to_string(), "x86_64_v3");
         assert_eq!(platform.libc.to_string(), "gnu");
+    }
+
+    /// Regression test for <https://github.com/astral-sh/uv/issues/19137>
+    /// When libc detection returns `Gnueabihf` (which already has the hard-float suffix),
+    /// `as_cargo_dist_triple()` should not append "eabihf" again.
+    #[test]
+    fn test_armv7_gnueabihf_triple() {
+        let platform = Platform {
+            os: Os::from_str("linux").unwrap(),
+            arch: Arch::from_str("armv7").unwrap(),
+            libc: Libc::from_str("gnueabihf").unwrap(),
+        };
+        // The triple should be `armv7-unknown-linux-gnueabihf`, not `armv7-unknown-linux-gnueabihfeabihf`
+        assert_eq!(
+            platform.as_cargo_dist_triple(),
+            "armv7-unknown-linux-gnueabihf"
+        );
+    }
+
+    /// Test that armv7 with base `gnu` libc still gets the hard-float suffix appended.
+    #[test]
+    fn test_armv7_gnu_triple() {
+        let platform = Platform {
+            os: Os::from_str("linux").unwrap(),
+            arch: Arch::from_str("armv7").unwrap(),
+            libc: Libc::from_str("gnu").unwrap(),
+        };
+        // The triple should get "eabihf" appended to the base "gnu"
+        assert_eq!(
+            platform.as_cargo_dist_triple(),
+            "armv7-unknown-linux-gnueabihf"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes uv self update on ARMv7 Linux hosts where the generated platform string ended up with eabihf twice:

`armv7-unknown-linux-gnueabihfeabihf`

The issue was that `Platform::as_cargo_dist_triple()` always appended eabihf for ARMv7 Linux, even when libc detection already returned Gnueabihf.

This adds a small guard so we only append eabihf when it is not already present. The existing soft-float Gnu path still gets the suffix as expected.

Added regression coverage for both cases.

Closes #19137.