### PR TITLE
fix: warn when frozen add ignores bounds

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -698,6 +698,13 @@ pub(crate) async fn add(
     // If `--frozen`, exit early. There's no reason to lock and sync, since we don't need a `uv.lock`
     // to exist at all.
     if frozen.is_some() {
+        if let Some(bound_kind) = bounds
+            && edits.iter().any(DependencyEdit::requires_bound)
+        {
+            warn_user_once!(
+                "Bounds preference `{bound_kind}` is ignored when `--frozen` is provided; dependencies are added without constraints"
+            );
+        }
         return Ok(ExitStatus::Success);
     }
 
@@ -1444,4 +1451,29 @@ struct DependencyEdit {
     requirement: uv_pep508::Requirement,
     source: Option<Source>,
     edit: ArrayEdit,
+}
+
+impl DependencyEdit {
+    fn requires_bound(&self) -> bool {
+        // Only set a minimum version for newly-added dependencies (as opposed to updates).
+        let ArrayEdit::Add(_) = &self.edit else {
+            return false;
+        };
+
+        // Only set a minimum version for registry requirements.
+        if self
+            .source
+            .as_ref()
+            .is_some_and(|source| !matches!(source, Source::Registry { .. }))
+        {
+            return false;
+        }
+
+        // Only set a minimum version for requirements without version specifiers.
+        match self.requirement.version_or_url.as_ref() {
+            Some(VersionOrUrl::VersionSpecifier(version)) => version.is_empty(),
+            Some(VersionOrUrl::Url(_)) => false,
+            None => true,
+        }
+    }
 }

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -4525,6 +4525,57 @@ fn add_frozen() -> Result<()> {
     Ok(())
 }
 
+/// Warn when bounds are ignored under `--frozen`.
+#[test]
+fn add_frozen_warns_when_bounds_ignored() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // Remove the virtual environment.
+    fs_err::remove_dir_all(&context.venv)?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("anyio").arg("--bounds").arg("exact").arg("--frozen"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    warning: Bounds preference `exact` is ignored when `--frozen` is provided; dependencies are added without constraints
+    ");
+
+    let pyproject_toml = context.read("pyproject.toml");
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "anyio",
+        ]
+        "#
+        );
+    });
+
+    assert!(!context.temp_dir.join("uv.lock").exists());
+    assert!(!context.venv.exists());
+
+    Ok(())
+}
+
 /// Add a requirement without updating the environment.
 #[test]
 fn add_no_sync() -> Result<()> {


### PR DESCRIPTION
## Summary
- warn when `uv add --bounds <kind> --frozen` cannot apply the requested bounds because frozen mode exits before resolution
- only warn for newly-added unconstrained registry requirements, where bounds would otherwise be silently ignored
- add integration coverage for `--bounds=exact --frozen`

Fixes #19090

## Verification
- `cargo fmt --all --check` ✅
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2 cargo test --package uv --test it add_frozen_warns_when_bounds_ignored` ✅
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=2 cargo test --package uv --test it add_frozen` ✅

## Duplicate PR check
- Checked issue comments/timeline and PR searches for `19090`, `--bounds=exact --frozen`, and related bounds/frozen terms.
- No open PR addressing this issue was found; only historical related PR #12946 adds `uv add --bounds`.
