### PR TITLE
Handle broken managed Python installation directory

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -10,7 +10,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::{env, io, iter};
 use std::{path::Path, path::PathBuf, str::FromStr};
 use thiserror::Error;
-use tracing::{debug, instrument, trace};
+use tracing::{debug, instrument, trace, warn};
 use uv_cache::Cache;
 use uv_client::BaseClient;
 use uv_distribution_types::RequiresPython;
@@ -990,6 +990,13 @@ impl Error {
             },
             Self::VirtualEnv(VirtualEnvError::MissingPyVenvCfg(path)) => {
                 trace!("Skipping broken virtualenv at {}", path.display());
+                false
+            }
+            // If the managed Python installation directory is inaccessible (e.g., the drive it
+            // lives on was removed or unmounted), skip it and continue discovery. Managed
+            // installations are optional; uv can fall back to system Python or auto-download.
+            Self::ManagedPython(err) => {
+                warn!("Failed to read managed Python installations, skipping: {err}");
                 false
             }
             _ => true,


### PR DESCRIPTION
## Summary

When uv's managed Python directory lives on a drive that becomes inaccessible (e.g., a network drive that disconnects, or a drive that is destroyed and recreated), uv would previously error out during discovery — reporting Python as not installed while simultaneously listing it as an installed version. The only recovery path was a manual uv python uninstall or uv cache clean

This change catches Error::ManagedPython in the is_not_found filter, emits a warning, and continues discovery. Since managed installations are optional, uv can fall back to system Python or trigger an auto-download, which is the correct behavior when the underlying storage has been recreated

## Test Plan

repro:
```bash
# Build uv locally
cargo build -p uv

# Install a managed Python into a custom dir
UV_PYTHON_INSTALL_DIR=/tmp/uv-test-python ./target/debug/uv python install 3.14

# Break the directory
chmod 000 /tmp/uv-test-python

# Trigger discovery — observe warning + fallback (after change) vs. error (before change)
RUST_LOG=uv=warn UV_PYTHON_INSTALL_DIR=/tmp/uv-test-python ./target/debug/uv run foo.py
```

The error in this example is:
> error: Failed to discover managed Python installations
   Caused by: Failed to read Python installation directory
   Caused by: failed to read directory `foo_bar`: Permission denied (os error 13)


In the case of a recreated drive the error is a more opaque:
> `The system cannot find the path specified.`