### PR TITLE
fix(cache): accept legacy ID format from pre-0.11.9 cache entries (#19298)

### DIFF
--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -56,13 +56,9 @@ impl Hashed for Revision {
 
 /// A unique identifier for a revision of a source distribution.
 ///
-/// Note: for compatibility with the existing `sdists-v9` bucket, where revision pointers
-/// written by older uv versions used 21-character `nanoid` IDs, this is a newtype around a
-/// `String` rather than a newtype around `uv_fastid::Id`. New IDs are still generated via
-/// `uv_fastid::insecure()`, but existing on-disk entries in the `SourceDistributions`
-/// bucket continue to deserialize regardless of length. In the future, we may want to bump
-/// to `sdists-v10` and switch to using `uv_fastid::Id` directly (mirroring the path
-/// proposed for `ArchiveId` + the `archive-v0` bucket).
+/// Note: for compatibility with the existing `sdists-v9` bucket, this is a newtype around a
+/// `String` rather than a newtype around `uv_fastid::Id`. In the future, we may want to bump
+/// to `sdists-v10` and switch to using `uv_fastid::Id` directly.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct RevisionId(String);
 

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -55,13 +55,18 @@ impl Hashed for Revision {
 }
 
 /// A unique identifier for a revision of a source distribution.
+///
+/// Note: for compatibility with revision pointers written by older uv versions (which used
+/// 21-character `nanoid` IDs), this is a newtype around a `String` rather than a newtype
+/// around `uv_fastid::Id`. New IDs are still generated via `uv_fastid::insecure()`, but
+/// existing on-disk entries continue to deserialize regardless of length.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) struct RevisionId(uv_fastid::Id);
+pub(crate) struct RevisionId(String);
 
 impl RevisionId {
     /// Generate a new unique identifier for an archive.
     fn new() -> Self {
-        Self(uv_fastid::insecure())
+        Self(uv_fastid::insecure().to_string())
     }
 
     pub(crate) fn as_str(&self) -> &str {
@@ -78,5 +83,39 @@ impl AsRef<str> for RevisionId {
 impl AsRef<Path> for RevisionId {
     fn as_ref(&self) -> &Path {
         self.0.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for <https://github.com/astral-sh/uv/issues/19298>.
+    ///
+    /// Revision pointers written by uv <= 0.11.8 used 21-character `nanoid` IDs.
+    /// After #19201 switched to `uv_fastid`'s 16-character IDs, deserializing an
+    /// existing on-disk pointer must still succeed, otherwise upgrading uv against
+    /// a populated cache hard-errors with `Failed to deserialize cache entry`.
+    #[test]
+    fn deserialize_legacy_nanoid_revision() {
+        // A representative 21-character nanoid ID, drawn from the same alphabet
+        // used by both the old `nanoid` crate and `uv_fastid`.
+        let legacy = Revision {
+            id: RevisionId("HM0NxJml5hc7UjbfTWT1r".to_string()),
+            hashes: HashDigests::empty(),
+        };
+        let bytes = rmp_serde::to_vec(&legacy).expect("serialize legacy revision");
+        let parsed: Revision = rmp_serde::from_slice(&bytes).expect("deserialize legacy revision");
+        assert_eq!(parsed.id().as_str(), "HM0NxJml5hc7UjbfTWT1r");
+        assert_eq!(parsed.id().as_str().len(), 21);
+    }
+
+    #[test]
+    fn round_trip_current_revision() {
+        let original = Revision::new();
+        let bytes = rmp_serde::to_vec(&original).expect("serialize revision");
+        let parsed: Revision = rmp_serde::from_slice(&bytes).expect("deserialize revision");
+        assert_eq!(parsed.id().as_str(), original.id().as_str());
+        assert_eq!(parsed.id().as_str().len(), 16);
     }
 }

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -90,11 +90,6 @@ mod tests {
     use super::*;
 
     /// Regression test for <https://github.com/astral-sh/uv/issues/19298>.
-    ///
-    /// Revision pointers written by uv <= 0.11.8 used 21-character `nanoid` IDs.
-    /// After #19201 switched to `uv_fastid`'s 16-character IDs, deserializing an
-    /// existing on-disk pointer must still succeed, otherwise upgrading uv against
-    /// a populated cache hard-errors with `Failed to deserialize cache entry`.
     #[test]
     fn deserialize_legacy_nanoid_revision() {
         // A representative 21-character nanoid ID, drawn from the same alphabet
@@ -106,7 +101,6 @@ mod tests {
         let bytes = rmp_serde::to_vec(&legacy).expect("serialize legacy revision");
         let parsed: Revision = rmp_serde::from_slice(&bytes).expect("deserialize legacy revision");
         assert_eq!(parsed.id().as_str(), "HM0NxJml5hc7UjbfTWT1r");
-        assert_eq!(parsed.id().as_str().len(), 21);
     }
 
     #[test]
@@ -115,6 +109,5 @@ mod tests {
         let bytes = rmp_serde::to_vec(&original).expect("serialize revision");
         let parsed: Revision = rmp_serde::from_slice(&bytes).expect("deserialize revision");
         assert_eq!(parsed.id().as_str(), original.id().as_str());
-        assert_eq!(parsed.id().as_str().len(), 16);
     }
 }

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -56,10 +56,13 @@ impl Hashed for Revision {
 
 /// A unique identifier for a revision of a source distribution.
 ///
-/// Note: for compatibility with revision pointers written by older uv versions (which used
-/// 21-character `nanoid` IDs), this is a newtype around a `String` rather than a newtype
-/// around `uv_fastid::Id`. New IDs are still generated via `uv_fastid::insecure()`, but
-/// existing on-disk entries continue to deserialize regardless of length.
+/// Note: for compatibility with the existing `sdists-v9` bucket, where revision pointers
+/// written by older uv versions used 21-character `nanoid` IDs, this is a newtype around a
+/// `String` rather than a newtype around `uv_fastid::Id`. New IDs are still generated via
+/// `uv_fastid::insecure()`, but existing on-disk entries in the `SourceDistributions`
+/// bucket continue to deserialize regardless of length. In the future, we may want to bump
+/// to `sdists-v10` and switch to using `uv_fastid::Id` directly (mirroring the path
+/// proposed for `ArchiveId` + the `archive-v0` bucket).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct RevisionId(String);
 


### PR DESCRIPTION
## Summary

Closes #19298.

#19201 (0.11.9) switched revision IDs from 21-character `nanoid` to `uv_fastid`'s 16-character IDs, but didn't bump the cache bucket version. As a result, when 0.11.9+ opens a cache populated by an older uv, deserialization of an existing revision pointer hard-fails with:

```
Failed to deserialize cache entry
invalid ID: "HM0NxJml5hc7UjbfTWT1r" (must be 16 ID characters in the alphabet)
```

This effectively poisons long-lived caches on shared CI workers after upgrade.

## Fix

Mirror the existing convention already documented on `ArchiveId` in `crates/uv-cache/src/archive.rs`:

```rust
/// Note: for compatibility with the existing `archive-v0` bucket, this is a newtype
/// around a `String` instead of a newtype around `uv_fastid::Id`. In the future,
/// we may want to bump to `archive-v1` and switch to using `uv_fastid::Id` directly.
```

`RevisionId` had the same shape but was migrated to `uv_fastid::Id` directly in #19201, which is what made the legacy 21-character pointers undecodable. Switching `RevisionId` back to `String` (with the same `uv_fastid::insecure()` source for new IDs) restores forward-compatibility with both formats. The ID is only used as an opaque path/string component, so no other call site needs to change.

## Test plan

- [x] New unit test in `crates/uv-distribution/src/source/revision.rs`:
  - `deserialize_legacy_nanoid_revision` round-trips a `Revision` with a 21-character legacy ID through `rmp_serde` (the exact failing path from the bug report)
  - `round_trip_current_revision` confirms freshly-generated IDs still serialize as the new 16-character form
- [x] `cargo build -p uv` clean
- [x] `cargo test -p uv-distribution --lib` -> 21/21 passing (incl. the 2 new tests)
- [x] `cargo test -p uv-fastid` -> 4/4 passing
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p uv-distribution --lib --tests` clean