### PR TITLE
Fix transitive Git path dependencies in lockfiles

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -10,12 +10,12 @@ use uv_distribution_filename::DistExtension;
 use uv_distribution_types::{
     Index, IndexLocations, IndexMetadata, IndexName, Origin, Requirement, RequirementSource,
 };
-use uv_fs::normalize_path;
+use uv_fs::{Simplified, normalize_absolute_path, normalize_path};
 use uv_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::{MarkerTree, VerbatimUrl, VersionOrUrl, looks_like_git_repository};
-use uv_pypi_types::{ConflictItem, ParsedGitUrl, ParsedUrlError, VerbatimParsedUrl};
+use uv_pypi_types::{ConflictItem, ParsedGitUrl, ParsedUrl, ParsedUrlError, VerbatimParsedUrl};
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 use uv_workspace::Workspace;
 use uv_workspace::pyproject::{PyProjectToml, Source, Sources};
@@ -137,7 +137,10 @@ impl LoweredRequirement {
         }
 
         let Some(sources) = sources else {
-            return Either::Left(std::iter::once(Ok(Self(Requirement::from(requirement)))));
+            return Either::Left(std::iter::once(Self::preserve_git_source(
+                requirement,
+                git_member,
+            )));
         };
 
         // Determine whether the markers cover the full space for the requirement. If not, fill the
@@ -509,6 +512,40 @@ impl LoweredRequirement {
         )
     }
 
