### PR TITLE
docs: Clarify that `uv init` creates git files/folders in projects guide

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -29,7 +29,7 @@ pin file (`.python-version`).
 
 ```console
 $ tree example-app
-example-app
+example-app/
 ├── .python-version
 ├── README.md
 ├── main.py
@@ -88,7 +88,7 @@ The source code is moved into a `src` directory with a module directory and an `
 
 ```console
 $ tree example-pkg
-example-pkg
+example-pkg/
 ├── .python-version
 ├── README.md
 ├── pyproject.toml
@@ -168,7 +168,7 @@ marker is included to indicate to consumers that types can be read from the libr
 
 ```console
 $ tree example-lib
-example-lib
+example-lib/
 ├── .python-version
 ├── README.md
 ├── pyproject.toml
@@ -250,7 +250,7 @@ files:
 
 ```console
 $ tree example-ext
-example-ext
+example-ext/
 ├── .python-version
 ├── Cargo.toml
 ├── README.md

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -60,6 +60,7 @@ A complete listing would look like:
 │   ├── bin
 │   ├── lib
 │   └── pyvenv.cfg
+├── .gitignore
 ├── .python-version
 ├── README.md
 ├── main.py

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -26,9 +26,10 @@ $ cd hello-world
 $ uv init
 ```
 
-uv will create the following files:
+uv will create the following files and directories:
 
 ```text
+├── .git/
 ├── .gitignore
 ├── .python-version
 ├── README.md
@@ -54,7 +55,8 @@ A complete listing would look like:
 
 ```text
 .
-├── .venv
+├── .git/
+├── .venv/
 │   ├── bin
 │   ├── lib
 │   └── pyvenv.cfg


### PR DESCRIPTION


<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

.git is created as part of the 'uv init', and it is more idiomatic to use slashes after dirs in Markdown docs.
