### PR TITLE
fetch available CPython releases from the network

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6221,9 +6221,9 @@ pub enum PythonCommand {
     /// Download and install Python versions.
     ///
     /// Supports CPython and PyPy. CPython distributions are downloaded from the Astral
-    /// `python-build-standalone` project. PyPy distributions are downloaded from `python.org`. The
-    /// available Python versions are bundled with each uv release. To install new Python versions,
-    /// you may need upgrade uv.
+    /// `python-build-standalone` project. PyPy distributions are downloaded from `python.org`.
+    /// Available CPython versions are fetched at runtime and fall back to metadata bundled with
+    /// each uv release if that fetch fails.
     ///
     /// Python versions are installed into the uv Python directory, which can be retrieved with `uv
     /// python dir`.
@@ -6353,7 +6353,7 @@ pub struct PythonListArgs {
     #[arg(long, value_enum, default_value_t = PythonListFormat::default())]
     pub output_format: PythonListFormat,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[arg(long, value_hint = ValueHint::Other)]
     pub python_downloads_json_url: Option<String>,
 }
@@ -6479,7 +6479,7 @@ pub struct PythonInstallArgs {
     #[arg(long, value_hint = ValueHint::Url)]
     pub pypy_mirror: Option<String>,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[arg(long, value_hint = ValueHint::Other)]
     pub python_downloads_json_url: Option<String>,
 
@@ -6584,7 +6584,7 @@ pub struct PythonUpgradeArgs {
     #[arg(long, short)]
     pub reinstall: bool,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[arg(long, value_hint = ValueHint::Other)]
     pub python_downloads_json_url: Option<String>,
 
@@ -6679,7 +6679,7 @@ pub struct PythonFindArgs {
     #[arg(long)]
     pub resolve_links: bool,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[arg(long, value_hint = ValueHint::Other)]
     pub python_downloads_json_url: Option<String>,
 }
@@ -6736,7 +6736,7 @@ pub struct PythonPinArgs {
     #[arg(long, conflicts_with = "request", conflicts_with = "resolved")]
     pub rm: bool,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[arg(long, value_hint = ValueHint::Other)]
     pub python_downloads_json_url: Option<String>,
 }

--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -64,6 +64,51 @@ impl Platform {
         Ok(Self { os, arch, libc })
     }
 
+    /// Parse a platform from a `cargo-dist` style triple string (e.g., `aarch64-apple-darwin`).
+    ///
+    /// See [`Self::as_cargo_dist_triple`] for the inverse operation.
+    pub fn from_cargo_dist_triple(triple: &str) -> Result<Self, Error> {
+        let parts: Vec<&str> = triple.split('-').collect();
+        if parts.len() < 3 {
+            return Err(Error::InvalidPlatformFormat(format!(
+                "expected at least 3 parts in cargo-dist triple, got {} in '{triple}'",
+                parts.len()
+            )));
+        }
+
+        let arch_str = match parts[0] {
+            "armv5tel" => "armv5te",
+            "ppc64" => "powerpc64",
+            "ppc64le" => "powerpc64le",
+            "riscv64" | "riscv64gc" => "riscv64gc",
+            arch => arch,
+        };
+        let arch = Arch::from_str(arch_str)?;
+
+        let os_str = match parts[2] {
+            "darwin" => "macos",
+            os => os,
+        };
+        let os = Os::from_str(os_str)?;
+
+        let libc_str = if parts.len() > 3 {
+            match parts[3] {
+                "gnu" | "gnuabi64" => "gnu",
+                "gnueabi" => "gnueabi",
+                "gnueabihf" => "gnueabihf",
+                "musl" | "muslabi64" => "musl",
+                "msvc" => "none",
+                "android" | "androideabi" => "none",
+                _ => "none",
+            }
+        } else {
+            "none"
+        };
+        let libc = Libc::from_str(libc_str)?;
+
+        Ok(Self { os, arch, libc })
+    }
+
     /// Check if this platform supports running another platform.
     pub fn supports(&self, other: &Self) -> bool {
         // If platforms are exactly equal, they're compatible
@@ -135,6 +180,8 @@ impl Platform {
     }
 
     /// Convert this platform to a `cargo-dist` style triple string.
+    ///
+    /// See [`Self::from_cargo_dist_triple`] for the inverse operation.
     pub fn as_cargo_dist_triple(&self) -> String {
         use target_lexicon::{
             Architecture, ArmArchitecture, Environment, OperatingSystem, Riscv64Architecture,
@@ -545,6 +592,90 @@ mod tests {
                 expected,
                 "linux-{arch}-{libc}"
             );
+        }
+    }
+
+    #[test]
+    fn test_from_cargo_dist_triple() {
+        let platform = Platform::from_cargo_dist_triple("aarch64-apple-darwin").unwrap();
+        assert_eq!(platform.arch.to_string(), "aarch64");
+        assert_eq!(platform.os.to_string(), "macos");
+        assert_eq!(platform.libc.to_string(), "none");
+
+        let platform = Platform::from_cargo_dist_triple("x86_64-apple-darwin").unwrap();
+        assert_eq!(platform.arch.to_string(), "x86_64");
+        assert_eq!(platform.os.to_string(), "macos");
+        assert_eq!(platform.libc.to_string(), "none");
+
+        let platform = Platform::from_cargo_dist_triple("x86_64-unknown-linux-gnu").unwrap();
+        assert_eq!(platform.arch.to_string(), "x86_64");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnu");
+
+        let platform = Platform::from_cargo_dist_triple("aarch64-unknown-linux-gnu").unwrap();
+        assert_eq!(platform.arch.to_string(), "aarch64");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnu");
+
+        let platform = Platform::from_cargo_dist_triple("x86_64-unknown-linux-musl").unwrap();
+        assert_eq!(platform.arch.to_string(), "x86_64");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "musl");
+
+        let platform = Platform::from_cargo_dist_triple("x86_64-pc-windows-msvc").unwrap();
+        assert_eq!(platform.arch.to_string(), "x86_64");
+        assert_eq!(platform.os.to_string(), "windows");
+        assert_eq!(platform.libc.to_string(), "none");
+
+        let platform = Platform::from_cargo_dist_triple("aarch64-pc-windows-msvc").unwrap();
+        assert_eq!(platform.arch.to_string(), "aarch64");
+        assert_eq!(platform.os.to_string(), "windows");
+        assert_eq!(platform.libc.to_string(), "none");
+
+        let platform = Platform::from_cargo_dist_triple("x86_64_v3-unknown-linux-gnu").unwrap();
+        assert_eq!(platform.arch.to_string(), "x86_64_v3");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnu");
+
+        let platform = Platform::from_cargo_dist_triple("armv7-unknown-linux-gnueabihf").unwrap();
+        assert_eq!(platform.arch.to_string(), "armv7");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnueabihf");
+
+        let platform = Platform::from_cargo_dist_triple("ppc64le-unknown-linux-gnu").unwrap();
+        assert_eq!(platform.arch.to_string(), "powerpc64le");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnu");
+
+        let platform = Platform::from_cargo_dist_triple("riscv64gc-unknown-linux-gnu").unwrap();
+        assert_eq!(platform.arch.to_string(), "riscv64gc");
+        assert_eq!(platform.os.to_string(), "linux");
+        assert_eq!(platform.libc.to_string(), "gnu");
+    }
+
+    #[test]
+    fn test_from_cargo_dist_triple_errors() {
+        assert!(Platform::from_cargo_dist_triple("x86_64-unknown").is_err());
+        assert!(Platform::from_cargo_dist_triple("x86_64").is_err());
+        assert!(Platform::from_cargo_dist_triple("invalid_arch-unknown-linux-gnu").is_err());
+        assert!(Platform::from_cargo_dist_triple("x86_64-unknown-invalid_os-gnu").is_err());
+    }
+
+    #[test]
+    fn test_cargo_dist_triple_roundtrip() {
+        let platforms = [
+            Platform::from_parts("macos", "aarch64", "none").unwrap(),
+            Platform::from_parts("macos", "x86_64", "none").unwrap(),
+            Platform::from_parts("linux", "x86_64", "gnu").unwrap(),
+            Platform::from_parts("linux", "x86_64", "musl").unwrap(),
+            Platform::from_parts("linux", "aarch64", "gnu").unwrap(),
+            Platform::from_parts("windows", "x86_64", "none").unwrap(),
+        ];
+
+        for original in platforms {
+            let triple = original.as_cargo_dist_triple();
+            let parsed = Platform::from_cargo_dist_triple(&triple).unwrap();
+            assert_eq!(original, parsed, "roundtrip failed for {triple}");
         }
     }
 }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1456,6 +1456,7 @@ pub(crate) async fn find_best_python_installation(
                     let download_list = ManagedPythonDownloadList::new(
                         &download_list_client,
                         python_downloads_json_url,
+                        Some(cache),
                     )
                     .await?;
                     let retry_policy = client_builder.retry_policy();

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Display;
+use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -117,6 +118,10 @@ pub enum Error {
     UnsupportedPythonDownloadsJSON(String),
     #[error("Error while fetching remote python downloads json from '{0}'")]
     FetchingPythonDownloadsJSONError(String, #[source] Box<Self>),
+    #[error("Unable to parse NDJSON line at {0}")]
+    InvalidPythonDownloadsNdjsonLine(String, #[source] serde_json::Error),
+    #[error("Error while fetching remote python downloads NDJSON from '{0}'")]
+    FetchingPythonDownloadsNdjsonError(String, #[source] Box<Self>),
     #[error("An offline Python installation was requested, but {file} (from {url}) is missing in {}", python_builds_dir.user_display())]
     OfflinePythonMissing {
         file: Box<PythonInstallationKey>,
@@ -951,6 +956,17 @@ impl FromStr for PythonDownloadRequest {
 const BUILTIN_PYTHON_DOWNLOADS_JSON: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/download-metadata-minified.json"));
 
+// 2025-03-11, the first CPython release date whose musl builds are dynamically linked.
+const CPYTHON_MUSL_STATIC_RELEASE_END: u64 = 2025 * 10_000 + 3 * 100 + 11;
+const NDJSON_FLAVOR_PREFERENCES: &[&str] = &[
+    "install_only_stripped",
+    "install_only",
+    "shared-pgo",
+    "shared-noopt",
+    "static-noopt",
+];
+const NDJSON_KNOWN_FLAVORS: &[&str] = &["full", "install_only", "install_only_stripped"];
+
 pub struct ManagedPythonDownloadList {
     downloads: Vec<ManagedPythonDownload>,
 }
@@ -977,10 +993,44 @@ struct JsonArch {
     variant: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+struct NdjsonPythonVersionInfo {
+    version: String,
+    artifacts: Vec<NdjsonPythonArtifact>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct NdjsonPythonArtifact {
+    platform: String,
+    variant: String,
+    url: String,
+    sha256: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub enum DownloadResult {
     AlreadyAvailable(PathBuf),
     Fetched(PathBuf),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownloadListFormat {
+    Json,
+    Ndjson,
+}
+
+fn detect_download_list_format(url_or_path: &str) -> DownloadListFormat {
+    let path = Url::parse(url_or_path)
+        .ok()
+        .filter(|url| matches!(url.scheme(), "http" | "https" | "file"))
+        .map(|url| url.path().to_owned());
+    let path = path.as_deref().unwrap_or(url_or_path);
+
+    if path.ends_with(".ndjson") {
+        DownloadListFormat::Ndjson
+    } else {
+        DownloadListFormat::Json
+    }
 }
 
 /// A wrapper type to display a `ManagedPythonDownload` with its build information.
@@ -1044,6 +1094,10 @@ impl ManagedPythonDownloadList {
         client: &BaseClient,
         python_downloads_json_url: Option<&str>,
     ) -> Result<Self, Error> {
+        let format = python_downloads_json_url
+            .map(detect_download_list_format)
+            .unwrap_or(DownloadListFormat::Json);
+
         // Although read_url() handles file:// URLs and converts them to local file reads, here we
         // want to also support parsing bare filenames like "/tmp/py.json", not just
         // "file:///tmp/py.json". Note that "C:\Temp\py.json" should be considered a filename, even
@@ -1073,38 +1127,54 @@ impl ManagedPythonDownloadList {
         let buf: Cow<'_, [u8]> = match json_source {
             Source::BuiltIn => BUILTIN_PYTHON_DOWNLOADS_JSON.into(),
             Source::Path(ref path) => fs_err::read(path.as_ref())?.into(),
-            Source::Http(ref url) => fetch_bytes_from_url(client, url)
-                .await
-                .map_err(|e| Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(e)))?
-                .into(),
+            Source::Http(ref url) => {
+                let buf = fetch_bytes_from_url(client, url)
+                    .await
+                    .map_err(|err| match format {
+                        DownloadListFormat::Json => {
+                            Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(err))
+                        }
+                        DownloadListFormat::Ndjson => Error::FetchingPythonDownloadsNdjsonError(
+                            url.to_string(),
+                            Box::new(err),
+                        ),
+                    })?;
+                buf.into()
+            }
         };
-        let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(&buf)
-            .map_err(
-                // As an explicit compatibility mechanism, if there's a top-level "version" key, it
-                // means it's a newer format than we know how to deal with.  Before reporting a
-                // parse error about the format of JsonPythonDownload, check for that key. We can do
-                // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
-                // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
-                // have the same parsing effect.)
-                #[expect(clippy::zero_sized_map_values)]
-                |e| {
-                    let source = match json_source {
-                        Source::BuiltIn => "EMBEDDED IN THE BINARY".to_owned(),
-                        Source::Path(path) => path.to_string_lossy().to_string(),
-                        Source::Http(url) => url.to_string(),
-                    };
-                    if let Ok(keys) =
-                        serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(&buf)
-                        && keys.contains_key("version")
-                    {
-                        Error::UnsupportedPythonDownloadsJSON(source)
-                    } else {
-                        Error::InvalidPythonDownloadsJSON(source, e)
-                    }
-                },
-            )?;
 
-        let result = parse_json_downloads(json_downloads);
+        let source = match json_source {
+            Source::BuiltIn => "EMBEDDED IN THE BINARY".to_owned(),
+            Source::Path(path) => path.to_string_lossy().to_string(),
+            Source::Http(url) => url.to_string(),
+        };
+        let result = match format {
+            DownloadListFormat::Json => {
+                let json_downloads: HashMap<String, JsonPythonDownload> =
+                    serde_json::from_slice(&buf).map_err(
+                        // As an explicit compatibility mechanism, if there's a top-level "version" key, it
+                        // means it's a newer format than we know how to deal with.  Before reporting a
+                        // parse error about the format of JsonPythonDownload, check for that key. We can do
+                        // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
+                        // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
+                        // have the same parsing effect.)
+                        #[expect(clippy::zero_sized_map_values)]
+                        |err| {
+                            if let Ok(keys) = serde_json::from_slice::<
+                                HashMap<String, serde::de::IgnoredAny>,
+                            >(&buf)
+                                && keys.contains_key("version")
+                            {
+                                Error::UnsupportedPythonDownloadsJSON(source.clone())
+                            } else {
+                                Error::InvalidPythonDownloadsJSON(source.clone(), err)
+                            }
+                        },
+                    )?;
+                parse_json_downloads(json_downloads)
+            }
+            DownloadListFormat::Ndjson => parse_ndjson_bytes(&source, &buf)?,
+        };
         Ok(Self { downloads: result })
     }
 
@@ -1706,6 +1776,238 @@ fn parse_json_downloads(
         .collect()
 }
 
+fn parse_version_with_build(s: &str) -> Result<(PythonVersion, Option<&str>), Error> {
+    if let Some((version_str, build)) = s.split_once('+') {
+        let version = PythonVersion::from_str(version_str)
+            .map_err(|_| Error::InvalidPythonVersion(s.to_string()))?;
+        Ok((version, Some(build)))
+    } else {
+        let version =
+            PythonVersion::from_str(s).map_err(|_| Error::InvalidPythonVersion(s.to_string()))?;
+        Ok((version, None))
+    }
+}
+
+/// Parse one NDJSON version record into managed downloads, selecting the best
+/// artifact for each platform and [`PythonVariant`].
+fn parse_ndjson_version_info(version_info: NdjsonPythonVersionInfo) -> Vec<ManagedPythonDownload> {
+    let (version, build) = match parse_version_with_build(&version_info.version) {
+        Ok((version, build)) => (version, build),
+        Err(err) => {
+            debug!(
+                "Skipping NDJSON entry: invalid version '{}' - {}",
+                version_info.version, err
+            );
+            return Vec::new();
+        }
+    };
+
+    let release = build.and_then(|value| value.parse::<u64>().ok());
+    let build = build.map(|value| Box::leak(value.to_owned().into_boxed_str()) as &'static str);
+
+    let mut artifacts = version_info.artifacts;
+    // Match the built-in metadata generator's deterministic tie-breaker when two artifacts have
+    // the same platform, variant, and priority.
+    artifacts.sort_by(|a, b| a.url.cmp(&b.url));
+
+    let mut selected = BTreeMap::new();
+    for artifact in artifacts {
+        let Some((download, priority)) = parse_ndjson_artifact(&version, build, release, artifact)
+        else {
+            continue;
+        };
+        let key = (download.key().platform().clone(), *download.key().variant());
+
+        // Collapse duplicate artifacts for the same platform and variant to
+        // the preferred flavor/build-option combination.
+        if let Some((existing_download, existing_priority)) = selected.get(&key)
+            && priority >= *existing_priority
+        {
+            debug!(
+                "Skipping NDJSON artifact {} (priority {:?}): lower priority than {} (priority {:?})",
+                download, priority, existing_download, existing_priority
+            );
+            continue;
+        }
+
+        selected.insert(key, (download, priority));
+    }
+
+    selected
+        .into_values()
+        .map(|(download, _priority)| download)
+        .collect()
+}
+
+fn parse_ndjson_artifact(
+    version: &PythonVersion,
+    build: Option<&'static str>,
+    release: Option<u64>,
+    artifact: NdjsonPythonArtifact,
+) -> Option<(ManagedPythonDownload, (usize, i8))> {
+    let (platform, mut build_options) = parse_ndjson_platform(&artifact.platform)?;
+    let (flavor, variant_build_options) = parse_ndjson_artifact_variant(&artifact.variant);
+    build_options.extend(variant_build_options);
+
+    if build_options.contains(&"static") {
+        debug!(
+            "Skipping NDJSON artifact: static unsupported - {}",
+            artifact.url
+        );
+        return None;
+    }
+
+    if release.is_some_and(|release| release < CPYTHON_MUSL_STATIC_RELEASE_END)
+        && matches!(platform.libc, Libc::Some(target_lexicon::Environment::Musl))
+    {
+        return None;
+    }
+
+    let variant = python_variant_from_ndjson_build_options(&build_options);
+    let priority = ndjson_artifact_priority(flavor, &build_options);
+
+    Some((
+        ManagedPythonDownload {
+            key: PythonInstallationKey::new_from_version(
+                LenientImplementationName::Known(ImplementationName::CPython),
+                version,
+                platform,
+                variant,
+            ),
+            url: Cow::Owned(artifact.url),
+            sha256: artifact.sha256.map(Cow::Owned),
+            build,
+        },
+        priority,
+    ))
+}
+
+fn parse_ndjson_platform(platform: &str) -> Option<(Platform, Vec<&str>)> {
+    let mut platform = platform;
+    let mut build_options = Vec::new();
+
+    for (suffix, build_option) in [("-debug", "debug"), ("-freethreaded", "freethreaded")] {
+        if let Some(stripped) = platform.strip_suffix(suffix) {
+            platform = stripped;
+            build_options.push(build_option);
+        }
+    }
+
+    let platform = match Platform::from_cargo_dist_triple(platform) {
+        Ok(platform) => platform,
+        Err(err) => {
+            debug!(
+                "Skipping NDJSON artifact: invalid platform '{}' - {}",
+                platform, err
+            );
+            return None;
+        }
+    };
+
+    Some((platform, build_options))
+}
+
+fn parse_ndjson_artifact_variant(variant: &str) -> (&str, Vec<&str>) {
+    let mut parts = Vec::new();
+    for part in variant.split('+') {
+        match part {
+            "shared-freethreaded" => parts.extend(["shared", "freethreaded"]),
+            "shared-noopt" => parts.extend(["shared", "noopt"]),
+            "shared-pgo" => parts.extend(["shared", "pgo"]),
+            "static-noopt" => parts.extend(["static", "noopt"]),
+            part => parts.push(part),
+        }
+    }
+    if parts
+        .last()
+        .is_some_and(|flavor| NDJSON_KNOWN_FLAVORS.contains(flavor))
+        && let Some(flavor) = parts.pop()
+    {
+        (flavor, parts)
+    } else {
+        (variant, Vec::new())
+    }
+}
+
+fn python_variant_from_ndjson_build_options(build_options: &[&str]) -> PythonVariant {
+    let debug = build_options.contains(&"debug");
+    let freethreaded = build_options.contains(&"freethreaded");
+
+    match (debug, freethreaded) {
+        (true, true) => PythonVariant::FreethreadedDebug,
+        (true, false) => PythonVariant::Debug,
+        (false, true) => PythonVariant::Freethreaded,
+        (false, false) => PythonVariant::default(),
+    }
+}
+
+fn ndjson_artifact_priority(flavor: &str, build_options: &[&str]) -> (usize, i8) {
+    let flavor_priority = NDJSON_FLAVOR_PREFERENCES
+        .iter()
+        .position(|preference| *preference == flavor)
+        .unwrap_or(NDJSON_FLAVOR_PREFERENCES.len() + 1);
+
+    let build_option_priority = -i8::from(build_options.contains(&"lto"))
+        - i8::from(build_options.contains(&"pgo"))
+        - i8::from(!build_options.contains(&"static"));
+
+    (flavor_priority, build_option_priority)
+}
+
+fn parse_ndjson_line(source: &str, line: &[u8]) -> Result<NdjsonPythonVersionInfo, Error> {
+    let line_str = std::str::from_utf8(line).map_err(|_| {
+        Error::InvalidPythonDownloadsNdjsonLine(
+            source.to_owned(),
+            serde_json::from_str::<()>("invalid utf8").unwrap_err(),
+        )
+    })?;
+    serde_json::from_str(line_str)
+        .map_err(|err| Error::InvalidPythonDownloadsNdjsonLine(source.to_owned(), err))
+}
+
+fn visit_ndjson_line<T>(
+    source: &str,
+    line: &[u8],
+    visitor: &mut impl FnMut(ManagedPythonDownload) -> ControlFlow<T, ()>,
+) -> Result<Option<T>, Error> {
+    if line.is_empty() || line.iter().all(u8::is_ascii_whitespace) {
+        return Ok(None);
+    }
+
+    let version_info = parse_ndjson_line(source, line)?;
+    for download in parse_ndjson_version_info(version_info) {
+        if let ControlFlow::Break(value) = visitor(download) {
+            return Ok(Some(value));
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_ndjson_bytes_with<T>(
+    source: &str,
+    buf: &[u8],
+    mut visitor: impl FnMut(ManagedPythonDownload) -> ControlFlow<T, ()>,
+) -> Result<Option<T>, Error> {
+    for line in buf.split(|byte| *byte == b'\n') {
+        if let Some(value) = visit_ndjson_line(source, line, &mut visitor)? {
+            return Ok(Some(value));
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_ndjson_bytes(source: &str, buf: &[u8]) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let mut downloads = Vec::new();
+    parse_ndjson_bytes_with(source, buf, |download| {
+        downloads.push(download);
+        ControlFlow::<()>::Continue(())
+    })?;
+    downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+    Ok(downloads)
+}
+
 impl Error {
     pub(crate) fn from_reqwest(
         url: DisplaySafeUrl,
@@ -2132,6 +2434,68 @@ mod tests {
     }
 
     #[test]
+    fn parse_ndjson_bytes_matches_generator_artifact_selection() {
+        let ndjson = br#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"},{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only_stripped"}]}
+{"version":"3.10.0+20211017","artifacts":[{"url":"https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst","platform":"x86_64-unknown-linux-gnu","sha256":"ghi789","variant":"pgo+lto+full"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
+        let downloads = downloads
+            .iter()
+            .map(|download| (download.key().to_string(), download.url().as_ref()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            downloads,
+            vec![
+                (
+                    "cpython-3.14.1-macos-aarch64-none".to_string(),
+                    "https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz",
+                ),
+                (
+                    "cpython-3.10.0-linux-x86_64-gnu".to_string(),
+                    "https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst",
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_accepts_powerpc_manifest_alias() {
+        let ndjson = br#"{"version":"3.13.2","artifacts":[{"url":"https://example.com/cpython-3.13.2-ppc64le-unknown-linux-gnu-install_only.tar.gz","platform":"ppc64le-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(
+            downloads[0].key().to_string(),
+            "cpython-3.13.2-linux-powerpc64le-gnu"
+        );
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_splits_compound_variant_tokens() {
+        let ndjson = br#"{"version":"3.15.0b1","artifacts":[{"url":"https://example.com/cpython-3.15.0b1-x86_64-pc-windows-msvc-shared-freethreaded-pgo-full.tar.zst","platform":"x86_64-pc-windows-msvc","sha256":"abc123","variant":"shared-freethreaded+pgo+full"},{"url":"https://example.com/cpython-3.15.0b1-x86_64-pc-windows-msvc-install_only.tar.gz","platform":"x86_64-pc-windows-msvc","sha256":"def456","variant":"install_only"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
+
+        assert!(downloads.iter().any(|download| {
+            download.key().to_string() == "cpython-3.15.0b1+freethreaded-windows-x86_64-none"
+        }));
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_skips_compound_static_variant_tokens() {
+        let ndjson = br#"{"version":"3.12.13","artifacts":[{"url":"https://example.com/cpython-3.12.13-x86_64-unknown-linux-musl-static-noopt-full.tar.zst","platform":"x86_64-unknown-linux-musl","sha256":"abc123","variant":"static-noopt+full"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
+
+        assert!(downloads.is_empty());
+    }
+
     fn upgrade_request_native_defaults() {
         let request = PythonDownloadRequest::default()
             .with_implementation(ImplementationName::CPython)

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -956,6 +956,9 @@ impl FromStr for PythonDownloadRequest {
 const BUILTIN_PYTHON_DOWNLOADS_JSON: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/download-metadata-minified.json"));
 
+/// Default URL for runtime Python download metadata.
+const REMOTE_PYTHON_DOWNLOAD_METADATA_URL: &str = "https://raw.githubusercontent.com/astral-sh/versions/refs/heads/main/v1/python-build-standalone.ndjson";
+
 // 2025-03-11, the first CPython release date whose musl builds are dynamically linked.
 const CPYTHON_MUSL_STATIC_RELEASE_END: u64 = 2025 * 10_000 + 3 * 100 + 11;
 const NDJSON_FLAVOR_PREFERENCES: &[&str] = &[
@@ -1019,6 +1022,19 @@ enum DownloadListFormat {
     Ndjson,
 }
 
+#[derive(Debug, Clone)]
+struct DownloadListSource<'a> {
+    location: DownloadListLocation<'a>,
+    format: DownloadListFormat,
+    implicit: bool,
+}
+
+#[derive(Debug, Clone)]
+enum DownloadListLocation<'a> {
+    Path(Cow<'a, Path>),
+    Http(DisplaySafeUrl),
+}
+
 fn detect_download_list_format(url_or_path: &str) -> DownloadListFormat {
     let path = Url::parse(url_or_path)
         .ok()
@@ -1031,6 +1047,48 @@ fn detect_download_list_format(url_or_path: &str) -> DownloadListFormat {
     } else {
         DownloadListFormat::Json
     }
+}
+
+fn resolve_download_list_source(
+    python_downloads_json_url: Option<&str>,
+) -> Result<DownloadListSource<'_>, Error> {
+    let implicit = python_downloads_json_url.is_none();
+    let source = if let Some(source) = python_downloads_json_url {
+        Cow::Borrowed(source)
+    } else if let Some(source) = env::var_os(EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL)
+        .filter(|value| !value.is_empty())
+        .map(|value| Cow::Owned(value.to_string_lossy().into_owned()))
+    {
+        source
+    } else {
+        return Ok(DownloadListSource {
+            location: DownloadListLocation::Http(
+                DisplaySafeUrl::parse(REMOTE_PYTHON_DOWNLOAD_METADATA_URL)
+                    .expect("default remote Python download metadata URL should be valid"),
+            ),
+            format: DownloadListFormat::Ndjson,
+            implicit,
+        });
+    };
+
+    let format = detect_download_list_format(&source);
+    let location = if let Ok(url) = DisplaySafeUrl::parse(&source) {
+        match url.scheme() {
+            "http" | "https" => DownloadListLocation::Http(url),
+            "file" => DownloadListLocation::Path(Cow::Owned(
+                url.to_file_path().or(Err(Error::InvalidUrlFormat(url)))?,
+            )),
+            _ => DownloadListLocation::Path(Cow::Owned(PathBuf::from(source.as_ref()))),
+        }
+    } else {
+        DownloadListLocation::Path(Cow::Owned(PathBuf::from(source.as_ref())))
+    };
+
+    Ok(DownloadListSource {
+        location,
+        format,
+        implicit,
+    })
 }
 
 /// A wrapper type to display a `ManagedPythonDownload` with its build information.
@@ -1082,100 +1140,91 @@ impl ManagedPythonDownloadList {
         Err(Error::NoDownloadFound(request.clone()))
     }
 
-    /// Load available Python distributions from a provided source or the compiled-in list.
+    /// Load available Python distributions from a provided source.
     ///
-    /// `python_downloads_json_url` can be either `None`, to use the default list (taken from
-    /// `crates/uv-python/download-metadata.json`), or `Some` local path
-    /// or file://, http://, or https:// URL.
-    ///
-    /// Returns an error if the provided list could not be opened, if the JSON is invalid, or if it
-    /// does not parse into the expected data structure.
+    /// If no explicit source is provided, uv fetches metadata from the default remote NDJSON
+    /// endpoint and falls back to the embedded metadata if the fetch or parse fails.
     pub async fn new(
         client: &BaseClient,
         python_downloads_json_url: Option<&str>,
     ) -> Result<Self, Error> {
-        let format = python_downloads_json_url
-            .map(detect_download_list_format)
-            .unwrap_or(DownloadListFormat::Json);
+        let source = resolve_download_list_source(python_downloads_json_url)?;
 
-        // Although read_url() handles file:// URLs and converts them to local file reads, here we
-        // want to also support parsing bare filenames like "/tmp/py.json", not just
-        // "file:///tmp/py.json". Note that "C:\Temp\py.json" should be considered a filename, even
-        // though Url::parse would successfully misparse it as a URL with scheme "C".
-        enum Source<'a> {
-            BuiltIn,
-            Path(Cow<'a, Path>),
-            Http(DisplaySafeUrl),
-        }
-
-        let json_source = if let Some(url_or_path) = python_downloads_json_url {
-            if let Ok(url) = DisplaySafeUrl::parse(url_or_path) {
-                match url.scheme() {
-                    "http" | "https" => Source::Http(url),
-                    "file" => Source::Path(Cow::Owned(
-                        url.to_file_path().or(Err(Error::InvalidUrlFormat(url)))?,
-                    )),
-                    _ => Source::Path(Cow::Borrowed(Path::new(url_or_path))),
-                }
-            } else {
-                Source::Path(Cow::Borrowed(Path::new(url_or_path)))
+        let downloads = match (&source.location, source.format) {
+            (DownloadListLocation::Path(path), DownloadListFormat::Json) => {
+                parse_json_download_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?)?
             }
-        } else {
-            Source::BuiltIn
-        };
-
-        let buf: Cow<'_, [u8]> = match json_source {
-            Source::BuiltIn => BUILTIN_PYTHON_DOWNLOADS_JSON.into(),
-            Source::Path(ref path) => fs_err::read(path.as_ref())?.into(),
-            Source::Http(ref url) => {
-                let buf = fetch_bytes_from_url(client, url)
-                    .await
-                    .map_err(|err| match format {
-                        DownloadListFormat::Json => {
-                            Error::FetchingPythonDownloadsJSONError(url.to_string(), Box::new(err))
+            (DownloadListLocation::Path(path), DownloadListFormat::Ndjson) => {
+                match parse_ndjson_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?) {
+                    Ok(downloads) => {
+                        if source.implicit {
+                            merge_with_embedded_non_cpython(downloads)?
+                        } else {
+                            downloads
                         }
-                        DownloadListFormat::Ndjson => Error::FetchingPythonDownloadsNdjsonError(
+                    }
+                    Err(err) => {
+                        if source.implicit {
+                            debug!(
+                                "Falling back to embedded Python downloads metadata after NDJSON parse failure: {err}"
+                            );
+                            embedded_downloads()?
+                        } else {
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+            (DownloadListLocation::Http(url), DownloadListFormat::Json) => {
+                match fetch_bytes_from_url(client, url).await {
+                    Ok(buf) => parse_json_download_bytes(&url.to_string(), &buf)?,
+                    Err(err) => {
+                        return Err(Error::FetchingPythonDownloadsJSONError(
                             url.to_string(),
                             Box::new(err),
-                        ),
-                    })?;
-                buf.into()
+                        ));
+                    }
+                }
+            }
+            (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
+                match fetch_bytes_from_url(client, url).await {
+                    Ok(buf) => match parse_ndjson_bytes(&url.to_string(), &buf) {
+                        Ok(downloads) => {
+                            if source.implicit {
+                                merge_with_embedded_non_cpython(downloads)?
+                            } else {
+                                downloads
+                            }
+                        }
+                        Err(err) => {
+                            if source.implicit {
+                                debug!(
+                                    "Falling back to embedded Python downloads metadata after NDJSON parse failure: {err}"
+                                );
+                                embedded_downloads()?
+                            } else {
+                                return Err(err);
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        if source.implicit {
+                            debug!(
+                                "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                            );
+                            embedded_downloads()?
+                        } else {
+                            return Err(Error::FetchingPythonDownloadsNdjsonError(
+                                url.to_string(),
+                                Box::new(err),
+                            ));
+                        }
+                    }
+                }
             }
         };
 
-        let source = match json_source {
-            Source::BuiltIn => "EMBEDDED IN THE BINARY".to_owned(),
-            Source::Path(path) => path.to_string_lossy().to_string(),
-            Source::Http(url) => url.to_string(),
-        };
-        let result = match format {
-            DownloadListFormat::Json => {
-                let json_downloads: HashMap<String, JsonPythonDownload> =
-                    serde_json::from_slice(&buf).map_err(
-                        // As an explicit compatibility mechanism, if there's a top-level "version" key, it
-                        // means it's a newer format than we know how to deal with.  Before reporting a
-                        // parse error about the format of JsonPythonDownload, check for that key. We can do
-                        // this by parsing into a Map<String, IgnoredAny> which allows any valid JSON on the
-                        // value side. (Because it's zero-sized, Clippy suggests Set<String>, but that won't
-                        // have the same parsing effect.)
-                        #[expect(clippy::zero_sized_map_values)]
-                        |err| {
-                            if let Ok(keys) = serde_json::from_slice::<
-                                HashMap<String, serde::de::IgnoredAny>,
-                            >(&buf)
-                                && keys.contains_key("version")
-                            {
-                                Error::UnsupportedPythonDownloadsJSON(source.clone())
-                            } else {
-                                Error::InvalidPythonDownloadsJSON(source.clone(), err)
-                            }
-                        },
-                    )?;
-                parse_json_downloads(json_downloads)
-            }
-            DownloadListFormat::Ndjson => parse_ndjson_bytes(&source, &buf)?,
-        };
-        Ok(Self { downloads: result })
+        Ok(Self { downloads })
     }
 
     /// Load available Python distributions from the compiled-in list only.
@@ -1196,6 +1245,36 @@ async fn fetch_bytes_from_url(client: &BaseClient, url: &DisplaySafeUrl) -> Resu
     let mut buf = Vec::with_capacity(capacity);
     reader.read_to_end(&mut buf).await?;
     Ok(buf)
+}
+
+fn embedded_non_cpython_downloads() -> Result<Vec<ManagedPythonDownload>, Error> {
+    Ok(embedded_downloads()?
+        .into_iter()
+        .filter(|download| {
+            !matches!(
+                download.key().implementation().as_ref(),
+                LenientImplementationName::Known(ImplementationName::CPython)
+            )
+        })
+        .collect())
+}
+
+fn merge_with_embedded_non_cpython(
+    downloads: Vec<ManagedPythonDownload>,
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let mut merged = BTreeMap::new();
+
+    for download in downloads {
+        merged.entry(download.key().clone()).or_insert(download);
+    }
+
+    for download in embedded_non_cpython_downloads()? {
+        merged.entry(download.key().clone()).or_insert(download);
+    }
+
+    let mut downloads = merged.into_values().collect::<Vec<_>>();
+    downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+    Ok(downloads)
 }
 
 impl ManagedPythonDownload {
@@ -1664,6 +1743,33 @@ impl ManagedPythonDownload {
 
         Ok(vec![DisplaySafeUrl::parse(&self.url)?])
     }
+}
+
+fn embedded_downloads() -> Result<Vec<ManagedPythonDownload>, Error> {
+    let json_downloads: HashMap<String, JsonPythonDownload> =
+        serde_json::from_slice(BUILTIN_PYTHON_DOWNLOADS_JSON).map_err(|err| {
+            Error::InvalidPythonDownloadsJSON("EMBEDDED IN THE BINARY".to_owned(), err)
+        })?;
+    Ok(parse_json_downloads(json_downloads))
+}
+
+fn parse_json_download_bytes(
+    source: &str,
+    buf: &[u8],
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(buf).map_err(
+        #[expect(clippy::zero_sized_map_values)]
+        |err| {
+            if let Ok(keys) = serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(buf)
+                && keys.contains_key("version")
+            {
+                Error::UnsupportedPythonDownloadsJSON(source.to_owned())
+            } else {
+                Error::InvalidPythonDownloadsJSON(source.to_owned(), err)
+            }
+        },
+    )?;
+    Ok(parse_json_downloads(json_downloads))
 }
 
 fn parse_json_downloads(

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant, SystemTimeError};
+use std::time::{Duration, Instant, SystemTime, SystemTimeError};
 use std::{env, io};
 
 use futures::TryStreamExt;
@@ -24,13 +24,16 @@ use tokio_util::either::Either;
 use tracing::{debug, instrument};
 use url::Url;
 
+use uv_cache::{Cache, CacheBucket, CacheEntry, CacheShard};
+use uv_cache_info::Timestamp;
+use uv_cache_key::cache_digest;
 use uv_client::{
     BaseClient, RetriableError, WrappedReqwestError, fetch_with_url_fallback,
     retryable_on_request_failure,
 };
 use uv_distribution_filename::{ExtensionError, SourceDistExtension};
 use uv_extract::hash::Hasher;
-use uv_fs::{Simplified, rename_with_retry};
+use uv_fs::{Simplified, rename_with_retry, write_atomic};
 use uv_platform::{self as platform, Arch, Libc, Os, Platform};
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
@@ -961,6 +964,9 @@ const BUILTIN_PYTHON_DOWNLOADS_JSON: &[u8] =
 /// Default URL for runtime Python download metadata.
 const REMOTE_PYTHON_DOWNLOAD_METADATA_URL: &str = "https://raw.githubusercontent.com/astral-sh/versions/refs/heads/main/v1/python-build-standalone.ndjson";
 
+const VERSIONS_CACHE_FILENAME: &str = "python-build-standalone.ndjson";
+const VERSIONS_CACHE_META_FILENAME: &str = "python-build-standalone.meta.json";
+const VERSIONS_CACHE_FRESHNESS: Duration = Duration::from_mins(10);
 // 2025-03-11, the first CPython release date whose musl builds are dynamically linked.
 const CPYTHON_MUSL_STATIC_RELEASE_END: u64 = 2025 * 10_000 + 3 * 100 + 11;
 const NDJSON_FLAVOR_PREFERENCES: &[&str] = &[
@@ -971,6 +977,32 @@ const NDJSON_FLAVOR_PREFERENCES: &[&str] = &[
     "static-noopt",
 ];
 const NDJSON_KNOWN_FLAVORS: &[&str] = &["full", "install_only", "install_only_stripped"];
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct VersionsCacheMeta {
+    content_length: u64,
+    etag: Option<String>,
+    checked_at: Timestamp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DownloadListFormat {
+    Json,
+    Ndjson,
+}
+
+#[derive(Debug, Clone)]
+struct DownloadListSource<'a> {
+    location: DownloadListLocation<'a>,
+    format: DownloadListFormat,
+    implicit: bool,
+}
+
+#[derive(Debug, Clone)]
+enum DownloadListLocation<'a> {
+    Path(Cow<'a, Path>),
+    Http(DisplaySafeUrl),
+}
 
 pub struct ManagedPythonDownloadList {
     downloads: Vec<ManagedPythonDownload>,
@@ -1016,25 +1048,6 @@ struct NdjsonPythonArtifact {
 pub enum DownloadResult {
     AlreadyAvailable(PathBuf),
     Fetched(PathBuf),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DownloadListFormat {
-    Json,
-    Ndjson,
-}
-
-#[derive(Debug, Clone)]
-struct DownloadListSource<'a> {
-    location: DownloadListLocation<'a>,
-    format: DownloadListFormat,
-    implicit: bool,
-}
-
-#[derive(Debug, Clone)]
-enum DownloadListLocation<'a> {
-    Path(Cow<'a, Path>),
-    Http(DisplaySafeUrl),
 }
 
 fn detect_download_list_format(url_or_path: &str) -> DownloadListFormat {
@@ -1134,6 +1147,359 @@ impl DownloadListSource<'_> {
     }
 }
 
+fn versions_cache_shard_key(url: &DisplaySafeUrl) -> String {
+    if url.as_str() == REMOTE_PYTHON_DOWNLOAD_METADATA_URL {
+        "versions/default".to_string()
+    } else {
+        let unredacted_url = url.as_str();
+        format!("versions/url/{}", cache_digest(&unredacted_url))
+    }
+}
+
+fn versions_cache_shard(cache: &Cache, url: &DisplaySafeUrl) -> CacheShard {
+    cache.shard(CacheBucket::Python, versions_cache_shard_key(url))
+}
+
+fn versions_cache_entries(shard: &CacheShard) -> (CacheEntry, CacheEntry) {
+    (
+        shard.entry(VERSIONS_CACHE_FILENAME),
+        shard.entry(VERSIONS_CACHE_META_FILENAME),
+    )
+}
+
+fn supports_incremental_versions_cache(url: &DisplaySafeUrl) -> bool {
+    url.as_str() == REMOTE_PYTHON_DOWNLOAD_METADATA_URL
+}
+
+async fn read_versions_cache(
+    content_entry: &CacheEntry,
+    meta_entry: &CacheEntry,
+) -> Option<(Vec<u8>, VersionsCacheMeta)> {
+    let meta_bytes = fs_err::tokio::read(meta_entry.path()).await.ok()?;
+    let meta: VersionsCacheMeta = serde_json::from_slice(&meta_bytes).ok()?;
+    let content = fs_err::tokio::read(content_entry.path()).await.ok()?;
+    if content.len() as u64 != meta.content_length {
+        debug!(
+            "Cached Python downloads metadata length mismatch: expected {}, got {}",
+            meta.content_length,
+            content.len()
+        );
+        return None;
+    }
+    Some((content, meta))
+}
+
+fn versions_cache_is_fresh(meta: &VersionsCacheMeta) -> bool {
+    let Some(revalidate_after) = SystemTime::now().checked_sub(VERSIONS_CACHE_FRESHNESS) else {
+        return false;
+    };
+    meta.checked_at >= Timestamp::from(revalidate_after)
+}
+
+async fn write_versions_cache_meta(
+    meta_entry: &CacheEntry,
+    meta: &VersionsCacheMeta,
+) -> Result<(), Error> {
+    fs_err::tokio::create_dir_all(meta_entry.dir()).await?;
+    let meta_bytes = serde_json::to_vec(meta)
+        .map_err(|err| io::Error::other(format!("Failed to serialize cache metadata: {err}")))?;
+    write_atomic(meta_entry.path(), &meta_bytes).await?;
+    Ok(())
+}
+
+async fn write_versions_cache(
+    content_entry: &CacheEntry,
+    meta_entry: &CacheEntry,
+    content: &[u8],
+    meta: &VersionsCacheMeta,
+) -> Result<(), Error> {
+    fs_err::tokio::create_dir_all(content_entry.dir()).await?;
+    write_atomic(content_entry.path(), content).await?;
+    write_versions_cache_meta(meta_entry, meta).await?;
+    Ok(())
+}
+
+fn validate_ndjson_bytes(source: &str, buf: &[u8]) -> Result<(), Error> {
+    parse_ndjson_bytes_with(source, buf, |_| ControlFlow::<()>::Continue(()))?;
+    Ok(())
+}
+
+fn ndjson_cache_content_is_valid(source: &str, content: &[u8]) -> bool {
+    match validate_ndjson_bytes(source, content) {
+        Ok(()) => true,
+        Err(err) => {
+            debug!(
+                "Skipping Python downloads metadata cache write because NDJSON did not parse: {err}"
+            );
+            false
+        }
+    }
+}
+
+async fn write_versions_cache_if_valid(
+    content_entry: &CacheEntry,
+    meta_entry: &CacheEntry,
+    source: &str,
+    content: &[u8],
+    meta: &VersionsCacheMeta,
+) {
+    if ndjson_cache_content_is_valid(source, content)
+        && let Err(err) = write_versions_cache(content_entry, meta_entry, content, meta).await
+    {
+        debug!("Failed to write cached Python downloads metadata: {err}");
+    }
+}
+
+async fn read_versions_cache_content(
+    cache: &Cache,
+    url: &DisplaySafeUrl,
+) -> Option<(Vec<u8>, VersionsCacheMeta)> {
+    let shard = versions_cache_shard(cache, url);
+    let _lock = shard.lock().await.ok()?;
+    let (content_entry, meta_entry) = versions_cache_entries(&shard);
+    read_versions_cache(&content_entry, &meta_entry).await
+}
+
+async fn fetch_versions_cache_etag(client: &BaseClient, url: &DisplaySafeUrl) -> Option<String> {
+    let response = match client
+        .for_host(url)
+        .head(Url::from(url.clone()))
+        .send()
+        .await
+    {
+        Ok(response) => match response.error_for_status() {
+            Ok(response) => response,
+            Err(err) => {
+                debug!("Failed to validate Python downloads metadata with HEAD request: {err}");
+                return None;
+            }
+        },
+        Err(err) => {
+            debug!("Failed to send HEAD request for Python downloads metadata: {err}");
+            return None;
+        }
+    };
+
+    response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+async fn write_streamed_versions_cache_if_valid(
+    cache: &Cache,
+    url: &DisplaySafeUrl,
+    source: &str,
+    content: &[u8],
+    etag: Option<String>,
+) {
+    let shard = versions_cache_shard(cache, url);
+    let Ok(_lock) = shard.lock().await else {
+        debug!("Failed to lock Python downloads cache");
+        return;
+    };
+    let (content_entry, meta_entry) = versions_cache_entries(&shard);
+    let meta = VersionsCacheMeta {
+        content_length: content.len() as u64,
+        etag,
+        checked_at: Timestamp::now(),
+    };
+    write_versions_cache_if_valid(&content_entry, &meta_entry, source, content, &meta).await;
+}
+
+async fn prepend_versions_cache_content(
+    content_entry: &CacheEntry,
+    new_content: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let existing = fs_err::tokio::read(content_entry.path()).await?;
+    let mut combined = Vec::with_capacity(new_content.len() + existing.len());
+    combined.extend_from_slice(new_content);
+    combined.extend_from_slice(&existing);
+    Ok(combined)
+}
+
+async fn fetch_ndjson_cached(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    cache: Option<&Cache>,
+) -> Result<Vec<u8>, Error> {
+    let Some(cache) = cache else {
+        return fetch_bytes_from_url(client, url).await;
+    };
+
+    let shard = versions_cache_shard(cache, url);
+    let _lock = shard
+        .lock()
+        .await
+        .map_err(|err| io::Error::other(format!("Failed to lock Python downloads cache: {err}")))?;
+    let (content_entry, meta_entry) = versions_cache_entries(&shard);
+    let cached = read_versions_cache(&content_entry, &meta_entry).await;
+    let source = url.to_string();
+
+    if client.connectivity().is_offline() {
+        if let Some((content, _)) = cached {
+            debug!("Using cached Python downloads metadata in offline mode");
+            return Ok(content);
+        }
+        return fetch_bytes_from_url(client, url).await;
+    }
+
+    if let Some((content, meta)) = &cached
+        && versions_cache_is_fresh(meta)
+    {
+        debug!("Using fresh cached Python downloads metadata without revalidation");
+        return Ok(content.clone());
+    }
+
+    let head_result = client
+        .for_host(url)
+        .head(Url::from(url.clone()))
+        .send()
+        .await;
+    let head_response = match head_result {
+        Ok(response) => match response.error_for_status() {
+            Ok(response) => Some(response),
+            Err(err) => {
+                debug!("Failed to validate Python downloads metadata with HEAD request: {err}");
+                None
+            }
+        },
+        Err(err) => {
+            debug!("Failed to send HEAD request for Python downloads metadata: {err}");
+            None
+        }
+    };
+
+    let Some(head_response) = head_response else {
+        return match fetch_bytes_from_url(client, url).await {
+            Ok(content) => {
+                let meta = VersionsCacheMeta {
+                    content_length: content.len() as u64,
+                    etag: None,
+                    checked_at: Timestamp::now(),
+                };
+                write_versions_cache_if_valid(
+                    &content_entry,
+                    &meta_entry,
+                    &source,
+                    &content,
+                    &meta,
+                )
+                .await;
+                Ok(content)
+            }
+            Err(err) => Err(err),
+        };
+    };
+
+    let current_length = head_response
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    let current_etag = head_response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+
+    if let Some((cached_content, cached_meta)) = &cached {
+        if current_etag.is_some() && current_etag == cached_meta.etag {
+            debug!("Using cached Python downloads metadata with matching ETag");
+            let meta = VersionsCacheMeta {
+                checked_at: Timestamp::now(),
+                ..cached_meta.clone()
+            };
+            if let Err(err) = write_versions_cache_meta(&meta_entry, &meta).await {
+                debug!("Failed to refresh Python downloads cache metadata: {err}");
+            }
+            return Ok(cached_content.clone());
+        }
+
+        if supports_incremental_versions_cache(url)
+            && current_etag.is_none()
+            && current_length == Some(cached_meta.content_length)
+        {
+            debug!("Using cached Python downloads metadata with unchanged content length");
+            let meta = VersionsCacheMeta {
+                checked_at: Timestamp::now(),
+                ..cached_meta.clone()
+            };
+            if let Err(err) = write_versions_cache_meta(&meta_entry, &meta).await {
+                debug!("Failed to refresh Python downloads cache metadata: {err}");
+            }
+            return Ok(cached_content.clone());
+        }
+
+        if supports_incremental_versions_cache(url)
+            && let Some(current_length) = current_length
+            && current_length > cached_meta.content_length
+        {
+            let delta_size = current_length - cached_meta.content_length;
+            if delta_size > 0 {
+                let range_header = format!("bytes=0-{}", delta_size - 1);
+                match client
+                    .for_host(url)
+                    .get(Url::from(url.clone()))
+                    .header(reqwest::header::RANGE, &range_header)
+                    .send()
+                    .await
+                {
+                    Ok(response) if response.status() == reqwest::StatusCode::PARTIAL_CONTENT => {
+                        let delta_bytes = response.bytes().await.map_err(|err| {
+                            Error::from_reqwest(url.clone(), err, None, Instant::now())
+                        })?;
+                        let meta = VersionsCacheMeta {
+                            content_length: current_length,
+                            etag: current_etag.clone(),
+                            checked_at: Timestamp::now(),
+                        };
+                        match prepend_versions_cache_content(&content_entry, &delta_bytes).await {
+                            Ok(combined) => {
+                                write_versions_cache_if_valid(
+                                    &content_entry,
+                                    &meta_entry,
+                                    &source,
+                                    &combined,
+                                    &meta,
+                                )
+                                .await;
+                                return Ok(combined);
+                            }
+                            Err(err) => {
+                                debug!(
+                                    "Failed to update cached Python downloads metadata with delta: {err}"
+                                );
+                            }
+                        }
+                    }
+                    Ok(_) => {
+                        debug!("Python downloads metadata server did not honor range request");
+                    }
+                    Err(err) => {
+                        debug!("Failed to fetch Python downloads metadata delta: {err}");
+                    }
+                }
+            }
+        }
+    }
+
+    match fetch_bytes_from_url(client, url).await {
+        Ok(content) => {
+            let meta = VersionsCacheMeta {
+                content_length: content.len() as u64,
+                etag: current_etag,
+                checked_at: Timestamp::now(),
+            };
+            write_versions_cache_if_valid(&content_entry, &meta_entry, &source, &content, &meta)
+                .await;
+            Ok(content)
+        }
+        Err(err) => Err(err),
+    }
+}
+
 /// A wrapper type to display a `ManagedPythonDownload` with its build information.
 pub struct ManagedPythonDownloadWithBuild<'a>(&'a ManagedPythonDownload);
 
@@ -1190,64 +1556,54 @@ impl ManagedPythonDownloadList {
     pub async fn new(
         client: &BaseClient,
         python_downloads_json_url: Option<&str>,
+        cache: Option<&Cache>,
     ) -> Result<Self, Error> {
         let source = resolve_download_list_source(python_downloads_json_url)?;
 
         let downloads = match (&source.location, source.format) {
-            (DownloadListLocation::Path(path), DownloadListFormat::Json) => {
-                parse_json_download_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?)?
-            }
-            (DownloadListLocation::Path(path), DownloadListFormat::Ndjson) => {
-                match parse_ndjson_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?) {
-                    Ok(downloads) => {
-                        if source.implicit {
-                            merge_with_embedded_non_cpython(downloads, None, None)?
-                        } else {
-                            downloads
-                        }
-                    }
+            (DownloadListLocation::Path(path), DownloadListFormat::Json) => source
+                .merge_downloads(
+                    parse_json_download_bytes(
+                        &path.to_string_lossy(),
+                        &fs_err::read(path.as_ref())?,
+                    )?,
+                    None,
+                    None,
+                )?,
+            (DownloadListLocation::Path(path), DownloadListFormat::Ndjson) => source
+                .merge_downloads(
+                    parse_ndjson_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?)?,
+                    None,
+                    None,
+                )?,
+            (DownloadListLocation::Http(url), DownloadListFormat::Json) => {
+                match fetch_bytes_from_url(client, url).await {
+                    Ok(buf) => source.merge_downloads(
+                        parse_json_download_bytes(&url.to_string(), &buf)?,
+                        None,
+                        None,
+                    )?,
                     Err(err) => {
                         if source.implicit {
                             debug!(
-                                "Falling back to embedded Python downloads metadata after NDJSON parse failure: {err}"
+                                "Falling back to embedded Python downloads metadata after JSON fetch failure: {err}"
                             );
                             embedded_downloads()?
                         } else {
-                            return Err(err);
+                            return Err(Error::FetchingPythonDownloadsJSONError(
+                                url.to_string(),
+                                Box::new(err),
+                            ));
                         }
-                    }
-                }
-            }
-            (DownloadListLocation::Http(url), DownloadListFormat::Json) => {
-                match fetch_bytes_from_url(client, url).await {
-                    Ok(buf) => parse_json_download_bytes(&url.to_string(), &buf)?,
-                    Err(err) => {
-                        return Err(Error::FetchingPythonDownloadsJSONError(
-                            url.to_string(),
-                            Box::new(err),
-                        ));
                     }
                 }
             }
             (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
-                match fetch_bytes_from_url(client, url).await {
+                match fetch_ndjson_cached(client, url, cache).await {
                     Ok(buf) => match parse_ndjson_bytes(&url.to_string(), &buf) {
-                        Ok(downloads) => {
-                            if source.implicit {
-                                merge_with_embedded_non_cpython(downloads, None, None)?
-                            } else {
-                                downloads
-                            }
-                        }
+                        Ok(downloads) => source.merge_downloads(downloads, None, None)?,
                         Err(err) => {
-                            if source.implicit {
-                                debug!(
-                                    "Falling back to embedded Python downloads metadata after NDJSON parse failure: {err}"
-                                );
-                                embedded_downloads()?
-                            } else {
-                                return Err(err);
-                            }
+                            source.on_implicit_ndjson_parse_error(err, embedded_downloads)?
                         }
                     },
                     Err(err) => {
@@ -1277,6 +1633,7 @@ impl ManagedPythonDownloadList {
     pub async fn new_filtered(
         client: &BaseClient,
         python_downloads_json_url: Option<&str>,
+        cache: Option<&Cache>,
         filter: Option<&PythonDownloadRequest>,
         limit: Option<usize>,
     ) -> Result<Self, Error> {
@@ -1298,40 +1655,90 @@ impl ManagedPythonDownloadList {
             }
             (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
                 let source_url = url.to_string();
-                match fetch_ndjson_collect(
-                    client,
-                    url,
-                    |download| {
-                        filter
-                            .map(|request| request.satisfied_by_download(download))
-                            .unwrap_or(true)
-                    },
-                    limit,
-                )
-                .await
-                {
-                    Ok(downloads) => source.merge_downloads(downloads, filter, limit)?,
-                    Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
-                        .on_implicit_ndjson_parse_error(err, || {
-                            Ok(filter_downloads(embedded_downloads()?, filter, limit))
-                        })?,
-                    Err(err) => {
-                        if source.implicit {
-                            debug!(
-                                "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
-                            );
-                            filter_downloads(embedded_downloads()?, filter, limit)
-                        } else {
-                            return Err(Error::FetchingPythonDownloadsNdjsonError(
-                                source_url,
-                                Box::new(err),
-                            ));
+
+                if cache.is_some() && client.connectivity().is_offline() {
+                    match fetch_ndjson_cached(client, url, cache).await {
+                        Ok(buf) => match parse_ndjson_bytes_filtered(
+                            &source_url,
+                            &buf,
+                            |download| {
+                                filter
+                                    .map(|request| request.satisfied_by_download(download))
+                                    .unwrap_or(true)
+                            },
+                            limit,
+                        ) {
+                            Ok(downloads) => source.merge_downloads(downloads, filter, limit),
+                            Err(err) => source.on_implicit_ndjson_parse_error(err, || {
+                                Ok(filter_downloads(embedded_downloads()?, filter, limit))
+                            }),
+                        },
+                        Err(err) => {
+                            if source.implicit {
+                                debug!(
+                                    "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                                );
+                                Ok(filter_downloads(embedded_downloads()?, filter, limit))
+                            } else {
+                                return Err(Error::FetchingPythonDownloadsNdjsonError(
+                                    source_url,
+                                    Box::new(err),
+                                ));
+                            }
                         }
                     }
-                }
+                } else {
+                    let downloads = if let Some(cache) = cache {
+                        fetch_ndjson_collect_streaming_cached(
+                            client,
+                            url,
+                            cache,
+                            |download| {
+                                filter
+                                    .map(|request| request.satisfied_by_download(download))
+                                    .unwrap_or(true)
+                            },
+                            limit,
+                        )
+                        .await
+                    } else {
+                        fetch_ndjson_collect(
+                            client,
+                            url,
+                            |download| {
+                                filter
+                                    .map(|request| request.satisfied_by_download(download))
+                                    .unwrap_or(true)
+                            },
+                            limit,
+                        )
+                        .await
+                    };
+
+                    match downloads {
+                        Ok(downloads) => source.merge_downloads(downloads, filter, limit),
+                        Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
+                            .on_implicit_ndjson_parse_error(err, || {
+                                Ok(filter_downloads(embedded_downloads()?, filter, limit))
+                            }),
+                        Err(err) => {
+                            if source.implicit {
+                                debug!(
+                                    "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                                );
+                                Ok(filter_downloads(embedded_downloads()?, filter, limit))
+                            } else {
+                                return Err(Error::FetchingPythonDownloadsNdjsonError(
+                                    source_url,
+                                    Box::new(err),
+                                ));
+                            }
+                        }
+                    }
+                }?
             }
             _ => filter_downloads(
-                Self::new(client, python_downloads_json_url)
+                Self::new(client, python_downloads_json_url, cache)
                     .await?
                     .downloads,
                 filter,
@@ -1349,11 +1756,12 @@ impl ManagedPythonDownloadList {
     pub async fn find_streaming(
         client: &BaseClient,
         python_downloads_json_url: Option<&str>,
+        cache: Option<&Cache>,
         request: &PythonDownloadRequest,
     ) -> Result<Option<ManagedPythonDownload>, Error> {
         let source = resolve_download_list_source(python_downloads_json_url)?;
 
-        if let Some(download) = find_matching_download(client, &source, request).await? {
+        if let Some(download) = find_matching_download(client, &source, cache, request).await? {
             return Ok(Some(download));
         }
 
@@ -1361,18 +1769,21 @@ impl ManagedPythonDownloadList {
             return Ok(None);
         }
 
-        find_matching_download(client, &source, &request.clone().with_prereleases(true)).await
+        find_matching_download(
+            client,
+            &source,
+            cache,
+            &request.clone().with_prereleases(true),
+        )
+        .await
     }
 
     /// Load available Python distributions from the compiled-in list only.
     /// for testing purposes.
     pub fn new_only_embedded() -> Result<Self, Error> {
-        let json_downloads: HashMap<String, JsonPythonDownload> =
-            serde_json::from_slice(BUILTIN_PYTHON_DOWNLOADS_JSON).map_err(|e| {
-                Error::InvalidPythonDownloadsJSON("EMBEDDED IN THE BINARY".to_owned(), e)
-            })?;
-        let result = parse_json_downloads(json_downloads);
-        Ok(Self { downloads: result })
+        Ok(Self {
+            downloads: embedded_downloads()?,
+        })
     }
 }
 
@@ -1467,6 +1878,7 @@ fn find_matching_or_implicit_embedded(
 async fn find_matching_download(
     client: &BaseClient,
     source: &DownloadListSource<'_>,
+    cache: Option<&Cache>,
     request: &PythonDownloadRequest,
 ) -> Result<Option<ManagedPythonDownload>, Error> {
     match (&source.location, source.format) {
@@ -1480,25 +1892,55 @@ async fn find_matching_download(
         }
         (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
             let source_url = url.to_string();
-            match fetch_ndjson_find(client, url, |download| {
-                request.satisfied_by_download(download)
-            })
-            .await
-            {
-                Ok(download) => find_matching_or_implicit_embedded(source, download, request),
-                Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
-                    .on_implicit_ndjson_parse_error(err, || find_in_embedded_downloads(request)),
-                Err(err) => {
-                    if source.implicit {
-                        debug!(
-                            "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
-                        );
-                        find_in_embedded_downloads(request)
-                    } else {
-                        Err(Error::FetchingPythonDownloadsNdjsonError(
-                            source_url,
-                            Box::new(err),
-                        ))
+            if cache.is_some() && client.connectivity().is_offline() {
+                match fetch_ndjson_cached(client, url, cache).await {
+                    Ok(buf) => match parse_ndjson_bytes_find(&source_url, &buf, |download| {
+                        request.satisfied_by_download(download)
+                    }) {
+                        Ok(download) => {
+                            find_matching_or_implicit_embedded(source, download, request)
+                        }
+                        Err(err) => source.on_implicit_ndjson_parse_error(err, || {
+                            find_in_embedded_downloads(request)
+                        }),
+                    },
+                    Err(err) => {
+                        if source.implicit {
+                            debug!(
+                                "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                            );
+                            find_in_embedded_downloads(request)
+                        } else {
+                            Err(Error::FetchingPythonDownloadsNdjsonError(
+                                source_url,
+                                Box::new(err),
+                            ))
+                        }
+                    }
+                }
+            } else {
+                match fetch_ndjson_find(client, url, |download| {
+                    request.satisfied_by_download(download)
+                })
+                .await
+                {
+                    Ok(download) => find_matching_or_implicit_embedded(source, download, request),
+                    Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
+                        .on_implicit_ndjson_parse_error(err, || {
+                            find_in_embedded_downloads(request)
+                        }),
+                    Err(err) => {
+                        if source.implicit {
+                            debug!(
+                                "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                            );
+                            find_in_embedded_downloads(request)
+                        } else {
+                            Err(Error::FetchingPythonDownloadsNdjsonError(
+                                source_url,
+                                Box::new(err),
+                            ))
+                        }
                     }
                 }
             }
@@ -2005,33 +2447,6 @@ impl ManagedPythonDownload {
     }
 }
 
-fn embedded_downloads() -> Result<Vec<ManagedPythonDownload>, Error> {
-    let json_downloads: HashMap<String, JsonPythonDownload> =
-        serde_json::from_slice(BUILTIN_PYTHON_DOWNLOADS_JSON).map_err(|err| {
-            Error::InvalidPythonDownloadsJSON("EMBEDDED IN THE BINARY".to_owned(), err)
-        })?;
-    Ok(parse_json_downloads(json_downloads))
-}
-
-fn parse_json_download_bytes(
-    source: &str,
-    buf: &[u8],
-) -> Result<Vec<ManagedPythonDownload>, Error> {
-    let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(buf).map_err(
-        #[expect(clippy::zero_sized_map_values)]
-        |err| {
-            if let Ok(keys) = serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(buf)
-                && keys.contains_key("version")
-            {
-                Error::UnsupportedPythonDownloadsJSON(source.to_owned())
-            } else {
-                Error::InvalidPythonDownloadsJSON(source.to_owned(), err)
-            }
-        },
-    )?;
-    Ok(parse_json_downloads(json_downloads))
-}
-
 fn parse_json_downloads(
     json_downloads: HashMap<String, JsonPythonDownload>,
 ) -> Vec<ManagedPythonDownload> {
@@ -2140,6 +2555,33 @@ fn parse_json_downloads(
         })
         .sorted_by(|a, b| Ord::cmp(&b.key, &a.key))
         .collect()
+}
+
+fn embedded_downloads() -> Result<Vec<ManagedPythonDownload>, Error> {
+    let json_downloads: HashMap<String, JsonPythonDownload> =
+        serde_json::from_slice(BUILTIN_PYTHON_DOWNLOADS_JSON).map_err(|err| {
+            Error::InvalidPythonDownloadsJSON("EMBEDDED IN THE BINARY".to_owned(), err)
+        })?;
+    Ok(parse_json_downloads(json_downloads))
+}
+
+fn parse_json_download_bytes(
+    source: &str,
+    buf: &[u8],
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let json_downloads: HashMap<String, JsonPythonDownload> = serde_json::from_slice(buf).map_err(
+        #[expect(clippy::zero_sized_map_values)]
+        |err| {
+            if let Ok(keys) = serde_json::from_slice::<HashMap<String, serde::de::IgnoredAny>>(buf)
+                && keys.contains_key("version")
+            {
+                Error::UnsupportedPythonDownloadsJSON(source.to_owned())
+            } else {
+                Error::InvalidPythonDownloadsJSON(source.to_owned(), err)
+            }
+        },
+    )?;
+    Ok(parse_json_downloads(json_downloads))
 }
 
 fn parse_version_with_build(s: &str) -> Result<(PythonVersion, Option<&str>), Error> {
@@ -2475,6 +2917,87 @@ async fn fetch_ndjson_collect(
     Ok(downloads)
 }
 
+async fn fetch_ndjson_collect_streaming_cached(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    cache: &Cache,
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+    limit: Option<usize>,
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let source = url.to_string();
+    let cached = read_versions_cache_content(cache, url).await;
+    if let Some((content, meta)) = &cached
+        && versions_cache_is_fresh(meta)
+    {
+        return parse_ndjson_bytes_filtered(&source, content, predicate, limit);
+    }
+
+    let etag = fetch_versions_cache_etag(client, url).await;
+    if let Some((content, meta)) = &cached
+        && etag.is_some()
+        && etag == meta.etag
+    {
+        let shard = versions_cache_shard(cache, url);
+        if let Ok(_lock) = shard.lock().await {
+            let (_, meta_entry) = versions_cache_entries(&shard);
+            let meta = VersionsCacheMeta {
+                checked_at: Timestamp::now(),
+                ..meta.clone()
+            };
+            if let Err(err) = write_versions_cache_meta(&meta_entry, &meta).await {
+                debug!("Failed to refresh Python downloads cache metadata: {err}");
+            }
+        } else {
+            debug!("Failed to lock Python downloads cache");
+        }
+        return parse_ndjson_bytes_filtered(&source, content, predicate, limit);
+    }
+
+    let (reader, _) = read_url(url, client).await?;
+    let mut reader = BufReader::new(reader);
+    let mut line = Vec::new();
+    let mut content = Vec::new();
+    let mut downloads = Vec::new();
+    let mut completed = true;
+    let mut visitor = |download| {
+        if predicate(&download) {
+            downloads.push(download);
+            if limit.is_some_and(|limit| downloads.len() >= limit) {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    };
+
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line).await? == 0 {
+            break;
+        }
+
+        content.extend_from_slice(&line);
+
+        if line.last() == Some(&b'\n') {
+            line.pop();
+        }
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+
+        if visit_ndjson_line(&source, &line, &mut visitor)?.is_some() {
+            completed = false;
+            break;
+        }
+    }
+
+    if completed {
+        write_streamed_versions_cache_if_valid(cache, url, &source, &content, etag).await;
+    }
+
+    downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+    Ok(downloads)
+}
+
 impl Error {
     pub(crate) fn from_reqwest(
         url: DisplaySafeUrl,
@@ -2630,10 +3153,15 @@ async fn read_url(
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::io::{Read, Write};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration as StdDuration;
 
     use crate::PythonVariant;
     use crate::implementation::LenientImplementationName;
     use crate::installation::PythonInstallationKey;
+    use uv_client::BaseClientBuilder;
     use uv_platform::{Arch, Libc, Os, Platform};
 
     use super::*;
@@ -2858,10 +3386,7 @@ mod tests {
             .with_implementation(ImplementationName::CPython)
             .with_build("20240814".to_string());
 
-        let client = uv_client::BaseClientBuilder::default()
-            .build()
-            .expect("failed to build base client");
-        let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
+        let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
 
         let downloads: Vec<_> = download_list
             .iter_all()
@@ -2886,10 +3411,7 @@ mod tests {
             .with_implementation(ImplementationName::CPython)
             .with_build("99999999".to_string());
 
-        let client = uv_client::BaseClientBuilder::default()
-            .build()
-            .expect("failed to build base client");
-        let download_list = ManagedPythonDownloadList::new(&client, None).await.unwrap();
+        let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
 
         // Should find no matching downloads
         let downloads: Vec<_> = download_list
@@ -2898,33 +3420,6 @@ mod tests {
             .collect();
 
         assert_eq!(downloads.len(), 0);
-    }
-
-    #[test]
-    fn parse_ndjson_bytes_matches_generator_artifact_selection() {
-        let ndjson = br#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"},{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only_stripped"}]}
-{"version":"3.10.0+20211017","artifacts":[{"url":"https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst","platform":"x86_64-unknown-linux-gnu","sha256":"ghi789","variant":"pgo+lto+full"}]}
-"#;
-
-        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
-        let downloads = downloads
-            .iter()
-            .map(|download| (download.key().to_string(), download.url().as_ref()))
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            downloads,
-            vec![
-                (
-                    "cpython-3.14.1-macos-aarch64-none".to_string(),
-                    "https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz",
-                ),
-                (
-                    "cpython-3.10.0-linux-x86_64-gnu".to_string(),
-                    "https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst",
-                ),
-            ]
-        );
     }
 
     #[test]
@@ -2957,6 +3452,33 @@ mod tests {
         assert_eq!(
             download.url().as_ref(),
             "https://example.com/cpython-3.13.2-aarch64-apple-darwin.tar.gz"
+        );
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_matches_generator_artifact_selection() {
+        let ndjson = br#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"},{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only_stripped"}]}
+{"version":"3.10.0+20211017","artifacts":[{"url":"https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst","platform":"x86_64-unknown-linux-gnu","sha256":"ghi789","variant":"pgo+lto+full"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes("test.ndjson", ndjson).expect("NDJSON should parse");
+        let downloads = downloads
+            .iter()
+            .map(|download| (download.key().to_string(), download.url().as_ref()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            downloads,
+            vec![
+                (
+                    "cpython-3.14.1-macos-aarch64-none".to_string(),
+                    "https://example.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz",
+                ),
+                (
+                    "cpython-3.10.0-linux-x86_64-gnu".to_string(),
+                    "https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst",
+                ),
+            ]
         );
     }
 
@@ -2996,6 +3518,203 @@ mod tests {
         assert!(downloads.is_empty());
     }
 
+    #[test]
+    fn versions_cache_shard_key_hashes_unredacted_url() {
+        let url_a = DisplaySafeUrl::parse("https://user:tokenA@example.com/versions.ndjson")
+            .expect("URL should parse");
+        let url_b = DisplaySafeUrl::parse("https://user:tokenB@example.com/versions.ndjson")
+            .expect("URL should parse");
+
+        assert_eq!(url_a.to_string(), url_b.to_string());
+        assert_ne!(
+            versions_cache_shard_key(&url_a),
+            versions_cache_shard_key(&url_b)
+        );
+    }
+
+    #[tokio::test]
+    async fn find_streaming_with_cache_returns_before_body_stream_failure() {
+        let first_line = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/cpython-3.14.1-x86_64-unknown-linux-gnu.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{:X}\r\n",
+                first_line.len()
+            )
+            .unwrap();
+            stream.write_all(first_line).unwrap();
+            stream.write_all(b"\r\nZZZ\r\n").unwrap();
+        });
+
+        let client = BaseClientBuilder::default().build().unwrap();
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let request = PythonDownloadRequest::from_str("cpython-3.14-linux-x86_64-gnu").unwrap();
+        let download = ManagedPythonDownloadList::find_streaming(
+            &client,
+            Some(&format!("http://{address}/versions.ndjson")),
+            Some(&cache),
+            &request,
+        )
+        .await
+        .unwrap()
+        .expect("matching download should be found");
+
+        assert_eq!(download.key().version().to_string(), "3.14.1");
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn custom_ndjson_cache_revalidates_without_etag_even_when_length_matches() {
+        let cached = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-a.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+        let refreshed = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-b.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+        assert_eq!(cached.len(), refreshed.len());
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let get_requests = Arc::new(AtomicUsize::new(0));
+        let get_requests_server = Arc::clone(&get_requests);
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + StdDuration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 4096];
+                        let read = stream.read(&mut buf).unwrap_or_default();
+                        let request = String::from_utf8_lossy(&buf[..read]);
+                        if request.starts_with("HEAD ") {
+                            write!(
+                                stream,
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+                                refreshed.len()
+                            )
+                            .unwrap();
+                        } else if request.starts_with("GET ") {
+                            get_requests_server.fetch_add(1, Ordering::SeqCst);
+                            write!(
+                                stream,
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/x-ndjson\r\n\r\n",
+                                refreshed.len()
+                            )
+                            .unwrap();
+                            stream.write_all(refreshed).unwrap();
+                            return;
+                        }
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(StdDuration::from_millis(10));
+                    }
+                    Err(err) => panic!("failed to accept connection: {err}"),
+                }
+            }
+        });
+
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let url = DisplaySafeUrl::parse(&format!("http://{address}/versions.ndjson")).unwrap();
+        let shard = versions_cache_shard(&cache, &url);
+        let (content_entry, meta_entry) = versions_cache_entries(&shard);
+        write_versions_cache(
+            &content_entry,
+            &meta_entry,
+            cached,
+            &VersionsCacheMeta {
+                content_length: cached.len() as u64,
+                etag: None,
+                checked_at: Timestamp::from(SystemTime::UNIX_EPOCH),
+            },
+        )
+        .await
+        .unwrap();
+
+        let client = BaseClientBuilder::default().build().unwrap();
+        let contents = fetch_ndjson_cached(&client, &url, Some(&cache))
+            .await
+            .unwrap();
+
+        assert_eq!(contents, refreshed);
+        assert_eq!(get_requests.load(Ordering::SeqCst), 1);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn streaming_cache_reuses_matching_etag_without_get() {
+        let cached = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-a.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let get_requests = Arc::new(AtomicUsize::new(0));
+        let get_requests_server = Arc::clone(&get_requests);
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + StdDuration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 4096];
+                        let read = stream.read(&mut buf).unwrap_or_default();
+                        let request = String::from_utf8_lossy(&buf[..read]);
+                        if request.starts_with("HEAD ") {
+                            write!(
+                                stream,
+                                "HTTP/1.1 200 OK\r\nETag: \"v1\"\r\nContent-Length: {}\r\n\r\n",
+                                cached.len()
+                            )
+                            .unwrap();
+                            return;
+                        }
+                        if request.starts_with("GET ") {
+                            get_requests_server.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(StdDuration::from_millis(10));
+                    }
+                    Err(err) => panic!("failed to accept connection: {err}"),
+                }
+            }
+        });
+
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let url = DisplaySafeUrl::parse(&format!("http://{address}/versions.ndjson")).unwrap();
+        let shard = versions_cache_shard(&cache, &url);
+        let (content_entry, meta_entry) = versions_cache_entries(&shard);
+        write_versions_cache(
+            &content_entry,
+            &meta_entry,
+            cached,
+            &VersionsCacheMeta {
+                content_length: cached.len() as u64,
+                etag: Some("\"v1\"".to_string()),
+                checked_at: Timestamp::from(SystemTime::UNIX_EPOCH),
+            },
+        )
+        .await
+        .unwrap();
+
+        let client = BaseClientBuilder::default().retries(0).build().unwrap();
+        let downloads =
+            fetch_ndjson_collect_streaming_cached(&client, &url, &cache, |_| true, None)
+                .await
+                .unwrap();
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(
+            downloads[0].url().as_ref(),
+            "https://example.com/token-a.tar.gz"
+        );
+        assert_eq!(get_requests.load(Ordering::SeqCst), 0);
+        server.join().unwrap();
+    }
+    #[test]
     fn upgrade_request_native_defaults() {
         let request = PythonDownloadRequest::default()
             .with_implementation(ImplementationName::CPython)

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -16,7 +16,9 @@ use reqwest_retry::RetryError;
 use reqwest_retry::policies::ExponentialBackoff;
 use serde::Deserialize;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufWriter, ReadBuf};
+use tokio::io::{
+    AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter, ReadBuf,
+};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::either::Either;
 use tracing::{debug, instrument};
@@ -1091,6 +1093,47 @@ fn resolve_download_list_source(
     })
 }
 
+impl DownloadListSource<'_> {
+    fn merge_downloads(
+        &self,
+        downloads: Vec<ManagedPythonDownload>,
+        filter: Option<&PythonDownloadRequest>,
+        limit: Option<usize>,
+    ) -> Result<Vec<ManagedPythonDownload>, Error> {
+        if self.implicit {
+            merge_with_embedded_non_cpython(downloads, filter, limit)
+        } else {
+            Ok(filter_downloads(downloads, filter, limit))
+        }
+    }
+
+    fn find_in_implicit_embedded_non_cpython(
+        &self,
+        request: &PythonDownloadRequest,
+    ) -> Result<Option<ManagedPythonDownload>, Error> {
+        if self.implicit {
+            find_in_embedded_non_cpython(request)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn on_implicit_ndjson_parse_error<T>(
+        &self,
+        err: Error,
+        fallback: impl FnOnce() -> Result<T, Error>,
+    ) -> Result<T, Error> {
+        if self.implicit {
+            debug!(
+                "Falling back to embedded Python downloads metadata after NDJSON parse failure: {err}"
+            );
+            fallback()
+        } else {
+            Err(err)
+        }
+    }
+}
+
 /// A wrapper type to display a `ManagedPythonDownload` with its build information.
 pub struct ManagedPythonDownloadWithBuild<'a>(&'a ManagedPythonDownload);
 
@@ -1158,7 +1201,7 @@ impl ManagedPythonDownloadList {
                 match parse_ndjson_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?) {
                     Ok(downloads) => {
                         if source.implicit {
-                            merge_with_embedded_non_cpython(downloads)?
+                            merge_with_embedded_non_cpython(downloads, None, None)?
                         } else {
                             downloads
                         }
@@ -1191,7 +1234,7 @@ impl ManagedPythonDownloadList {
                     Ok(buf) => match parse_ndjson_bytes(&url.to_string(), &buf) {
                         Ok(downloads) => {
                             if source.implicit {
-                                merge_with_embedded_non_cpython(downloads)?
+                                merge_with_embedded_non_cpython(downloads, None, None)?
                             } else {
                                 downloads
                             }
@@ -1225,6 +1268,100 @@ impl ManagedPythonDownloadList {
         };
 
         Ok(Self { downloads })
+    }
+
+    /// Load available Python distributions with optional filtering and limiting.
+    ///
+    /// For NDJSON sources, this parses matching downloads eagerly and stops once `limit` matches
+    /// have been collected.
+    pub async fn new_filtered(
+        client: &BaseClient,
+        python_downloads_json_url: Option<&str>,
+        filter: Option<&PythonDownloadRequest>,
+        limit: Option<usize>,
+    ) -> Result<Self, Error> {
+        let source = resolve_download_list_source(python_downloads_json_url)?;
+
+        let downloads = match (&source.location, source.format) {
+            (DownloadListLocation::Path(path), DownloadListFormat::Ndjson) => {
+                let downloads = parse_ndjson_bytes_filtered(
+                    &path.to_string_lossy(),
+                    &fs_err::read(path.as_ref())?,
+                    |download| {
+                        filter
+                            .map(|request| request.satisfied_by_download(download))
+                            .unwrap_or(true)
+                    },
+                    limit,
+                )?;
+                source.merge_downloads(downloads, filter, limit)?
+            }
+            (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
+                let source_url = url.to_string();
+                match fetch_ndjson_collect(
+                    client,
+                    url,
+                    |download| {
+                        filter
+                            .map(|request| request.satisfied_by_download(download))
+                            .unwrap_or(true)
+                    },
+                    limit,
+                )
+                .await
+                {
+                    Ok(downloads) => source.merge_downloads(downloads, filter, limit)?,
+                    Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
+                        .on_implicit_ndjson_parse_error(err, || {
+                            Ok(filter_downloads(embedded_downloads()?, filter, limit))
+                        })?,
+                    Err(err) => {
+                        if source.implicit {
+                            debug!(
+                                "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                            );
+                            filter_downloads(embedded_downloads()?, filter, limit)
+                        } else {
+                            return Err(Error::FetchingPythonDownloadsNdjsonError(
+                                source_url,
+                                Box::new(err),
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => filter_downloads(
+                Self::new(client, python_downloads_json_url)
+                    .await?
+                    .downloads,
+                filter,
+                limit,
+            ),
+        };
+
+        Ok(Self { downloads })
+    }
+
+    /// Find a single download matching the request, using early-exit parsing for NDJSON sources.
+    ///
+    /// NDJSON metadata is ordered newest-first, so the first matching download is the preferred
+    /// download for the request.
+    pub async fn find_streaming(
+        client: &BaseClient,
+        python_downloads_json_url: Option<&str>,
+        request: &PythonDownloadRequest,
+    ) -> Result<Option<ManagedPythonDownload>, Error> {
+        let source = resolve_download_list_source(python_downloads_json_url)?;
+
+        if let Some(download) = find_matching_download(client, &source, request).await? {
+            return Ok(Some(download));
+        }
+
+        if request.allows_prereleases() {
+            return Ok(None);
+        }
+
+        find_matching_download(client, &source, &request.clone().with_prereleases(true)).await
     }
 
     /// Load available Python distributions from the compiled-in list only.
@@ -1261,6 +1398,8 @@ fn embedded_non_cpython_downloads() -> Result<Vec<ManagedPythonDownload>, Error>
 
 fn merge_with_embedded_non_cpython(
     downloads: Vec<ManagedPythonDownload>,
+    filter: Option<&PythonDownloadRequest>,
+    limit: Option<usize>,
 ) -> Result<Vec<ManagedPythonDownload>, Error> {
     let mut merged = BTreeMap::new();
 
@@ -1268,13 +1407,134 @@ fn merge_with_embedded_non_cpython(
         merged.entry(download.key().clone()).or_insert(download);
     }
 
-    for download in embedded_non_cpython_downloads()? {
+    for download in filter_downloads(embedded_non_cpython_downloads()?, filter, None) {
         merged.entry(download.key().clone()).or_insert(download);
     }
 
     let mut downloads = merged.into_values().collect::<Vec<_>>();
     downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+
+    if let Some(limit) = limit {
+        downloads.truncate(limit);
+    }
+
     Ok(downloads)
+}
+
+fn find_in_embedded_non_cpython(
+    request: &PythonDownloadRequest,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    Ok(embedded_non_cpython_downloads()?
+        .into_iter()
+        .find(|download| request.satisfied_by_download(download)))
+}
+
+fn find_in_embedded_downloads(
+    request: &PythonDownloadRequest,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    Ok(embedded_downloads()?
+        .into_iter()
+        .find(|download| request.satisfied_by_download(download)))
+}
+
+fn filter_downloads(
+    mut downloads: Vec<ManagedPythonDownload>,
+    filter: Option<&PythonDownloadRequest>,
+    limit: Option<usize>,
+) -> Vec<ManagedPythonDownload> {
+    if let Some(filter) = filter {
+        downloads.retain(|download| filter.satisfied_by_download(download));
+    }
+
+    if let Some(limit) = limit {
+        downloads.truncate(limit);
+    }
+
+    downloads
+}
+
+fn find_matching_or_implicit_embedded(
+    source: &DownloadListSource<'_>,
+    download: Option<ManagedPythonDownload>,
+    request: &PythonDownloadRequest,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    match download {
+        Some(download) => Ok(Some(download)),
+        None => source.find_in_implicit_embedded_non_cpython(request),
+    }
+}
+
+async fn find_matching_download(
+    client: &BaseClient,
+    source: &DownloadListSource<'_>,
+    request: &PythonDownloadRequest,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    match (&source.location, source.format) {
+        (DownloadListLocation::Path(path), DownloadListFormat::Ndjson) => {
+            let download = parse_ndjson_bytes_find(
+                &path.to_string_lossy(),
+                &fs_err::read(path.as_ref())?,
+                |download| request.satisfied_by_download(download),
+            )?;
+            find_matching_or_implicit_embedded(source, download, request)
+        }
+        (DownloadListLocation::Http(url), DownloadListFormat::Ndjson) => {
+            let source_url = url.to_string();
+            match fetch_ndjson_find(client, url, |download| {
+                request.satisfied_by_download(download)
+            })
+            .await
+            {
+                Ok(download) => find_matching_or_implicit_embedded(source, download, request),
+                Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
+                    .on_implicit_ndjson_parse_error(err, || find_in_embedded_downloads(request)),
+                Err(err) => {
+                    if source.implicit {
+                        debug!(
+                            "Falling back to embedded Python downloads metadata after NDJSON fetch failure: {err}"
+                        );
+                        find_in_embedded_downloads(request)
+                    } else {
+                        Err(Error::FetchingPythonDownloadsNdjsonError(
+                            source_url,
+                            Box::new(err),
+                        ))
+                    }
+                }
+            }
+        }
+        (DownloadListLocation::Path(path), DownloadListFormat::Json) => {
+            let download =
+                parse_json_download_bytes(&path.to_string_lossy(), &fs_err::read(path.as_ref())?)?
+                    .into_iter()
+                    .find(|download| request.satisfied_by_download(download));
+            find_matching_or_implicit_embedded(source, download, request)
+        }
+        (DownloadListLocation::Http(url), DownloadListFormat::Json) => {
+            let source_url = url.to_string();
+            match fetch_bytes_from_url(client, url).await {
+                Ok(buf) => {
+                    let download = parse_json_download_bytes(&source_url, &buf)?
+                        .into_iter()
+                        .find(|download| request.satisfied_by_download(download));
+                    find_matching_or_implicit_embedded(source, download, request)
+                }
+                Err(err) => {
+                    if source.implicit {
+                        debug!(
+                            "Falling back to embedded Python downloads metadata after JSON fetch failure: {err}"
+                        );
+                        find_in_embedded_downloads(request)
+                    } else {
+                        Err(Error::FetchingPythonDownloadsJSONError(
+                            source_url,
+                            Box::new(err),
+                        ))
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl ManagedPythonDownload {
@@ -2114,6 +2374,107 @@ fn parse_ndjson_bytes(source: &str, buf: &[u8]) -> Result<Vec<ManagedPythonDownl
     Ok(downloads)
 }
 
+fn parse_ndjson_bytes_filtered(
+    source: &str,
+    buf: &[u8],
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+    limit: Option<usize>,
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let mut downloads = Vec::new();
+    parse_ndjson_bytes_with(source, buf, |download| {
+        if predicate(&download) {
+            downloads.push(download);
+            if limit.is_some_and(|limit| downloads.len() >= limit) {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    })?;
+    downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+    Ok(downloads)
+}
+
+fn parse_ndjson_bytes_find(
+    source: &str,
+    buf: &[u8],
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    parse_ndjson_bytes_with(source, buf, |download| {
+        if predicate(&download) {
+            ControlFlow::Break(download)
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+}
+
+async fn fetch_ndjson_streaming<T>(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    mut visitor: impl FnMut(ManagedPythonDownload) -> ControlFlow<T, ()>,
+) -> Result<Option<T>, Error> {
+    let source = url.to_string();
+    let (reader, _) = read_url(url, client).await?;
+    let mut reader = BufReader::new(reader);
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line).await? == 0 {
+            break;
+        }
+
+        if line.last() == Some(&b'\n') {
+            line.pop();
+        }
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+
+        if let Some(value) = visit_ndjson_line(&source, &line, &mut visitor)? {
+            return Ok(Some(value));
+        }
+    }
+
+    Ok(None)
+}
+
+async fn fetch_ndjson_find(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    fetch_ndjson_streaming(client, url, |download| {
+        if predicate(&download) {
+            ControlFlow::Break(download)
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .await
+}
+
+async fn fetch_ndjson_collect(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+    limit: Option<usize>,
+) -> Result<Vec<ManagedPythonDownload>, Error> {
+    let mut downloads = Vec::new();
+    fetch_ndjson_streaming(client, url, |download| {
+        if predicate(&download) {
+            downloads.push(download);
+            if limit.is_some_and(|limit| downloads.len() >= limit) {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    })
+    .await?;
+    downloads.sort_by(|a, b| Ord::cmp(&b.key, &a.key));
+    Ok(downloads)
+}
+
 impl Error {
     pub(crate) fn from_reqwest(
         url: DisplaySafeUrl,
@@ -2563,6 +2924,39 @@ mod tests {
                     "https://example.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst",
                 ),
             ]
+        );
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_filtered_applies_limit() {
+        let ndjson = br#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+{"version":"3.13.2","artifacts":[{"url":"https://example.com/cpython-3.13.2-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only"}]}
+"#;
+
+        let downloads = parse_ndjson_bytes_filtered("test.ndjson", ndjson, |_| true, Some(1))
+            .expect("NDJSON should parse");
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(downloads[0].key().version().to_string(), "3.14.1");
+        assert_eq!(downloads[0].build(), Some("20260420"));
+    }
+
+    #[test]
+    fn parse_ndjson_bytes_find_returns_first_match() {
+        let ndjson = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+{"version":"3.13.2","artifacts":[{"url":"https://example.com/cpython-3.13.2-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only"}]}
+"#;
+
+        let download = parse_ndjson_bytes_find("test.ndjson", ndjson, |download| {
+            download.key().version().to_string() == "3.13.2"
+        })
+        .expect("NDJSON should parse")
+        .expect("matching download should be found");
+
+        assert_eq!(download.key().version().to_string(), "3.13.2");
+        assert_eq!(
+            download.url().as_ref(),
+            "https://example.com/cpython-3.13.2-aarch64-apple-darwin.tar.gz"
         );
     }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1389,7 +1389,14 @@ async fn fetch_ndjson_cached(
                 .await;
                 Ok(content)
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                if let Some((content, _)) = cached {
+                    debug!("Using stale cached Python downloads metadata after HEAD failure");
+                    Ok(content)
+                } else {
+                    Err(err)
+                }
+            }
         };
     };
 
@@ -1496,7 +1503,14 @@ async fn fetch_ndjson_cached(
                 .await;
             Ok(content)
         }
-        Err(err) => Err(err),
+        Err(err) => {
+            if let Some((content, _)) = cached {
+                debug!("Using stale cached Python downloads metadata after fetch failure");
+                Ok(content)
+            } else {
+                Err(err)
+            }
+        }
     }
 }
 
@@ -1919,11 +1933,19 @@ async fn find_matching_download(
                     }
                 }
             } else {
-                match fetch_ndjson_find(client, url, |download| {
-                    request.satisfied_by_download(download)
-                })
-                .await
-                {
+                let result = if let Some(cache) = cache {
+                    fetch_ndjson_find_cached(client, url, cache, |download| {
+                        request.satisfied_by_download(download)
+                    })
+                    .await
+                } else {
+                    fetch_ndjson_find(client, url, |download| {
+                        request.satisfied_by_download(download)
+                    })
+                    .await
+                };
+
+                match result {
                     Ok(download) => find_matching_or_implicit_embedded(source, download, request),
                     Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => source
                         .on_implicit_ndjson_parse_error(err, || {
@@ -2896,6 +2918,53 @@ async fn fetch_ndjson_find(
     .await
 }
 
+async fn fetch_ndjson_find_cached(
+    client: &BaseClient,
+    url: &DisplaySafeUrl,
+    cache: &Cache,
+    predicate: impl Fn(&ManagedPythonDownload) -> bool,
+) -> Result<Option<ManagedPythonDownload>, Error> {
+    let source = url.to_string();
+    let cached = read_versions_cache_content(cache, url).await;
+    if let Some((content, meta)) = &cached
+        && versions_cache_is_fresh(meta)
+    {
+        return parse_ndjson_bytes_find(&source, content, predicate);
+    }
+
+    if let Some((content, meta)) = &cached {
+        let etag = fetch_versions_cache_etag(client, url).await;
+        if etag.is_some() && etag == meta.etag {
+            let shard = versions_cache_shard(cache, url);
+            if let Ok(_lock) = shard.lock().await {
+                let (_, meta_entry) = versions_cache_entries(&shard);
+                let meta = VersionsCacheMeta {
+                    checked_at: Timestamp::now(),
+                    ..meta.clone()
+                };
+                if let Err(err) = write_versions_cache_meta(&meta_entry, &meta).await {
+                    debug!("Failed to refresh Python downloads cache metadata: {err}");
+                }
+            } else {
+                debug!("Failed to lock Python downloads cache");
+            }
+            return parse_ndjson_bytes_find(&source, content, predicate);
+        }
+    }
+
+    match fetch_ndjson_find(client, url, &predicate).await {
+        Ok(download) => Ok(download),
+        Err(err @ Error::InvalidPythonDownloadsNdjsonLine(..)) => Err(err),
+        Err(err) => {
+            if let Some((content, _)) = cached {
+                debug!("Using stale cached Python downloads metadata after fetch failure");
+                return parse_ndjson_bytes_find(&source, &content, predicate);
+            }
+            Err(err)
+        }
+    }
+}
+
 async fn fetch_ndjson_collect(
     client: &BaseClient,
     url: &DisplaySafeUrl,
@@ -2953,7 +3022,16 @@ async fn fetch_ndjson_collect_streaming_cached(
         return parse_ndjson_bytes_filtered(&source, content, predicate, limit);
     }
 
-    let (reader, _) = read_url(url, client).await?;
+    let (reader, _) = match read_url(url, client).await {
+        Ok(reader) => reader,
+        Err(err) => {
+            if let Some((content, _)) = cached {
+                debug!("Using stale cached Python downloads metadata after fetch failure");
+                return parse_ndjson_bytes_filtered(&source, &content, predicate, limit);
+            }
+            return Err(err);
+        }
+    };
     let mut reader = BufReader::new(reader);
     let mut line = Vec::new();
     let mut content = Vec::new();
@@ -2971,8 +3049,16 @@ async fn fetch_ndjson_collect_streaming_cached(
 
     loop {
         line.clear();
-        if reader.read_until(b'\n', &mut line).await? == 0 {
-            break;
+        match reader.read_until(b'\n', &mut line).await {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(err) => {
+                if let Some((content, _)) = cached {
+                    debug!("Using stale cached Python downloads metadata after fetch failure");
+                    return parse_ndjson_bytes_filtered(&source, &content, predicate, limit);
+                }
+                return Err(err.into());
+            }
         }
 
         content.extend_from_slice(&line);
@@ -3712,6 +3798,195 @@ mod tests {
             "https://example.com/token-a.tar.gz"
         );
         assert_eq!(get_requests.load(Ordering::SeqCst), 0);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn find_streaming_cache_reuses_matching_etag_without_get() {
+        let cached = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-a.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let get_requests = Arc::new(AtomicUsize::new(0));
+        let get_requests_server = Arc::clone(&get_requests);
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + StdDuration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 4096];
+                        let read = stream.read(&mut buf).unwrap_or_default();
+                        let request = String::from_utf8_lossy(&buf[..read]);
+                        if request.starts_with("HEAD ") {
+                            write!(
+                                stream,
+                                "HTTP/1.1 200 OK\r\nETag: \"v1\"\r\nContent-Length: {}\r\n\r\n",
+                                cached.len()
+                            )
+                            .unwrap();
+                            return;
+                        }
+                        if request.starts_with("GET ") {
+                            get_requests_server.fetch_add(1, Ordering::SeqCst);
+                            write!(
+                                stream,
+                                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/x-ndjson\r\n\r\n",
+                                cached.len()
+                            )
+                            .unwrap();
+                            stream.write_all(cached).unwrap();
+                            return;
+                        }
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(StdDuration::from_millis(10));
+                    }
+                    Err(err) => panic!("failed to accept connection: {err}"),
+                }
+            }
+        });
+
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let url = DisplaySafeUrl::parse(&format!("http://{address}/versions.ndjson")).unwrap();
+        let shard = versions_cache_shard(&cache, &url);
+        let (content_entry, meta_entry) = versions_cache_entries(&shard);
+        write_versions_cache(
+            &content_entry,
+            &meta_entry,
+            cached,
+            &VersionsCacheMeta {
+                content_length: cached.len() as u64,
+                etag: Some("\"v1\"".to_string()),
+                checked_at: Timestamp::from(SystemTime::UNIX_EPOCH),
+            },
+        )
+        .await
+        .unwrap();
+
+        let client = BaseClientBuilder::default().retries(0).build().unwrap();
+        let request = PythonDownloadRequest::from_str("cpython-3.14-linux-x86_64-gnu").unwrap();
+        let download = ManagedPythonDownloadList::find_streaming(
+            &client,
+            Some(url.as_str()),
+            Some(&cache),
+            &request,
+        )
+        .await
+        .unwrap()
+        .expect("matching download should be found");
+
+        assert_eq!(
+            download.url().as_ref(),
+            "https://example.com/token-a.tar.gz"
+        );
+        assert_eq!(get_requests.load(Ordering::SeqCst), 0);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn streaming_cache_uses_stale_content_after_refresh_failure() {
+        let cached = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-a.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                write!(
+                    stream,
+                    "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"
+                )
+                .unwrap();
+            }
+        });
+
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let url = DisplaySafeUrl::parse(&format!("http://{address}/versions.ndjson")).unwrap();
+        let shard = versions_cache_shard(&cache, &url);
+        let (content_entry, meta_entry) = versions_cache_entries(&shard);
+        write_versions_cache(
+            &content_entry,
+            &meta_entry,
+            cached,
+            &VersionsCacheMeta {
+                content_length: cached.len() as u64,
+                etag: None,
+                checked_at: Timestamp::from(SystemTime::UNIX_EPOCH),
+            },
+        )
+        .await
+        .unwrap();
+
+        let client = BaseClientBuilder::default().retries(0).build().unwrap();
+        let downloads =
+            fetch_ndjson_collect_streaming_cached(&client, &url, &cache, |_| true, None)
+                .await
+                .unwrap();
+
+        assert_eq!(downloads.len(), 1);
+        assert_eq!(
+            downloads[0].url().as_ref(),
+            "https://example.com/token-a.tar.gz"
+        );
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn find_streaming_uses_stale_content_after_refresh_failure() {
+        let cached = br#"{"version":"3.14.1","artifacts":[{"url":"https://example.com/token-a.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            write!(
+                stream,
+                "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"
+            )
+            .unwrap();
+        });
+
+        let cache = Cache::temp().unwrap().init().await.unwrap();
+        let url = DisplaySafeUrl::parse(&format!("http://{address}/versions.ndjson")).unwrap();
+        let shard = versions_cache_shard(&cache, &url);
+        let (content_entry, meta_entry) = versions_cache_entries(&shard);
+        write_versions_cache(
+            &content_entry,
+            &meta_entry,
+            cached,
+            &VersionsCacheMeta {
+                content_length: cached.len() as u64,
+                etag: None,
+                checked_at: Timestamp::from(SystemTime::UNIX_EPOCH),
+            },
+        )
+        .await
+        .unwrap();
+
+        let client = BaseClientBuilder::default().retries(0).build().unwrap();
+        let request = PythonDownloadRequest::from_str("cpython-3.14-linux-x86_64-gnu").unwrap();
+        let download = ManagedPythonDownloadList::find_streaming(
+            &client,
+            Some(url.as_str()),
+            Some(&cache),
+            &request,
+        )
+        .await
+        .unwrap()
+        .expect("matching download should be found");
+
+        assert_eq!(
+            download.url().as_ref(),
+            "https://example.com/token-a.tar.gz"
+        );
         server.join().unwrap();
     }
     #[test]

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -176,42 +176,74 @@ impl PythonInstallation {
             return Err(err);
         };
 
-        let download_list_client = client_builder.build()?;
-        let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
-                .await?;
+        // Python downloads are performing their own retries to catch stream errors, disable the
+        // default retries to avoid the middleware performing uncontrolled retries.
+        let retry_policy = client_builder.retry_policy();
+        let download_list = if python_downloads_json_url.is_some() {
+            let download_list_client = client_builder.build()?;
+            Some(
+                ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
+                    .await?,
+            )
+        } else {
+            None
+        };
+        let client = client_builder.clone().retries(0).build()?;
 
         let downloads_enabled = preference.allows_managed()
             && python_downloads.is_automatic()
             && client_builder.connectivity.is_online();
 
-        let download = download_request
-            .clone()
-            .fill()
-            .map(|request| download_list.find(&request));
-
-        // Regardless of whether downloads are enabled, we want to determine if the download is
-        // available to power error messages. However, if downloads aren't enabled, we don't want to
-        // report any errors related to them.
-        let download = match download {
-            Ok(Ok(download)) => Some(download),
-            // If the download cannot be found, return the _original_ discovery error
-            Ok(Err(downloads::Error::NoDownloadFound(_))) => {
-                if downloads_enabled {
-                    debug!("No downloads are available for {request}");
-                    if matches!(request, PythonRequest::Default | PythonRequest::Any) {
-                        return Err(err);
+        let download = match download_request.clone().fill() {
+            Ok(download_request) => {
+                let download = if let Some(download_list) = download_list.as_ref() {
+                    match download_list.find(&download_request) {
+                        Ok(download) => Some(Cow::Borrowed(download)),
+                        Err(downloads::Error::NoDownloadFound(_)) => None,
+                        Err(err) => {
+                            if downloads_enabled {
+                                return Err(err.into());
+                            }
+                            None
+                        }
                     }
-                    return Err(err.with_missing_python_hint(
-                        "uv fetches available Python downloads at runtime and falls back to embedded metadata on failure. If this is a newly released Python version, retry later."
-                            .to_string(),
-                    ));
+                } else {
+                    match ManagedPythonDownloadList::find_streaming(
+                        &client,
+                        python_downloads_json_url,
+                        &download_request,
+                    )
+                    .await
+                    {
+                        Ok(download) => download.map(Cow::Owned),
+                        Err(err) => {
+                            if downloads_enabled {
+                                return Err(err.into());
+                            }
+                            None
+                        }
+                    }
+                };
+
+                if let Some(download) = download {
+                    Some(download)
+                } else {
+                    if downloads_enabled {
+                        debug!("No downloads are available for {request}");
+                        if matches!(request, PythonRequest::Default | PythonRequest::Any) {
+                            return Err(err);
+                        }
+                        return Err(err.with_missing_python_hint(
+                            "uv fetches available Python downloads at runtime and falls back to embedded metadata on failure. If this is a newly released Python version, retry later."
+                                .to_string(),
+                        ));
+                    }
+                    None
                 }
-                None
             }
-            Err(err) | Ok(Err(err)) => {
+            Err(err) => {
                 if downloads_enabled {
-                    // We failed to determine the platform information
+                    // We failed to determine the platform information.
                     return Err(err.into());
                 }
                 None
@@ -267,14 +299,9 @@ impl PythonInstallation {
             return Err(err);
         }
 
-        // Python downloads are performing their own retries to catch stream errors, disable the
-        // default retries to avoid the middleware performing uncontrolled retries.
-        let retry_policy = client_builder.retry_policy();
-        let download_client = client_builder.clone().retries(0).build()?;
-
         let installation = Self::fetch(
-            download,
-            &download_client,
+            download.as_ref(),
+            &client,
             &retry_policy,
             cache,
             reporter,
@@ -283,7 +310,17 @@ impl PythonInstallation {
         )
         .await?;
 
-        installation.warn_if_outdated_prerelease(request, &download_list);
+        if let Some(download_list) = download_list.as_ref() {
+            installation.warn_if_outdated_prerelease(request, download_list);
+        } else {
+            installation
+                .download_and_warn_if_outdated_prerelease(
+                    request,
+                    client_builder,
+                    python_downloads_json_url,
+                )
+                .await?;
+        }
 
         Ok(installation)
     }

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -203,7 +203,7 @@ impl PythonInstallation {
                         return Err(err);
                     }
                     return Err(err.with_missing_python_hint(
-                        "uv embeds available Python downloads and may require an update to install new versions. Consider retrying on a newer version of uv."
+                        "uv fetches available Python downloads at runtime and falls back to embedded metadata on failure. If this is a newly released Python version, retry later."
                             .to_string(),
                     ));
                 }

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -125,6 +125,7 @@ impl PythonInstallation {
                 request,
                 client_builder,
                 python_downloads_json_url,
+                cache,
             )
             .await?;
         Ok(installation)
@@ -155,6 +156,7 @@ impl PythonInstallation {
                         request,
                         client_builder,
                         python_downloads_json_url,
+                        cache,
                     )
                     .await?;
                 return Ok(installation);
@@ -182,8 +184,12 @@ impl PythonInstallation {
         let download_list = if python_downloads_json_url.is_some() {
             let download_list_client = client_builder.build()?;
             Some(
-                ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
-                    .await?,
+                ManagedPythonDownloadList::new(
+                    &download_list_client,
+                    python_downloads_json_url,
+                    Some(cache),
+                )
+                .await?,
             )
         } else {
             None
@@ -211,6 +217,7 @@ impl PythonInstallation {
                     match ManagedPythonDownloadList::find_streaming(
                         &client,
                         python_downloads_json_url,
+                        Some(cache),
                         &download_request,
                     )
                     .await
@@ -318,6 +325,7 @@ impl PythonInstallation {
                     request,
                     client_builder,
                     python_downloads_json_url,
+                    cache,
                 )
                 .await?;
         }
@@ -551,15 +559,19 @@ impl PythonInstallation {
         request: &PythonRequest,
         client_builder: &BaseClientBuilder<'_>,
         python_downloads_json_url: Option<&str>,
+        cache: &Cache,
     ) -> Result<(), Error> {
         if !self.should_check_outdated_prerelease_warning(request) {
             return Ok(());
         }
 
         let download_list_client = client_builder.build()?;
-        let download_list =
-            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
-                .await?;
+        let download_list = ManagedPythonDownloadList::new(
+            &download_list_client,
+            python_downloads_json_url,
+            Some(cache),
+        )
+        .await?;
         self.warn_if_outdated_prerelease(request, &download_list);
 
         Ok(())

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1162,7 +1162,7 @@ pub struct PythonInstallMirrors {
     )]
     pub pypy_install_mirror: Option<String>,
 
-    /// URL pointing to JSON of custom Python installations.
+    /// URL pointing to JSON or NDJSON describing custom Python installations.
     #[option(
         default = "None",
         value_type = "str",

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -646,6 +646,12 @@ impl EnvVars {
     #[attr_added_in("0.8.0")]
     pub const UV_INTERNAL__TEST_PYTHON_MANAGED: &'static str = "UV_INTERNAL__TEST_PYTHON_MANAGED";
 
+    /// Used to override the Python download metadata source during tests without affecting user-visible settings.
+    #[attr_hidden]
+    #[attr_added_in("0.11.7")]
+    pub const UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL: &'static str =
+        "UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL";
+
     /// Used to force ignoring Git LFS commands as `git-lfs` detection cannot be overridden via PATH.
     #[attr_hidden]
     #[attr_added_in("0.9.15")]

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1104,6 +1104,8 @@ impl TestContext {
             "archive-v$1/[HASH]".to_string(),
         ));
 
+        let python_downloads_json = workspace_root.join("crates/uv-python/download-metadata.json");
+
         Self {
             root: ChildPath::new(root.path()),
             temp_dir,
@@ -1118,7 +1120,10 @@ impl TestContext {
             python_versions,
             uv_bin,
             filters,
-            extra_env: vec![],
+            extra_env: vec![(
+                EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL.into(),
+                python_downloads_json.into_os_string(),
+            )],
             _root: root,
             _extra_tempdirs: vec![],
         }

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -90,6 +90,7 @@ pub(crate) async fn find(
             &python_request,
             client_builder,
             python_downloads_json_url,
+            cache,
         )
         .await?;
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -49,7 +49,7 @@ struct InstallRequest<'a> {
     /// A download request corresponding to the `request` with platform information filled
     download_request: PythonDownloadRequest,
     /// A download that satisfies the request
-    download: &'a ManagedPythonDownload,
+    download: Cow<'a, ManagedPythonDownload>,
 }
 
 impl<'a> InstallRequest<'a> {
@@ -66,7 +66,7 @@ impl<'a> InstallRequest<'a> {
 
         // Find a matching download
         let download = match download_list.find(&download_request) {
-            Ok(download) => download,
+            Ok(download) => Cow::Borrowed(download),
             Err(downloads::Error::NoDownloadFound(request))
                 if request.libc().is_some_and(Libc::is_musl)
                     && request.arch().is_some_and(|arch| {
@@ -81,6 +81,49 @@ impl<'a> InstallRequest<'a> {
         };
 
         Ok(Self {
+            request,
+            download_request,
+            download,
+        })
+    }
+
+    async fn new_streaming(
+        request: PythonRequest,
+        client: &uv_client::BaseClient,
+        python_downloads_json_url: Option<&str>,
+    ) -> Result<InstallRequest<'static>> {
+        let download_request = PythonDownloadRequest::from_request(&request)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`{}` is not a valid Python download request; see `uv help python` for supported formats and `uv python list --only-downloads` for available versions",
+                    request.to_canonical_string()
+                )
+            })?
+            .fill()?;
+
+        let download = match ManagedPythonDownloadList::find_streaming(
+            client,
+            python_downloads_json_url,
+            &download_request,
+        )
+        .await
+        {
+            Ok(Some(download)) => Cow::Owned(download),
+            Ok(None)
+                if download_request.libc().is_some_and(Libc::is_musl)
+                    && download_request.arch().is_some_and(|arch| {
+                        arch.inner() == Arch::from(&uv_platform_tags::Arch::Armv7L)
+                    }) =>
+            {
+                return Err(anyhow::anyhow!(
+                    "uv does not yet provide musl Python distributions on armv7."
+                ));
+            }
+            Ok(None) => return Err(downloads::Error::NoDownloadFound(download_request).into()),
+            Err(err) => return Err(err.into()),
+        };
+
+        Ok(InstallRequest {
             request,
             download_request,
             download,
@@ -339,8 +382,7 @@ async fn perform_install(
     // Python downloads are performing their own retries to catch stream errors, disable the
     // default retries to avoid the middleware from performing uncontrolled retries.
     let client = client_builder.retries(0).build()?;
-    let download_list =
-        ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
+    let mut download_list = None;
     // TODO(zanieb): We use this variable to special-case .python-version files, but it'd be nice to
     // have generalized request source tracking instead
     let mut is_from_python_version_file = false;
@@ -349,6 +391,16 @@ async fn perform_install(
             upgrade,
             PythonUpgrade::Enabled(PythonUpgradeSource::Upgrade)
         ) {
+            if download_list.is_none() {
+                download_list = Some(
+                    ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
+                        .await?,
+                );
+            }
+            let download_list = download_list
+                .as_ref()
+                .expect("download list should be loaded before upgrade resolution");
+
             is_unspecified_upgrade = true;
             // On upgrade, derive requests for all of the existing installations
             let mut minor_version_requests = IndexSet::<InstallRequest>::default();
@@ -359,12 +411,12 @@ async fn perform_install(
                 // Drop the patch and prerelease parts from the request
                 request = request.with_version(version.only_minor());
                 let install_request =
-                    InstallRequest::new(PythonRequest::Key(request), &download_list)?;
+                    InstallRequest::new(PythonRequest::Key(request), download_list)?;
                 minor_version_requests.insert(install_request);
             }
             minor_version_requests.into_iter().collect::<Vec<_>>()
         } else {
-            PythonVersionFile::discover(
+            let version_requests = PythonVersionFile::discover(
                 project_dir,
                 &VersionFileDiscoveryOptions::default()
                     .with_no_config(no_config)
@@ -390,16 +442,45 @@ async fn perform_install(
                 } else {
                     PythonRequest::Default
                 }]
-            })
-            .into_iter()
-            .map(|request| InstallRequest::new(request, &download_list))
-            .collect::<Result<Vec<_>>>()?
+            });
+
+            if download_list.is_none() {
+                download_list = Some(
+                    ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
+                        .await?,
+                );
+            }
+            let download_list = download_list
+                .as_ref()
+                .expect("download list should be loaded before version-file resolution");
+            version_requests
+                .into_iter()
+                .map(|request| InstallRequest::new(request, download_list))
+                .collect::<Result<Vec<_>>>()?
         }
+    } else if targets.len() == 1 {
+        vec![
+            InstallRequest::new_streaming(
+                PythonRequest::parse(&targets[0]),
+                &client,
+                python_downloads_json_url.as_deref(),
+            )
+            .await?,
+        ]
     } else {
+        if download_list.is_none() {
+            download_list = Some(
+                ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
+                    .await?,
+            );
+        }
+        let download_list = download_list
+            .as_ref()
+            .expect("download list should be loaded before multi-target resolution");
         targets
             .iter()
             .map(|target| PythonRequest::parse(target.as_str()))
-            .map(|request| InstallRequest::new(request, &download_list))
+            .map(|request| InstallRequest::new(request, download_list))
             .collect::<Result<Vec<_>>>()?
     };
 
@@ -456,6 +537,17 @@ async fn perform_install(
         }
     }
 
+    let reinstall_download_list = if reinstall
+        && requests
+            .iter()
+            .any(|request| matches!(&request.request, &PythonRequest::Any))
+        && download_list.is_none()
+    {
+        Some(ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?)
+    } else {
+        None
+    };
+
     // Find requests that are already satisfied
     let mut changelog = Changelog::default();
     let (satisfied, unsatisfied): (Vec<_>, Vec<_>) = if reinstall {
@@ -482,7 +574,10 @@ async fn perform_install(
                     // Construct an install request matching the existing installation
                     match InstallRequest::new(
                         PythonRequest::Key(installation.into()),
-                        &download_list,
+                        download_list
+                            .as_ref()
+                            .or(reinstall_download_list.as_ref())
+                            .expect("reinstall Any requests should have a download list"),
                     ) {
                         Ok(request) => {
                             debug!("Will reinstall `{}`", installation.key());
@@ -590,9 +685,9 @@ async fn perform_install(
                 request.download, request,
             );
         })
-        .map(|request| request.download)
+        .map(|request| request.download.as_ref())
         // Ensure we only download each version once
-        .unique_by(|download| download.key())
+        .unique_by(|download| download.key().clone())
         .collect::<Vec<_>>();
 
     // Download and unpack the Python versions concurrently
@@ -601,7 +696,7 @@ async fn perform_install(
     let mut tasks = futures::stream::iter(&downloads)
         .map(async |download| {
             (
-                *download,
+                download,
                 download
                     .fetch_with_retry(
                         &client,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -91,6 +91,7 @@ impl<'a> InstallRequest<'a> {
         request: PythonRequest,
         client: &uv_client::BaseClient,
         python_downloads_json_url: Option<&str>,
+        cache: &Cache,
     ) -> Result<InstallRequest<'static>> {
         let download_request = PythonDownloadRequest::from_request(&request)
             .ok_or_else(|| {
@@ -104,6 +105,7 @@ impl<'a> InstallRequest<'a> {
         let download = match ManagedPythonDownloadList::find_streaming(
             client,
             python_downloads_json_url,
+            Some(cache),
             &download_request,
         )
         .await
@@ -286,6 +288,7 @@ pub(crate) async fn install(
         no_config,
         compile_bytecode.then_some(sender),
         concurrency,
+        cache,
         preview,
         printer,
     );
@@ -345,6 +348,7 @@ async fn perform_install(
     no_config: bool,
     bytecode_compilation_sender: Option<mpsc::UnboundedSender<ManagedPythonInstallation>>,
     concurrency: &Concurrency,
+    cache: &Cache,
     preview: Preview,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -393,13 +397,15 @@ async fn perform_install(
         ) {
             if download_list.is_none() {
                 download_list = Some(
-                    ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
-                        .await?,
+                    ManagedPythonDownloadList::new(
+                        &client,
+                        python_downloads_json_url.as_deref(),
+                        Some(cache),
+                    )
+                    .await?,
                 );
             }
-            let download_list = download_list
-                .as_ref()
-                .expect("download list should be loaded before upgrade resolution");
+            let download_list = download_list.as_ref().unwrap();
 
             is_unspecified_upgrade = true;
             // On upgrade, derive requests for all of the existing installations
@@ -446,13 +452,15 @@ async fn perform_install(
 
             if download_list.is_none() {
                 download_list = Some(
-                    ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
-                        .await?,
+                    ManagedPythonDownloadList::new(
+                        &client,
+                        python_downloads_json_url.as_deref(),
+                        Some(cache),
+                    )
+                    .await?,
                 );
             }
-            let download_list = download_list
-                .as_ref()
-                .expect("download list should be loaded before version-file resolution");
+            let download_list = download_list.as_ref().unwrap();
             version_requests
                 .into_iter()
                 .map(|request| InstallRequest::new(request, download_list))
@@ -464,19 +472,22 @@ async fn perform_install(
                 PythonRequest::parse(&targets[0]),
                 &client,
                 python_downloads_json_url.as_deref(),
+                cache,
             )
             .await?,
         ]
     } else {
         if download_list.is_none() {
             download_list = Some(
-                ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref())
-                    .await?,
+                ManagedPythonDownloadList::new(
+                    &client,
+                    python_downloads_json_url.as_deref(),
+                    Some(cache),
+                )
+                .await?,
             );
         }
-        let download_list = download_list
-            .as_ref()
-            .expect("download list should be loaded before multi-target resolution");
+        let download_list = download_list.as_ref().unwrap();
         targets
             .iter()
             .map(|target| PythonRequest::parse(target.as_str()))
@@ -543,7 +554,14 @@ async fn perform_install(
             .any(|request| matches!(&request.request, &PythonRequest::Any))
         && download_list.is_none()
     {
-        Some(ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?)
+        Some(
+            ManagedPythonDownloadList::new(
+                &client,
+                python_downloads_json_url.as_deref(),
+                Some(cache),
+            )
+            .await?,
+        )
     } else {
         None
     };
@@ -577,7 +595,7 @@ async fn perform_install(
                         download_list
                             .as_ref()
                             .or(reinstall_download_list.as_ref())
-                            .expect("reinstall Any requests should have a download list"),
+                            .unwrap(),
                     ) {
                         Ok(request) => {
                             debug!("Will reinstall `{}`", installation.key());

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -106,7 +106,6 @@ pub(crate) async fn list(
                 }
             }
         }
-        // Include pre-release versions
         .map(|request| request.with_prereleases(true))
     } else {
         None
@@ -118,6 +117,7 @@ pub(crate) async fn list(
         let download_list = ManagedPythonDownloadList::new_filtered(
             &client,
             python_downloads_json_url.as_deref(),
+            Some(cache),
             Some(download_request),
             None,
         )

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -81,12 +81,8 @@ pub(crate) async fn list(
         PythonDownloadRequest::from_request(request.as_ref().unwrap_or(&PythonRequest::Any))
     };
 
-    let client = client_builder.build()?;
-    let download_list =
-        ManagedPythonDownloadList::new(&client, python_downloads_json_url.as_deref()).await?;
-    let mut output = BTreeSet::new();
-    if let Some(base_download_request) = base_download_request {
-        let download_request = match kinds {
+    let download_request = if let Some(base_download_request) = base_download_request {
+        match kinds {
             PythonListKinds::Installed => None,
             PythonListKinds::Downloads => Some(if all_platforms {
                 base_download_request
@@ -111,13 +107,23 @@ pub(crate) async fn list(
             }
         }
         // Include pre-release versions
-        .map(|request| request.with_prereleases(true));
+        .map(|request| request.with_prereleases(true))
+    } else {
+        None
+    };
 
-        let downloads = download_request
-            .as_ref()
-            .map(|request| download_list.iter_matching(request))
-            .into_iter()
-            .flatten()
+    let mut output = BTreeSet::new();
+    if let Some(download_request) = &download_request {
+        let client = client_builder.build()?;
+        let download_list = ManagedPythonDownloadList::new_filtered(
+            &client,
+            python_downloads_json_url.as_deref(),
+            Some(download_request),
+            None,
+        )
+        .await?;
+        let downloads = download_list
+            .iter_matching(download_request)
             // TODO(zanieb): Add a way to show debug downloads, we just hide them for now
             .filter(|download| !download.key().variant().is_debug());
 

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -100,6 +100,7 @@ pub(crate) async fn pin(
                     ManagedPythonDownloadList::new(
                         &download_list_client,
                         install_mirrors.python_downloads_json_url.as_deref(),
+                        Some(cache),
                     )
                     .await?,
                 )

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -470,9 +470,9 @@ fn help_subsubcommand() {
     Download and install Python versions.
 
     Supports CPython and PyPy. CPython distributions are downloaded from the Astral
-    `python-build-standalone` project. PyPy distributions are downloaded from `python.org`. The
-    available Python versions are bundled with each uv release. To install new Python versions, you may
-    need upgrade uv.
+    `python-build-standalone` project. PyPy distributions are downloaded from `python.org`. Available
+    CPython versions are fetched at runtime and fall back to metadata bundled with each uv release if
+    that fetch fails.
 
     Python versions are installed into the uv Python directory, which can be retrieved with `uv python
     dir`.
@@ -540,7 +540,7 @@ fn help_subsubcommand() {
               Distributions can be read from a local directory by using the `file://` URL scheme.
 
           --python-downloads-json-url <PYTHON_DOWNLOADS_JSON_URL>
-              URL pointing to JSON of custom Python installations
+              URL pointing to JSON or NDJSON describing custom Python installations
 
       -r, --reinstall
               Reinstall the requested Python version, if it's already installed.
@@ -834,7 +834,7 @@ fn help_flag_subsubcommand() {
           --pypy-mirror <PYPY_MIRROR>
               Set the URL to use as the source for downloading PyPy installations
           --python-downloads-json-url <PYTHON_DOWNLOADS_JSON_URL>
-              URL pointing to JSON of custom Python installations
+              URL pointing to JSON or NDJSON describing custom Python installations
       -r, --reinstall
               Reinstall the requested Python version, if it's already installed
       -f, --force

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -4,6 +4,8 @@ use assert_fs::{fixture::FileWriteStr, prelude::PathCreateDir};
 use indoc::indoc;
 
 use uv_platform::{Arch, Os};
+use uv_python::PythonRequest;
+use uv_python::downloads::{ManagedPythonDownloadList, PythonDownloadRequest};
 use uv_static::EnvVars;
 
 use uv_test::{uv_snapshot, venv_bin_path};
@@ -1480,6 +1482,61 @@ fn python_find_prerelease_version_specifiers() {
     [TEMP_DIR]/managed/cpython-3.14.0-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
 
     ----- stderr -----
+    ");
+}
+
+#[test]
+#[cfg(feature = "test-python-managed")]
+fn python_find_prerelease_warning_with_ndjson_manifest() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_python_sources()
+        .with_managed_python_dirs()
+        .with_python_download_cache()
+        .with_filtered_python_install_bin()
+        .with_filtered_python_names()
+        .with_filtered_exe_suffix();
+
+    context.python_install().arg("3.14.0rc3").assert().success();
+
+    let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.14"))
+        .unwrap()
+        .fill()
+        .unwrap();
+    let download = download_list.find(&download_request).unwrap();
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download.sha256().unwrap();
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context
+        .python_find()
+        .arg("3.14")
+        .arg("--resolve-links")
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            manifest.path(),
+        ), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/managed/cpython-3.14.0rc3-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+
+    ----- stderr -----
+    warning: You're using a pre-release version of Python (3.14.0rc3) but a stable version is available. Use `uv python upgrade 3.14` to upgrade.
     ");
 }
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -4713,24 +4713,19 @@ fn python_install_with_ndjson_manifest() {
         .with_empty_python_install_mirror()
         .with_python_download_cache();
 
-    let download_list =
-        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
+    let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
     let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.14"))
-        .expect("Python request should map to a download request")
+        .unwrap()
         .fill()
-        .expect("download request should be fillable");
-    let download = download_list
-        .find(&download_request)
-        .expect("embedded downloads should contain CPython 3.14");
+        .unwrap();
+    let download = download_list.find(&download_request).unwrap();
 
     let version = if let Some(build) = download.build() {
         format!("{}+{build}", download.key().version())
     } else {
         download.key().version().to_string()
     };
-    let sha256 = download
-        .sha256()
-        .expect("download should include a checksum");
+    let sha256 = download.sha256().unwrap();
     let manifest = context.temp_dir.child("python-downloads.ndjson");
     manifest
         .write_str(&format!(
@@ -4739,7 +4734,7 @@ fn python_install_with_ndjson_manifest() {
             download.key().platform().as_cargo_dist_triple(),
             sha256,
         ))
-        .expect("manifest should be writable");
+        .unwrap();
 
     uv_snapshot!(context.filters(), context
         .python_install()
@@ -4767,24 +4762,19 @@ fn python_install_with_debug_ndjson_manifest() {
         .with_empty_python_install_mirror()
         .with_python_download_cache();
 
-    let download_list =
-        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
+    let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
     let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.12d"))
-        .expect("Python request should map to a download request")
+        .unwrap()
         .fill()
-        .expect("download request should be fillable");
-    let download = download_list
-        .find(&download_request)
-        .expect("embedded downloads should contain debug CPython 3.12");
+        .unwrap();
+    let download = download_list.find(&download_request).unwrap();
 
     let version = if let Some(build) = download.build() {
         format!("{}+{build}", download.key().version())
     } else {
         download.key().version().to_string()
     };
-    let sha256 = download
-        .sha256()
-        .expect("download should include a checksum");
+    let sha256 = download.sha256().unwrap();
     let manifest = context.temp_dir.child("python-downloads.ndjson");
     manifest
         .write_str(&format!(
@@ -4793,7 +4783,7 @@ fn python_install_with_debug_ndjson_manifest() {
             download.key().platform().as_cargo_dist_triple(),
             sha256,
         ))
-        .expect("manifest should be writable");
+        .unwrap();
 
     uv_snapshot!(context.filters(), context
         .python_install()

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -15,6 +15,8 @@ use tracing::debug;
 use uv_test::{LATEST_PYTHON_3_12, uv_snapshot};
 
 use uv_fs::Simplified;
+use uv_python::PythonRequest;
+use uv_python::downloads::{ManagedPythonDownloadList, PythonDownloadRequest};
 use uv_python::managed::platform_key_from_env;
 use uv_static::EnvVars;
 use walkdir::WalkDir;
@@ -4698,5 +4700,112 @@ fn python_install_compile_bytecode_pypy() {
     Installed Python 3.11.15 in [TIME]
      + pypy-3.11.15-[PLATFORM] (pypy3.11)
     Bytecode compiled [COUNT] files in [TIME]
+    ");
+}
+
+#[test]
+fn python_install_with_ndjson_manifest() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    let download_list =
+        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.14"))
+        .expect("Python request should map to a download request")
+        .fill()
+        .expect("download request should be fillable");
+    let download = download_list
+        .find(&download_request)
+        .expect("embedded downloads should contain CPython 3.14");
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download
+        .sha256()
+        .expect("download should include a checksum");
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .expect("manifest should be writable");
+
+    uv_snapshot!(context.filters(), context
+        .python_install()
+        .arg("3.14")
+        .arg("--python-downloads-json-url")
+        .arg(manifest.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.14.[LATEST] in [TIME]
+     + cpython-3.14.[LATEST]-[PLATFORM] (python3.14)
+    ");
+}
+
+#[cfg(unix)]
+#[test]
+fn python_install_with_debug_ndjson_manifest() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    let download_list =
+        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.12d"))
+        .expect("Python request should map to a download request")
+        .fill()
+        .expect("download request should be fillable");
+    let download = download_list
+        .find(&download_request)
+        .expect("embedded downloads should contain debug CPython 3.12");
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download
+        .sha256()
+        .expect("download should include a checksum");
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"debug+full\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .expect("manifest should be writable");
+
+    uv_snapshot!(context.filters(), context
+        .python_install()
+        .arg("3.12d")
+        .arg("--python-downloads-json-url")
+        .arg(manifest.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.12.[LATEST] in [TIME]
+     + cpython-3.12.[LATEST]+debug-[PLATFORM] (python3.12d)
     ");
 }

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -1,4 +1,9 @@
+use assert_fs::fixture::FileWriteStr;
+use assert_fs::prelude::PathChild;
+
 use uv_platform::{Arch, Os};
+use uv_python::PythonRequest;
+use uv_python::downloads::{ManagedPythonDownloadList, PythonDownloadRequest};
 use uv_static::EnvVars;
 
 use anyhow::Result;
@@ -129,6 +134,131 @@ fn python_list() {
 
     ----- stderr -----
     ");
+}
+
+#[test]
+fn python_list_implicit_ndjson_source_preserves_non_cpython_downloads() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+
+    let download_list =
+        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.10"))
+        .expect("Python request should map to a download request")
+        .fill()
+        .expect("download request should be fillable");
+    let download = download_list
+        .find(&download_request)
+        .expect("embedded downloads should contain CPython 3.10");
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download
+        .sha256()
+        .expect("download should include a checksum");
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .expect("manifest should be writable");
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .arg("3.10")
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            manifest.path(),
+        ), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
+    pypy-3.10.16-[PLATFORM]       <download available>
+    graalpy-3.10.0-[PLATFORM]     <download available>
+
+    ----- stderr -----
+    ");
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_falls_back_to_embedded() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_collapsed_whitespace()
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            format!("{}/versions.ndjson", server.uri()),
+        )
+        .arg("3.10"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM] <download available>
+    pypy-3.10.16-[PLATFORM] <download available>
+    graalpy-3.10.0-[PLATFORM] <download available>
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_parse_error_falls_back() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_collapsed_whitespace()
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("{", "application/x-ndjson"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            format!("{}/versions.ndjson", server.uri()),
+        )
+        .arg("3.10"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM] <download available>
+    pypy-3.10.16-[PLATFORM] <download available>
+    graalpy-3.10.0-[PLATFORM] <download available>
+
+    ----- stderr -----
+    ");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -190,6 +190,34 @@ fn python_list_implicit_ndjson_source_preserves_non_cpython_downloads() {
 }
 
 #[tokio::test]
+async fn python_list_only_installed_skips_implicit_download_metadata() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            format!("{}/versions.ndjson", server.uri()),
+        )
+        .arg("--only-installed"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    let Some(requests) = server.received_requests().await else {
+        anyhow::bail!("failed to read received requests");
+    };
+    assert_eq!(requests.len(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn python_list_remote_python_downloads_ndjson_falls_back_to_embedded() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[])
         .with_collapsed_whitespace()

--- a/crates/uv/tests/it/python_list.rs
+++ b/crates/uv/tests/it/python_list.rs
@@ -1,16 +1,22 @@
 use assert_fs::fixture::FileWriteStr;
 use assert_fs::prelude::PathChild;
+use std::fmt::Write;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
-use uv_platform::{Arch, Os};
+use uv_platform::{Arch, Os, Platform};
 use uv_python::PythonRequest;
 use uv_python::downloads::{ManagedPythonDownloadList, PythonDownloadRequest};
 use uv_static::EnvVars;
 
 use anyhow::Result;
+use url::Url;
 use uv_test::uv_snapshot;
 use wiremock::{
-    Mock, MockServer, ResponseTemplate,
-    matchers::{method, path},
+    Mock, MockServer, Request, ResponseTemplate,
+    matchers::{header, method, path},
 };
 
 #[test]
@@ -134,159 +140,6 @@ fn python_list() {
 
     ----- stderr -----
     ");
-}
-
-#[test]
-fn python_list_implicit_ndjson_source_preserves_non_cpython_downloads() {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_filtered_python_keys()
-        .with_filtered_latest_python_versions();
-
-    let download_list =
-        ManagedPythonDownloadList::new_only_embedded().expect("embedded downloads should parse");
-    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.10"))
-        .expect("Python request should map to a download request")
-        .fill()
-        .expect("download request should be fillable");
-    let download = download_list
-        .find(&download_request)
-        .expect("embedded downloads should contain CPython 3.10");
-
-    let version = if let Some(build) = download.build() {
-        format!("{}+{build}", download.key().version())
-    } else {
-        download.key().version().to_string()
-    };
-    let sha256 = download
-        .sha256()
-        .expect("download should include a checksum");
-    let manifest = context.temp_dir.child("python-downloads.ndjson");
-    manifest
-        .write_str(&format!(
-            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
-            download.url(),
-            download.key().platform().as_cargo_dist_triple(),
-            sha256,
-        ))
-        .expect("manifest should be writable");
-
-    uv_snapshot!(context.filters(), context
-        .python_list()
-        .arg("3.10")
-        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
-        .env(
-            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
-            manifest.path(),
-        ), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
-    pypy-3.10.16-[PLATFORM]       <download available>
-    graalpy-3.10.0-[PLATFORM]     <download available>
-
-    ----- stderr -----
-    ");
-}
-
-#[tokio::test]
-async fn python_list_only_installed_skips_implicit_download_metadata() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
-    let server = MockServer::start().await;
-
-    uv_snapshot!(context.filters(), context
-        .python_list()
-        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
-        .env(
-            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
-            format!("{}/versions.ndjson", server.uri()),
-        )
-        .arg("--only-installed"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    ");
-
-    let Some(requests) = server.received_requests().await else {
-        anyhow::bail!("failed to read received requests");
-    };
-    assert_eq!(requests.len(), 0);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn python_list_remote_python_downloads_ndjson_falls_back_to_embedded() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_collapsed_whitespace()
-        .with_filtered_python_keys()
-        .with_filtered_latest_python_versions();
-    let server = MockServer::start().await;
-
-    Mock::given(method("GET"))
-        .and(path("/versions.ndjson"))
-        .respond_with(ResponseTemplate::new(404))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    uv_snapshot!(context.filters(), context
-        .python_list()
-        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
-        .env(
-            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
-            format!("{}/versions.ndjson", server.uri()),
-        )
-        .arg("3.10"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    cpython-3.10.[LATEST]-[PLATFORM] <download available>
-    pypy-3.10.16-[PLATFORM] <download available>
-    graalpy-3.10.0-[PLATFORM] <download available>
-
-    ----- stderr -----
-    ");
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn python_list_remote_python_downloads_ndjson_parse_error_falls_back() -> Result<()> {
-    let context = uv_test::test_context_with_versions!(&[])
-        .with_collapsed_whitespace()
-        .with_filtered_python_keys()
-        .with_filtered_latest_python_versions();
-    let server = MockServer::start().await;
-
-    Mock::given(method("GET"))
-        .and(path("/versions.ndjson"))
-        .respond_with(ResponseTemplate::new(200).set_body_raw("{", "application/x-ndjson"))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    uv_snapshot!(context.filters(), context
-        .python_list()
-        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
-        .env(
-            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
-            format!("{}/versions.ndjson", server.uri()),
-        )
-        .arg("3.10"), @"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    cpython-3.10.[LATEST]-[PLATFORM] <download available>
-    pypy-3.10.16-[PLATFORM] <download available>
-    graalpy-3.10.0-[PLATFORM] <download available>
-
-    ----- stderr -----
-    ");
-
-    Ok(())
 }
 
 #[test]
@@ -572,6 +425,118 @@ fn python_list_downloads() {
 }
 
 #[test]
+fn python_list_implicit_ndjson_source_preserves_non_cpython_downloads() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+
+    let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.10"))
+        .unwrap()
+        .fill()
+        .unwrap();
+    let download = download_list.find(&download_request).unwrap();
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download.sha256().unwrap();
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .arg("3.10")
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(
+            EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+            manifest.path(),
+        ), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM]    <download available>
+    pypy-3.10.16-[PLATFORM]       <download available>
+    graalpy-3.10.0-[PLATFORM]     <download available>
+
+    ----- stderr -----
+    ");
+}
+
+#[tokio::test]
+async fn python_list_only_installed_skips_implicit_download_metadata() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL, format!("{}/versions.ndjson", server.uri()))
+        .arg("--only-installed"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    let Some(requests) = server.received_requests().await else {
+        anyhow::bail!("failed to read received requests");
+    };
+    assert_eq!(requests.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn python_list_does_not_limit_before_deduplication() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_collapsed_whitespace()
+        .with_filtered_python_keys();
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    let platform = Platform::from_env()?.as_cargo_dist_triple();
+    let mut contents = String::new();
+
+    for patch in 1..=200 {
+        writeln!(
+            contents,
+            r#"{{"version":"3.14.{patch}","artifacts":[{{"url":"https://custom.com/cpython-3.14.{patch}-{platform}.tar.gz","platform":"{platform}","sha256":"abc123","variant":"install_only"}}]}}"#
+        )?;
+    }
+    writeln!(
+        contents,
+        r#"{{"version":"3.13.0","artifacts":[{{"url":"https://custom.com/cpython-3.13.0-{platform}.tar.gz","platform":"{platform}","sha256":"abc123","variant":"install_only"}}]}}"#
+    )?;
+    manifest.write_str(&contents)?;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--only-downloads")
+        .arg("--python-downloads-json-url")
+        .arg(manifest.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.200-[PLATFORM] <download available>
+    cpython-3.13.0-[PLATFORM] <download available>
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-python-managed")]
 fn python_list_downloads_installed() {
     use assert_cmd::assert::OutputAssertExt;
@@ -809,6 +774,469 @@ async fn python_list_remote_python_downloads_json_url() -> Result<()> {
     ----- stderr -----
     error: Unable to parse the JSON Python download list at http://[LOCALHOST]/invalid
       Caused by: EOF while parsing an object at line 1 column 1
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_url() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    let remote_ndjson = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/cpython-3.14.1-aarch64-apple-darwin-install_only.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"},{"url":"https://custom.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only_stripped"}]}
+{"version":"3.13.2+20260420","artifacts":[{"url":"https://custom.com/cpython-3.13.2-x86_64-unknown-linux-gnu-freethreaded-pgo-lto-full.tar.gz","platform":"x86_64-unknown-linux-gnu","sha256":"ghi789","variant":"freethreaded+pgo+lto+full"}]}
+{"version":"3.10.0+20211017","artifacts":[{"url":"https://custom.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst","platform":"x86_64-unknown-linux-gnu","sha256":"jkl012","variant":"pgo+lto+full"}]}
+"#;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson, "application/x-ndjson"),
+        )
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/invalid.ndjson"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("{", "application/x-ndjson"))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--all-versions")
+        .arg("--all-platforms")
+        .arg("--all-arches")
+        .arg("--show-urls")
+        .arg("--python-downloads-json-url").arg(format!("{}/versions.ndjson", server.uri())), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz
+    cpython-3.13.2+freethreaded-linux-x86_64-gnu https://custom.com/cpython-3.13.2-x86_64-unknown-linux-gnu-freethreaded-pgo-lto-full.tar.gz
+    cpython-3.10.0-linux-x86_64-gnu https://custom.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--all-versions")
+        .arg("--all-platforms")
+        .arg("--all-arches")
+        .arg("--show-urls")
+        .arg("--python-downloads-json-url").arg(format!("{}/versions.ndjson?token=secret", server.uri())), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin-install_only_stripped.tar.gz
+    cpython-3.13.2+freethreaded-linux-x86_64-gnu https://custom.com/cpython-3.13.2-x86_64-unknown-linux-gnu-freethreaded-pgo-lto-full.tar.gz
+    cpython-3.10.0-linux-x86_64-gnu https://custom.com/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo-lto-full.tar.zst
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--python-downloads-json-url").arg(format!("{}/404.ndjson", server.uri())), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Error while fetching remote python downloads NDJSON from 'http://[LOCALHOST]/404.ndjson'
+     Caused by: Failed to download http://[LOCALHOST]/404.ndjson
+     Caused by: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/404.ndjson)
+    ");
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .arg("--python-downloads-json-url").arg(format!("{}/invalid.ndjson", server.uri())), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unable to parse NDJSON line at http://[LOCALHOST]/invalid.ndjson
+     Caused by: EOF while parsing an object at line 1 column 1
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_default_source() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    let remote_ndjson = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Length", remote_ndjson.len().to_string())
+                .insert_header("ETag", "\"v1\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson, "application/x-ndjson"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL, format!("{}/versions.ndjson", server.uri()))
+        .arg("3.14")
+        .arg("--all-versions")
+        .arg("--all-platforms")
+        .arg("--all-arches")
+        .arg("--show-urls"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_cache_reuse() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    let remote_ndjson = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Length", remote_ndjson.len().to_string())
+                .insert_header("ETag", "\"v1\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson, "application/x-ndjson"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let command = || {
+        let mut command = context.python_list();
+        command
+            .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+            .env(
+                EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL,
+                format!("{}/versions.ndjson", server.uri()),
+            )
+            .arg("3.14")
+            .arg("--all-versions")
+            .arg("--all-platforms")
+            .arg("--all-arches")
+            .arg("--show-urls");
+        command
+    };
+
+    uv_snapshot!(context.filters(), command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_parse_error_is_not_cached() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    let invalid_ndjson = "{";
+    let valid_ndjson = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+"#;
+
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let response_get_count = Arc::clone(&get_count);
+    Mock::given(path("/versions.ndjson"))
+        .respond_with(move |request: &Request| {
+            if request.method.as_str() == "HEAD" {
+                if response_get_count.load(Ordering::SeqCst) == 0 {
+                    return ResponseTemplate::new(200)
+                        .insert_header("Content-Length", invalid_ndjson.len().to_string())
+                        .insert_header("ETag", "\"invalid\"");
+                }
+
+                return ResponseTemplate::new(200)
+                    .insert_header("Content-Length", valid_ndjson.len().to_string())
+                    .insert_header("ETag", "\"valid\"");
+            }
+
+            if request.method.as_str() == "GET" {
+                if response_get_count.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return ResponseTemplate::new(200)
+                        .set_body_raw(invalid_ndjson, "application/x-ndjson");
+                }
+
+                return ResponseTemplate::new(200)
+                    .set_body_raw(valid_ndjson, "application/x-ndjson");
+            }
+
+            ResponseTemplate::new(405)
+        })
+        .mount(&server)
+        .await;
+
+    let command = || {
+        let mut command = context.python_list();
+        command
+            .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+            .arg("3.14")
+            .arg("--all-versions")
+            .arg("--all-platforms")
+            .arg("--all-arches")
+            .arg("--show-urls")
+            .arg("--python-downloads-json-url")
+            .arg(format!("{}/versions.ndjson", server.uri()));
+        command
+    };
+
+    uv_snapshot!(context.filters(), command(), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unable to parse NDJSON line at http://[LOCALHOST]/versions.ndjson
+     Caused by: EOF while parsing an object at line 1 column 1
+    ");
+
+    uv_snapshot!(context.filters(), command(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/cpython-3.14.1-aarch64-apple-darwin.tar.gz
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_cache_keys_include_credentials() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]).with_collapsed_whitespace();
+    let server = MockServer::start().await;
+
+    let remote_ndjson_a = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/token-a.tar.gz","platform":"aarch64-apple-darwin","sha256":"abc123","variant":"install_only"}]}
+"#;
+    let remote_ndjson_b = r#"{"version":"3.14.1+20260420","artifacts":[{"url":"https://custom.com/token-b.tar.gz","platform":"aarch64-apple-darwin","sha256":"def456","variant":"install_only"}]}
+"#;
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .and(header("authorization", "Basic dXNlcjp0b2tlbkE="))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Length", remote_ndjson_a.len().to_string())
+                .insert_header("ETag", "\"token-a\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .and(header("authorization", "Basic dXNlcjp0b2tlbkE="))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson_a, "application/x-ndjson"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .and(header("authorization", "Basic dXNlcjp0b2tlbkI="))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Length", remote_ndjson_b.len().to_string())
+                .insert_header("ETag", "\"token-b\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .and(header("authorization", "Basic dXNlcjp0b2tlbkI="))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson_b, "application/x-ndjson"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let metadata_url = |password: &str| {
+        let mut url = Url::parse(&server.uri()).expect("mock server URI should be valid");
+        url.set_path("versions.ndjson");
+        url.set_username("user")
+            .expect("mock username should be valid");
+        url.set_password(Some(password))
+            .expect("mock password should be valid");
+        url.to_string()
+    };
+
+    let command = |metadata_url: String| {
+        let mut command = context.python_list();
+        command
+            .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+            .arg("3.14")
+            .arg("--all-versions")
+            .arg("--all-platforms")
+            .arg("--all-arches")
+            .arg("--show-urls")
+            .arg("--python-downloads-json-url")
+            .arg(metadata_url);
+        command
+    };
+
+    uv_snapshot!(context.filters(), command(metadata_url("tokenA")), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/token-a.tar.gz
+
+    ----- stderr -----
+    ");
+
+    uv_snapshot!(context.filters(), command(metadata_url("tokenB")), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.14.1-macos-aarch64-none https://custom.com/token-b.tar.gz
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_falls_back_to_embedded() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_collapsed_whitespace()
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+    let server = MockServer::start().await;
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL, format!("{}/versions.ndjson", server.uri()))
+        .arg("3.10"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM] <download available>
+    pypy-3.10.16-[PLATFORM] <download available>
+    graalpy-3.10.0-[PLATFORM] <download available>
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn python_list_remote_python_downloads_ndjson_parse_error_falls_back() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_collapsed_whitespace()
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions();
+    let server = MockServer::start().await;
+    let remote_ndjson = "{";
+
+    Mock::given(method("HEAD"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("Content-Length", remote_ndjson.len().to_string())
+                .insert_header("ETag", "\"v1\""),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/versions.ndjson"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(remote_ndjson, "application/x-ndjson"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_list()
+        .env_remove(EnvVars::UV_PYTHON_DOWNLOADS)
+        .env(EnvVars::UV_INTERNAL__TEST_PYTHON_DOWNLOADS_JSON_URL, format!("{}/versions.ndjson", server.uri()))
+        .arg("3.10"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.10.[LATEST]-[PLATFORM] <download available>
+    pypy-3.10.16-[PLATFORM] <download available>
+    graalpy-3.10.0-[PLATFORM] <download available>
+
+    ----- stderr -----
     ");
 
     Ok(())

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -5,7 +5,8 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCreateDir};
 use insta::assert_snapshot;
 use uv_platform::{Arch, Os};
-use uv_python::{PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME};
+use uv_python::downloads::{ManagedPythonDownloadList, PythonDownloadRequest};
+use uv_python::{PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME, PythonRequest};
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
 use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
@@ -870,6 +871,117 @@ fn python_pin_install() {
 
     ----- stderr -----
     ");
+}
+
+#[test]
+#[cfg(feature = "test-python-managed")]
+fn python_pin_with_ndjson_manifest() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_sources()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    let download_list = ManagedPythonDownloadList::new_only_embedded().unwrap();
+    let download_request = PythonDownloadRequest::from_request(&PythonRequest::parse("3.12"))
+        .unwrap()
+        .fill()
+        .unwrap();
+    let download = download_list.find(&download_request).unwrap();
+
+    let version = if let Some(build) = download.build() {
+        format!("{}+{build}", download.key().version())
+    } else {
+        download.key().version().to_string()
+    };
+    let sha256 = download.sha256().unwrap();
+    let manifest = context.temp_dir.child("python-downloads.ndjson");
+    manifest
+        .write_str(&format!(
+            "{{\"version\":\"{version}\",\"artifacts\":[{{\"url\":\"{}\",\"platform\":\"{}\",\"sha256\":\"{}\",\"variant\":\"install_only\"}}]}}\n",
+            download.url(),
+            download.key().platform().as_cargo_dist_triple(),
+            sha256,
+        ))
+        .unwrap();
+
+    uv_snapshot!(context.filters(), context
+        .python_pin()
+        .arg("3.12")
+        .arg("--python-downloads-json-url")
+        .arg(manifest.path())
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "auto"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Pinned `.python-version` to `3.12`
+
+    ----- stderr -----
+    ");
+}
+
+#[tokio::test]
+#[cfg(feature = "test-python-managed")]
+async fn python_pin_custom_ndjson_url_does_not_fallback() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_sources()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+    let server = MockServer::start().await;
+
+    uv_snapshot!(context.filters(), context
+        .python_pin()
+        .arg("--resolved")
+        .arg("3.12")
+        .arg("--python-downloads-json-url")
+        .arg(format!("{}/versions.ndjson", server.uri()))
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "auto"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Error while fetching remote python downloads NDJSON from 'http://[LOCALHOST]/versions.ndjson'
+      Caused by: Failed to download http://[LOCALHOST]/versions.ndjson
+      Caused by: HTTP status client error (404 Not Found) for url (http://[LOCALHOST]/versions.ndjson)
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(feature = "test-python-managed")]
+async fn python_pin_custom_ndjson_url_reports_parse_errors() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_sources()
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("{", "application/x-ndjson"))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_pin()
+        .arg("--resolved")
+        .arg("3.12")
+        .arg("--python-downloads-json-url")
+        .arg(format!("{}/versions.ndjson", server.uri()))
+        .env(EnvVars::UV_PYTHON_DOWNLOADS, "auto"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unable to parse NDJSON line at http://[LOCALHOST]/versions.ndjson
+      Caused by: EOF while parsing an object at line 1 column 1
+    ");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -14275,7 +14275,7 @@ fn sync_python_missing_download_hint() -> Result<()> {
     ----- stderr -----
     error: No interpreter found for Python 3.100 in [PYTHON SOURCES]
 
-    hint: uv embeds available Python downloads and may require an update to install new versions. Consider retrying on a newer version of uv.
+    hint: uv fetches available Python downloads at runtime and falls back to embedded metadata on failure. If this is a newly released Python version, retry later.
     ");
 
     Ok(())

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -118,8 +118,8 @@ present, uv will install all the Python versions listed in the file.
 
 !!! important
 
-    The available Python versions are frozen for each uv release. To install new Python versions,
-    you may need upgrade uv.
+    Available CPython versions are fetched at runtime and fall back to metadata bundled with each
+    uv release if that fetch fails.
 
 See the [storage documentation](../reference/storage.md#python-versions) for details about where
 installed Python versions are stored.

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -462,7 +462,7 @@
       ]
     },
     "python-downloads-json-url": {
-      "description": "URL pointing to JSON of custom Python installations.",
+      "description": "URL pointing to JSON or NDJSON describing custom Python installations.",
       "type": ["string", "null"]
     },
     "python-install-mirror": {


### PR DESCRIPTION
Use the ndjson-based version metadata for PBS available at `releases.astral.sh` (falling back to github).

- fall back to the baked-in metadata in case of fetch errors
- cache the fetched metadata
- stream the metadata line by line, prepending to the already cached ones