### PR TITLE
Move parsing of `UV_RUN_MAX_RECURSION_DEPTH` to EnvironmentOptions; update `str_to_bool` comment about nonstandard values

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3795,7 +3795,7 @@ pub struct RunArgs {
     /// cleared, uv will fail to detect the recursion depth.
     ///
     /// If uv reaches the maximum recursion depth, it will exit with an error.
-    #[arg(long, hide = true, env = EnvVars::UV_RUN_MAX_RECURSION_DEPTH)]
+    #[arg(long, hide = true)]
     pub max_recursion_depth: Option<u32>,
 
     /// The platform for which requirements should be installed.

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -751,6 +751,7 @@ pub struct EnvironmentOptions {
     pub venv_clear: EnvFlag,
     pub venv_relocatable: EnvFlag,
     pub init_bare: EnvFlag,
+    pub max_recursion_depth: Option<u32>,
 }
 
 impl EnvironmentOptions {
@@ -847,6 +848,10 @@ impl EnvironmentOptions {
             venv_clear: EnvFlag::new(EnvVars::UV_VENV_CLEAR)?,
             venv_relocatable: EnvFlag::new(EnvVars::UV_VENV_RELOCATABLE)?,
             init_bare: EnvFlag::new(EnvVars::UV_INIT_BARE)?,
+            max_recursion_depth: parse_integer_environment_variable(
+                EnvVars::UV_RUN_MAX_RECURSION_DEPTH,
+                None,
+            )?,
         })
     }
 }

--- a/crates/uv-static/src/lib.rs
+++ b/crates/uv-static/src/lib.rs
@@ -29,9 +29,10 @@ pub fn parse_boolish_environment_variable(
 
     // Converts a string literal representation of truth to true or false.
     //
+    // `true` values are `y`, `yes`, `t`, `true`, `on`, and `1` (case insensitive).
     // `false` values are `n`, `no`, `f`, `false`, `off`, and `0` (case insensitive).
     //
-    // Any other value will be considered as `true`.
+    // Any other value will result in a parsing error, usually fatal.
     fn str_to_bool(val: impl AsRef<str>) -> Option<bool> {
         let pat: &str = &val.as_ref().to_lowercase();
         if TRUE_LITERALS.contains(&pat) {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -743,7 +743,9 @@ impl RunSettings {
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
-            max_recursion_depth: max_recursion_depth.unwrap_or(Self::DEFAULT_MAX_RECURSION_DEPTH),
+            max_recursion_depth: max_recursion_depth
+                .or(environment.max_recursion_depth)
+                .unwrap_or(Self::DEFAULT_MAX_RECURSION_DEPTH),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This follows changes in previous PRs relating to #14720. To be specific, for the `UV_RUN_MAX_RECURSION_DEPTH` environment variable, I disable clap's use of its value if --max-recursion-depth arg is missing, add a `max_recursion_depth` field and its parsing logic to EnvironmentOptions, and then, in RunSettings::resolve, merge the `max_recursion_depth` from args with `max_recursion_depth` from environment and the default value.

There was an option to add a `u32` field to EnvironmentOptions by resolving a None to the default value, but i like carrying an `Option<u32>` better. This way, both steps of the resolution-chain (from args -> from env-var -> default) are in one place, and also env-variable parsing is separated from the resolution of empty values. (EnvironmentOptions::new does resolve the only u32 it previously parsed, but does not resolve any flags; another Option<u32> does not seem to break this convention too much.)

Note: previously, non-integer values of `UV_RUN_MAX_RECURSION_DEPTH` were only fatal in `uv run`, and now they will be fatal whenever EnvironmentOptions::new runs. This seems fine: even if commands other than `run` are not affected by an invalid value, it's still the case that user is asking for something weird, and calling their attention to that seems worth the ~inconvenience.

Regarding the `str_to_bool` comment: while looking at code relevant to the parent issue, it jumped out at me that the comment about all non-falsey values treated as true, lifted directly from clap, is wrong here: there are allowlists of values treated as true and as false, and all other values are instead treated as parse errors. I hesitated to open a whole new unprompted PR about a comment, so here it is as a drive-by change.

## Test Plan

Tested manually that `UV_RUN_MAX_RECURSION_DEPTH="asdf" uv run` now produces errors from `parse_integer_environment_variable` instead of errors typical to clap. Didn't seem to need a dedicated test of the error message, though of course one could be added.