### PR TITLE
Add UV_PYTHON_PLATFORM environment variable

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1676,7 +1676,7 @@ pub struct PipCompileArgs {
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Perform a universal resolution, attempting to generate a single `requirements.txt` output
@@ -2044,7 +2044,7 @@ pub struct PipSyncArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Validate the Python environment after completing the installation, to detect packages with
@@ -2414,7 +2414,7 @@ pub struct PipInstallArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Do not remove extraneous packages present in the environment.
@@ -2764,7 +2764,7 @@ pub struct PipCheckArgs {
     ///
     /// When targeting Android, the default minimum Android API level is `24`. Use
     /// `ANDROID_API_LEVEL` to specify a different minimum version, e.g., `26`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 }
 
@@ -3818,7 +3818,7 @@ pub struct RunArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 }
 
@@ -4143,7 +4143,7 @@ pub struct SyncArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Check if the Python environment is synchronized with the project.
@@ -4785,7 +4785,7 @@ pub struct TreeArgs {
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
-    #[arg(long, conflicts_with = "universal")]
+    #[arg(long, conflicts_with = "universal", env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// The Python interpreter to use for locking and filtering.
@@ -5246,7 +5246,7 @@ pub struct AuditArgs {
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
     /// `aarch64-apple-darwin`.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// Ignore a vulnerability by ID.
@@ -5576,7 +5576,7 @@ pub struct ToolRunArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`, or `auto`)
@@ -5769,7 +5769,7 @@ pub struct ToolInstallArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     /// The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`, or `auto`)
@@ -5915,7 +5915,7 @@ pub struct ToolUpgradeArgs {
     /// platform. Conversely, any distributions that are built from source may be incompatible with
     /// the _target_ platform, as they will be built for the _current_ platform. The
     /// `--python-platform` option is intended for advanced use cases.
-    #[arg(long)]
+    #[arg(long, env = EnvVars::UV_PYTHON_PLATFORM)]
     pub python_platform: Option<TargetTriple>,
 
     // The following is equivalent to flattening `ResolverInstallerArgs`, with the `--upgrade`,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -98,6 +98,11 @@ impl EnvVars {
     #[attr_added_in("0.1.40")]
     pub const UV_PYTHON: &'static str = "UV_PYTHON";
 
+    /// Equivalent to the `--python-platform` command-line argument. If set, uv will target this
+    /// platform when resolving dependencies and selecting wheels.
+    #[attr_added_in("0.11.7")]
+    pub const UV_PYTHON_PLATFORM: &'static str = "UV_PYTHON_PLATFORM";
+
     /// Equivalent to the `--break-system-packages` command-line argument. If set to `true`,
     /// uv will allow the installation of packages that conflict with system-installed packages.
     ///

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -13566,6 +13566,50 @@ fn sync_python_platform() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn sync_python_platform_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["black"]
+        "#,
+    )?;
+
+    // Lock the project
+    context.lock().assert().success();
+
+    // Sync with a specific platform from the environment should filter packages.
+    uv_snapshot!(
+        context.filters(),
+        context
+            .sync()
+            .env(EnvVars::UV_PYTHON_PLATFORM, "linux"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    Prepared 6 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    ");
+
+    Ok(())
+}
+
 /// See: <https://github.com/astral-sh/uv/issues/11648>
 #[test]
 #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
- add a dedicated `UV_PYTHON_PLATFORM` environment variable for commands that already support `--python-platform`
- register the new env var in the shared environment variable catalog
- cover `uv sync` with an integration test using the env var

Closes #15241

## Testing
- cargo test -p uv --test it sync_python_platform
- cargo test -p uv --test it sync_python_platform_env
- cargo run -- sync --help | rg "UV_PYTHON_PLATFORM"