### PR TITLE
feat: Add `uv lock --rewrite` (#15220)

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1154,7 +1154,7 @@ pub enum ProjectCommand {
     /// present, its contents will be used as preferences for the resolution.
     ///
     /// If there are no changes to the project's dependencies, locking will have no effect unless
-    /// the `--upgrade` flag is provided.
+    /// the `--upgrade` or `--rewrite` flag is provided.
     #[command(
         after_help = "Use `uv help lock` for more details.",
         after_long_help = ""
@@ -4193,6 +4193,11 @@ pub struct LockArgs {
         conflicts_with = "locked"
     )]
     pub dry_run: bool,
+
+    /// Require a re-resolution and rewrite of the lockfile, even if the dependencies
+    /// or requirements have not changed.
+    #[arg(long, conflicts_with_all = ["check", "locked", "check_exists", "dry_run"])]
+    pub rewrite: bool,
 
     /// Lock the specified Python script, rather than the current project.
     ///

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -87,6 +87,7 @@ pub(crate) async fn lock(
     lock_check: LockCheck,
     frozen: Option<FrozenSource>,
     dry_run: DryRun,
+    rewrite: bool,
     refresh: Refresh,
     python: Option<String>,
     install_mirrors: PythonInstallMirrors,
@@ -216,6 +217,7 @@ pub(crate) async fn lock(
             preview,
         )
         .with_refresh(&refresh)
+        .with_rewrite(rewrite)
         .execute(target),
     )
     .await
@@ -308,6 +310,7 @@ pub(crate) struct LockOperation<'env> {
     workspace_cache: &'env WorkspaceCache,
     printer: Printer,
     preview: Preview,
+    rewrite: bool,
 }
 
 impl<'env> LockOperation<'env> {
@@ -337,6 +340,7 @@ impl<'env> LockOperation<'env> {
             workspace_cache,
             printer,
             preview,
+            rewrite: false,
         }
     }
 
@@ -354,6 +358,13 @@ impl<'env> LockOperation<'env> {
     #[must_use]
     pub(crate) fn with_refresh(mut self, refresh: &'env Refresh) -> Self {
         self.refresh = Some(refresh);
+        self
+    }
+
+    /// Set the rewrite strategy for the [`LockOperation`].
+    #[must_use]
+    pub(crate) fn with_rewrite(mut self, rewrite: bool) -> Self {
+        self.rewrite = rewrite;
         self
     }
 
@@ -405,6 +416,7 @@ impl<'env> LockOperation<'env> {
                     self.workspace_cache,
                     self.printer,
                     self.preview,
+                    self.rewrite,
                 ))
                 .await?;
 
@@ -449,6 +461,7 @@ impl<'env> LockOperation<'env> {
                     self.workspace_cache,
                     self.printer,
                     self.preview,
+                    self.rewrite,
                 ))
                 .await?;
 
