### PR TITLE
Add Astral mirror URL override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5993,6 +5993,7 @@ dependencies = [
  "uv-pep440",
  "uv-platform",
  "uv-redacted",
+ "uv-static",
  "wiremock",
 ]
 

--- a/crates/uv-bin-install/Cargo.toml
+++ b/crates/uv-bin-install/Cargo.toml
@@ -23,6 +23,7 @@ uv-extract = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-platform = { workspace = true }
 uv-redacted = { workspace = true }
+uv-static = { workspace = true }
 
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }

--- a/crates/uv-bin-install/src/lib.rs
+++ b/crates/uv-bin-install/src/lib.rs
@@ -22,6 +22,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 use url::Url;
 use uv_client::retryable_on_request_failure;
 use uv_distribution_filename::SourceDistExtension;
+use uv_static::{astral_mirror_base_url, astral_mirror_url_from_env, custom_astral_mirror_url};
 
 use uv_cache::{Cache, CacheBucket, CacheEntry, Error as CacheError};
 use uv_client::{BaseClient, RetriableError, fetch_with_url_fallback};
@@ -72,69 +73,96 @@ impl Binary {
         platform: &str,
         format: ArchiveFormat,
     ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let custom_astral_mirror = astral_mirror_url_from_env();
+        (*self).download_urls_with_astral_mirror(
+            version,
+            platform,
+            format,
+            custom_astral_mirror.as_deref(),
+        )
+    }
+
+    fn download_urls_with_astral_mirror(
+        self,
+        version: &Version,
+        platform: &str,
+        format: ArchiveFormat,
+        astral_mirror_url: Option<&str>,
+    ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let astral_mirror_url = custom_astral_mirror_url(astral_mirror_url);
         match self {
             Self::Ruff => {
                 let suffix = format!("{version}/ruff-{platform}.{}", format.extension());
-                let canonical = format!("{RUFF_GITHUB_URL_PREFIX}{suffix}");
-                let mirror = format!("{RUFF_DEFAULT_MIRROR}{suffix}");
-                Ok(vec![
-                    DisplaySafeUrl::parse(&mirror).map_err(|err| Error::UrlParse {
-                        url: mirror,
-                        source: err,
-                    })?,
-                    DisplaySafeUrl::parse(&canonical).map_err(|err| Error::UrlParse {
-                        url: canonical,
-                        source: err,
-                    })?,
-                ])
+                let mirror_base = astral_mirror_base_url(astral_mirror_url);
+                let mirror = format!("{mirror_base}{RUFF_MIRROR_SUFFIX}{suffix}");
+                let mut urls = vec![parse_url(mirror)?];
+                // When using the default mirror, also fall back to GitHub.
+                if astral_mirror_url.is_none() {
+                    let canonical = format!("{RUFF_GITHUB_URL_PREFIX}{suffix}");
+                    urls.push(parse_url(canonical)?);
+                }
+                Ok(urls)
             }
             Self::Uv => {
                 let canonical = format!(
                     "{UV_GITHUB_URL_PREFIX}{version}/uv-{platform}.{}",
                     format.extension()
                 );
-                Ok(vec![DisplaySafeUrl::parse(&canonical).map_err(|err| {
-                    Error::UrlParse {
-                        url: canonical,
-                        source: err,
-                    }
-                })?])
+                Ok(vec![parse_url(canonical)?])
             }
         }
     }
 
     /// Return the ordered list of manifest URLs to try for this binary.
