### PR TITLE
re-anchor path deps inside parent git checkout to git sources

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -15,7 +15,9 @@ use uv_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::{MarkerTree, VerbatimUrl, VersionOrUrl, looks_like_git_repository};
-use uv_pypi_types::{ConflictItem, ParsedGitUrl, ParsedUrlError, VerbatimParsedUrl};
+use uv_pypi_types::{
+    ConflictItem, ParsedDirectoryUrl, ParsedGitUrl, ParsedUrl, ParsedUrlError, VerbatimParsedUrl,
+};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_workspace::Workspace;
 use uv_workspace::pyproject::{PyProjectToml, Source, Sources};
@@ -137,7 +139,16 @@ impl LoweredRequirement {
         }
 
         let Some(sources) = sources else {
-            return Either::Left(std::iter::once(Ok(Self(Requirement::from(requirement)))));
+            // If the requirement was lifted from the metadata of a package fetched via git, and it
+            // points to a directory inside that same git checkout (e.g. a `path = "../sibling"`
+            // declared in the upstream's `pyproject.toml`), re-anchor it to the parent git source
+            // so the absolute cache path doesn't leak into the lockfile.
+            let lowered = if let Some(git_member) = git_member {
+                rewrite_git_relative_url(requirement, git_member)
+            } else {
+                Requirement::from(requirement)
+            };
+            return Either::Left(std::iter::once(Ok(Self(lowered))));
         };
 
         // Determine whether the markers cover the full space for the requirement. If not, fill the
@@ -727,6 +738,62 @@ fn registry_source(
             index: Some(index),
             conflict,
         },
+    }
+}
+
+/// If a transitive requirement points to a directory inside a parent git
+/// checkout, rewrite it to a [`RequirementSource::Git`] with the appropriate
+/// `subdirectory`.
+///
+/// Why: when a git-fetched package declares a relative path dependency on a
+/// sibling directory of its own clone (typically via `[tool.poetry.dependencies]`
+/// `path = "../foo"`), the build backend resolves that path against the cache
+/// checkout. Without this rewrite, the resulting absolute cache path would be
+/// serialized into `uv.lock`, breaking portability across machines.
+///
+/// See <https://github.com/astral-sh/uv/issues/19152>.
+pub(super) fn rewrite_git_relative_url(
+    requirement: uv_pep508::Requirement<VerbatimParsedUrl>,
+    git_member: &GitWorkspaceMember<'_>,
+) -> Requirement {
+    let install_path = match requirement.version_or_url.as_ref() {
+        Some(VersionOrUrl::Url(VerbatimParsedUrl {
+            parsed_url: ParsedUrl::Directory(ParsedDirectoryUrl { install_path, .. }),
+            ..
+        })) => install_path.as_ref(),
+        _ => return Requirement::from(requirement),
+    };
+    let Ok(subdirectory) = uv_fs::relative_to(install_path, git_member.fetch_root) else {
+        return Requirement::from(requirement);
+    };
+    let subdirectory = normalize_path(&subdirectory);
+    // `relative_to` returns leading `..` components when the path lies outside
+    // the base; in that case there's no valid git subdirectory to anchor to.
+    if subdirectory.starts_with("..") {
+        return Requirement::from(requirement);
+    }
+    let subdirectory = if subdirectory.as_os_str().is_empty() {
+        None
+    } else {
+        Some(subdirectory.into_owned().into_boxed_path())
+    };
+
+    let git = git_member.git_source.git.clone();
+    let url = DisplaySafeUrl::from(ParsedGitUrl {
+        url: git.clone(),
+        subdirectory: subdirectory.clone(),
+    });
+    Requirement {
+        name: requirement.name,
+        groups: Box::new([]),
+        extras: requirement.extras,
+        marker: requirement.marker,
+        source: RequirementSource::Git {
+            git,
+            subdirectory,
+            url: VerbatimUrl::from_url(url),
+        },
+        origin: requirement.origin,
     }
 }
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -14,6 +14,7 @@ use uv_workspace::pyproject::{Sources, ToolUvSources};
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, ProjectWorkspace, WorkspaceCache};
 
 use crate::Metadata;
+use crate::metadata::lowering::rewrite_git_relative_url;
 use crate::metadata::{GitWorkspaceMember, LoweredRequirement, MetadataError};
 
 #[derive(Debug, Clone)]
@@ -33,6 +34,24 @@ impl RequiresDist {
             name: metadata.name,
             requires_dist: Box::into_iter(metadata.requires_dist)
                 .map(Requirement::from)
+                .collect(),
+            provides_extra: metadata.provides_extra,
+            dependency_groups: BTreeMap::default(),
+            dynamic: metadata.dynamic,
+        }
+    }
+
+    /// Like [`Self::from_metadata23`], but rewrites any directory requirements that point inside
+    /// `git_member`'s checkout to a [`RequirementSource::Git`] with the appropriate `subdirectory`,
+    /// so the lockfile remains portable across machines.
+    fn from_metadata23_with_git_member(
+        metadata: uv_pypi_types::RequiresDist,
+        git_member: &GitWorkspaceMember<'_>,
+    ) -> Self {
+        Self {
+            name: metadata.name,
+            requires_dist: Box::into_iter(metadata.requires_dist)
+                .map(|requirement| rewrite_git_relative_url(requirement, git_member))
                 .collect(),
             provides_extra: metadata.provides_extra,
             dependency_groups: BTreeMap::default(),
@@ -70,7 +89,14 @@ impl RequiresDist {
         let Some(project_workspace) =
             ProjectWorkspace::from_maybe_project_root(install_path, &discovery, cache).await?
         else {
-            return Ok(Self::from_metadata23(metadata));
+            // Poetry-only `pyproject.toml`s (no `[project]` section) reach this fallback. If the
+            // metadata was lifted from a git checkout, re-anchor any path requirements that point
+            // inside that checkout so absolute cache paths don't leak into the lockfile.
+            return Ok(if let Some(git_member) = git_member {
+                Self::from_metadata23_with_git_member(metadata, git_member)
+            } else {
+                Self::from_metadata23(metadata)
+            });
         };
 
         Self::from_project_workspace(


### PR DESCRIPTION
closes #19152 

**Issue:** When a project depends on a package fetched via git, and that package itself declares a relative path dependency on a sibling directory of its own checkout (e.g. deepfilterlib = { path = "../pyDF/" } inside [tool.poetry.dependencies]), uv lock dumps the absolute filesystem path of the git cache checkout straight into uv.lock something like source = { directory = "/Users/<user>/.cache/uv/git-v0/checkouts/<hash>/<rev>/pyDF" }. That path only exists on the machine that ran lock, so anyone else running uv sync gets "Distribution not found." Even on the same machine, running with --no-cache breaks sync immediately, because the temp checkout dir gets wiped right after lock finishes. 

**Fix**: When lowering the metadata of a git-fetched package, if a directory requirement's resolved install path lives inside that same git checkout, we rewrite it back to a Git source keeping the parent's git URL and rev, and using the relative path inside the checkout as subdirectory. The lockfile then records source = { git = "https://github.com/.../repo?subdirectory=pyDF&...#<rev>" }, which is portable and points at exactly the same content. I left absolute paths that fall outside the checkout, non-directory URLs (sdist/archive), and metadata with no parent git source untouched those are either intentional or have nothing to anchor against, so unrelated lockfiles aren't affected.