### PR TITLE
Add support for AuthScheme::None to opt-out of authentication

### DIFF
--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -33,6 +33,8 @@ pub enum Credentials {
         /// The token to use for authentication.
         token: Token,
     },
+    /// No authentication.
+    None,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
@@ -155,6 +157,7 @@ impl Credentials {
         match self {
             Self::Basic { username, .. } => username.as_deref(),
             Self::Bearer { .. } => None,
+            Self::None => None,
         }
     }
 
@@ -162,6 +165,7 @@ impl Credentials {
         match self {
             Self::Basic { username, .. } => username.clone(),
             Self::Bearer { .. } => Username::none(),
+            Self::None => Username::none(),
         }
     }
 
@@ -169,6 +173,7 @@ impl Credentials {
         match self {
             Self::Basic { username, .. } => Cow::Borrowed(username),
             Self::Bearer { .. } => Cow::Owned(Username::none()),
+            Self::None => Cow::Owned(Username::none()),
         }
     }
 
@@ -176,6 +181,7 @@ impl Credentials {
         match self {
             Self::Basic { password, .. } => password.as_ref().map(Password::as_str),
             Self::Bearer { .. } => None,
+            Self::None => None,
         }
     }
 
@@ -186,6 +192,7 @@ impl Credentials {
                 password,
             } => password.is_some(),
             Self::Bearer { token } => !token.is_empty(),
+            Self::None => true,
         }
     }
 
@@ -193,6 +200,16 @@ impl Credentials {
         match self {
             Self::Basic { username, password } => username.is_none() && password.is_none(),
             Self::Bearer { token } => token.is_empty(),
+            Self::None => false,
+        }
+    }
+
+    /// Return the name of the authentication scheme.
+    pub fn scheme_name(&self) -> &'static str {
+        match self {
+            Self::Basic { .. } => "HTTP Basic",
+            Self::Bearer { .. } => "Bearer",
+            Self::None => "None",
         }
     }
 
