### PR TITLE
Allow releases to continue on failure to publish to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
     # "host" however must run to completion, no skipping allowed!
     # `custom-publish-crates` is allowed to fail without blocking the announcement
     # so that a crates.io hiccup doesn't hold up the GitHub Release and downstream
-    # docs/versions/mirror publishing; it can be re-run manually if it fails.
+    # docs/versions/mirror publishing.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success' || needs.custom-publish-crates.result == 'failure') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,10 +311,10 @@ jobs:
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    # `custom-publish-crates` is allowed to fail without blocking the announcement
-    # so that a crates.io hiccup doesn't hold up the GitHub Release and downstream
+    # `custom-publish-crates` is intentionally not gated on its result so that
+    # a crates.io hiccup doesn't hold up the GitHub Release and downstream
     # docs/versions/mirror publishing.
-    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success' || needs.custom-publish-crates.result == 'failure') }}
+    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:
       name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,8 +311,9 @@ jobs:
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    # `custom-publish-crates` is intentionally not gated on its result so that
-    # a crates.io hiccup doesn't hold up the GitHub Release and downstream
+    # `custom-publish-crates` is intentionally not gated on its result: it's
+    # not critical to the release and isn't idempotent on retry, so a crates.io
+    # hiccup shouldn't hold up the GitHub Release and downstream
     # docs/versions/mirror publishing.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,10 @@ jobs:
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success') }}
+    # `custom-publish-crates` is allowed to fail without blocking the announcement
+    # so that a crates.io hiccup doesn't hold up the GitHub Release and downstream
+    # docs/versions/mirror publishing; it can be re-run manually if it fails.
+    if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success' || needs.custom-publish-crates.result == 'failure') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:
       name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,9 +312,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     # `custom-publish-crates` is intentionally not gated on its result: it's
-    # not critical to the release and isn't idempotent on retry, so a crates.io
-    # hiccup shouldn't hold up the GitHub Release and downstream
-    # docs/versions/mirror publishing.
+    # not critical to the release and isn't idempotent on retry.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:


### PR DESCRIPTION
Alas this job can fail and retries cannot be performed 