### PR TITLE
fix(lock): warning suggests non-existent --no-frozen flag (#19290)

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -230,7 +230,7 @@ pub(crate) async fn lock(
                     }
                     FrozenSource::Env | FrozenSource::Configuration => {
                         warn_user!(
-                            "The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because {} was provided; use `--no-frozen` or `--check` instead",
+                            "The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because {} was provided; use `--check` instead",
                             MissingLockfileSource::from(frozen_source)
                         );
                     }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -35601,7 +35601,7 @@ fn lock_frozen_warning() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because `UV_FROZEN=1` was provided; use `--no-frozen` or `--check` instead
+    warning: The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because `UV_FROZEN=1` was provided; use `--check` instead
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary

When `uv lock` is invoked with `UV_FROZEN=1` (env) or `frozen` set via workspace configuration, the post-success warning suggested using `--no-frozen`, which does not exist as a CLI flag. Following that hint produces:

```
$ UV_FROZEN=1 uv lock --no-frozen
error: unexpected argument '--no-frozen' found

  tip: a similar argument exists: '--frozen'
```

Drop the bad suggestion and recommend `--check` only, matching the sibling warning emitted when `--frozen` is passed on the CLI (introduced in #17859).

## Old vs new warning

Before:
```
warning: The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because `UV_FROZEN=1` was provided; use `--no-frozen` or `--check` instead
```

After:
```
warning: The lockfile at `uv.lock` was only checked for validity, not whether it is up-to-date, because `UV_FROZEN=1` was provided; use `--check` instead
```

`--check` is defined on `LockArgs` in `crates/uv-cli/src/lib.rs` (the public, non-hidden flag for "check if the lockfile is up-to-date") and works regardless of whether `frozen` was set via env, configuration, or the CLI.

## Changes

- `crates/uv/src/commands/project/lock.rs`: drop `--no-frozen` from the env/configuration warning text.
- `crates/uv/tests/it/lock.rs`: update the `lock_frozen_warning` snapshot to match.

## Test plan

- [x] `cargo build -p uv`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p uv --all-targets -- -D warnings`
- [x] `cargo test -p uv --test it lock::lock_frozen_warning`

Closes #19290