### PR TITLE
Bump rand to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,7 +3580,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3648,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4008,7 +4008,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -6518,7 +6518,7 @@ name = "uv-fastid"
 version = "0.0.41"
 dependencies = [
  "fastrand",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
 pubgrub = { version = "0.3.3", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
-rand = { version = "0.9.2" }
+rand = { version = "0.9.3" }
 rayon = { version = "1.10.0" }
 ref-cast = { version = "1.0.24" }
 reflink-copy = { version = "0.1.19" }


### PR DESCRIPTION
## Summary

While scanning the Docker image `astral/uv:0.11.8-python3.13-trixie` with Trivy on a Unix-based platform, GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 was reported as a low-severity issue for `rand 0.9.2`.

This PR updates the workspace `rand` dependency from `0.9.2` to `0.9.3`, the first patched release for the `0.9.x` line according to [GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097](https://github.com/advisories/GHSA-cq8v-f236-94qc).

The previous `rand 0.9.2` lockfile entry falls in the affected range:

- affected: `>= 0.9.0, < 0.9.3`
- patched: `0.9.3`

This also updates `Cargo.lock` so existing dependents resolve to `rand 0.9.3`.

## Platform

Unix-based platform using the Docker image:

```text
astral/uv:0.11.8-python3.13-trixie