@@ -328,8 +345,10 @@ impl Credentials {
 
     /// Create an HTTP Basic Authentication header for the credentials.
     ///
+    /// Returns `None` if the credentials are [`Credentials::None`].
+    ///
     /// Panics if the username or password cannot be base64 encoded.
-    pub fn to_header_value(&self) -> HeaderValue {
+    pub fn to_header_value(&self) -> Option<HeaderValue> {
         match self {
             Self::Basic { .. } => {
                 // See: <https://github.com/seanmonstar/reqwest/blob/2c11ef000b151c2eebeed2c18a7b81042220c6b0/src/util.rs#L3>
@@ -346,14 +365,15 @@ impl Credentials {
                 let mut header =
                     HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
                 header.set_sensitive(true);
-                header
+                Some(header)
             }
             Self::Bearer { token } => {
                 let mut header = HeaderValue::from_bytes(&[b"Bearer ", token.as_slice()].concat())
                     .expect("Bearer token is always valid HeaderValue");
                 header.set_sensitive(true);
-                header
+                Some(header)
             }
+            Self::None => None,
         }
     }
 
@@ -376,9 +396,11 @@ impl Credentials {
     /// Any existing credentials will be overridden.
     #[must_use]
     pub fn authenticate(&self, mut request: Request) -> Request {
-        request
-            .headers_mut()
-            .insert(reqwest::header::AUTHORIZATION, Self::to_header_value(self));
+        if let Some(header) = self.to_header_value() {
+            request
+                .headers_mut()
+                .insert(reqwest::header::AUTHORIZATION, header);
+        }
         request
     }
 }

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -350,30 +350,39 @@ impl Credentials {
     /// Panics if the username or password cannot be base64 encoded.
     pub fn to_header_value(&self) -> Option<HeaderValue> {
         match self {
-            Self::Basic { .. } => {
-                // See: <https://github.com/seanmonstar/reqwest/blob/2c11ef000b151c2eebeed2c18a7b81042220c6b0/src/util.rs#L3>
-                let mut buf = b"Basic ".to_vec();
-                {
-                    let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
-                    write!(encoder, "{}:", self.username().unwrap_or_default())
-                        .expect("Write to base64 encoder should succeed");
-                    if let Some(password) = self.password() {
-                        write!(encoder, "{password}")
+            Self::None => None,
+            Self::Basic { username, password } => {
+                if username.is_some() || password.is_some() {
+                    // See: <https://github.com/seanmonstar/reqwest/blob/2c11ef000b151c2eebeed2c18a7b81042220c6b0/src/util.rs#L3>
+                    let mut buf = b"Basic ".to_vec();
+                    {
+                        let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
+                        write!(encoder, "{}:", username.as_deref().unwrap_or_default())
                             .expect("Write to base64 encoder should succeed");
+                        if let Some(password) = password {
+                            write!(encoder, "{}", password.as_str())
+                                .expect("Write to base64 encoder should succeed");
+                        }
                     }
+                    let mut header =
+                        HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
+                    header.set_sensitive(true);
+                    Some(header)
+                } else {
+                    None
                 }
-                let mut header =
-                    HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
-                header.set_sensitive(true);
-                Some(header)
             }
             Self::Bearer { token } => {
-                let mut header = HeaderValue::from_bytes(&[b"Bearer ", token.as_slice()].concat())
-                    .expect("Bearer token is always valid HeaderValue");
-                header.set_sensitive(true);
-                Some(header)
+                if token.is_empty() {
+                    None
+                } else {
+                    let mut header =
+                        HeaderValue::from_bytes(&[b"Bearer ", token.as_slice()].concat())
+                            .expect("Bearer token is always valid HeaderValue");
+                    header.set_sensitive(true);
+                    Some(header)
+                }
             }
-            Self::None => None,
         }
     }
 

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -588,7 +588,7 @@ scheme = "none"
     #[tokio::test]
     async fn test_nested_service_lookup() {
         let mut store = TextCredentialStore::default();
-        
+
         // Root service with Basic auth
         let root_service = Service::from_str("https://example.com").unwrap();
         let root_creds = Credentials::basic(Some("root".to_string()), Some("rootpass".to_string()));

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -66,6 +66,8 @@ pub enum AuthScheme {
     ///
     /// Uses a token provided as `Bearer <token>` in the `Authorization` header.
     Bearer,
+    /// No authentication.
+    None,
 }
 
 /// Errors that can occur when working with TOML credential storage.
@@ -83,6 +85,8 @@ pub enum TomlCredentialError {
     BasicAuthError(#[from] BasicAuthError),
     #[error(transparent)]
     BearerAuthError(#[from] BearerAuthError),
+    #[error(transparent)]
+    NoneAuthError(#[from] NoneAuthError),
     #[error("Failed to determine credentials directory")]
     CredentialsDirError,
     #[error("Token is not valid unicode")]
@@ -98,6 +102,7 @@ impl TomlCredentialError {
             | Self::SerializeError(_)
             | Self::BasicAuthError(_)
             | Self::BearerAuthError(_)
+            | Self::NoneAuthError(_)
             | Self::CredentialsDirError
             | Self::TokenNotUnicode(_) => None,
         }
@@ -120,6 +125,16 @@ pub enum BearerAuthError {
     UnexpectedUsername,
     #[error("`password` cannot be provided with `scheme = bearer`")]
     UnexpectedPassword,
+}
+
+#[derive(Debug, Error)]
+pub enum NoneAuthError {
+    #[error("`username` cannot be provided with `scheme = none`")]
+    Username,
+    #[error("`password` cannot be provided with `scheme = none`")]
+    Password,
+    #[error("`token` cannot be provided with `scheme = none`")]
+    Token,
 }
 
 #[derive(Debug, Error, PartialEq)]
@@ -169,6 +184,13 @@ impl From<TomlCredential> for TomlCredentialWire {
                 scheme: AuthScheme::Bearer,
                 password: None,
                 token: Some(String::from_utf8(token.into_bytes()).expect("Token is valid UTF-8")),
+            },
+            Credentials::None => Self {
+                service: value.service,
+                username: Username::new(None),
+                scheme: AuthScheme::None,
+                password: None,
+                token: None,
             },
         }
     }
@@ -221,6 +243,21 @@ impl TryFrom<TomlCredentialWire> for TomlCredential {
                 Ok(Self {
                     service: value.service,
                     credentials,
+                })
+            }
+            AuthScheme::None => {
+                if value.username.is_some() {
+                    return Err(TomlCredentialError::NoneAuthError(NoneAuthError::Username));
+                }
+                if value.password.is_some() {
+                    return Err(TomlCredentialError::NoneAuthError(NoneAuthError::Password));
+                }
+                if value.token.is_some() {
+                    return Err(TomlCredentialError::NoneAuthError(NoneAuthError::Token));
+                }
+                Ok(Self {
+                    service: value.service,
+                    credentials: Credentials::None,
                 })
             }
         }
@@ -280,6 +317,7 @@ impl TextCredentialStore {
                 let username = match &credential.credentials {
                     Credentials::Basic { username, .. } => username.clone(),
                     Credentials::Bearer { .. } => Username::none(),
+                    Credentials::None => Username::none(),
                 };
                 (
                     (credential.service.clone(), username),
@@ -400,6 +438,7 @@ impl TextCredentialStore {
         let username = match &credentials {
             Credentials::Basic { username, .. } => username.clone(),
             Credentials::Bearer { .. } => Username::none(),
+            Credentials::None => Username::none(),
         };
         self.credentials.insert((service, username), credentials)
     }
@@ -523,6 +562,66 @@ password = "pass2"
         let content = fs::read_to_string(temp_output.path()).unwrap();
         assert!(content.contains("example.com"));
         assert!(content.contains("testuser"));
+    }
+
+    #[tokio::test]
+    async fn test_auth_scheme_none() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(
+            temp_file,
+            r#"
+[[credential]]
+service = "https://example.com"
+scheme = "none"
+"#
+        )
+        .unwrap();
+
+        let store = TextCredentialStore::from_file(temp_file.path()).unwrap();
+        let url = DisplaySafeUrl::parse("https://example.com/").unwrap();
+        let cred = store.get_credentials(&url, None).unwrap().unwrap();
+        assert!(matches!(cred, Credentials::None));
+        assert!(cred.is_authenticated());
+        assert!(cred.to_header_value().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_nested_service_lookup() {
+        let mut store = TextCredentialStore::default();
+        
+        // Root service with Basic auth
+        let root_service = Service::from_str("https://example.com").unwrap();
+        let root_creds = Credentials::basic(Some("root".to_string()), Some("rootpass".to_string()));
+        store.insert(root_service, root_creds);
+
+        // Subpath service with None auth
+        let sub_service = Service::from_str("https://example.com/sub/path").unwrap();
+        let sub_creds = Credentials::None;
+        store.insert(sub_service, sub_creds);
+
+        // 1. Root URL should use root credentials
+        let url = DisplaySafeUrl::parse("https://example.com").unwrap();
+        let cred = store.get_credentials(&url, None).unwrap().unwrap();
+        assert_eq!(cred.username(), Some("root"));
+        assert_eq!(cred.scheme_name(), "HTTP Basic");
+
+        // 2. Subpath URL should use subpath credentials (None)
+        let url = DisplaySafeUrl::parse("https://example.com/sub/path").unwrap();
+        let cred = store.get_credentials(&url, None).unwrap().unwrap();
+        assert!(matches!(cred, Credentials::None));
+        assert_eq!(cred.scheme_name(), "None");
+
+        // 3. Sub-subpath URL should use subpath credentials (None)
+        let url = DisplaySafeUrl::parse("https://example.com/sub/path/extra").unwrap();
+        let cred = store.get_credentials(&url, None).unwrap().unwrap();
+        assert!(matches!(cred, Credentials::None));
+        assert_eq!(cred.scheme_name(), "None");
+
+        // 4. Other path should fall back to root credentials
+        let url = DisplaySafeUrl::parse("https://example.com/other/path").unwrap();
+        let cred = store.get_credentials(&url, None).unwrap().unwrap();
+        assert_eq!(cred.username(), Some("root"));
+        assert_eq!(cred.scheme_name(), "HTTP Basic");
     }
 
     #[test]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6752,13 +6752,24 @@ pub struct AuthLoginArgs {
     pub service: Service,
 
     /// The username to use for the service.
-    #[arg(long, short, conflicts_with = "token", value_hint = ValueHint::Other)]
+    #[arg(
+        long,
+        short,
+        conflicts_with = "token",
+        conflicts_with = "none",
+        value_hint = ValueHint::Other
+    )]
     pub username: Option<String>,
 
     /// The password to use for the service.
     ///
     /// Use `-` to read the password from stdin.
-    #[arg(long, conflicts_with = "token", value_hint = ValueHint::Other)]
+    #[arg(
+        long,
+        conflicts_with = "token",
+        conflicts_with = "none",
+        value_hint = ValueHint::Other
+    )]
     pub password: Option<String>,
 
     /// The token to use for the service.
@@ -6766,8 +6777,24 @@ pub struct AuthLoginArgs {
     /// The username will be set to `__token__`.
     ///
     /// Use `-` to read the token from stdin.
-    #[arg(long, short, conflicts_with = "username", conflicts_with = "password", value_hint = ValueHint::Other)]
+    #[arg(
+        long,
+        short,
+        conflicts_with = "username",
+        conflicts_with = "password",
+        conflicts_with = "none",
+        value_hint = ValueHint::Other
+    )]
     pub token: Option<String>,
+
+    /// Use no authentication for the service.
+    #[arg(
+        long,
+        conflicts_with = "username",
+        conflicts_with = "password",
+        conflicts_with = "token"
+    )]
+    pub none: bool,
 
     /// The keyring provider to use for storage of credentials.
     ///

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -963,7 +963,9 @@ fn request_into_redirect(
         if let Some(credentials) = Credentials::from_url(&redirect_url) {
             let _ = redirect_url.set_username("");
             let _ = redirect_url.set_password(None);
-            headers.insert(AUTHORIZATION, credentials.to_header_value());
+            if let Some(header) = credentials.to_header_value() {
+                headers.insert(AUTHORIZATION, header);
+            }
         }
     }
 

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1361,17 +1361,9 @@ async fn build_upload_request<'a>(
             "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
         );
 
-    match credentials {
-        Credentials::Basic { password, .. } => {
-            if password.is_some() {
-                debug!("Using HTTP Basic authentication");
-                request = request.header(AUTHORIZATION, credentials.to_header_value());
-            }
-        }
-        Credentials::Bearer { .. } => {
-            debug!("Using Bearer token authentication");
-            request = request.header(AUTHORIZATION, credentials.to_header_value());
-        }
+    if let Some(header) = credentials.to_header_value() {
+        debug!("Using {} authentication", credentials.scheme_name());
+        request = request.header(AUTHORIZATION, header);
     }
 
     Ok((request, idx))
@@ -1416,17 +1408,9 @@ fn build_metadata_request<'a>(
             "application/json;q=0.9, text/plain;q=0.8, text/html;q=0.7",
         );
 
-    match credentials {
-        Credentials::Basic { password, .. } => {
-            if password.is_some() {
-                debug!("Using HTTP Basic authentication");
-                request = request.header(AUTHORIZATION, credentials.to_header_value());
-            }
-        }
-        Credentials::Bearer { .. } => {
-            debug!("Using Bearer token authentication");
-            request = request.header(AUTHORIZATION, credentials.to_header_value());
-        }
+    if let Some(header) = credentials.to_header_value() {
+        debug!("Using {} authentication", credentials.scheme_name());
+        request = request.header(AUTHORIZATION, header);
     }
 
     request

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1362,8 +1362,10 @@ async fn build_upload_request<'a>(
         );
 
     if let Some(header) = credentials.to_header_value() {
-        debug!("Using {} authentication", credentials.scheme_name());
-        request = request.header(AUTHORIZATION, header);
+        if credentials.is_authenticated() {
+            debug!("Using {} authentication", credentials.scheme_name());
+            request = request.header(AUTHORIZATION, header);
+        }
     }
 
     Ok((request, idx))
@@ -1409,8 +1411,10 @@ fn build_metadata_request<'a>(
         );
 
     if let Some(header) = credentials.to_header_value() {
-        debug!("Using {} authentication", credentials.scheme_name());
-        request = request.header(AUTHORIZATION, header);
+        if credentials.is_authenticated() {
+            debug!("Using {} authentication", credentials.scheme_name());
+            request = request.header(AUTHORIZATION, header);
+        }
     }
 
     request

--- a/crates/uv/src/commands/auth/helper.rs
+++ b/crates/uv/src/commands/auth/helper.rs
@@ -45,16 +45,19 @@ struct BazelCredentialResponse {
 
 impl TryFrom<Credentials> for BazelCredentialResponse {
     fn try_from(creds: Credentials) -> Result<Self> {
-        let header_str = creds
-            .to_header_value()
-            .to_str()
-            // TODO: this is infallible in practice
-            .context("Failed to convert header value to string")?
-            .to_owned();
+        if let Some(header) = creds.to_header_value() {
+            let header_str = header
+                .to_str()
+                // TODO: this is infallible in practice
+                .context("Failed to convert header value to string")?
+                .to_owned();
 
-        Ok(Self {
-            headers: HashMap::from([("Authorization".to_owned(), vec![header_str])]),
-        })
+            Ok(Self {
+                headers: HashMap::from([("Authorization".to_owned(), vec![header_str])]),
+            })
+        } else {
+            Ok(Self::default())
+        }
     }
 
     type Error = anyhow::Error;

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -27,12 +27,16 @@ pub(crate) async fn login(
     username: Option<String>,
     password: Option<String>,
     token: Option<String>,
+    none: bool,
     client_builder: BaseClientBuilder<'_>,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
     let pyx_store = PyxTokenStore::from_settings()?;
     if pyx_store.is_known_domain(service.url()) || is_default_pyx_domain(service.url()) {
+        if none {
+            bail!("Cannot specify `--none` when logging in to pyx");
+        }
         if username.is_some() {
             bail!("Cannot specify a username when logging in to pyx");
         }
@@ -69,6 +73,25 @@ pub(crate) async fn login(
         Some(root) => (Service::try_from(root.clone())?, root),
         None => (service, url),
     };
+
+    if none {
+        match backend {
+            AuthBackend::System(_) => {
+                bail!("The system keyring does not support disabling authentication; use the plaintext credential store instead");
+            }
+            AuthBackend::TextStore(mut store, _lock) => {
+                store.insert(service.clone(), Credentials::None);
+                store.write(TextCredentialStore::default_file()?, _lock)?;
+            }
+        }
+
+        writeln!(
+            printer.stderr(),
+            "Disabled authentication for {}",
+            url.bold().cyan()
+        )?;
+        return Ok(ExitStatus::Success);
+    }
 
     // Extract credentials from URL if present
     let url_credentials = Credentials::from_url(&url);

--- a/crates/uv/src/commands/auth/login.rs
+++ b/crates/uv/src/commands/auth/login.rs
@@ -77,7 +77,9 @@ pub(crate) async fn login(
     if none {
         match backend {
             AuthBackend::System(_) => {
-                bail!("The system keyring does not support disabling authentication; use the plaintext credential store instead");
+                bail!(
+                    "The system keyring does not support disabling authentication; use the plaintext credential store instead"
+                );
             }
             AuthBackend::TextStore(mut store, _lock) => {
                 store.insert(service.clone(), Credentials::None);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -532,6 +532,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.username,
                 args.password,
                 args.token,
+                args.none,
                 client_builder,
                 printer,
                 globals.preview,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -4449,6 +4449,7 @@ pub(crate) struct AuthLoginSettings {
     pub(crate) username: Option<String>,
     pub(crate) password: Option<String>,
     pub(crate) token: Option<String>,
+    pub(crate) none: bool,
 }
 
 impl AuthLoginSettings {
@@ -4459,6 +4460,7 @@ impl AuthLoginSettings {
             username: args.username,
             password: args.password,
             token: args.token,
+            none: args.none,
         }
     }
 }

--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -15,6 +15,15 @@ This will prompt for the credentials.
 The credentials can also be provided using the `--username` and `--password` options, or the
 `--token` option for services which use a `__token__` or arbitrary username.
 
+To explicitly disable authentication for a service, use the `--none` flag:
+
+```console
+$ uv auth login example.com --none
+```
+
+This will prevent uv from attempting to authenticate with the service, including via discovery from
+the keyring or other providers.
+
 !!! note
 
     We recommend providing the secret via stdin. Use `-` to indicate the value should be read from

--- a/docs/concepts/authentication/http.md
+++ b/docs/concepts/authentication/http.md
@@ -33,6 +33,15 @@ Credentials are stored in a plaintext file in uv's state directory, e.g.,
 `~/.local/share/uv/credentials/credentials.toml` on Unix. This file is currently not intended to be
 edited manually.
 
+The credentials store can also be used to explicitly disable authentication for a service by setting
+the `scheme` to `none`:
+
+```toml
+[[credential]]
+service = "https://example.com"
+scheme = "none"
+```
+
 !!! note
 
     A secure, system native storage mechanism is in [preview](../preview.md) — it is still


### PR DESCRIPTION
 # Add support for `AuthScheme::None` to opt-out of authentication

   ## Summary

   Add a new `None` authentication scheme to `uv`, allowing for explicitly disabling authentication for specific services or indices. This prevents unwanted credential lookups or prompts for public indices that may require an unauthenticated request.

   This is particularly useful for GitLab, which has specific behavior regarding private projects with public registries:
   - Unauthenticated users can access the public registry of private projects.
   - Authenticated users must be at least a "Reporter" member of the project to access the same public registry.
   
So this feature allow authenticated user to still be able to use public registries without being member of the project

   The `None` scheme allows users to explicitly opt-out of authentication for these registries even if they have credentials stored for the base GitLab domain in their keyring or credentials store.

   **Note:** This work was prepared with the assistance of an AI agent (Gemini CLI), but all changes have been thoroughly reviewed, understood, and validated by me to ensure they meet `uv`'s engineering and architectural standards.

 
   ## Design Decisions: Keyring Provider
   I deliberately chose **not** to implement `AuthScheme::None` support for the `KeyringProvider` (system native keyrings) for the following reasons:
   - **Semantic fit**: Keyrings are designed for secure secret storage. `None` is a configuration preference (the absence of a secret), which belongs in configuration files like `credentials.toml`.
   - **Avoidance of "sentinel" values**: Since keyrings only store strings, implementing `None` would require using "magic" sentinel strings (e.g., `__UV_NONE__`), which is brittle and confusing for users
   inspecting their native keyring.
   - **Priority Override**: Because `credentials.toml` is checked before the system keyring, it already acts as an effective "blocklist" or null-route for keyring credentials.
 
 ## IA Generated
   ### Key Changes
   - Add `Credentials::None` and `AuthScheme::None` to `uv-auth`.
   - Implement support for `scheme = "none"` in `credentials.toml`.
   - Add a `--none` flag to `uv auth login` to disable authentication for a service via the CLI.
   - Update `uv-publish`, `uv-client`, and `uv auth helper` to respect the `None` scheme.
   - Simplify authentication logic and logging using a new `scheme_name()` method.
   - Ensure `Credentials::None` is treated as "authenticated" to satisfy `AuthPolicy::Always` without prompts.
   - Allow `Credentials::None` to be cached by setting `is_empty` to `false`.

   ### Test Plan

   - Added unit tests in `crates/uv-auth/src/store.rs`:
       - `test_auth_scheme_none`: Verifies parsing of `scheme = "none"` from TOML and ensures no headers are generated.
       - `test_nested_service_lookup`: Verifies that `None` acts as a proper override even when nested under a service with active credentials.
   - Verified that `uv auth login --none` correctly updates the `credentials.toml` file.
   - Verified that `uv auth login --none` conflicts with `--username`, `--password`, and `--token`.
   - Verified that `uv auth login --none` bails when using the system keyring.
   - Ran `cargo test -p uv-auth` and `cargo check -p uv`.