### PR TITLE
Generalize detected FP environment handling on ARMv7

### DIFF
--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -164,7 +164,13 @@ impl Platform {
             (OperatingSystem::Linux, Libc::Some(env)) => Some({
                 // If we've detected a bare `gnu` or `musl` environment on ARMv7,
                 // that means our floating point environment detection failed.
-                // We currently assume hard-float in that case.
+                // We currently assume hard-float in that case, for two reasons:
+                // 1. Statistically, we expect the overwhelming majority of ARMv7 Linux hosts to
+                //    be hard-float.
+                // 2. We currently only ship hard-float ARMv7 builds of ruff and uv anyways,
+                //    so we don't even have a soft-float build to fall back to.
+                // By contrast, we *do* ship soft-float Python builds via PBS, but PBS
+                // installations don't take this pathway.
                 if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7))
                     && matches!(env, Environment::Gnu | Environment::Musl)
                 {

--- a/crates/uv-platform/src/lib.rs
+++ b/crates/uv-platform/src/lib.rs
@@ -137,7 +137,8 @@ impl Platform {
     /// Convert this platform to a `cargo-dist` style triple string.
     pub fn as_cargo_dist_triple(&self) -> String {
         use target_lexicon::{
-            Architecture, ArmArchitecture, OperatingSystem, Riscv64Architecture, X86_32Architecture,
+            Architecture, ArmArchitecture, Environment, OperatingSystem, Riscv64Architecture,
+            X86_32Architecture,
         };
 
         let Self { os, arch, libc } = &self;
@@ -161,8 +162,12 @@ impl Platform {
         let abi = match (&**os, libc) {
             (OperatingSystem::Windows, _) => Some("msvc".to_string()),
             (OperatingSystem::Linux, Libc::Some(env)) => Some({
-                // Special suffix for ARM with hardware float
-                if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7)) {
+                // If we've detected a bare `gnu` or `musl` environment on ARMv7,
+                // that means our floating point environment detection failed.
+                // We currently assume hard-float in that case.
+                if matches!(arch.family(), Architecture::Arm(ArmArchitecture::Armv7))
+                    && matches!(env, Environment::Gnu | Environment::Musl)
+                {
                     format!("{env}eabihf")
                 } else {
                     env.to_string()
@@ -507,5 +512,33 @@ mod tests {
         assert_eq!(platform_linux.os.to_string(), "linux");
         assert_eq!(platform_linux.arch.to_string(), "aarch64");
         assert_eq!(platform_linux.libc.to_string(), "gnu");
+    }
+
+    #[test]
+    fn test_as_cargo_dist_triple_armv7_libc_handling() {
+        // This mapping reflects our current behavior: we currently ship
+        // only hard-float artifacts for ARMv7, so if we fail to detect
+        // the float ABI (i.e., we get the generic `Gnu` or `Musl`),
+        // we assume hard-float.
+        for (arch, libc, expected) in [
+            // ARMv7: detected ABI passes through unchanged.
+            ("armv7", "gnueabihf", "armv7-unknown-linux-gnueabihf"),
+            ("armv7", "gnueabi", "armv7-unknown-linux-gnueabi"),
+            ("armv7", "musleabihf", "armv7-unknown-linux-musleabihf"),
+            ("armv7", "musleabi", "armv7-unknown-linux-musleabi"),
+            // ARMv7: generic libc (detection failure) is biased to hard-float.
+            ("armv7", "gnu", "armv7-unknown-linux-gnueabihf"),
+            ("armv7", "musl", "armv7-unknown-linux-musleabihf"),
+            // Non-ARMv7: libc passes through unchanged.
+            ("aarch64", "gnu", "aarch64-unknown-linux-gnu"),
+            ("x86_64", "musl", "x86_64-unknown-linux-musl"),
+        ] {
+            let platform = Platform::from_parts("linux", arch, libc).unwrap();
+            assert_eq!(
+                platform.as_cargo_dist_triple(),
+                expected,
+                "linux-{arch}-{libc}"
+            );
+        }
     }
 }

--- a/crates/uv-platform/src/libc.rs
+++ b/crates/uv-platform/src/libc.rs
@@ -73,9 +73,6 @@ impl Libc {
 
                 Ok(Self::Some(match detect_linux_libc()? {
                     LibcVersion::Manylinux { .. } => match env::consts::ARCH {
-                        // Checks if the CPU supports hardware floating-point operations.
-                        // Depending on the result, it selects either the `gnueabihf` (hard-float) or `gnueabi` (soft-float) environment.
-                        // download-metadata.json only includes armv7.
                         "arm" | "armv5te" | "armv7" => {
                             match detect_hardware_floating_point_support() {
                                 Ok(true) => target_lexicon::Environment::Gnueabihf,
@@ -85,7 +82,16 @@ impl Libc {
                         }
                         _ => target_lexicon::Environment::Gnu,
                     },
-                    LibcVersion::Musllinux { .. } => target_lexicon::Environment::Musl,
+                    LibcVersion::Musllinux { .. } => match env::consts::ARCH {
+                        "arm" | "armv5te" | "armv7" => {
+                            match detect_hardware_floating_point_support() {
+                                Ok(true) => target_lexicon::Environment::Musleabihf,
+                                Ok(false) => target_lexicon::Environment::Musleabi,
+                                Err(_) => target_lexicon::Environment::Musl,
+                            }
+                        }
+                        _ => target_lexicon::Environment::Musl,
+                    },
                 }))
             }
             "windows" | "macos" => Ok(Self::None),
@@ -95,7 +101,14 @@ impl Libc {
     }
 
     pub fn is_musl(&self) -> bool {
-        matches!(self, Self::Some(target_lexicon::Environment::Musl))
+        matches!(
+            self,
+            Self::Some(
+                target_lexicon::Environment::Musl
+                    | target_lexicon::Environment::Musleabi
+                    | target_lexicon::Environment::Musleabihf
+            )
+        )
     }
 }
 
@@ -108,6 +121,8 @@ impl FromStr for Libc {
             "gnueabi" => Ok(Self::Some(target_lexicon::Environment::Gnueabi)),
             "gnueabihf" => Ok(Self::Some(target_lexicon::Environment::Gnueabihf)),
             "musl" => Ok(Self::Some(target_lexicon::Environment::Musl)),
+            "musleabi" => Ok(Self::Some(target_lexicon::Environment::Musleabi)),
+            "musleabihf" => Ok(Self::Some(target_lexicon::Environment::Musleabihf)),
             "none" => Ok(Self::None),
             _ => Err(crate::Error::UnknownLibc(s.to_string())),
         }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -215,7 +215,8 @@ impl EnvVars {
     pub const UV_PYTHON_DOWNLOADS: &'static str = "UV_PYTHON_DOWNLOADS";
 
     /// Overrides the environment-determined libc on linux systems when filling in the current platform
-    /// within Python version requests. Options are: `gnu`, `gnueabi`, `gnueabihf`, `musl`, and `none`.
+    /// within Python version requests. Options are: `gnu`, `gnueabi`, `gnueabihf`, `musl`,
+    /// `musleabi`, `musleabihf`, and `none`.
     #[attr_added_in("0.7.22")]
     pub const UV_LIBC: &'static str = "UV_LIBC";
 


### PR DESCRIPTION
## Summary

This is an attempt at fixing #19137. See https://github.com/astral-sh/uv/pull/19139#issuecomment-4320889645 for my understanding of the situation and motivation for this approach (versus the simpler approach in #19139).

TL;DR: we were unconditionally appending `eabihf` to all libc variants when constructing `cargo dist`-style triplets. This was incorrect for a long time, but didn't surface on hot user paths until #18674 reused that pathway for uv's own self-upgrade logic. The fix is as simple as not doing that, _except_ that we _do_ want to do it in the bare `Gnu` and `Musl` cases, since those signal FP detection errors (and we optimistically assume the user really has a hardfloat environment). So now we emit the appropriate `Musleabi`/`Musleabihf` variants and specialize the append to just the FP detection failure cases for both `Gnu` and `Musl` explicitly.

Closes #19137. Closes #19139.

## Test Plan

Added a unit test demonstrating the new `as_cargo_dist_triple` behavior.