### PR TITLE
Move `UV_RUN_MAX_RECURSION_DEPTH` parsing to `EnvironmentOptions`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3795,7 +3795,7 @@ pub struct RunArgs {
     /// cleared, uv will fail to detect the recursion depth.
     ///
     /// If uv reaches the maximum recursion depth, it will exit with an error.
-    #[arg(long, hide = true, env = EnvVars::UV_RUN_MAX_RECURSION_DEPTH)]
+    #[arg(long, hide = true)]
     pub max_recursion_depth: Option<u32>,
 
     /// The platform for which requirements should be installed.

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -849,6 +849,14 @@ impl EnvironmentOptions {
             init_bare: EnvFlag::new(EnvVars::UV_INIT_BARE)?,
         })
     }
+
+    /// Parse the maximum recursion depth configured for `uv run`.
+    ///
+    /// The value is scoped to `uv run`, so invalid command-specific environment variables do not
+    /// affect unrelated commands.
+    pub fn run_max_recursion_depth(&self) -> Result<Option<u32>, Error> {
+        parse_integer_environment_variable(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, None)
+    }
 }
 
 /// Parse a string environment variable.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2140,7 +2140,7 @@ async fn run_project(
         }
         ProjectCommand::Run(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::RunSettings::resolve(args, filesystem, environment);
+            let args = settings::RunSettings::resolve(args, filesystem, environment)?;
             show_settings!(args);
 
             // Check for conflicts between offline and refresh.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -619,7 +619,7 @@ impl RunSettings {
         args: RunArgs,
         filesystem: Option<FilesystemOptions>,
         environment: EnvironmentOptions,
-    ) -> Self {
+    ) -> Result<Self, uv_settings::Error> {
         let RunArgs {
             extra,
             all_extras,
@@ -684,8 +684,9 @@ impl RunSettings {
         let isolated = isolated || environment.isolated.value == Some(true);
         let show_resolution = show_resolution || environment.show_resolution.value == Some(true);
         let no_env_file = no_env_file || environment.no_env_file.value == Some(true);
+        let max_recursion_depth = max_recursion_depth.or(environment.run_max_recursion_depth()?);
 
-        Self {
+        Ok(Self {
             lock_check: resolve_lock_check(locked),
             frozen: resolve_frozen(frozen),
             extras: ExtrasSpecification::from_args(
@@ -744,7 +745,7 @@ impl RunSettings {
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
             max_recursion_depth: max_recursion_depth.unwrap_or(Self::DEFAULT_MAX_RECURSION_DEPTH),
-        }
+        })
     }
 }
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -5911,6 +5911,51 @@ fn detect_infinite_recursion() -> Result<()> {
 }
 
 #[test]
+fn run_max_recursion_depth_env_invalid() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .run()
+            .arg("python")
+            .arg("-c")
+            .arg("print('Hello, world!')")
+            .env(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, "foo"),
+        @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse environment variable `UV_RUN_MAX_RECURSION_DEPTH` with invalid value `foo`: invalid digit found in string
+    "
+    );
+}
+
+#[test]
+fn run_max_recursion_depth_env_invalid_ignored_for_other_commands() {
+    let context = uv_test::test_context_with_versions!(&[]);
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .arg("cache")
+            .arg("dir")
+            .env(EnvVars::UV_RUN_MAX_RECURSION_DEPTH, "foo"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [CACHE_DIR]/
+
+    ----- stderr -----
+    "
+    );
+}
+
+#[test]
 fn run_uv_variable() {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
## Summary

Moves `UV_RUN_MAX_RECURSION_DEPTH` parsing out of the `uv run` Clap argument and into `EnvironmentOptions`, then applies it while resolving `RunSettings`.

This preserves the existing precedence of the CLI flag over the environment variable and keeps the default recursion depth unchanged.

Relates #14720.

## Test Plan

- `cargo fmt --check`
- `cargo test -p uv --test it run_max_recursion_depth_env_invalid`
