### PR TITLE
Configure logging before globals

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -56,7 +56,7 @@ use crate::printer::Printer;
 use crate::settings::{
     CacheSettings, GlobalSettings, PipCheckSettings, PipCompileSettings, PipFreezeSettings,
     PipInstallSettings, PipListSettings, PipShowSettings, PipSyncSettings, PipUninstallSettings,
-    PublishSettings,
+    PublishSettings, resolve_color,
 };
 
 pub(crate) mod child;
@@ -116,6 +116,24 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
 
     // Make the early preview flags globally available.
     uv_preview::set(early_preview)?;
+
+    // Configure the `tracing` crate, which controls internal logging.
+    #[cfg(feature = "tracing-durations-export")]
+    let (durations_layer, _duration_guard) =
+        logging::setup_durations(environment.tracing_durations_file.as_ref())?;
+    #[cfg(not(feature = "tracing-durations-export"))]
+    let durations_layer = None::<tracing_subscriber::layer::Identity>;
+    logging::setup_logging(
+        match cli.top_level.global_args.verbose {
+            0 => logging::Level::Off,
+            1 => logging::Level::DebugUv,
+            2 => logging::Level::TraceUv,
+            3.. => logging::Level::TraceAll,
+        },
+        durations_layer,
+        resolve_color(&cli.top_level.global_args),
+        environment.log_context.unwrap_or_default(),
+    )?;
 
     // Determine the project directory.
     //
@@ -384,24 +402,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     // Set the global flags.
     uv_flags::init(EnvironmentFlags::from(&environment))
         .map_err(|()| anyhow::anyhow!("Flags are already initialized"))?;
-
-    // Configure the `tracing` crate, which controls internal logging.
-    #[cfg(feature = "tracing-durations-export")]
-    let (durations_layer, _duration_guard) =
-        logging::setup_durations(environment.tracing_durations_file.as_ref())?;
-    #[cfg(not(feature = "tracing-durations-export"))]
-    let durations_layer = None::<tracing_subscriber::layer::Identity>;
-    logging::setup_logging(
-        match globals.verbose {
-            0 => logging::Level::Off,
-            1 => logging::Level::DebugUv,
-            2 => logging::Level::TraceUv,
-            3.. => logging::Level::TraceAll,
-        },
-        durations_layer,
-        globals.color,
-        environment.log_context.unwrap_or_default(),
-    )?;
 
     debug!("uv {}", uv_cli::version::uv_self_version());
     if let Some(config_file) = cli.top_level.config_file.as_ref() {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -95,35 +95,13 @@ impl GlobalSettings {
     ) -> Self {
         let network_settings = NetworkSettings::resolve(args, workspace, environment);
         let python_preference = resolve_python_preference(args, workspace, environment);
+        let color = resolve_color(args);
         Self {
             required_version: workspace
                 .and_then(|workspace| workspace.globals.required_version.clone()),
             quiet: args.quiet,
             verbose: args.verbose,
-            color: if let Some(color_choice) = args.color {
-                // If `--color` is passed explicitly, use its value.
-                color_choice
-            } else if args.no_color {
-                // If `--no-color` is passed explicitly, disable color output.
-                ColorChoice::Never
-            } else if std::env::var_os(EnvVars::NO_COLOR)
-                .filter(|v| !v.is_empty())
-                .is_some()
-            {
-                // If the `NO_COLOR` is set, disable color output.
-                ColorChoice::Never
-            } else if std::env::var_os(EnvVars::FORCE_COLOR)
-                .filter(|v| !v.is_empty())
-                .is_some()
-                || std::env::var_os(EnvVars::CLICOLOR_FORCE)
-                    .filter(|v| !v.is_empty())
-                    .is_some()
-            {
-                // If `FORCE_COLOR` or `CLICOLOR_FORCE` is set, always enable color output.
-                ColorChoice::Always
-            } else {
-                ColorChoice::Auto
-            },
+            color,
             network_settings,
             concurrency: Concurrency::new(
                 environment
@@ -173,6 +151,34 @@ impl GlobalSettings {
             )
             .is_enabled(),
         }
+    }
+}
+
+/// Resolve the color choice from CLI arguments and environment variables.
+pub(crate) fn resolve_color(args: &GlobalArgs) -> ColorChoice {
+    if let Some(color_choice) = args.color {
+        // If `--color` is passed explicitly, use its value.
+        color_choice
+    } else if args.no_color {
+        // If `--no-color` is passed explicitly, disable color output.
+        ColorChoice::Never
+    } else if std::env::var_os(EnvVars::NO_COLOR)
+        .filter(|v| !v.is_empty())
+        .is_some()
+    {
+        // If the `NO_COLOR` is set, disable color output.
+        ColorChoice::Never
+    } else if std::env::var_os(EnvVars::FORCE_COLOR)
+        .filter(|v| !v.is_empty())
+        .is_some()
+        || std::env::var_os(EnvVars::CLICOLOR_FORCE)
+            .filter(|v| !v.is_empty())
+            .is_some()
+    {
+        // If `FORCE_COLOR` or `CLICOLOR_FORCE` is set, always enable color output.
+        ColorChoice::Always
+    } else {
+        ColorChoice::Auto
     }
 }
 

--- a/crates/uv/tests/it/cache_clean.rs
+++ b/crates/uv/tests/it/cache_clean.rs
@@ -28,6 +28,7 @@ fn clean_all() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -60,6 +61,7 @@ fn clear_all_alias() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -89,6 +91,7 @@ async fn clean_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -111,6 +114,7 @@ async fn clean_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Lock is busy for `[CACHE_DIR]/`
     DEBUG Cache is currently in use, proceeding due to `--force`
@@ -167,6 +171,7 @@ fn clean_package_pypi() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
@@ -185,6 +190,7 @@ fn clean_package_pypi() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -242,6 +248,7 @@ fn clean_package_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
@@ -313,6 +320,7 @@ fn clean_handles_verbatim_paths() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed 2 files

--- a/crates/uv/tests/it/cache_prune.rs
+++ b/crates/uv/tests/it/cache_prune.rs
@@ -34,6 +34,7 @@ fn prune_no_op() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -73,6 +74,7 @@ fn prune_stale_directory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache bucket: [CACHE_DIR]/simple-v4
@@ -133,6 +135,7 @@ fn prune_cached_env() {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache environment: [CACHE_DIR]/environments-v2/[ENTRY]
@@ -178,6 +181,7 @@ fn prune_stale_symlink() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
@@ -208,6 +212,7 @@ async fn prune_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -227,6 +232,7 @@ async fn prune_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Lock is busy for `[CACHE_DIR]/`
     DEBUG Cache is currently in use, proceeding due to `--force`
@@ -401,6 +407,10 @@ fn prune_stale_revision() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    DEBUG Skipping `pyproject.toml` in `[TEMP_DIR]/` (no `[tool]` section)
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling source revision: [CACHE_DIR]/sdists-v9/[ENTRY]

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -19969,6 +19969,10 @@ fn lock_explicit_default_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    DEBUG Found workspace configuration at `[TEMP_DIR]/pyproject.toml`
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/uv.toml`
     DEBUG uv [VERSION] ([COMMIT] DATE)
     DEBUG Found project root: `[TEMP_DIR]/`
     DEBUG No workspace root found, using project root


### PR DESCRIPTION
We were missing configuration and workspace discovery in logging and tracing.
