### PR TITLE
Use a single codepath for extracting a .tar.zst wheel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,7 +6508,6 @@ dependencies = [
  "reqwest",
  "rustc-hash",
  "sha2",
- "tar",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -6520,7 +6519,6 @@ dependencies = [
  "uv-warnings",
  "xz2",
  "zip",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,6 @@ zip = { version = "8.1.0", default-features = false, features = [
   "lzma",
   "xz",
 ] }
-zstd = { version = "0.13.3" }
 
 # dev-dependencies
 assert_cmd = { version = "2.0.16" }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -890,16 +890,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .await
                     .map_err(Error::CacheWrite)?;
 
-                // If no hashes are required, parallelize the unzip operation.
+                // If no hashes are required, extract the wheel without hashing.
                 let (files, hashes) = if hashes.is_none() {
-                    // Unzip the wheel into a temporary directory.
-                    let file = file.into_std().await;
                     let target = temp_dir.path().to_owned();
-                    let files = tokio::task::spawn_blocking(move || match extension {
-                        WheelExtension::Whl => uv_extract::unzip(file, &target),
-                        WheelExtension::WhlZst => uv_extract::stream::untar_zst_file(file, &target),
-                    })
-                    .await?
+                    let files = match extension {
+                        WheelExtension::Whl => {
+                            let file = file.into_std().await;
+                            tokio::task::spawn_blocking(move || uv_extract::unzip(file, &target))
+                                .await?
+                        }
+                        WheelExtension::WhlZst => {
+                            uv_extract::stream::untar_zst(file, &target).await
+                        }
+                    }
                     .map_err(|err| Error::Extract(filename.to_string(), err))?;
 
                     (files, HashDigests::empty())

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -34,14 +34,12 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 rustc-hash = { workspace = true }
 sha2 = { workspace = true }
-tar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 xz2 = { workspace = true }
 zip = { workspace = true }
-zstd = { workspace = true }
 
 [features]
 default = []

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -731,62 +731,6 @@ pub async fn untar_zst<R: tokio::io::AsyncRead + Unpin>(
         .map_err(Error::io_or_compression)
 }
 
-/// Unpack a `.tar.zst` archive from a file on disk into the target directory.
-///
-/// Returns the list of unpacked files and their sizes.
-pub fn untar_zst_file<R: std::io::Read>(
-    reader: R,
-    target: impl AsRef<Path>,
-) -> Result<Vec<(PathBuf, u64)>, Error> {
-    let reader = std::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
-    let decompressed = zstd::Decoder::new(reader).map_err(Error::Io)?;
-    let mut archive = tar::Archive::new(decompressed);
-    archive.set_preserve_mtime(false);
-
-    // The logic below is `Archive::unpack`, with slight simplifications as we know the target is
-    // a real directory, using our error handling and adding file recording.
-    let mut files = Vec::new();
-
-    // Canonicalizing the dst directory will prepend the path with '\\?\'
-    // on windows which will allow windows APIs to treat the path as an
-    // extended-length path with a 32,767 character limit. Otherwise all
-    // unpacked paths over 260 characters will fail on creation with a
-    // NotFound exception.
-    let dst = fs_err::canonicalize(&target).unwrap_or(target.as_ref().to_path_buf());
-
-    // Delay any directory entries until the end (they will be created if needed by
-    // descendants), to ensure that directory permissions do not interfere with descendant
-    // extraction.
-    let mut directories = Vec::new();
-    for entry in archive.entries().map_err(Error::io_or_compression)? {
-        let mut file = entry.map_err(Error::io_or_compression)?;
-        if file.header().entry_type() == tar::EntryType::Directory {
-            directories.push(file);
-        } else {
-            let entry_type = file.header().entry_type();
-            let path = file.path().map_err(Error::io_or_compression)?.into_owned();
-            let size = file.header().size().map_err(Error::io_or_compression)?;
-            if entry_type.is_file() || entry_type.is_hard_link() {
-                files.push((path, size));
-            }
-            file.unpack_in(&dst).map_err(Error::io_or_compression)?;
-        }
-    }
-
-    // Apply the directories.
-    //
-    // Note: the order of application is important to permissions. That is, we must traverse
-    // the filesystem graph in topological ordering or else we risk not being able to create
-    // child directories within those of more restrictive permissions. See [0] for details.
-    //
-    // [0]: <https://github.com/alexcrichton/tar-rs/issues/242>
-    directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
-    for mut dir in directories {
-        dir.unpack_in(&dst).map_err(Error::io_or_compression)?;
-    }
-    Ok(files)
-}
-
 /// Unpack a `.tar.xz` archive into the target directory, without requiring `Seek`.
 ///
 /// This is useful for unpacking files as they're being downloaded.


### PR DESCRIPTION
This extraction code is duplicated in two places, and the one this PR deletes has a few missing validations. Instead of fixing, this PR consolidates the codepaths.
This means uv won't depend on `zstd` or `tar` directly after merging this.