### PR TITLE
docs(init): show .git/ and .gitignore in concepts/projects/init.md (#19281)

### DIFF
--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -24,12 +24,13 @@ Applications are the default target for `uv init`, but can also be specified wit
 $ uv init example-app
 ```
 
-The project includes a `pyproject.toml`, a sample file (`main.py`), a readme, and a Python version
-pin file (`.python-version`).
+The project includes a `pyproject.toml`, a sample file (`main.py`), a readme, a Python version pin
+file (`.python-version`), and a Git repository with a `.gitignore`:
 
-```console
-$ tree example-app
+```text
 example-app/
+├── .git/
+├── .gitignore
 ├── .python-version
 ├── README.md
 ├── main.py
@@ -86,9 +87,10 @@ $ uv init --package example-pkg
 
 The source code is moved into a `src` directory with a module directory and an `__init__.py` file:
 
-```console
-$ tree example-pkg
+```text
 example-pkg/
+├── .git/
+├── .gitignore
 ├── .python-version
 ├── README.md
 ├── pyproject.toml
@@ -166,9 +168,10 @@ $ uv init --lib example-lib
 As with a [packaged application](#packaged-applications), a `src` layout is used. A `py.typed`
 marker is included to indicate to consumers that types can be read from the library:
 
-```console
-$ tree example-lib
+```text
 example-lib/
+├── .git/
+├── .gitignore
 ├── .python-version
 ├── README.md
 ├── pyproject.toml
@@ -248,9 +251,10 @@ $ uv init --build-backend maturin example-ext
 The project contains a `Cargo.toml` and a `lib.rs` file in addition to the typical Python project
 files:
 
-```console
-$ tree example-ext
+```text
 example-ext/
+├── .git/
+├── .gitignore
 ├── .python-version
 ├── Cargo.toml
 ├── README.md
@@ -317,8 +321,7 @@ $ uv init example-bare --bare
 uv will skip creating a Python version pin file, a README, and any source directories or files.
 Additionally, uv will not initialize a version control system (i.e., `git`).
 
-```console
-$ tree example-bare
+```text
 example-bare
 └── pyproject.toml
 ```


### PR DESCRIPTION
Closes #19281.

## Summary

The Concepts page at `docs/concepts/projects/init.md` showed file trees that omitted `.git/` and `.gitignore`, even though `uv init` creates both by default. The Guides section was corrected in #19183 — this brings Concepts in line.

Affected sections:

- [Applications](https://docs.astral.sh/uv/concepts/projects/init/#applications)
- [Packaged applications](https://docs.astral.sh/uv/concepts/projects/init/#packaged-applications)
- [Libraries](https://docs.astral.sh/uv/concepts/projects/init/#libraries)
- [Build extension](https://docs.astral.sh/uv/concepts/projects/init/#build-extension) (same root cause)

The `--bare` example is intentionally left without `.git/` / `.gitignore` because `uv init --bare` skips VCS init.

## Why the entries were missing

The blocks rendered `$ tree <name>` output. `tree` hides dotfiles by default, so `.git/` and `.gitignore` were not in the captured output when the page was first written. The Guides page already switched to plain `text` blocks for the same reason. This PR does the same for Concepts.

## Diff shape

One file changed (`docs/concepts/projects/init.md`), +15/-12. No code, no tests, no other doc pages touched.