@@ -481,6 +494,7 @@ async fn do_lock(
     workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
+    rewrite: bool,
 ) -> Result<LockResult, ProjectError> {
     let start = std::time::Instant::now();
 
@@ -849,6 +863,7 @@ async fn do_lock(
             state.index(),
             &database,
             printer,
+            rewrite,
         )
         .await
         {
@@ -1064,6 +1079,7 @@ impl ValidatedLock {
         index: &InMemoryIndex,
         database: &DistributionDatabase<'_, Context>,
         printer: Printer,
+        rewrite: bool,
     ) -> Result<Self, ProjectError> {
         // Perform checks in a deliberate order, such that the most extreme conditions are tested
         // first (i.e., every check that returns `Self::Unusable`, followed by every check that
@@ -1241,6 +1257,12 @@ impl ValidatedLock {
         } else {
             Some(index_locations)
         };
+
+        // If the user specified `--rewrite`, then we have to re-resolve.
+        if rewrite {
+            debug!("Resolving with existing lockfile due to `--rewrite`");
+            return Ok(Self::Preferable(lock));
+        }
 
         // Determine whether the lockfile satisfies the workspace requirements.
         match lock

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2299,6 +2299,7 @@ async fn run_project(
                 args.lock_check,
                 args.frozen,
                 args.dry_run,
+                args.rewrite,
                 args.refresh,
                 args.python,
                 args.install_mirrors,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1780,6 +1780,7 @@ pub(crate) struct LockSettings {
     pub(crate) lock_check: LockCheck,
     pub(crate) frozen: Option<FrozenSource>,
     pub(crate) dry_run: DryRun,
+    pub(crate) rewrite: bool,
     pub(crate) script: Option<PathBuf>,
     pub(crate) python: Option<String>,
     pub(crate) install_mirrors: PythonInstallMirrors,
@@ -1799,6 +1800,7 @@ impl LockSettings {
             locked,
             check_exists,
             dry_run,
+            rewrite,
             script,
             resolver,
             build,
@@ -1818,6 +1820,16 @@ impl LockSettings {
         // Check for conflicts between locked and frozen.
         check_conflicts(locked, frozen);
 
+        // Check for conflicts between rewrite (CLI only for now) and locked, and rewrite and frozen.
+        let rewrite_flag = if rewrite {
+            Flag::from_cli("rewrite")
+        } else {
+            Flag::Disabled
+        };
+
+        check_conflicts(rewrite_flag, locked);
+        check_conflicts(rewrite_flag, frozen);
+
         let lock_check = if check {
             LockCheck::Enabled(LockCheckSource::Check)
         } else {
@@ -1828,6 +1840,7 @@ impl LockSettings {
             lock_check,
             frozen: resolve_frozen(frozen),
             dry_run: DryRun::from_args(dry_run),
+            rewrite,
             script,
             python: python.and_then(Maybe::into_option),
             refresh: Refresh::from(refresh),

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -34776,6 +34776,239 @@ fn lock_required_intersection() -> Result<()> {
 }
 
 #[test]
+fn lock_rewrite() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    // Write a `uv.lock` that accidentally omits the `anyio` wheel, and uses an outdated revision.
+    context.temp_dir.child("uv.lock").write_str(
+        r#"
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "anyio"
+        version = "3.7.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737, upload-time = "2023-05-27T11:12:46.688Z" }
+
+        [[package]]
+        name = "idna"
+        version = "3.6"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "anyio" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+        ]
+    "#,
+    )?;
+
+    // Run `uv lock`.
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // The revision should still be 2, and the wheel should still be missing.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+
+        version = 1
+        revision = 2
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "anyio"
+        version = "3.7.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737, upload-time = "2023-05-27T11:12:46.688Z" }
+
+        [[package]]
+        name = "idna"
+        version = "3.6"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "anyio" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+        ]
+        "#
+        );
+    });
+
+    // Re-run with `--rewrite`.
+    uv_snapshot!(context.filters(), context.lock().arg("--rewrite"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+
+    // The wheel should be present, and the revision should be incremented.
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "anyio"
+        version = "3.7.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737, upload-time = "2023-05-27T11:12:46.688Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873, upload-time = "2023-05-27T11:12:44.474Z" },
+        ]
+
+        [[package]]
+        name = "idna"
+        version = "3.6"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426, upload-time = "2023-11-25T15:40:54.902Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567, upload-time = "2023-11-25T15:40:52.604Z" },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "anyio" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "anyio", specifier = "==3.7.0" }]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+        ]
+        "#
+        );
+    });
+
+    Ok(())
+}
+
+#[test]
+fn lock_rewrite_conflicts_locked_env() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // Running `UV_LOCKED=1 uv lock --rewrite` should fail.
+    uv_snapshot!(context.filters(), context.lock().env("UV_LOCKED", "1").arg("--rewrite"), @"
+        success: false
+        exit_code: 2
+        ----- stdout -----
+
+        ----- stderr -----
+        error: the argument `--rewrite` cannot be used with `UV_LOCKED` (environment variable)
+        ");
+
+    Ok(())
+}
+
+#[test]
 fn lock_refresh() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -34992,7 +34992,7 @@ fn lock_rewrite() -> Result<()> {
 }
 
 #[test]
-fn lock_rewrite_conflicts_locked_env() -> Result<()> {
+fn lock_rewrite_conflicts_locked_env() {
     let context = uv_test::test_context!("3.12");
 
     // Running `UV_LOCKED=1 uv lock --rewrite` should fail.
@@ -35004,8 +35004,6 @@ fn lock_rewrite_conflicts_locked_env() -> Result<()> {
         ----- stderr -----
         error: the argument `--rewrite` cannot be used with `UV_LOCKED` (environment variable)
         ");
-
-    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -10614,6 +10614,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {
@@ -10747,6 +10748,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {
@@ -10873,6 +10875,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {
@@ -10997,6 +11000,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {
@@ -11118,6 +11122,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {
@@ -11240,6 +11245,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
         lock_check: Disabled,
         frozen: None,
         dry_run: Disabled,
+        rewrite: false,
         script: None,
         python: None,
         install_mirrors: PythonInstallMirrors {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds a new CLI flag `--rewrite` that forces a re-resolution and rewrite of the lockfile even if the dependencies and requirements have not changed.

Changes:
- Add `rewrite` to CLI as a `bool`
- Wind `rewrite` argument through to `validate()` following builder pattern of `refresh` flag (#15994)
- Return `ValidatedLock::Preferable` from `validate()` if `rewrite`

This is most useful for teams who do not enforce a shared `uv` version and see large lockfile diffs that are not semantically meaningful. Closes #15220.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

- Test `lock_rewrite()` modeled on `lock_refresh()`
- Test `lock_rewrite_conflicts_locked_env()` to check guarantees that `rewrite` does not coexist with `locked` (other guarantees enforced by `clap` annotations and `LockSettings::resolve()`)

<!-- How was it tested? -->

## Other Qs/commentary

- Very open to feedback and requests. This is my first PR.
- This PR complies with the AI policy
- Should I add env/config support for `--rewrite`? As-is, this is only available as a CLI flag. I thought I'd keep things simple for my first PR, but I can also add it.
- Should `--rewrite` force a new lockfile write even if the text contents would not change at all? E.g., imagine running `uv lock --rewrite` twice. I am split on the expected behavior. This PR resolves the original user's issue without this, but there may be other situations where someone really wants to blindly rewrite (e.g., they use their filesystem's timestamp to ensure freshness?), and this would be the intuitive flag to use to force that behavior.