### PR TITLE
Bump astral-tokio-tar to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ anstream = { version = "1.0.0" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }
 arrayvec = { version = "0.7.6" }
-astral-tokio-tar = { version = "0.6.0" }
+astral-tokio-tar = { version = "0.6.1" }
 async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = [
   "bzip2",


### PR DESCRIPTION
## Summary

Bumps our own astral-tokio-tar dep.

## Test Plan

NFC, existing tests will cover.
