### PR TITLE
fix: `uv tool uninstall` no longer aborts after first dangling tool

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -137,11 +137,12 @@ async fn do_uninstall(
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
                     Ok(()) => {
+                        dangling = true;
                         writeln!(
                             printer.stderr(),
                             "Removed dangling environment for `{name}`"
                         )?;
-                        return Ok(());
+                        continue;
                     }
                     Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
                         if err.kind() == std::io::ErrorKind::NotFound =>


### PR DESCRIPTION
## Summary

When uninstalling multiple tools by name, if the first tool had a corrupt or missing receipt, `do_uninstall` removed its dangling environment and then returned early via `return Ok(())`, skipping all remaining tools. The user saw exit code 0 with no indication that other tools were not uninstalled.

## Root cause

In `do_uninstall` (uninstall.rs:144), the named-tool branch (`else` at line 133) uses `return Ok(())` after removing a dangling environment. This exits the entire function. The unnamed branch (`if names.is_empty()` at line 103) correctly uses `continue` at line 115 to proceed to the next tool.

## Fix

Replace `return Ok(())` with `dangling = true; continue;` to match the unnamed branch's behavior. This ensures all remaining tools are processed after removing a dangling environment.

The `dangling = true` flag was already used by the unnamed branch but was not set in the named branch, which also meant the "Nothing to uninstall" message could be incorrectly shown when only dangling environments were removed.

Fixes #19219