### PR TITLE
Bump mimalloc crate to 0.1.50 while keeping v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,12 +2598,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.44"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -2764,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.48"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/uv-performance-memory-allocator/Cargo.toml
+++ b/crates/uv-performance-memory-allocator/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 test = false
 
 [target.'cfg(all(target_os = "windows"))'.dependencies]
-mimalloc = { version = "0.1.43" }
+mimalloc = { version = "0.1.50", features = ["v2"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }


### PR DESCRIPTION
See https://github.com/astral-sh/ruff/issues/24880, mimalloc v3 causes a crash in uv too when run under aarch64 windows.

This PR bumps the crate dependency, adding the `v2` feature to avoid the crash.
