### PR TITLE
warn csh users when creating a relocatable virtual environment

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -314,7 +314,8 @@ pub(crate) async fn venv(
     }
 
     // Determine the appropriate activation command.
-    let activation = match Shell::from_env() {
+    let shell = Shell::from_env();
+    let activation = match shell {
         None => None,
         Some(Shell::Bash | Shell::Zsh | Shell::Ksh) => Some(format!(
             "source {}",
@@ -328,6 +329,8 @@ pub(crate) async fn venv(
             "overlay use {}",
             shlex_posix(venv.scripts().join("activate.nu"))
         )),
+        // csh can't determine its own script path, so `activate.csh` is not generated for relocatable venvs.
+        Some(Shell::Csh) if relocatable => None,
         Some(Shell::Csh) => Some(format!(
             "source {}",
             shlex_posix(venv.scripts().join("activate.csh"))
@@ -340,6 +343,12 @@ pub(crate) async fn venv(
     };
     if let Some(act) = activation {
         writeln!(printer.stderr(), "Activate with: {}", act.green())?;
+    } else if relocatable && matches!(shell, Some(Shell::Csh)) {
+        warn_user!(
+            "csh activation is not supported for relocatable virtual environments; \
+             activate from a POSIX shell with `source {}` instead",
+            shlex_posix(venv.scripts().join("activate"))
+        );
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -1307,6 +1307,39 @@ fn verify_pyvenv_cfg_relocatable() {
     activate_csh.assert(predicates::path::missing());
 }
 
+/// Regression test for #19181: with csh + `--relocatable`, uv must warn instead of
+/// pointing the user at the (intentionally absent) `activate.csh`.
+#[test]
+#[cfg(unix)]
+fn relocatable_csh_emits_warning_instead_of_activation() {
+    let context = uv_test::test_context!("3.12");
+
+    // Force `Shell::from_env` past the shell-version probes so it falls through to `SHELL`.
+    uv_snapshot!(context.filters(), context.venv()
+        .arg(context.venv.as_os_str())
+        .arg("--clear")
+        .arg("--python")
+        .arg("3.12")
+        .arg("--relocatable")
+        .env_remove(EnvVars::BASH_VERSION)
+        .env_remove(EnvVars::ZSH_VERSION)
+        .env_remove(EnvVars::FISH_VERSION)
+        .env_remove(EnvVars::NU_VERSION)
+        .env_remove(EnvVars::KSH_VERSION)
+        .env_remove(EnvVars::PS_MODULE_PATH)
+        .env(EnvVars::SHELL, "/bin/csh"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: .venv
+    warning: csh activation is not supported for relocatable virtual environments; activate from a POSIX shell with `source .venv/bin/activate` instead
+    "
+    );
+}
+
 /// With `UV_VENV_RELOCATABLE=1`, the virtual environment is relocatable.
 #[test]
 fn verify_pyvenv_cfg_relocatable_env_var() {


### PR DESCRIPTION
closes #19181 

when `uv venv --relocatable` is run from a csh shell, uv printed Activate with: source .venv/bin/activate.csh even though            activate.csh is intentionally not generated for relocatable environments #17759.

Fix suppresses the broken hint and emits a targeted warning instead.