### PR TITLE
Ensure that all Python downloads do not panic on `VersionRequest::from(PythonVersion)`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -2391,15 +2391,12 @@ mod tests {
             .map(|download| download.python_version().to_string())
             .collect();
 
-        let bad: Vec<&String> = unique_versions
-            .iter()
-            .filter(|version| VersionRequest::from_str(version).is_err())
-            .collect();
-
-        assert!(
-            bad.is_empty(),
-            "Python versions in the embedded download metadata that fail to parse as a \
-             `VersionRequest` (would panic in `From<&PythonVersion>`): {bad:?}",
-        );
+        for version in &unique_versions {
+            assert!(
+                VersionRequest::from_str(version).is_ok(),
+                "Embedded download version `{version}` does not parse as a \
+                 `VersionRequest` (would panic in `From<&PythonVersion>`)",
+            );
+        }
     }
 }

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1838,7 +1838,7 @@ async fn read_url(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::HashSet;
 
     use crate::PythonVariant;
     use crate::implementation::LenientImplementationName;
@@ -2377,26 +2377,22 @@ mod tests {
         assert!(err.should_try_next_url());
     }
 
-    /// Every Python version in the embedded download metadata must round-trip through
-    /// [`VersionRequest::from_str`]. The `From<&PythonVersion> for VersionRequest`
-    /// conversion in `discovery.rs` `expect()`s this, so any failure here causes
+    /// Every [`PythonVersion`] in the embedded download metadata must convert to a
+    /// [`VersionRequest`]. The `From<&PythonVersion> for VersionRequest` conversion
+    /// in `discovery.rs` `expect()`s this, so any failure here causes
     /// `uv python upgrade` to panic (issue #19277).
     #[test]
-    fn embedded_download_versions_parse_as_version_requests() {
+    fn embedded_download_versions_convert_to_version_requests() {
         let downloads = ManagedPythonDownloadList::new_only_embedded()
             .expect("embedded download metadata should load");
 
-        let unique_versions: BTreeSet<String> = downloads
+        let unique_versions: HashSet<PythonVersion> = downloads
             .iter_all()
-            .map(|download| download.python_version().to_string())
+            .map(ManagedPythonDownload::python_version)
             .collect();
 
         for version in &unique_versions {
-            assert!(
-                VersionRequest::from_str(version).is_ok(),
-                "Embedded download version `{version}` does not parse as a \
-                 `VersionRequest` (would panic in `From<&PythonVersion>`)",
-            );
+            let _ = VersionRequest::from(version);
         }
     }
 }

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -2377,10 +2377,8 @@ mod tests {
         assert!(err.should_try_next_url());
     }
 
-    /// Every [`PythonVersion`] in the embedded download metadata must convert to a
-    /// [`VersionRequest`]. The `From<&PythonVersion> for VersionRequest` conversion
-    /// in `discovery.rs` `expect()`s this, so any failure here causes
-    /// `uv python upgrade` to panic (issue #19277).
+    /// Every [`PythonVersion`] in the embedded download metadata must be convertable
+    /// to a [`VersionRequest`] to avoid runtime panics.
     #[test]
     fn embedded_download_versions_convert_to_version_requests() {
         let downloads = ManagedPythonDownloadList::new_only_embedded()

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1838,6 +1838,8 @@ async fn read_url(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use crate::PythonVariant;
     use crate::implementation::LenientImplementationName;
     use crate::installation::PythonInstallationKey;
@@ -2373,5 +2375,31 @@ mod tests {
         );
         let err = Error::NetworkError(url, wrapped);
         assert!(err.should_try_next_url());
+    }
+
+    /// Every Python version in the embedded download metadata must round-trip through
+    /// [`VersionRequest::from_str`]. The `From<&PythonVersion> for VersionRequest`
+    /// conversion in `discovery.rs` `expect()`s this, so any failure here causes
+    /// `uv python upgrade` to panic (issue #19277).
+    #[test]
+    fn embedded_download_versions_parse_as_version_requests() {
+        let downloads = ManagedPythonDownloadList::new_only_embedded()
+            .expect("embedded download metadata should load");
+
+        let unique_versions: BTreeSet<String> = downloads
+            .iter_all()
+            .map(|download| download.python_version().to_string())
+            .collect();
+
+        let bad: Vec<&String> = unique_versions
+            .iter()
+            .filter(|version| VersionRequest::from_str(version).is_err())
+            .collect();
+
+        assert!(
+            bad.is_empty(),
+            "Python versions in the embedded download metadata that fail to parse as a \
+             `VersionRequest` (would panic in `From<&PythonVersion>`): {bad:?}",
+        );
     }
 }

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -2377,7 +2377,7 @@ mod tests {
         assert!(err.should_try_next_url());
     }
 
-    /// Every [`PythonVersion`] in the embedded download metadata must be convertable
+    /// Every [`PythonVersion`] in the embedded download metadata must be convertible
     /// to a [`VersionRequest`] to avoid runtime panics.
     #[test]
     fn embedded_download_versions_convert_to_version_requests() {


### PR DESCRIPTION
Avoids future regressions like #19277