### PR TITLE
Bump rand/digest/hashing crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -506,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,11 +540,11 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -548,6 +554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -687,7 +702,7 @@ dependencies = [
  "libc",
  "miow",
  "same-file",
- "sha2",
+ "sha2 0.10.9",
  "shell-escape",
  "tempfile",
  "tracing",
@@ -735,6 +750,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "charset"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,7 +803,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -860,6 +886,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codspeed"
@@ -987,6 +1019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1084,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1120,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1205,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1236,7 +1301,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1282,10 +1347,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1815,6 +1892,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1971,7 +2049,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2045,6 +2123,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2671,12 +2758,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3133,7 +3220,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -3202,7 +3289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3277,7 +3364,7 @@ dependencies = [
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -3627,6 +3714,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,6 +3761,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3874,7 +3978,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -3905,7 +4009,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -3988,11 +4092,11 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4089,15 +4193,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -4343,7 +4447,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4376,7 +4480,7 @@ dependencies = [
  "num",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -4538,8 +4642,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4549,8 +4653,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4601,7 +4716,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4907,7 +5022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -5459,9 +5574,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -5672,6 +5787,7 @@ dependencies = [
  "astral_async_zip",
  "axoupdater",
  "backon",
+ "base16ct",
  "base64",
  "byteorder",
  "bytes",
@@ -5710,7 +5826,7 @@ dependencies = [
  "self-replace",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "textwrap",
  "thiserror",
@@ -5945,6 +6061,7 @@ dependencies = [
  "astral-tokio-tar",
  "astral-version-ranges",
  "astral_async_zip",
+ "base16ct",
  "base64",
  "csv",
  "flate2",
@@ -5960,7 +6077,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "spdx",
  "tempfile",
  "thiserror",
@@ -6456,6 +6573,7 @@ dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
  "async-compression",
+ "base16ct",
  "blake2",
  "flate2",
  "fs-err",
@@ -6465,7 +6583,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rustc-hash",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -6483,7 +6601,7 @@ name = "uv-fastid"
 version = "0.0.52"
 dependencies = [
  "fastrand",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
 ]
@@ -6604,7 +6722,7 @@ dependencies = [
  "self-replace",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tracing",
  "uv-distribution-filename",
@@ -6695,10 +6813,11 @@ dependencies = [
 name = "uv-macros"
 version = "0.0.52"
 dependencies = [
- "proc-macro2",
  "quote",
+ "serde",
  "syn",
  "textwrap",
+ "uv-options-metadata",
 ]
 
 [[package]]
@@ -7262,7 +7381,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "similar 3.1.0",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,9 +119,10 @@ async_zip = { version = "0.0.18", package = "astral_async_zip", features = [
 ] }
 axoupdater = { version = "0.10.0", default-features = false }
 backon = { version = "1.3.0" }
+base16ct = { version = "1.0.0" }
 base64 = { version = "0.22.1" }
 bitflags = { version = "2.6.0" }
-blake2 = { version = "0.10.6" }
+blake2 = { version = "0.11.0-rc.6" }
 boxcar = { version = "0.2.5" }
 bytecheck = { version = "0.8.0" }
 cargo-util = { version = "0.2.14" }
@@ -177,7 +178,7 @@ itertools = { version = "0.14.0" }
 jiff = { version = "0.2.0", features = ["serde"] }
 junction = { version = "2.0.0" }
 mailparse = { version = "0.16.0" }
-md-5 = { version = "0.10.6" }
+md-5 = { version = "0.11.0" }
 memchr = { version = "2.7.4" }
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
@@ -187,11 +188,10 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 percent-encoding = { version = "2.3.1" }
 petgraph = { version = "0.8.0" }
-proc-macro2 = { version = "1.0.86" }
 procfs = { version = "0.18.0", default-features = false, features = ["flate2"] }
 pubgrub = { version = "0.3.3", package = "astral-pubgrub" }
 quote = { version = "1.0.37" }
-rand = { version = "0.9.4" }
+rand = { version = "0.10.1" }
 rayon = { version = "1.10.0" }
 ref-cast = { version = "1.0.24" }
 reflink-copy = { version = "0.1.19" }
@@ -254,7 +254,7 @@ self-replace = { version = "1.5.0" }
 serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde-untagged = { version = "0.1.6" }
 serde_json = { version = "1.0.128" }
-sha2 = { version = "0.10.8" }
+sha2 = { version = "0.11.0" }
 smallvec = { version = "1.13.2" }
 spdx = { version = "0.13.0" }
 syn = { version = "2.0.77" }

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -31,6 +31,7 @@ uv-warnings = { workspace = true }
 
 astral-tokio-tar = { workspace = true }
 async_zip = { workspace = true }
+base16ct = { workspace = true }
 base64 = { workspace = true }
 csv = { workspace = true }
 flate2 = { workspace = true, default-features = false }

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -472,6 +472,7 @@ pub(crate) fn error_on_venv(file_name: &OsStr, path: &Path) -> Result<(), Error>
 mod tests {
     use super::*;
     use async_zip::base::read::mem::ZipFileReader;
+    use base16ct::HexDisplay;
     use flate2::bufread::GzDecoder;
     use fs_err::File;
     use futures_lite::{StreamExt, future::block_on};
@@ -787,7 +788,7 @@ mod tests {
         );
         // Check that the source dist is reproducible across platforms.
         assert_snapshot!(
-            format!("{:x}", sha2::Sha256::digest(fs_err::read(&source_dist_path).unwrap())),
+            format!("{:x}", HexDisplay(&sha2::Sha256::digest(fs_err::read(&source_dist_path).unwrap()))),
             @"8bed1f7a8059064bcbeedb61a867cca7f63a474306011d0114280de631ac705e"
         );
         // Check both the files we report and the actual files
@@ -841,7 +842,7 @@ mod tests {
         );
         // Check that the wheel is reproducible across platforms.
         assert_snapshot!(
-            format!("{:x}", sha2::Sha256::digest(fs_err::read(&wheel_path).unwrap())),
+            format!("{:x}", HexDisplay(&sha2::Sha256::digest(fs_err::read(&wheel_path).unwrap()))),
             @"9e8d80fef76be79a7fe73a2ccac3bdd0132b10fdcff7271ca8b868c99061b8ce"
         );
         assert_snapshot!(build.wheel_contents.join("\n"), @"

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -25,6 +25,7 @@ uv-warnings = { workspace = true }
 astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd", "xz"] }
 async_zip = { workspace = true }
+base16ct = { workspace = true }
 blake2 = { workspace = true }
 flate2 = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }

--- a/crates/uv-extract/src/hash.rs
+++ b/crates/uv-extract/src/hash.rs
@@ -1,3 +1,4 @@
+use base16ct::HexDisplay;
 use blake2::digest::consts::U32;
 use sha2::Digest;
 use std::pin::Pin;
@@ -44,23 +45,23 @@ impl From<Hasher> for HashDigest {
         match hasher {
             Hasher::Md5(hasher) => Self {
                 algorithm: HashAlgorithm::Md5,
-                digest: format!("{:x}", hasher.finalize()).into(),
+                digest: format!("{:x}", HexDisplay(&hasher.finalize())).into(),
             },
             Hasher::Sha256(hasher) => Self {
                 algorithm: HashAlgorithm::Sha256,
-                digest: format!("{:x}", hasher.finalize()).into(),
+                digest: format!("{:x}", HexDisplay(&hasher.finalize())).into(),
             },
             Hasher::Sha384(hasher) => Self {
                 algorithm: HashAlgorithm::Sha384,
-                digest: format!("{:x}", hasher.finalize()).into(),
+                digest: format!("{:x}", HexDisplay(&hasher.finalize())).into(),
             },
             Hasher::Sha512(hasher) => Self {
                 algorithm: HashAlgorithm::Sha512,
-                digest: format!("{:x}", hasher.finalize()).into(),
+                digest: format!("{:x}", HexDisplay(&hasher.finalize())).into(),
             },
             Hasher::Blake2b(hasher) => Self {
                 algorithm: HashAlgorithm::Blake2b,
-                digest: format!("{:x}", hasher.finalize()).into(),
+                digest: format!("{:x}", HexDisplay(&hasher.finalize())).into(),
             },
         }
     }

--- a/crates/uv-fastid/src/lib.rs
+++ b/crates/uv-fastid/src/lib.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::str::FromStr;
 
-use rand::RngCore as _;
+use rand::Rng as _;
 
 const ALPHABET: [u8; 64] = [
     b'_', b'-', b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b', b'c', b'd',

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -18,7 +18,10 @@ test = false
 workspace = true
 
 [dependencies]
-proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 textwrap = { workspace = true }
+
+[dev-dependencies]
+serde = { workspace = true, features = ["derive"] }
+uv-options-metadata = { workspace = true }

--- a/crates/uv-macros/src/lib.rs
+++ b/crates/uv-macros/src/lib.rs
@@ -9,9 +9,7 @@ use syn::{Attribute, DeriveInput, ImplItem, ItemImpl, LitStr, parse_macro_input}
 pub fn derive_options_metadata(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    options_metadata::derive_impl(input)
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
+    options_metadata::derive_impl(input).unwrap_or_else(|err| err.into_compile_error().into())
 }
 
 #[proc_macro_derive(CombineOptions)]

--- a/crates/uv-macros/src/options_metadata.rs
+++ b/crates/uv-macros/src/options_metadata.rs
@@ -2,8 +2,8 @@
 //!
 //! See: <https://github.com/astral-sh/ruff/blob/dc8db1afb08704ad6a788c497068b01edf8b460d/crates/ruff_macros/src/config.rs>
 
-use proc_macro2::{TokenStream, TokenTree};
-use quote::{quote, quote_spanned};
+use proc_macro::{TokenStream, TokenTree};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::meta::ParseNestedMeta;
 use syn::spanned::Spanned;
 use syn::{
@@ -25,7 +25,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             fields: Fields::Named(fields),
             ..
         }) => {
-            let mut output = vec![];
+            let mut output: Vec<Box<dyn ToTokens>> = vec![];
 
             for field in &fields.named {
                 if let Some(attr) = field
@@ -33,13 +33,13 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     .iter()
                     .find(|attr| attr.path().is_ident("option"))
                 {
-                    output.push(handle_option(field, attr)?);
+                    output.push(Box::new(handle_option(field, attr)?));
                 } else if field
                     .attrs
                     .iter()
                     .any(|attr| attr.path().is_ident("option_group"))
                 {
-                    output.push(handle_option_group(field)?);
+                    output.push(Box::new(handle_option_group(field)?));
                 } else if let Some(serde) = field
                     .attrs
                     .iter()
@@ -48,12 +48,12 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     // If a field has the `serde(flatten)` attribute, flatten the options into the parent
                     // by calling `Type::record` instead of `visitor.visit_set`
                     if let (Type::Path(ty), Meta::List(list)) = (&field.ty, &serde.meta) {
-                        for token in list.tokens.clone() {
+                        for token in TokenStream::from(list.tokens.clone()) {
                             if let TokenTree::Ident(ident) = token {
-                                if ident == "flatten" {
-                                    output.push(quote_spanned!(
+                                if ident.to_string() == "flatten" {
+                                    output.push(Box::new(quote_spanned!(
                                         ty.span() => (<#ty>::record(visit))
-                                    ));
+                                    )));
 
                                     break;
                                 }
@@ -98,7 +98,8 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
                     #documentation
                 }
-            })
+            }
+            .into())
         }
         _ => Err(syn::Error::new(
             ident.span(),
@@ -110,7 +111,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 /// For a field with type `Option<Foobar>` where `Foobar` itself is a struct
 /// deriving `ConfigurationOptions`, create code that calls retrieves options
 /// from that group: `Foobar::get_available_options()`
-fn handle_option_group(field: &Field) -> syn::Result<TokenStream> {
+fn handle_option_group(field: &Field) -> syn::Result<impl ToTokens> {
     let ident = field
         .ident
         .as_ref()
@@ -159,7 +160,7 @@ fn parse_doc(doc: &Attribute) -> syn::Result<String> {
 
 /// Parse an `#[option(doc="...", default="...", value_type="...",
 /// example="...")]` attribute and return data in the form of an `OptionField`.
-fn handle_option(field: &Field, attr: &Attribute) -> syn::Result<TokenStream> {
+fn handle_option(field: &Field, attr: &Attribute) -> syn::Result<impl ToTokens> {
     let docs: Vec<&Attribute> = field
         .attrs
         .iter()
@@ -210,7 +211,7 @@ fn handle_option(field: &Field, attr: &Attribute) -> syn::Result<TokenStream> {
         .iter()
         .find(|attr| attr.path().is_ident("deprecated"))
     {
-        fn quote_option(option: Option<String>) -> TokenStream {
+        fn quote_option(option: Option<String>) -> impl ToTokens {
             match option {
                 None => quote!(None),
                 Some(value) => quote!(Some(#value)),

--- a/crates/uv-macros/tests/options_metadata.rs
+++ b/crates/uv-macros/tests/options_metadata.rs
@@ -1,0 +1,38 @@
+use uv_macros::OptionsMetadata;
+use uv_options_metadata::{OptionEntry, OptionField, OptionsMetadata};
+
+#[derive(serde::Deserialize, OptionsMetadata)]
+#[allow(dead_code)]
+struct RootOptions {
+    #[serde(flatten)]
+    nested: NestedOptions,
+}
+
+#[derive(serde::Deserialize, OptionsMetadata)]
+#[allow(dead_code)]
+struct NestedOptions {
+    /// Whether to enable the child option.
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = "child-option = true"
+    )]
+    child_option: Option<bool>,
+}
+
+#[test]
+fn options_metadata_flattens_serde_fields() {
+    assert_eq!(
+        RootOptions::metadata().find("child-option"),
+        Some(OptionEntry::Field(OptionField {
+            doc: "Whether to enable the child option.",
+            default: "false",
+            value_type: "bool",
+            scope: None,
+            example: "child-option = true",
+            deprecated: None,
+            possible_values: None,
+            uv_toml_only: false,
+        }))
+    );
+}

--- a/crates/uv-trampoline/Cargo.lock
+++ b/crates/uv-trampoline/Cargo.lock
@@ -140,7 +140,6 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 name = "uv-macros"
 version = "0.0.52"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.87",
  "textwrap",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -133,6 +133,7 @@ uv-test = { workspace = true }
 assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 backon = { workspace = true }
+base16ct = { workspace = true }
 base64 = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -1,5 +1,6 @@
 use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileTouch, FileWriteStr, PathChild};
+use base16ct::HexDisplay;
 use fs_err::OpenOptions;
 use indoc::{formatdoc, indoc};
 use serde_json::json;
@@ -450,7 +451,10 @@ async fn read_index_credential_env_vars_for_check_url() {
 
     let filename = "astral_test_private-0.1.0-py3-none-any.whl";
     let wheel = context.temp_dir.join("dist").join(filename);
-    let sha256 = format!("{:x}", Sha256::digest(fs_err::read(&wheel).unwrap()));
+    let sha256 = format!(
+        "{:x}",
+        HexDisplay(&Sha256::digest(fs_err::read(&wheel).unwrap()))
+    );
 
     let simple_index = json! ({
           "files": [


### PR DESCRIPTION
## Summary

See https://github.com/astral-sh/uv/pull/19256. Closes https://github.com/astral-sh/uv/pull/19256.

TL;DR this bumps `rand`, `digest`, and our hashing crates. We shouldn't merge this until we can debloat by removing some older rand versions.

We also need to add `base16ct` as a dependency since we don't get `LowerHex` intrinsically via the `digest` crate anymore: https://github.com/RustCrypto/hybrid-array/issues/201

Debloat tasks:

- [x] https://github.com/TrueLayer/retry-policies/issues/31
    - [x] https://github.com/TrueLayer/retry-policies/pull/32
- [x] https://github.com/quinn-rs/quinn/issues/2636
- [ ] https://github.com/tomtomwombat/fastbloom/pull/27

## Test Plan

NFC.