### PR TITLE
Use symlinks instead of junctions on Wine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6574,6 +6574,7 @@ dependencies = [
  "tracing",
  "uv-static",
  "uv-warnings",
+ "uv-windows",
  "walkdir",
  "windows",
 ]
@@ -6982,7 +6983,6 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
- "junction",
  "owo-colors",
  "ref-cast",
  "regex",

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -43,6 +43,7 @@ rustix = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 backon = { workspace = true }
 junction = { workspace = true }
+uv-windows = { workspace = true }
 windows = { workspace = true }
 
 [features]

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -78,31 +78,47 @@ pub async fn read_to_string_transcode(path: impl AsRef<Path>) -> std::io::Result
     Ok(buf)
 }
 
-/// Create a symlink at `dst` pointing to `src`, replacing any existing symlink.
+/// Create a directory link at `dst` pointing to `src`, replacing any existing link.
 ///
-/// On Windows, this uses the `junction` crate to create a junction point. The
-/// operation is _not_ atomic, as we first delete the junction, then create a
-/// junction at the same path.
+/// On Windows, this normally creates an NTFS junction, since junctions don't
+/// require elevated privileges. When running under Wine, which doesn't implement
+/// the reparse-point ioctl that junction creation depends on, this transparently
+/// creates a Windows directory symbolic link instead via `CreateSymbolicLinkW`
+/// (Wine maps that to a Unix symlink, so it succeeds without privileges).
 ///
-/// Note that because junctions are used, the source must be a directory.
+/// The operation is _not_ atomic: any existing entry at `dst` is removed first,
+/// then the new link is created at the same path.
+///
+/// Note that the source must be a directory.
 ///
 /// Changes to this function should be reflected in [`create_symlink`].
 #[cfg(windows)]
 pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    // If the source is a file, we can't create a junction
-    if src.as_ref().is_file() {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+
+    if src.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "Cannot create a junction for {}: is not a directory",
-                src.as_ref().display()
+                "Cannot create a directory link for {}: is not a directory",
+                src.display()
             ),
         ));
     }
 
-    // Remove the existing symlink, if any.
-    match junction::delete(dunce::simplified(dst.as_ref())) {
-        Ok(()) => match fs_err::remove_dir_all(dst.as_ref()) {
+    if uv_windows::is_wine() {
+        replace_with_symlink_dir(src, dst)
+    } else {
+        replace_with_junction(src, dst)
+    }
+}
+
+#[cfg(windows)]
+fn replace_with_junction(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Remove the existing junction, if any.
+    match junction::delete(dunce::simplified(dst)) {
+        Ok(()) => match fs_err::remove_dir_all(dst) {
             Ok(()) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => return Err(err),
@@ -111,11 +127,45 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
         Err(err) => return Err(err),
     }
 
-    // Replace it with a new symlink.
-    junction::create(
-        dunce::simplified(src.as_ref()),
-        dunce::simplified(dst.as_ref()),
-    )
+    // Replace it with a new junction.
+    junction::create(dunce::simplified(src), dunce::simplified(dst))
+}
+
+#[cfg(windows)]
+fn replace_with_symlink_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    // Best-effort removal of any existing entry. The destination may be a
+    // directory, file, or symlink, so try the directory removal first and
+    // fall back to file removal if that fails.
+    match fs_err::remove_dir_all(dst) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(_) => match fs_err::remove_file(dst) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        },
+    }
+
+    fs_err::os::windows::fs::symlink_dir(dunce::simplified(src), dunce::simplified(dst))
+}
+
+/// Read the target of a directory link created by [`create_symlink`] or
+/// [`replace_symlink`].
+///
+/// On Windows, uv normally creates junctions for directory links, but creates
+/// directory symbolic links under Wine. This function reads the appropriate link
+/// type for the current environment. For junctions, this uses the `junction`
+/// crate, which handles the `\??\` prefix that Windows uses internally for
+/// junction targets.
+#[cfg(windows)]
+pub fn read_link(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    let path = path.as_ref();
+
+    if uv_windows::is_wine() {
+        fs_err::read_link(path)
+    } else {
+        junction::get_target(dunce::simplified(path))
+    }
 }
 
 /// Create a symlink at `dst` pointing to `src`, replacing any existing symlink if necessary.
@@ -141,30 +191,35 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
     }
 }
 
-/// Create a symlink at `dst` pointing to `src`.
+/// Create a directory link at `dst` pointing to `src`.
 ///
-/// On Windows, this uses the `junction` crate to create a junction point.
+/// On Windows, this normally creates an NTFS junction, falling back to a Windows
+/// directory symbolic link when running under Wine. See [`replace_symlink`] for
+/// the rationale.
 ///
-/// Note that because junctions are used, the source must be a directory.
+/// Note that the source must be a directory.
 ///
 /// Changes to this function should be reflected in [`replace_symlink`].
 #[cfg(windows)]
 pub fn create_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    // If the source is a file, we can't create a junction
-    if src.as_ref().is_file() {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+
+    if src.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "Cannot create a junction for {}: is not a directory",
-                src.as_ref().display()
+                "Cannot create a directory link for {}: is not a directory",
+                src.display()
             ),
         ));
     }
 
-    junction::create(
-        dunce::simplified(src.as_ref()),
-        dunce::simplified(dst.as_ref()),
-    )
+    if uv_windows::is_wine() {
+        fs_err::os::windows::fs::symlink_dir(dunce::simplified(src), dunce::simplified(dst))
+    } else {
+        junction::create(dunce::simplified(src), dunce::simplified(dst))
+    }
 }
 
 /// Create a symlink at `dst` pointing to `src`.