-    fn manifest_urls(self) -> Vec<DisplaySafeUrl> {
+    fn manifest_urls(self) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let custom_astral_mirror = astral_mirror_url_from_env();
+        self.manifest_urls_with_astral_mirror(custom_astral_mirror.as_deref())
+    }
+
+    fn manifest_urls_with_astral_mirror(
+        self,
+        astral_mirror_url: Option<&str>,
+    ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let astral_mirror_url = custom_astral_mirror_url(astral_mirror_url);
         let name = self.name();
-        match self {
-            // These are static strings so parsing cannot fail.
-            Self::Ruff => vec![
-                DisplaySafeUrl::parse(&format!("{VERSIONS_MANIFEST_MIRROR}/{name}.ndjson"))
-                    .unwrap(),
-                DisplaySafeUrl::parse(&format!("{VERSIONS_MANIFEST_URL}/{name}.ndjson")).unwrap(),
-            ],
-            Self::Uv => vec![
-                DisplaySafeUrl::parse(&format!("{VERSIONS_MANIFEST_MIRROR}/{name}.ndjson"))
-                    .unwrap(),
-                DisplaySafeUrl::parse(&format!("{VERSIONS_MANIFEST_URL}/{name}.ndjson")).unwrap(),
-            ],
+        let mirror_base = astral_mirror_base_url(astral_mirror_url);
+        let mirror = format!("{mirror_base}{VERSIONS_MANIFEST_MIRROR_SUFFIX}/{name}.ndjson");
+        let mut urls = vec![parse_url(mirror)?];
+        // When using the default mirror, also fall back to the canonical raw GitHub URL.
+        if astral_mirror_url.is_none() {
+            let canonical = format!("{VERSIONS_MANIFEST_URL}/{name}.ndjson");
+            urls.push(parse_url(canonical)?);
         }
+        Ok(urls)
     }
 
     /// Given a canonical artifact URL (e.g., from the versions manifest), return the ordered list
     /// of URLs to try for this binary.
-    fn mirror_urls(self, canonical_url: DisplaySafeUrl) -> Vec<DisplaySafeUrl> {
+    fn mirror_urls(self, canonical_url: DisplaySafeUrl) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let custom_astral_mirror = astral_mirror_url_from_env();
+        self.mirror_urls_with_astral_mirror(canonical_url, custom_astral_mirror.as_deref())
+    }
+
+    fn mirror_urls_with_astral_mirror(
+        self,
+        canonical_url: DisplaySafeUrl,
+        astral_mirror_url: Option<&str>,
+    ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let astral_mirror_url = custom_astral_mirror_url(astral_mirror_url);
         match self {
             Self::Ruff => {
                 if let Some(suffix) = canonical_url.as_str().strip_prefix(RUFF_GITHUB_URL_PREFIX) {
-                    let mirror_str = format!("{RUFF_DEFAULT_MIRROR}{suffix}");
-                    if let Ok(mirror_url) = DisplaySafeUrl::parse(&mirror_str) {
-                        return vec![mirror_url, canonical_url];
+                    let mirror_base = astral_mirror_base_url(astral_mirror_url);
+                    let mirror = format!("{mirror_base}{RUFF_MIRROR_SUFFIX}{suffix}");
+                    let mirror_url = parse_url(mirror)?;
+                    if astral_mirror_url.is_some() {
+                        return Ok(vec![mirror_url]);
                     }
+                    return Ok(vec![mirror_url, canonical_url]);
                 }
-                vec![canonical_url]
+                Ok(vec![canonical_url])
             }
-            Self::Uv => vec![canonical_url],
+            Self::Uv => Ok(vec![canonical_url]),
         }
     }
 
@@ -223,17 +251,18 @@ const RUFF_GITHUB_URL_PREFIX: &str = "https://github.com/astral-sh/ruff/releases
 /// The canonical GitHub URL prefix for uv releases.
 const UV_GITHUB_URL_PREFIX: &str = "https://github.com/astral-sh/uv/releases/download/";
 
-/// The default Astral mirror for Ruff releases.
-///
-/// This mirror is tried first for Ruff downloads. If it fails, uv falls back to the canonical
-/// GitHub URL.
-const RUFF_DEFAULT_MIRROR: &str = "https://releases.astral.sh/github/ruff/releases/download/";
+/// The suffix appended to the Astral mirror base for Ruff releases.
+const RUFF_MIRROR_SUFFIX: &str = "/github/ruff/releases/download/";
+
+/// The suffix appended to the Astral mirror base for the versions manifest.
+const VERSIONS_MANIFEST_MIRROR_SUFFIX: &str = "/github/versions/main/v1";
 
 /// The canonical base URL for the versions manifest.
 const VERSIONS_MANIFEST_URL: &str = "https://raw.githubusercontent.com/astral-sh/versions/main/v1";
 
-/// The default Astral mirror for the versions manifest.
-const VERSIONS_MANIFEST_MIRROR: &str = "https://releases.astral.sh/github/versions/main/v1";
+fn parse_url(url: String) -> Result<DisplaySafeUrl, Error> {
+    DisplaySafeUrl::parse(&url).map_err(|source| Error::UrlParse { url, source })
+}
 
 /// Binary version information from the versions manifest.
 #[derive(Debug, Deserialize)]
@@ -452,8 +481,10 @@ pub async fn find_matching_version(
     let platform = Platform::from_env()?;
     let platform_name = platform.as_cargo_dist_triple();
 
+    let manifest_urls = binary.manifest_urls()?;
+
     fetch_with_url_fallback(
-        &binary.manifest_urls(),
+        &manifest_urls,
         *retry_policy,
         &format!("manifest for `{binary}`"),
         |url| {
@@ -506,13 +537,13 @@ async fn fetch_and_find_matching_version(
             return Ok(None);
         }
         let version_info: BinVersionInfo = serde_json::from_str(line_str)?;
-        Ok(check_version_match(
+        check_version_match(
             binary,
             &version_info,
             constraints,
             exclude_newer,
             platform_name,
-        ))
+        )
     };
 
     // Stream the response line by line
@@ -559,27 +590,27 @@ async fn fetch_and_find_matching_version(
 
 /// Check if a version matches the constraints and find the artifact for the platform.
 ///
-/// Returns `Some(resolved)` if the version matches and an artifact is found,
-/// `None` if the version doesn't match or no artifact is available for the platform.
+/// Returns `Ok(Some(resolved))` if the version matches and an artifact is found,
+/// `Ok(None)` if the version doesn't match or no artifact is available for the platform.
 fn check_version_match(
     binary: Binary,
     version_info: &BinVersionInfo,
     constraints: Option<&uv_pep440::VersionSpecifiers>,
     exclude_newer: Option<jiff::Timestamp>,
     platform_name: &str,
-) -> Option<ResolvedVersion> {
+) -> Result<Option<ResolvedVersion>, Error> {
     // Skip versions newer than the exclude_newer cutoff
     if let Some(cutoff) = exclude_newer
         && version_info.date > cutoff
     {
-        return None;
+        return Ok(None);
     }
 
     // Skip versions that don't match the constraints
     if let Some(constraints) = constraints
         && !constraints.contains(&version_info.version)
     {
-        return None;
+        return Ok(None);
     }
 
     // Find an artifact matching the platform, trusting whichever archive format the
@@ -599,14 +630,14 @@ fn check_version_match(
             _ => continue,
         };
 
-        return Some(ResolvedVersion {
+        return Ok(Some(ResolvedVersion {
             version: version_info.version.clone(),
-            artifact_urls: binary.mirror_urls(canonical_url),
+            artifact_urls: binary.mirror_urls(canonical_url)?,
             archive_format,
-        });
+        }));
     }
 
-    None
+    Ok(None)
 }
 
 /// Install the given binary from a [`ResolvedVersion`].
@@ -952,6 +983,129 @@ mod tests {
                     .to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_ruff_download_urls_custom_astral_mirror() {
+        let urls = Binary::Ruff
+            .download_urls_with_astral_mirror(
+                &Version::new([0, 15, 1]),
+                "x86_64-unknown-linux-gnu",
+                ArchiveFormat::TarGz,
+                Some("https://nexus.example.com/repository/releases.astral.sh/"),
+            )
+            .expect("ruff download URLs should be valid");
+
+        let urls = urls
+            .into_iter()
+            .map(|url| url.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![
+                "https://nexus.example.com/repository/releases.astral.sh/github/ruff/releases/download/0.15.1/ruff-x86_64-unknown-linux-gnu.tar.gz"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_ruff_download_urls_empty_astral_mirror_uses_default() {
+        let default_urls = Binary::Ruff
+            .download_urls_with_astral_mirror(
+                &Version::new([0, 15, 1]),
+                "x86_64-unknown-linux-gnu",
+                ArchiveFormat::TarGz,
+                None,
+            )
+            .expect("ruff download URLs should be valid");
+        let empty_urls = Binary::Ruff
+            .download_urls_with_astral_mirror(
+                &Version::new([0, 15, 1]),
+                "x86_64-unknown-linux-gnu",
+                ArchiveFormat::TarGz,
+                Some(""),
+            )
+            .expect("ruff download URLs should be valid");
+
+        assert_eq!(default_urls, empty_urls);
+    }
+
+    #[test]
+    fn test_manifest_urls_custom_astral_mirror() {
+        for (binary, filename) in [(Binary::Ruff, "ruff.ndjson"), (Binary::Uv, "uv.ndjson")] {
+            let urls = binary
+                .manifest_urls_with_astral_mirror(Some(
+                    "https://nexus.example.com/repository/releases.astral.sh/",
+                ))
+                .expect("manifest URLs should be valid");
+
+            let urls = urls
+                .into_iter()
+                .map(|url| url.to_string())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                urls,
+                vec![format!(
+                    "https://nexus.example.com/repository/releases.astral.sh/github/versions/main/v1/{filename}"
+                )]
+            );
+        }
+    }
+
+    #[test]
+    fn test_ruff_mirror_urls_custom_astral_mirror() {
+        let canonical_url = DisplaySafeUrl::parse(
+            "https://github.com/astral-sh/ruff/releases/download/0.15.1/ruff-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .unwrap();
+        let urls = Binary::Ruff
+            .mirror_urls_with_astral_mirror(
+                canonical_url,
+                Some("https://nexus.example.com/repository/releases.astral.sh/"),
+            )
+            .expect("mirror URLs should be valid");
+
+        let urls = urls
+            .into_iter()
+            .map(|url| url.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![
+                "https://nexus.example.com/repository/releases.astral.sh/github/ruff/releases/download/0.15.1/ruff-x86_64-unknown-linux-gnu.tar.gz"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_manifest_urls_empty_astral_mirror_uses_default() {
+        for binary in [Binary::Ruff, Binary::Uv] {
+            let default_urls = binary
+                .manifest_urls_with_astral_mirror(None)
+                .expect("manifest URLs should be valid");
+            let empty_urls = binary
+                .manifest_urls_with_astral_mirror(Some(""))
+                .expect("manifest URLs should be valid");
+            assert_eq!(default_urls, empty_urls);
+        }
+    }
+
+    #[test]
+    fn test_ruff_mirror_urls_empty_astral_mirror_uses_default() {
+        let canonical_url = DisplaySafeUrl::parse(
+            "https://github.com/astral-sh/ruff/releases/download/0.15.1/ruff-x86_64-unknown-linux-gnu.tar.gz",
+        )
+        .unwrap();
+        let default_urls = Binary::Ruff
+            .mirror_urls_with_astral_mirror(canonical_url.clone(), None)
+            .expect("mirror URLs should be valid");
+        let empty_urls = Binary::Ruff
+            .mirror_urls_with_astral_mirror(canonical_url, Some(""))
+            .expect("mirror URLs should be valid");
+
+        assert_eq!(default_urls, empty_urls);
     }
 
     #[tokio::test]

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -31,7 +31,9 @@ use uv_fs::{Simplified, rename_with_retry};
 use uv_platform::{self as platform, Arch, Libc, Os, Platform};
 use uv_pypi_types::{HashAlgorithm, HashDigest};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
-use uv_static::EnvVars;
+use uv_static::{
+    EnvVars, astral_mirror_base_url, astral_mirror_url_from_env, custom_astral_mirror_url,
+};
 
 use crate::PythonVariant;
 use crate::implementation::{
@@ -185,12 +187,16 @@ impl RetriableError for Error {
 const CPYTHON_DOWNLOADS_URL_PREFIX: &str =
     "https://github.com/astral-sh/python-build-standalone/releases/download/";
 
-/// The default Astral mirror for `python-build-standalone` releases.
-///
-/// This mirror is tried first for CPython downloads when no user-configured mirror is set.
-/// If the mirror fails, uv falls back to the canonical GitHub URL.
-const CPYTHON_DOWNLOAD_DEFAULT_MIRROR: &str =
-    "https://releases.astral.sh/github/python-build-standalone/releases/download/";
+/// The suffix appended to the Astral mirror base for `python-build-standalone` releases.
+const CPYTHON_MIRROR_SUFFIX: &str = "/github/python-build-standalone/releases/download/";
+
+/// Return the Astral mirror base URL for CPython downloads.
+fn effective_cpython_mirror(astral_mirror_url: Option<&str>) -> String {
+    format!(
+        "{}{CPYTHON_MIRROR_SUFFIX}",
+        astral_mirror_base_url(astral_mirror_url)
+    )
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct ManagedPythonDownload {
@@ -1523,6 +1529,21 @@ impl ManagedPythonDownload {
         python_install_mirror: Option<&str>,
         pypy_install_mirror: Option<&str>,
     ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let custom_astral_mirror = astral_mirror_url_from_env();
+        self.download_urls_with_astral_mirror(
+            python_install_mirror,
+            pypy_install_mirror,
+            custom_astral_mirror.as_deref(),
+        )
+    }
+
+    fn download_urls_with_astral_mirror(
+        &self,
+        python_install_mirror: Option<&str>,
+        pypy_install_mirror: Option<&str>,
+        astral_mirror_url: Option<&str>,
+    ) -> Result<Vec<DisplaySafeUrl>, Error> {
+        let astral_mirror_url = custom_astral_mirror_url(astral_mirror_url);
         match self.key.implementation {
             LenientImplementationName::Known(ImplementationName::CPython) => {
                 if let Some(mirror) = python_install_mirror {
@@ -1537,16 +1558,17 @@ impl ManagedPythonDownload {
                         format!("{}/{}", mirror.trim_end_matches('/'), suffix).as_str(),
                     )?]);
                 }
-                // No user mirror: try the default Astral mirror first, fall back to GitHub.
+                // No user mirror: try the default/custom Astral mirror first.
                 if let Some(suffix) = self.url.strip_prefix(CPYTHON_DOWNLOADS_URL_PREFIX) {
+                    let effective_mirror = effective_cpython_mirror(astral_mirror_url);
                     let mirror_url = DisplaySafeUrl::parse(
-                        format!(
-                            "{}/{}",
-                            CPYTHON_DOWNLOAD_DEFAULT_MIRROR.trim_end_matches('/'),
-                            suffix
-                        )
-                        .as_str(),
+                        format!("{}/{}", effective_mirror.trim_end_matches('/'), suffix).as_str(),
                     )?;
+                    // When a custom Astral mirror is set, use it exclusively.
+                    if astral_mirror_url.is_some() {
+                        return Ok(vec![mirror_url]);
+                    }
+                    // Otherwise fall back to the canonical GitHub URL.
                     let canonical_url = DisplaySafeUrl::parse(&self.url)?;
                     return Ok(vec![mirror_url, canonical_url]);
                 }
@@ -2271,6 +2293,97 @@ mod tests {
                 .as_deref(),
             Some("3.12")
         );
+    }
+
+    fn cpython_download_for_url(url: &'static str) -> ManagedPythonDownload {
+        let key = PythonInstallationKey::new(
+            LenientImplementationName::Known(crate::implementation::ImplementationName::CPython),
+            3,
+            12,
+            4,
+            None,
+            Platform::new(
+                Os::from_str("linux").unwrap(),
+                Arch::from_str("x86_64").unwrap(),
+                Libc::from_str("gnu").unwrap(),
+            ),
+            crate::PythonVariant::default(),
+        );
+
+        ManagedPythonDownload {
+            key,
+            url: Cow::Borrowed(url),
+            sha256: Some(Cow::Borrowed("abc123")),
+            build: Some("20240713"),
+        }
+    }
+
+    #[test]
+    fn test_cpython_download_urls_custom_astral_mirror() {
+        let download = cpython_download_for_url(
+            "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        );
+
+        let urls = download
+            .download_urls_with_astral_mirror(
+                None,
+                None,
+                Some("https://nexus.example.com/repository/releases.astral.sh/"),
+            )
+            .expect("download URLs should be valid");
+        let urls = urls
+            .into_iter()
+            .map(|url| url.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![
+                "https://nexus.example.com/repository/releases.astral.sh/github/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cpython_specific_mirror_takes_precedence_over_astral_mirror() {
+        let download = cpython_download_for_url(
+            "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        );
+
+        let urls = download
+            .download_urls_with_astral_mirror(
+                Some("https://python-mirror.example.com/releases/"),
+                None,
+                Some("https://nexus.example.com/repository/releases.astral.sh/"),
+            )
+            .expect("download URLs should be valid");
+        let urls = urls
+            .into_iter()
+            .map(|url| url.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![
+                "https://python-mirror.example.com/releases/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cpython_download_urls_empty_astral_mirror_uses_default() {
+        let download = cpython_download_for_url(
+            "https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-x86_64-unknown-linux-gnu-install_only.tar.gz",
+        );
+
+        let default_urls = download
+            .download_urls_with_astral_mirror(None, None, None)
+            .expect("download URLs should be valid");
+        let empty_urls = download
+            .download_urls_with_astral_mirror(None, None, Some(""))
+            .expect("download URLs should be valid");
+
+        assert_eq!(default_urls, empty_urls);
     }
 
     /// Test build display

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -450,6 +450,9 @@ impl EnvVars {
     /// The provided URL will replace `https://github.com/astral-sh/python-build-standalone/releases/download` in, e.g.,
     /// `https://github.com/astral-sh/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
     /// Distributions can be read from a local directory by using the `file://` URL scheme.
+    ///
+    /// This more-specific mirror takes precedence over
+    /// [`UV_ASTRAL_MIRROR_URL`](Self::UV_ASTRAL_MIRROR_URL) for CPython downloads.
     #[attr_added_in("0.2.35")]
     pub const UV_PYTHON_INSTALL_MIRROR: &'static str = "UV_PYTHON_INSTALL_MIRROR";
 
@@ -462,6 +465,26 @@ impl EnvVars {
     /// Distributions can be read from a local directory by using the `file://` URL scheme.
     #[attr_added_in("0.2.35")]
     pub const UV_PYPY_INSTALL_MIRROR: &'static str = "UV_PYPY_INSTALL_MIRROR";
+
+    /// Replaces the `https://releases.astral.sh` base URL for all Astral-mirrored
+    /// metadata and artifact downloads.
+    ///
+    /// When set, uv uses only the configured mirror URL and does not fall back to
+    /// GitHub or raw GitHub. Path components in the URL are preserved: only
+    /// trailing slashes are trimmed before appending the normal path suffix
+    /// (e.g., `/github/versions/main/v1/uv.ndjson`).
+    ///
+    /// This is useful for proxy repositories (e.g., Artifactory, Nexus) that
+    /// mirror `releases.astral.sh`.
+    ///
+    /// More-specific sources take precedence:
+    /// [`UV_PYTHON_INSTALL_MIRROR`](Self::UV_PYTHON_INSTALL_MIRROR) and
+    /// `python-install-mirror` override this variable for CPython downloads, while
+    /// [`UV_INSTALLER_GITHUB_BASE_URL`](Self::UV_INSTALLER_GITHUB_BASE_URL) and
+    /// [`UV_INSTALLER_GHE_BASE_URL`](Self::UV_INSTALLER_GHE_BASE_URL) override this
+    /// variable for `uv self update`.
+    #[attr_added_in("next release")]
+    pub const UV_ASTRAL_MIRROR_URL: &'static str = "UV_ASTRAL_MIRROR_URL";
 
     /// Pin managed CPython versions to a specific build version.
     ///
@@ -1213,11 +1236,17 @@ impl EnvVars {
 
     /// The URL from which to download uv using the standalone installer and `self update` feature,
     /// in lieu of the default GitHub URL.
+    ///
+    /// This more-specific installer source takes precedence over
+    /// [`UV_ASTRAL_MIRROR_URL`](Self::UV_ASTRAL_MIRROR_URL) for `uv self update`.
     #[attr_added_in("0.5.0")]
     pub const UV_INSTALLER_GITHUB_BASE_URL: &'static str = "UV_INSTALLER_GITHUB_BASE_URL";
 
     /// The URL from which to download uv using the standalone installer and `self update` feature,
     /// in lieu of the default GitHub Enterprise URL.
+    ///
+    /// This more-specific installer source takes precedence over
+    /// [`UV_ASTRAL_MIRROR_URL`](Self::UV_ASTRAL_MIRROR_URL) for `uv self update`.
     #[attr_added_in("0.5.0")]
     pub const UV_INSTALLER_GHE_BASE_URL: &'static str = "UV_INSTALLER_GHE_BASE_URL";
 

--- a/crates/uv-static/src/lib.rs
+++ b/crates/uv-static/src/lib.rs
@@ -2,7 +2,35 @@ pub use env_vars::*;
 
 mod env_vars;
 
+use std::borrow::Cow;
+
 use thiserror::Error;
+
+/// The base URL for the default Astral mirror.
+pub const ASTRAL_MIRROR_BASE_URL: &str = "https://releases.astral.sh";
+
+/// Read the user-configured Astral mirror URL from the environment, if set.
+pub fn astral_mirror_url_from_env() -> Option<String> {
+    std::env::var_os(EnvVars::UV_ASTRAL_MIRROR_URL).and_then(|url| {
+        if url.as_os_str().is_empty() {
+            None
+        } else {
+            Some(url.to_string_lossy().into_owned())
+        }
+    })
+}
+
+/// Return the effective Astral mirror base URL, using the default mirror when unset.
+pub fn astral_mirror_base_url(astral_mirror_url: Option<&str>) -> Cow<'_, str> {
+    custom_astral_mirror_url(astral_mirror_url)
+        .map(|url| Cow::Owned(url.trim_end_matches('/').to_string()))
+        .unwrap_or(Cow::Borrowed(ASTRAL_MIRROR_BASE_URL))
+}
+
+/// Return a user-configured Astral mirror URL, treating empty values as unset.
+pub fn custom_astral_mirror_url(astral_mirror_url: Option<&str>) -> Option<&str> {
+    astral_mirror_url.filter(|url| !url.is_empty())
+}
 
 #[derive(Debug, Error)]
 #[error("Failed to parse environment variable `{name}` with invalid value `{value}`: {err}")]

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -20,15 +20,42 @@ use uv_client::{BaseClientBuilder, RetriableError, WrappedReqwestError, fetch_wi
 use uv_fs::Simplified;
 use uv_pep440::{Version as Pep440Version, VersionSpecifier, VersionSpecifiers};
 use uv_redacted::DisplaySafeUrl;
-use uv_static::EnvVars;
+use uv_static::{
+    EnvVars, astral_mirror_base_url, astral_mirror_url_from_env, custom_astral_mirror_url,
+};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 const UV_GITHUB_RELEASES_DOWNLOAD_PREFIX: &str =
     "https://github.com/astral-sh/uv/releases/download/";
-const UV_MIRROR_RELEASES_DOWNLOAD_PREFIX: &str =
-    "https://releases.astral.sh/github/uv/releases/download/";
+
+/// The suffix appended to the Astral mirror base for uv release downloads.
+const UV_MIRROR_SUFFIX: &str = "/github/uv/releases/download/";
+
+/// Return the effective Astral mirror prefix for uv release downloads.
+fn effective_uv_mirror_prefix(astral_mirror_url: Option<&str>) -> String {
+    format!(
+        "{}{UV_MIRROR_SUFFIX}",
+        astral_mirror_base_url(astral_mirror_url)
+    )
+}
+
+/// Return the `UV_DOWNLOAD_URL` value for the standalone installer when a custom Astral mirror is
+/// configured.
+fn installer_download_url(
+    target_version: &Pep440Version,
+    astral_mirror_url: Option<&str>,
+) -> Option<String> {
+    let mirror = custom_astral_mirror_url(astral_mirror_url)?;
+    Some(format!(
+        "{}{}{}",
+        mirror.trim_end_matches('/'),
+        UV_MIRROR_SUFFIX,
+        target_version
+    ))
+}
+
 const AXOUPDATER_CONFIG_PATH: &str = "AXOUPDATER_CONFIG_PATH";
 const AXOUPDATER_CONFIG_WORKING_DIR: &str = "AXOUPDATER_CONFIG_WORKING_DIR";
 
@@ -318,7 +345,9 @@ async fn run_official_updater(
     client_builder: BaseClientBuilder<'_>,
     github_token: Option<&str>,
 ) -> Result<ExitStatus> {
-    let installer_urls = official_installer_urls(target_version)?;
+    let custom_astral_mirror = astral_mirror_url_from_env();
+    let installer_urls =
+        official_installer_urls_with_mirror(target_version, custom_astral_mirror.as_deref())?;
     let temp_dir = TempDir::new()?;
     let installer_path = temp_dir.path().join(installer_filename());
     let install_prefix = PathBuf::from(updater.install_prefix_root()?.as_str());
@@ -335,7 +364,14 @@ async fn run_official_updater(
     )
     .await?;
 
-    execute_official_installer(&installer_path, &install_prefix, modify_path).await?;
+    execute_official_installer(
+        &installer_path,
+        &install_prefix,
+        modify_path,
+        target_version,
+        custom_astral_mirror.as_deref(),
+    )
+    .await?;
 
     let direction = if current_version > target_version {
         "Downgraded"
@@ -368,19 +404,31 @@ fn installer_filename() -> &'static str {
 }
 
 /// Build the mirror-first URL list for the official standalone installer.
-fn official_installer_urls(version: &Pep440Version) -> Result<Vec<DisplaySafeUrl>> {
+fn official_installer_urls_with_mirror(
+    version: &Pep440Version,
+    astral_mirror_url: Option<&str>,
+) -> Result<Vec<DisplaySafeUrl>> {
+    let astral_mirror_url = custom_astral_mirror_url(astral_mirror_url);
     let filename = installer_filename();
-    let mirror = format!("{UV_MIRROR_RELEASES_DOWNLOAD_PREFIX}{version}/{filename}");
-    let canonical = format!("{UV_GITHUB_RELEASES_DOWNLOAD_PREFIX}{version}/{filename}");
+    let mirror_prefix = effective_uv_mirror_prefix(astral_mirror_url);
+    let mirror = format!("{mirror_prefix}{version}/{filename}");
 
-    Ok(vec![
+    let mut urls = vec![
         DisplaySafeUrl::parse(&mirror).with_context(|| format!("Failed to parse `{mirror}`"))?,
-        DisplaySafeUrl::parse(&canonical)
-            .with_context(|| format!("Failed to parse `{canonical}`"))?,
-    ])
+    ];
+
+    // When using the default mirror, also fall back to the canonical GitHub URL.
+    if astral_mirror_url.is_none() {
+        let canonical = format!("{UV_GITHUB_RELEASES_DOWNLOAD_PREFIX}{version}/{filename}");
+        urls.push(
+            DisplaySafeUrl::parse(&canonical)
+                .with_context(|| format!("Failed to parse `{canonical}`"))?,
+        );
+    }
+    Ok(urls)
 }
 
-/// Download the official installer from the mirror first, then fall back to GitHub.
+/// Download the official installer from the provided mirror/canonical URL list.
 async fn download_installer_from_urls(
     urls: &[DisplaySafeUrl],
     installer_path: &Path,
@@ -459,10 +507,16 @@ fn installer_download_github_token<'a>(
 
 /// Execute the standalone installer while preserving the existing install location and PATH
 /// behavior.
+///
+/// When [`UV_ASTRAL_MIRROR_URL`](EnvVars::UV_ASTRAL_MIRROR_URL) is set, the installer is also
+/// given `UV_DOWNLOAD_URL` pointing at the mirror's uv release directory so the installer itself
+/// fetches the uv archive from the mirror.
 async fn execute_official_installer(
     installer_path: &Path,
     install_prefix: &Path,
     modify_path: bool,
+    target_version: &Pep440Version,
+    astral_mirror_url: Option<&str>,
 ) -> Result<(), AxoupdateError> {
     let mut command = if cfg!(windows) {
         let mut command = Command::new("powershell");
@@ -487,6 +541,11 @@ async fn execute_official_installer(
     command.env_remove(EnvVars::PS_MODULE_PATH);
     command.env("CARGO_DIST_FORCE_INSTALL_DIR", install_prefix);
     command.env(EnvVars::UV_INSTALL_DIR, install_prefix);
+    // When a custom Astral mirror is configured, point the installer at the mirrored
+    // uv release directory so it downloads the archive from the mirror too.
+    if let Some(download_url) = installer_download_url(target_version, astral_mirror_url) {
+        command.env(EnvVars::UV_DOWNLOAD_URL, download_url);
+    }
     if !modify_path {
         let app_name_env_var = app_name_to_env_var("uv");
         command.env(format!("{app_name_env_var}_NO_MODIFY_PATH"), "1");
@@ -929,7 +988,7 @@ mod tests {
 
     #[test]
     fn test_official_installer_urls() {
-        let urls = official_installer_urls(&Pep440Version::new([1, 2, 3]))
+        let urls = official_installer_urls_with_mirror(&Pep440Version::new([1, 2, 3]), None)
             .unwrap()
             .into_iter()
             .map(|url| url.to_string())
@@ -946,6 +1005,56 @@ mod tests {
                     installer_filename()
                 ),
             ]
+        );
+    }
+
+    #[test]
+    fn test_official_installer_urls_custom_astral_mirror() {
+        let urls = official_installer_urls_with_mirror(
+            &Pep440Version::new([1, 2, 3]),
+            Some("https://nexus.example.com/repository/releases.astral.sh/"),
+        )
+        .unwrap()
+        .into_iter()
+        .map(|url| url.to_string())
+        .collect::<Vec<_>>();
+        assert_eq!(
+            urls,
+            vec![format!(
+                "https://nexus.example.com/repository/releases.astral.sh/github/uv/releases/download/1.2.3/{}",
+                installer_filename()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_official_installer_urls_empty_astral_mirror_uses_default() {
+        let default_urls =
+            official_installer_urls_with_mirror(&Pep440Version::new([1, 2, 3]), None).unwrap();
+        let empty_urls =
+            official_installer_urls_with_mirror(&Pep440Version::new([1, 2, 3]), Some("")).unwrap();
+        assert_eq!(default_urls, empty_urls);
+    }
+
+    #[test]
+    fn test_installer_download_url_custom_astral_mirror() {
+        assert_eq!(
+            installer_download_url(
+                &Pep440Version::new([1, 2, 3]),
+                Some("https://nexus.example.com/repository/releases.astral.sh/")
+            )
+            .as_deref(),
+            Some(
+                "https://nexus.example.com/repository/releases.astral.sh/github/uv/releases/download/1.2.3"
+            )
+        );
+    }
+
+    #[test]
+    fn test_installer_download_url_empty_astral_mirror_uses_default() {
+        assert_eq!(
+            installer_download_url(&Pep440Version::new([1, 2, 3]), Some("")),
+            None
         );
     }
 
@@ -1053,9 +1162,15 @@ mod tests {
         .unwrap();
         fs_err::set_permissions(&installer_path, std::fs::Permissions::from_mode(0o744)).unwrap();
 
-        let err = execute_official_installer(&installer_path, &install_prefix, true)
-            .await
-            .expect_err("failing installer should return an error");
+        let err = execute_official_installer(
+            &installer_path,
+            &install_prefix,
+            true,
+            &Pep440Version::new([1, 2, 3]),
+            None,
+        )
+        .await
+        .expect_err("failing installer should return an error");
         let AxoupdateError::InstallFailed {
             status,
             stdout,
@@ -1090,9 +1205,15 @@ mod tests {
         .unwrap();
         fs_err::set_permissions(&installer_path, std::fs::Permissions::from_mode(0o744)).unwrap();
 
-        execute_official_installer(&installer_path, &install_prefix, false)
-            .await
-            .unwrap();
+        execute_official_installer(
+            &installer_path,
+            &install_prefix,
+            false,
+            &Pep440Version::new([1, 2, 3]),
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             fs_err::read_to_string(&output_path).unwrap(),
@@ -1101,6 +1222,42 @@ mod tests {
                 install_prefix.display(),
                 install_prefix.display(),
             )
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_execute_official_installer_sets_download_url_for_astral_mirror() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let output_path = temp_dir.path().join("env.txt");
+        let installer_path = temp_dir.path().join("installer.sh");
+        let install_prefix = temp_dir.path().join("install-prefix");
+
+        fs_err::write(
+            &installer_path,
+            format!(
+                "#!/bin/sh\nset -eu\n{{\nprintf 'UV_DOWNLOAD_URL=%s\\n' \"${{UV_DOWNLOAD_URL-}}\"\n}} > \"{}\"\n",
+                output_path.display()
+            ),
+        )
+        .unwrap();
+        fs_err::set_permissions(&installer_path, std::fs::Permissions::from_mode(0o744)).unwrap();
+
+        execute_official_installer(
+            &installer_path,
+            &install_prefix,
+            true,
+            &Pep440Version::new([1, 2, 3]),
+            Some("https://nexus.example.com/repository/releases.astral.sh/"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            fs_err::read_to_string(&output_path).unwrap(),
+            "UV_DOWNLOAD_URL=https://nexus.example.com/repository/releases.astral.sh/github/uv/releases/download/1.2.3\n"
         );
     }
 
@@ -1124,9 +1281,15 @@ mod tests {
         .unwrap();
         fs_err::set_permissions(&installer_path, std::fs::Permissions::from_mode(0o744)).unwrap();
 
-        execute_official_installer(&installer_path, &install_prefix, true)
-            .await
-            .unwrap();
+        execute_official_installer(
+            &installer_path,
+            &install_prefix,
+            true,
+            &Pep440Version::new([1, 2, 3]),
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             fs_err::read_to_string(&output_path).unwrap(),


### PR DESCRIPTION
Support UV_ASTRAL_MIRROR_URL for mirrored Astral release metadata and artifacts, including Ruff, CPython downloads, and self-update. When set, no GitHub fallback takes place. The more specific env vars override this.

Closes https://github.com/astral-sh/uv/issues/9134
Closes https://github.com/astral-sh/uv/issues/16519
Closes https://github.com/astral-sh/uv/issues/17255
Closes https://github.com/astral-sh/uv/issues/15970
Closes https://github.com/astral-sh/uv/issues/18525