### PR TITLE
Redact pre-signed upload URLs in verbose output

### DIFF
--- a/crates/uv-redacted/src/lib.rs
+++ b/crates/uv-redacted/src/lib.rs
@@ -7,6 +7,12 @@ use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
 
+const SENSITIVE_QUERY_PARAMETERS: &[&str] = &[
+    "X-Amz-Credential",
+    "X-Amz-Security-Token",
+    "X-Amz-Signature",
+];
+
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum DisplaySafeUrlError {
     /// Failed to parse a URL.
@@ -19,7 +25,7 @@ pub enum DisplaySafeUrlError {
     AmbiguousAuthority(String),
 }
 
-/// A [`Url`] wrapper that redacts credentials when displaying the URL.
+/// A [`Url`] wrapper that redacts credentials and sensitive query parameters when displaying the URL.
 ///
 /// `DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask
 /// secrets by default when the URL is displayed or logged. This helps prevent accidental
@@ -246,7 +252,8 @@ impl Display for DisplaySafeUrl {
 
 impl Debug for DisplaySafeUrl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let url = &self.0;
+        let url = url_with_redacted_sensitive_query_values(&self.0);
+        let url = url.as_ref();
         // For URLs that use the `git` convention (i.e., `ssh://git@github.com/...`), avoid masking the
         // username.
         let (username, password) = if is_ssh_git_username(url) {
@@ -301,17 +308,46 @@ fn is_ssh_git_username(url: &Url) -> bool {
         && url.password().is_none()
 }
 
+fn is_sensitive_query_parameter(key: &str) -> bool {
+    SENSITIVE_QUERY_PARAMETERS
+        .iter()
+        .any(|sensitive| key.eq_ignore_ascii_case(sensitive))
+}
+
+fn url_with_redacted_sensitive_query_values(url: &Url) -> Cow<'_, Url> {
+    if !url
+        .query_pairs()
+        .any(|(key, _value)| is_sensitive_query_parameter(&key))
+    {
+        return Cow::Borrowed(url);
+    }
+
+    let query_pairs: Vec<_> = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_query_parameter(&key) {
+                Cow::Borrowed("****")
+            } else {
+                value
+            };
+            (key, value)
+        })
+        .collect();
+
+    let mut url = url.clone();
+    url.query_pairs_mut().clear().extend_pairs(query_pairs);
+    Cow::Owned(url)
+}
+
 fn display_with_redacted_credentials(
     url: &Url,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    if url.password().is_none() && url.username() == "" {
-        return write!(f, "{url}");
-    }
-
+    let url = url_with_redacted_sensitive_query_values(url);
+    let url = url.as_ref();
     // For URLs that use the `git` convention (i.e., `ssh://git@github.com/...`), avoid dropping the
     // username.
-    if is_ssh_git_username(url) {
+    if is_ssh_git_username(url) || (url.username().is_empty() && url.password().is_none()) {
         return write!(f, "{url}");
     }
 
@@ -458,6 +494,69 @@ mod tests {
         assert_eq!(
             log_safe_url.displayable_with_credentials().to_string(),
             url_str
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=credential&X-Amz-Date=20260424T120000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=signature&X-Amz-Security-Token=token",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=****&X-Amz-Date=20260424T120000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=****&X-Amz-Security-Token=****"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_case_insensitive() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?x-amz-credential=credential&x-amz-signature=signature&x-amz-security-token=token",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?x-amz-credential=****&x-amz-signature=****&x-amz-security-token=****"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_with_percent_encoded_keys() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz%2DSignature=signature&safe=value",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Signature=****&safe=value"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_in_debug() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Credential=credential&X-Amz-Signature=signature",
+        )
+        .unwrap();
+
+        let debug = format!("{log_safe_url:?}");
+        assert!(debug.contains(r#"query: Some("X-Amz-Credential=****&X-Amz-Signature=****")"#));
+        assert!(!debug.contains("credential"));
+        assert!(!debug.contains("signature"));
+    }
+
+    #[test]
+    fn does_not_redact_unknown_query_values() {
+        let log_safe_url =
+            DisplaySafeUrl::parse("https://bucket.s3.amazonaws.com/dist.whl?token=secret").unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?token=secret"
         );
     }
 

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -623,6 +623,67 @@ async fn gitlab_trusted_publishing_testpypi_id_token() {
     );
 }
 
+#[tokio::test]
+async fn direct_publish_redacts_presigned_upload_url() {
+    let context = uv_test::test_context!("3.12");
+    let server = MockServer::start().await;
+
+    let upload_url = format!(
+        "{}/s3/ok-1.0.0-py3-none-any.whl?X-Amz-Credential=credential&X-Amz-Signature=signature&X-Amz-Security-Token=token",
+        server.uri()
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/upload/reserve"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "upload_url": upload_url,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/s3/ok-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/upload/finalize"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--preview-features")
+        .arg("direct-publish")
+        .arg("--direct")
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::RUST_LOG, "uv_publish=debug"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Hashing ok-1.0.0-py3-none-any.whl ([SIZE])
+    DEBUG Hashing [WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    DEBUG Reserving upload slot at http://[LOCALHOST]/upload/reserve
+    DEBUG Using HTTP Basic authentication
+    DEBUG Got pre-signed URL for upload: http://[LOCALHOST]/s3/ok-1.0.0-py3-none-any.whl?X-Amz-Credential=****&X-Amz-Signature=****&X-Amz-Security-Token=****
+    DEBUG S3 upload complete for ok-1.0.0-py3-none-any.whl
+    DEBUG Finalizing upload at http://[LOCALHOST]/upload/finalize
+    DEBUG Using HTTP Basic authentication
+    DEBUG Response code for http://[LOCALHOST]/upload/finalize: 200 OK
+    DEBUG Upload finalized for ok-1.0.0-py3-none-any.whl
+    "
+    );
+}
+
 /// PyPI returns `application/json` errors with a `code` field.
 #[tokio::test]
 async fn upload_error_pypi_json() {


### PR DESCRIPTION
This teaches `DisplaySafeUrl` about sensitive query parameters (that are typically used to sign S3 requests) to avoid leaking them in verbose logs.

Note: Errors might still contain these in two places:
- reqwest errors contain a raw url
- aws can return an error that itself contains the signature (this is probably fine to display unredacted, as it only happens when the signature is invalid anyway)

<!-- start jj-vine stack -->
This PR is part of a stack containing 2 PRs:

1. `main`
2. **"Redact pre-signed upload URLs" (this PR)**
3. #19147
<!-- end jj-vine stack -->