@@ -176,6 +231,24 @@ pub fn create_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::
 #[cfg(unix)]
 pub fn remove_symlink(path: impl AsRef<Path>) -> std::io::Result<()> {
     fs_err::remove_file(path.as_ref())
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_link_reads_created_directory_link() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let target = tempdir.path().join("target");
+        fs_err::create_dir(&target)?;
+        let link = tempdir.path().join("link");
+
+        create_symlink(&target, &link)?;
+
+        assert_eq!(read_link(&link)?, dunce::simplified(&target));
+        Ok(())
+    }
 }
 
 /// Create a symlink at `dst` pointing to `src` on Unix or copy `src` to `dst` on Windows

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -68,7 +68,6 @@ url = { workspace = true }
 which = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-junction = { workspace = true }
 windows-registry = { workspace = true }
 windows = { workspace = true }
 

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -873,9 +873,8 @@ impl PythonMinorVersionLink {
 
     /// Read the target of the minor version link.
     ///
-    /// On Unix, this reads the symlink target. On Windows, this reads the junction target
-    /// using the `junction` crate which properly handles the `\??\` prefix that Windows
-    /// uses internally for junction targets.
+    /// On Unix, this reads the symlink target. On Windows, this reads the directory link
+    /// target, whether uv created it as a junction or as a directory symlink under Wine.
     pub fn read_target(&self) -> Option<PathBuf> {
         #[cfg(unix)]
         {
@@ -883,7 +882,7 @@ impl PythonMinorVersionLink {
         }
         #[cfg(windows)]
         {
-            junction::get_target(&self.symlink_directory).ok()
+            uv_fs::read_link(&self.symlink_directory).ok()
         }
     }
 }

--- a/crates/uv-windows/src/lib.rs
+++ b/crates/uv-windows/src/lib.rs
@@ -9,8 +9,11 @@ mod ctrl_handler;
 mod job;
 #[cfg(feature = "std")]
 mod spawn;
+mod wine;
 
 pub use ctrl_handler::{CtrlHandlerError, install_ctrl_handler};
 pub use job::{Job, JobError};
 #[cfg(feature = "std")]
 pub use spawn::spawn_child;
+#[cfg(feature = "std")]
+pub use wine::is_wine;

--- a/crates/uv-windows/src/wine.rs
+++ b/crates/uv-windows/src/wine.rs
@@ -1,0 +1,59 @@
+//! Wine detection for Windows builds running under the Wine compatibility layer.
+//!
+//! Wine implements the Win32 API on top of a Unix host. Most of the API is
+//! transparent to applications, but a handful of low-level filesystem
+//! operations (notably the reparse-point ioctl used to create NTFS junctions)
+//! are unimplemented, so callers may want to take a different code path when
+//! they detect Wine. See <https://github.com/astral-sh/uv/issues/19187>.
+//!
+//! Detection is based on the canonical method recommended by the Wine
+//! project: probing `ntdll.dll` for the Wine-only `wine_get_version` export.
+
+#![cfg(feature = "std")]
+
+use std::ptr::{addr_of_mut, null_mut};
+use std::sync::OnceLock;
+
+use windows::Win32::Foundation::HMODULE;
+use windows::Win32::System::LibraryLoader::{
+    GET_MODULE_HANDLE_EX_FLAG_PIN, GetModuleHandleExA, GetProcAddress,
+};
+use windows::core::s;
+
+/// Returns whether the current process is running under Wine.
+///
+/// The result is cached after the first call.
+#[must_use]
+pub fn is_wine() -> bool {
+    static IS_WINE: OnceLock<bool> = OnceLock::new();
+    *IS_WINE.get_or_init(detect_wine)
+}
+
+/// Detect Wine by probing `ntdll.dll` for the `wine_get_version` export, which
+/// is present in Wine's `ntdll` but not in the genuine Windows DLL.
+#[allow(unsafe_code)]
+fn detect_wine() -> bool {
+    let mut ntdll = HMODULE(null_mut());
+
+    // SAFETY: `GetModuleHandleExA` is safe to call with a static,
+    // NUL-terminated ASCII module name and a valid out-pointer. It returns an
+    // error if the module isn't loaded; we treat that as "not Wine" and bail
+    // out. `GET_MODULE_HANDLE_EX_FLAG_PIN` ensures the returned handle cannot be
+    // invalidated by unloading the module later.
+    if unsafe {
+        GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_PIN,
+            s!("ntdll.dll"),
+            addr_of_mut!(ntdll),
+        )
+    }
+    .is_err()
+    {
+        return false;
+    }
+
+    // SAFETY: `GetProcAddress` is safe to call with a valid module handle and
+    // a static, NUL-terminated ASCII export name. It returns `None` if the
+    // export isn't present, which is the case on real Windows.
+    unsafe { GetProcAddress(ntdll, s!("wine_get_version")) }.is_some()
+}

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -214,7 +214,7 @@ async fn do_uninstall(
     // Remove minor version links (symlinks on Unix, junctions on Windows) for minor
     // versions that will have no remaining installations. This must happen before
     // removing the installation directories so that the link targets still exist,
-    // which is required by `junction::get_target` on Windows.
+    // which is required when reading link targets on Windows.
     for installation in &matching_installations {
         if !anticipated_remaining_minor_versions.contains_key(installation.minor_version_key()) {
             if let Some(minor_version_link) =


### PR DESCRIPTION
Integration test coverage added in https://github.com/astral-sh/uv/pull/19214
Closes https://github.com/astral-sh/uv/issues/19187

On Wine, we're compiled for Windows but junctions are not available. Here, we switch to symlinks when we can detect Wine.