+    /// Preserve the Git origin for direct path dependencies discovered while lowering metadata from
+    /// a checked-out Git repository.
+    pub(crate) fn preserve_git_source(
+        requirement: uv_pep508::Requirement<VerbatimParsedUrl>,
+        git_member: Option<&GitWorkspaceMember>,
+    ) -> Result<Self, LoweringError> {
+        let Some(git_member) = git_member else {
+            return Ok(Self(Requirement::from(requirement)));
+        };
+
+        let Some(VersionOrUrl::Url(url)) = &requirement.version_or_url else {
+            return Ok(Self(Requirement::from(requirement)));
+        };
+
+        let ParsedUrl::Directory(directory) = &url.parsed_url else {
+            return Ok(Self(Requirement::from(requirement)));
+        };
+
+        let install_path = git_path(&directory.install_path)?;
+        let fetch_root = git_path(git_member.fetch_root)?;
+        if !install_path.starts_with(&fetch_root) {
+            return Ok(Self(Requirement::from(requirement)));
+        }
+
+        Ok(Self(Requirement {
+            name: requirement.name,
+            groups: Box::new([]),
+            extras: requirement.extras,
+            marker: requirement.marker,
+            source: git_source_from_path(&install_path, git_member)?,
+            origin: requirement.origin,
+        }))
+    }
+
     /// Convert back into a [`Requirement`].
     pub fn into_inner(self) -> Requirement {
         self.0
@@ -757,24 +794,7 @@ fn path_source(
     };
     if is_dir {
         if let Some(git_member) = git_member {
-            let git = git_member.git_source.git.clone();
-            let subdirectory = uv_fs::relative_to(install_path, git_member.fetch_root)
-                .expect("Workspace member must be relative");
-            let subdirectory = normalize_path(subdirectory);
-            let subdirectory = if subdirectory == PathBuf::new() {
-                None
-            } else {
-                Some(subdirectory.into_owned().into_boxed_path())
-            };
-            let url = DisplaySafeUrl::from(ParsedGitUrl {
-                url: git.clone(),
-                subdirectory: subdirectory.clone(),
-            });
-            return Ok(RequirementSource::Git {
-                git,
-                subdirectory,
-                url: VerbatimUrl::from_url(url),
-            });
+            return git_source_from_path(install_path, git_member);
         }
 
         if editable == Some(true) {
@@ -826,4 +846,36 @@ fn path_source(
             url,
         })
     }
+}
+
+fn git_source_from_path(
+    install_path: impl AsRef<Path>,
+    git_member: &GitWorkspaceMember,
+) -> Result<RequirementSource, LoweringError> {
+    let git = git_member.git_source.git.clone();
+    let install_path = git_path(install_path.as_ref())?;
+    let fetch_root = git_path(git_member.fetch_root)?;
+    let subdirectory =
+        uv_fs::relative_to(install_path, fetch_root).map_err(LoweringError::RelativeTo)?;
+    let subdirectory = normalize_path(subdirectory);
+    let subdirectory = if subdirectory == PathBuf::new() {
+        None
+    } else {
+        Some(subdirectory.into_owned().into_boxed_path())
+    };
+    let url = DisplaySafeUrl::from(ParsedGitUrl {
+        url: git.clone(),
+        subdirectory: subdirectory.clone(),
+    });
+    Ok(RequirementSource::Git {
+        git,
+        subdirectory,
+        url: VerbatimUrl::from_url(url),
+    })
+}
+
+fn git_path(path: &Path) -> Result<PathBuf, LoweringError> {
+    path.simple_canonicalize()
+        .or_else(|_| normalize_absolute_path(path))
+        .map_err(LoweringError::RelativeTo)
 }

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -70,7 +70,7 @@ impl RequiresDist {
         let Some(project_workspace) =
             ProjectWorkspace::from_maybe_project_root(install_path, &discovery, cache).await?
         else {
-            return Ok(Self::from_metadata23(metadata));
+            return Self::from_metadata23_with_source_context(metadata, git_member);
         };
 
         Self::from_project_workspace(
@@ -82,6 +82,28 @@ impl RequiresDist {
             editable,
             credentials_cache,
         )
+    }
+
+    fn from_metadata23_with_source_context(
+        metadata: uv_pypi_types::RequiresDist,
+        git_member: Option<&GitWorkspaceMember<'_>>,
+    ) -> Result<Self, MetadataError> {
+        let requires_dist = Box::into_iter(metadata.requires_dist)
+            .map(|requirement| {
+                let requirement_name = requirement.name.clone();
+                LoweredRequirement::preserve_git_source(requirement, git_member)
+                    .map(LoweredRequirement::into_inner)
+                    .map_err(|err| MetadataError::LoweringError(requirement_name, Box::new(err)))
+            })
+            .collect::<Result<Box<_>, _>>()?;
+
+        Ok(Self {
+            name: metadata.name,
+            requires_dist,
+            provides_extra: metadata.provides_extra,
+            dependency_groups: BTreeMap::default(),
+            dynamic: metadata.dynamic,
+        })
     }
 
     fn from_project_workspace(

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -1,10 +1,12 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use assert_cmd::prelude::*;
 use assert_fs::{fixture::ChildPath, prelude::*};
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
+use std::process::Command;
 use tempfile::tempdir_in;
+use url::Url;
 
 use uv_fs::Simplified;
 use uv_static::EnvVars;
@@ -10996,6 +10998,153 @@ fn sync_git_path_dependency() -> Result<()> {
      + package1==0.1.0 (from git+https://github.com/astral-sh/uv-path-dependency-test.git@28781b32cf1f260cdb2c8040628079eb265202bd#subdirectory=package1)
      + package2==0.1.0 (from git+https://github.com/astral-sh/uv-path-dependency-test.git@28781b32cf1f260cdb2c8040628079eb265202bd#subdirectory=package2)
     ");
+
+    Ok(())
+}
+
+/// Lock a Git repository with Poetry metadata that depends on a package within the same repository
+/// via a `path` dependency.
+///
+/// See: <https://github.com/astral-sh/uv/issues/19152>
+#[test]
+#[cfg(feature = "test-git")]
+fn lock_git_poetry_path_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    let repository = context.temp_dir.child("repository");
+    repository.child("root/root").create_dir_all()?;
+    repository.child("root/root/__init__.py").touch()?;
+    repository
+        .child("root/pyproject.toml")
+        .write_str(indoc! {r#"
+        [tool.poetry]
+        name = "root"
+        version = "0.1.0"
+        description = ""
+        authors = []
+        packages = [{ include = "root" }]
+
+        [tool.poetry.dependencies]
+        python = ">=3.13"
+        child = { path = "../child" }
+
+        [build-system]
+        requires = ["poetry-core"]
+        build-backend = "poetry.core.masonry.api"
+    "#})?;
+
+    repository.child("child/child").create_dir_all()?;
+    repository.child("child/child/__init__.py").touch()?;
+    repository
+        .child("child/pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#})?;
+
+    Command::new("git")
+        .arg("init")
+        .arg(repository.path())
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("add")
+        .arg(".")
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("-c")
+        .arg("user.name=Example")
+        .arg("-c")
+        .arg("user.email=example@example.com")
+        .arg("commit")
+        .arg("-m")
+        .arg("Initial commit")
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .assert()
+        .success();
+
+    let repository_url = Url::from_directory_path(repository.path())
+        .map_err(|()| anyhow!("failed to convert repository path to file URL"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["root"]
+
+        [tool.uv.sources]
+        root = {{ git = "{repository_url}", subdirectory = "root" }}
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--no-cache"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    let mut filters = context.filters();
+    filters.push((r"#[0-9a-f]{40}", "#[COMMIT]"));
+
+    insta::with_settings!(
+        {
+            filters => filters,
+        },
+        {
+            assert_snapshot!(
+                lock, @r#"
+            version = 1
+            revision = 3
+            requires-python = ">=3.13"
+
+            [options]
+            exclude-newer = "2024-03-25T00:00:00Z"
+
+            [[package]]
+            name = "child"
+            version = "0.1.0"
+            source = { git = "file://[TEMP_DIR]/repository/?subdirectory=child#[COMMIT]" }
+
+            [[package]]
+            name = "project"
+            version = "0.1.0"
+            source = { virtual = "." }
+            dependencies = [
+                { name = "root" },
+            ]
+
+            [package.metadata]
+            requires-dist = [{ name = "root", git = "file://[TEMP_DIR]/repository/?subdirectory=root" }]
+
+            [[package]]
+            name = "root"
+            version = "0.1.0"
+            source = { git = "file://[TEMP_DIR]/repository/?subdirectory=root#[COMMIT]" }
+            dependencies = [
+                { name = "child" },
+            ]
+            "#
+            );
+        }
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

We now preserve source identity for transitive path dependencies discovered while lowering metadata from Git-sourced packages. If a dependency resolves to a directory inside the same Git checkout, we lock it as the corresponding Git source with a `subdirectory` instead of serializing the absolute checkout path.

Closes https://github.com/astral-sh/uv/issues/19152.
