### PR TITLE
docs: fix two broken cross-references (#19296)

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,8 +2,8 @@
 
 The reference section provides information about specific parts of uv:
 
-- [Commands](./cli.md): A reference for uv's command line interface.
-- [Settings](./settings.md): A reference for uv's configuration schema.
+- [Commands](https://docs.astral.sh/uv/reference/cli/): A reference for uv's command line interface.
+- [Settings](https://docs.astral.sh/uv/reference/settings/): A reference for uv's configuration schema.
 - [Resolver](./internals/resolver.md): Details about the internals of uv's resolver.
 - [Storage](./storage.md): Information about where uv stores data on your system.
 - [Policies](./policies/index.md): uv's versioning policy, platform support policy, and license.


### PR DESCRIPTION
## Summary

The `Commands` and `Settings` bullets in `docs/reference/index.md` use relative links (`./cli.md` and `./settings.md`), but those files were removed from the repo in #16969 (they're now generated only at publish time). The links 404 when viewed on GitHub, and `mkdocs build --strict` emits two warnings for `reference/index.md` against a clean checkout.

This swaps the two links to absolute URLs, matching the pattern already used elsewhere in the docs (e.g., `docs/concepts/cache.md`, `docs/concepts/projects/init.md`).

### Before / after

```diff
-- [Commands](./cli.md): A reference for uv's command line interface.
-- [Settings](./settings.md): A reference for uv's configuration schema.
+- [Commands](https://docs.astral.sh/uv/reference/cli/): A reference for uv's command line interface.
+- [Settings](https://docs.astral.sh/uv/reference/settings/): A reference for uv's configuration schema.
```

The other three bullets in the same list (`./internals/resolver.md`, `./storage.md`, `./policies/index.md`) target files that exist in the repo and continue to work both on GitHub and on the rendered site, so they are left as-is.

## Test plan

- [x] Confirmed both target URLs resolve on docs.astral.sh.
- [x] `uv run --only-group docs mkdocs build --strict -f mkdocs.yml`: the two `Doc file 'reference/index.md' contains a link './cli.md' / './settings.md'` warnings are gone after this change.

Closes #19296.