### PR TITLE
uv audit: JSON output

### DIFF
--- a/crates/uv-audit/src/types.rs
+++ b/crates/uv-audit/src/types.rs
@@ -1,6 +1,7 @@
 //! Types for interacting with dependency audits.
 
 use jiff::Timestamp;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_redacted::DisplaySafeUrl;
@@ -66,6 +67,16 @@ pub enum AdverseStatus {
     Quarantined,
     /// The project is considered obsolete, and may have been superseded by another project.
     Deprecated,
+}
+
+impl Display for AdverseStatus {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        formatter.write_str(match self {
+            Self::Archived => "archived",
+            Self::Quarantined => "quarantined",
+            Self::Deprecated => "deprecated",
+        })
+    }
 }
 
 /// A vulnerability within a dependency.

--- a/crates/uv-audit/src/types.rs
+++ b/crates/uv-audit/src/types.rs
@@ -1,7 +1,6 @@
 //! Types for interacting with dependency audits.
 
 use jiff::Timestamp;
-use std::fmt::{Display, Formatter, Result as FmtResult};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
 use uv_redacted::DisplaySafeUrl;
@@ -69,8 +68,8 @@ pub enum AdverseStatus {
     Deprecated,
 }
 
-impl Display for AdverseStatus {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+impl std::fmt::Display for AdverseStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(match self {
             Self::Archived => "archived",
             Self::Quarantined => "quarantined",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -68,6 +68,15 @@ pub enum SyncFormat {
     Json,
 }
 
+#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+pub enum AuditOutputFormat {
+    /// Display the result in a human-readable format.
+    #[default]
+    Text,
+    /// Display the result in JSON format.
+    Json,
+}
+
 #[derive(Debug, Default, Clone, clap::ValueEnum)]
 pub enum ListFormat {
     /// Display the list of packages in a human-readable table.
@@ -5218,6 +5227,10 @@ pub struct AuditArgs {
     /// If the lockfile is missing, uv will exit with an error.
     #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
     pub frozen: bool,
+
+    /// Select the output format.
+    #[arg(long, value_enum, default_value_t = AuditOutputFormat::default())]
+    pub output_format: AuditOutputFormat,
 
     #[command(flatten)]
     pub build: BuildOptionsArgs,

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -505,7 +505,6 @@ impl AuditResults {
 
 #[derive(Debug, Serialize)]
 struct JsonReport {
-    schema: JsonSchema,
     summary: JsonSummary,
     vulnerabilities: Vec<JsonVulnerability>,
     adverse_statuses: Vec<JsonAdverseStatus>,
@@ -544,7 +543,6 @@ impl JsonReport {
         });
 
         Self {
-            schema: JsonSchema::default(),
             summary: JsonSummary {
                 audited_packages: n_packages,
                 vulnerabilities: vulnerabilities.len(),
@@ -554,18 +552,6 @@ impl JsonReport {
             adverse_statuses,
         }
     }
-}
-
-#[derive(Debug, Serialize, Default)]
-struct JsonSchema {
-    version: JsonSchemaVersion,
-}
-
-#[derive(Debug, Serialize, Default)]
-#[serde(rename_all = "snake_case")]
-enum JsonSchemaVersion {
-    #[default]
-    Preview,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools as _;
 use owo_colors::OwoColorize;
+use serde::Serialize;
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -22,8 +23,11 @@ use rustc_hash::FxHashSet;
 use tracing::trace;
 use uv_audit::service::project_status::ProjectStatusAudit;
 use uv_audit::service::{VulnerabilityServiceFormat, osv};
-use uv_audit::types::{AdverseStatus, Dependency, Finding, VulnerabilityID};
+use uv_audit::types::{
+    AdverseStatus, Dependency, Finding, ProjectStatus, Vulnerability, VulnerabilityID,
+};
 use uv_cache::Cache;
+use uv_cli::AuditOutputFormat;
 use uv_client::{BaseClientBuilder, RegistryClientBuilder};
 use uv_configuration::{Concurrency, DependencyGroups, ExtrasSpecification, TargetTriple};
 use uv_distribution_types::{IndexCapabilities, IndexUrl};
@@ -54,6 +58,7 @@ pub(crate) async fn audit(
     cache: Cache,
     printer: Printer,
     preview: Preview,
+    output_format: AuditOutputFormat,
     service: VulnerabilityServiceFormat,
     service_url: Option<String>,
     ignore: Vec<VulnerabilityID>,
@@ -64,6 +69,14 @@ pub(crate) async fn audit(
         warn_user!(
             "`uv audit` is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
             PreviewFeature::Audit
+        );
+    }
+    if matches!(output_format, AuditOutputFormat::Json)
+        && !preview.is_enabled(PreviewFeature::JsonOutput)
+    {
+        warn_user!(
+            "The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features {}` to disable this warning.",
+            PreviewFeature::JsonOutput
         );
     }
 
@@ -297,6 +310,7 @@ pub(crate) async fn audit(
     let display = AuditResults {
         printer,
         n_packages: auditable.len(),
+        output_format,
         findings: all_findings,
     };
     display.render()
@@ -305,20 +319,52 @@ pub(crate) async fn audit(
 struct AuditResults {
     printer: Printer,
     n_packages: usize,
+    output_format: AuditOutputFormat,
     findings: Vec<Finding>,
 }
 
 impl AuditResults {
     fn render(&self) -> Result<ExitStatus> {
-        let (vulns, statuses): (Vec<_>, Vec<_>) =
-            self.findings.iter().partition_map(|finding| match finding {
-                Finding::Vulnerability(vuln) => itertools::Either::Left(vuln),
-                Finding::ProjectStatus(status) => itertools::Either::Right(status),
-            });
+        match self.output_format {
+            AuditOutputFormat::Text => self.render_text(),
+            AuditOutputFormat::Json => self.render_json(),
+        }
+    }
 
-        let vuln_banner = if !vulns.is_empty() {
-            let s = if vulns.len() == 1 { "y" } else { "ies" };
-            format!("{} known vulnerabilit{s}", vulns.len())
+    fn split_findings(&self) -> (Vec<&Vulnerability>, Vec<&ProjectStatus>) {
+        self.findings.iter().partition_map(|finding| match finding {
+            Finding::Vulnerability(vulnerability) => {
+                itertools::Either::Left(vulnerability.as_ref())
+            }
+            Finding::ProjectStatus(status) => itertools::Either::Right(status),
+        })
+    }
+
+    fn exit_status(&self) -> ExitStatus {
+        // NOTE: intentional: we don't currently fail if there are any adverse statuses,
+        // only when there are vulnerabilities. We will likely change this once we allow users
+        // to ignore adverse statuses and configure policies.
+        if self
+            .findings
+            .iter()
+            .any(|finding| matches!(finding, Finding::Vulnerability(_)))
+        {
+            ExitStatus::Failure
+        } else {
+            ExitStatus::Success
+        }
+    }
+
+    fn render_text(&self) -> Result<ExitStatus> {
+        let (vulnerabilities, statuses) = self.split_findings();
+
+        let vulnerability_banner = if !vulnerabilities.is_empty() {
+            let suffix = if vulnerabilities.len() == 1 {
+                "y"
+            } else {
+                "ies"
+            };
+            format!("{} known vulnerabilit{suffix}", vulnerabilities.len())
                 .yellow()
                 .to_string()
         } else {
@@ -338,7 +384,7 @@ impl AuditResults {
 
         writeln!(
             self.printer.stderr(),
-            "Found {vuln_banner} and {status_banner} in {packages}",
+            "Found {vulnerability_banner} and {status_banner} in {packages}",
             packages = format!(
                 "{npackages} {label}",
                 npackages = self.n_packages,
@@ -351,37 +397,45 @@ impl AuditResults {
             .bold()
         )?;
 
-        let has_vulnerabilities = !vulns.is_empty();
-
-        if !vulns.is_empty() {
+        if !vulnerabilities.is_empty() {
             writeln!(self.printer.stdout_important(), "\nVulnerabilities:\n")?;
 
             // Group vulnerabilities by (dependency name, version).
-            let groups = vulns
-                .into_iter()
-                .chunk_by(|vuln| (vuln.dependency.name(), vuln.dependency.version()));
+            let groups = vulnerabilities.into_iter().chunk_by(|vulnerability| {
+                (
+                    vulnerability.dependency.name(),
+                    vulnerability.dependency.version(),
+                )
+            });
 
-            for (dependency, vulns) in &groups {
-                let vulns: Vec<_> = vulns.collect();
+            for (dependency, vulnerabilities) in &groups {
+                let vulnerabilities: Vec<_> = vulnerabilities.collect();
                 let (name, version) = dependency;
 
                 writeln!(
                     self.printer.stdout_important(),
                     "{name_version} has {n} known vulnerabilit{ies}:\n",
                     name_version = format!("{name} {version}").bold(),
-                    n = vulns.len(),
-                    ies = if vulns.len() == 1 { "y" } else { "ies" },
+                    n = vulnerabilities.len(),
+                    ies = if vulnerabilities.len() == 1 {
+                        "y"
+                    } else {
+                        "ies"
+                    },
                 )?;
 
-                for vuln in vulns {
+                for vulnerability in vulnerabilities {
                     writeln!(
                         self.printer.stdout_important(),
                         "- {id}: {description}",
-                        id = vuln.best_id().as_str().bold(),
-                        description = vuln.summary.as_deref().unwrap_or("No summary provided"),
+                        id = vulnerability.best_id().as_str().bold(),
+                        description = vulnerability
+                            .summary
+                            .as_deref()
+                            .unwrap_or("No summary provided"),
                     )?;
 
-                    if vuln.fix_versions.is_empty() {
+                    if vulnerability.fix_versions.is_empty() {
                         writeln!(
                             self.printer.stdout_important(),
                             "\n  No fix versions available\n"
@@ -390,7 +444,8 @@ impl AuditResults {
                         writeln!(
                             self.printer.stdout_important(),
                             "\n  Fixed in: {}\n",
-                            vuln.fix_versions
+                            vulnerability
+                                .fix_versions
                                 .iter()
                                 .map(std::string::ToString::to_string)
                                 .join(", ")
@@ -398,7 +453,7 @@ impl AuditResults {
                         )?;
                     }
 
-                    if let Some(link) = &vuln.link {
+                    if let Some(link) = &vulnerability.link {
                         writeln!(
                             self.printer.stdout_important(),
                             "  Advisory information: {link}\n",
@@ -413,10 +468,11 @@ impl AuditResults {
             writeln!(self.printer.stdout_important(), "\nAdverse statuses:\n")?;
 
             for status in statuses {
-                let label = match status.status {
-                    AdverseStatus::Archived => "archived".yellow().to_string(),
-                    AdverseStatus::Deprecated => "deprecated".yellow().to_string(),
-                    AdverseStatus::Quarantined => "quarantined".red().to_string(),
+                let label = match &status.status {
+                    AdverseStatus::Archived | AdverseStatus::Deprecated => {
+                        status.status.to_string().yellow().to_string()
+                    }
+                    AdverseStatus::Quarantined => status.status.to_string().red().to_string(),
                 };
                 let name = status.name.bold();
                 if let Some(reason) = &status.reason {
@@ -430,13 +486,171 @@ impl AuditResults {
             }
         }
 
-        // NOTE: intentional: we don't currently fail if there are any adverse statuses,
-        // only when there are vulnerabilities. We will likely change this once we allow users
-        // to ignore adverse statuses and configure policies.
-        if has_vulnerabilities {
-            Ok(ExitStatus::Failure)
-        } else {
-            Ok(ExitStatus::Success)
+        Ok(self.exit_status())
+    }
+
+    fn render_json(&self) -> Result<ExitStatus> {
+        let (vulnerabilities, statuses) = self.split_findings();
+        let report = JsonReport::from_findings(self.n_packages, &vulnerabilities, &statuses);
+
+        writeln!(
+            self.printer.stdout_important(),
+            "{}",
+            serde_json::to_string_pretty(&report)?
+        )?;
+
+        Ok(self.exit_status())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct JsonReport {
+    schema: JsonSchema,
+    summary: JsonSummary,
+    vulnerabilities: Vec<JsonVulnerability>,
+    adverse_statuses: Vec<JsonAdverseStatus>,
+}
+
+impl JsonReport {
+    fn from_findings(
+        n_packages: usize,
+        vulnerabilities: &[&Vulnerability],
+        statuses: &[&ProjectStatus],
+    ) -> Self {
+        let mut vulnerabilities = vulnerabilities
+            .iter()
+            .copied()
+            .map(JsonVulnerability::from)
+            .collect::<Vec<_>>();
+        vulnerabilities.sort_by(|first, second| {
+            first
+                .dependency
+                .name
+                .cmp(&second.dependency.name)
+                .then_with(|| first.dependency.version.cmp(&second.dependency.version))
+                .then_with(|| first.display_id.cmp(&second.display_id))
+        });
+
+        let mut adverse_statuses = statuses
+            .iter()
+            .copied()
+            .map(JsonAdverseStatus::from)
+            .collect::<Vec<_>>();
+        adverse_statuses.sort_by(|first, second| {
+            first
+                .name
+                .cmp(&second.name)
+                .then_with(|| first.status.cmp(&second.status))
+        });
+
+        Self {
+            schema: JsonSchema::default(),
+            summary: JsonSummary {
+                audited_packages: n_packages,
+                vulnerabilities: vulnerabilities.len(),
+                adverse_statuses: adverse_statuses.len(),
+            },
+            vulnerabilities,
+            adverse_statuses,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Default)]
+struct JsonSchema {
+    version: JsonSchemaVersion,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum JsonSchemaVersion {
+    #[default]
+    Preview,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonSummary {
+    audited_packages: usize,
+    vulnerabilities: usize,
+    adverse_statuses: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonDependency {
+    name: String,
+    version: String,
+}
+
+impl From<&Dependency> for JsonDependency {
+    fn from(dependency: &Dependency) -> Self {
+        Self {
+            name: dependency.name().to_string(),
+            version: dependency.version().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct JsonVulnerability {
+    dependency: JsonDependency,
+    id: String,
+    display_id: String,
+    aliases: Vec<String>,
+    summary: Option<String>,
+    description: Option<String>,
+    link: Option<String>,
+    fix_versions: Vec<String>,
+    published: Option<String>,
+    modified: Option<String>,
+}
+
+impl From<&Vulnerability> for JsonVulnerability {
+    fn from(vulnerability: &Vulnerability) -> Self {
+        Self {
+            dependency: JsonDependency::from(&vulnerability.dependency),
+            id: vulnerability.id.as_str().to_string(),
+            display_id: vulnerability.best_id().as_str().to_string(),
+            aliases: vulnerability
+                .aliases
+                .iter()
+                .map(|id| id.as_str().to_string())
+                .collect(),
+            summary: vulnerability.summary.clone(),
+            description: vulnerability.description.clone(),
+            link: vulnerability
+                .link
+                .as_ref()
+                .map(|link| link.as_str().to_string()),
+            fix_versions: vulnerability
+                .fix_versions
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+            published: vulnerability
+                .published
+                .as_ref()
+                .map(std::string::ToString::to_string),
+            modified: vulnerability
+                .modified
+                .as_ref()
+                .map(std::string::ToString::to_string),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct JsonAdverseStatus {
+    name: String,
+    status: String,
+    reason: Option<String>,
+}
+
+impl From<&ProjectStatus> for JsonAdverseStatus {
+    fn from(status: &ProjectStatus) -> Self {
+        Self {
+            name: status.name.to_string(),
+            status: status.status.to_string(),
+            reason: status.reason.clone(),
         }
     }
 }

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -505,6 +505,7 @@ impl AuditResults {
 
 #[derive(Debug, Serialize)]
 struct JsonReport {
+    schema: JsonSchema,
     summary: JsonSummary,
     vulnerabilities: Vec<JsonVulnerability>,
     adverse_statuses: Vec<JsonAdverseStatus>,
@@ -543,6 +544,7 @@ impl JsonReport {
         });
 
         Self {
+            schema: JsonSchema::default(),
             summary: JsonSummary {
                 audited_packages: n_packages,
                 vulnerabilities: vulnerabilities.len(),
@@ -552,6 +554,18 @@ impl JsonReport {
             adverse_statuses,
         }
     }
+}
+
+#[derive(Debug, Serialize, Default)]
+struct JsonSchema {
+    version: JsonSchemaVersion,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum JsonSchemaVersion {
+    #[default]
+    Preview,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -2697,6 +2697,7 @@ async fn run_project(
                 cache,
                 printer,
                 globals.preview,
+                args.output_format,
                 args.service_format,
                 args.service_url,
                 args.ignore,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -14,13 +14,13 @@ use uv_auth::Service;
 use uv_cache::{CacheArgs, Refresh};
 use uv_cli::comma::CommaSeparatedRequirements;
 use uv_cli::{
-    AddArgs, AuditArgs, AuthLoginArgs, AuthLogoutArgs, AuthTokenArgs, ColorChoice, ExternalCommand,
-    GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe, MetadataArgs, PipCheckArgs, PipCompileArgs,
-    PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs, PipSyncArgs, PipTreeArgs,
-    PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs, PythonListFormat,
-    PythonPinArgs, PythonUninstallArgs, PythonUpgradeArgs, RemoveArgs, RunArgs, SyncArgs,
-    SyncFormat, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs, ToolUninstallArgs,
-    TreeArgs, VenvArgs, VersionArgs, VersionBumpSpec, VersionFormat,
+    AddArgs, AuditArgs, AuditOutputFormat, AuthLoginArgs, AuthLogoutArgs, AuthTokenArgs,
+    ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe, MetadataArgs,
+    PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
+    PipSyncArgs, PipTreeArgs, PipUninstallArgs, PythonFindArgs, PythonInstallArgs, PythonListArgs,
+    PythonListFormat, PythonPinArgs, PythonUninstallArgs, PythonUpgradeArgs, RemoveArgs, RunArgs,
+    SyncArgs, SyncFormat, ToolDirArgs, ToolInstallArgs, ToolListArgs, ToolRunArgs,
+    ToolUninstallArgs, TreeArgs, VenvArgs, VersionArgs, VersionBumpSpec, VersionFormat,
 };
 use uv_cli::{
     AuthorFrom, BuildArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
@@ -2664,6 +2664,7 @@ pub(crate) struct AuditSettings {
     pub(crate) python_platform: Option<TargetTriple>,
     pub(crate) install_mirrors: PythonInstallMirrors,
     pub(crate) settings: ResolverSettings,
+    pub(crate) output_format: AuditOutputFormat,
     pub(crate) service_format: VulnerabilityServiceFormat,
     pub(crate) service_url: Option<String>,
     pub(crate) ignore: Vec<VulnerabilityID>,
@@ -2689,6 +2690,7 @@ impl AuditSettings {
             python_platform,
             locked,
             frozen,
+            output_format,
             build,
             resolver,
             ignore,
@@ -2744,6 +2746,7 @@ impl AuditSettings {
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
             settings: ResolverSettings::combine(resolver_options(resolver, build), filesystem),
+            output_format,
             service_format,
             service_url,
             ignore: {

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -131,9 +131,6 @@ async fn audit_json_no_vulnerabilities() {
     exit_code: 0
     ----- stdout -----
     {
-      "schema": {
-        "version": "preview"
-      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 0,
@@ -177,9 +174,6 @@ async fn audit_json_preview_warning() {
     exit_code: 0
     ----- stdout -----
     {
-      "schema": {
-        "version": "preview"
-      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 0,
@@ -2201,9 +2195,6 @@ async fn audit_json_vulnerability_and_project_status() {
     exit_code: 1
     ----- stdout -----
     {
-      "schema": {
-        "version": "preview"
-      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 1,

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -7,6 +7,57 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_test::uv_snapshot;
 
+fn write_audit_json_project(context: &uv_test::TestContext, index_url: &str) {
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+
+        [[tool.uv.index]]
+        url = "{index_url}"
+        default = true
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("uv.lock");
+    lockfile
+        .write_str(&formatdoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = {{ registry = "{index_url}" }}
+        sdist = {{ url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }}
+        wheels = [
+            {{ url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" }},
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = {{ virtual = "." }}
+        dependencies = [
+            {{ name = "iniconfig" }},
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            {{ name = "iniconfig", specifier = "==2.0.0" }},
+        ]
+    "#})
+        .unwrap();
+}
+
 /// Audit a project with no vulnerabilities found.
 #[tokio::test]
 async fn audit_no_vulnerabilities() {
@@ -48,6 +99,99 @@ async fn audit_no_vulnerabilities() {
     Resolved 2 packages in [TIME]
     Found no known vulnerabilities and no adverse project statuses in 1 package
     ");
+}
+
+/// Audit a project with no vulnerabilities found, emitting JSON output.
+#[tokio::test]
+async fn audit_json_no_vulnerabilities() {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+    write_audit_json_project(&context, &proxy.url("/simple"));
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit,json-output")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--frozen")
+        .arg("--service-url")
+        .arg(server.uri()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "summary": {
+        "audited_packages": 1,
+        "vulnerabilities": 0,
+        "adverse_statuses": 0
+      },
+      "vulnerabilities": [],
+      "adverse_statuses": []
+    }
+
+    ----- stderr -----
+    "#);
+}
+
+/// Requesting JSON output warns unless the JSON preview feature is enabled.
+#[tokio::test]
+async fn audit_json_preview_warning() {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+    write_audit_json_project(&context, &proxy.url("/simple"));
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--frozen")
+        .arg("--service-url")
+        .arg(server.uri()), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "summary": {
+        "audited_packages": 1,
+        "vulnerabilities": 0,
+        "adverse_statuses": 0
+      },
+      "vulnerabilities": [],
+      "adverse_statuses": []
+    }
+
+    ----- stderr -----
+    warning: The `--output-format json` option is experimental and the schema may change without warning. Pass `--preview-features json-output` to disable this warning.
+    "#);
 }
 
 /// Audit a project and find a single vulnerability with summary, fix version, and advisory link.
@@ -2002,4 +2146,97 @@ async fn audit_vulnerability_and_project_status() {
     Resolved 2 packages in [TIME]
     Found 1 known vulnerability and 1 adverse project status in 1 package
     ");
+}
+
+/// JSON output includes vulnerabilities and adverse project statuses in the
+/// same audit report.
+#[tokio::test]
+async fn audit_json_vulnerability_and_project_status() {
+    let context = uv_test::test_context!("3.12");
+    let proxy = crate::pypi_proxy::start().await;
+    write_audit_json_project(&context, &proxy.url("/status/archived/simple"));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2023-0001"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2023-0001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2023-0001",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A test vulnerability in iniconfig",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {"fixed": "2.1.0"}
+                    ]
+                }]
+            }],
+            "references": [{
+                "type": "ADVISORY",
+                "url": "https://example.com/advisory/PYSEC-2023-0001"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit,json-output")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--frozen")
+        .arg("--service-url")
+        .arg(server.uri()), @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    {
+      "schema": {
+        "version": "preview"
+      },
+      "summary": {
+        "audited_packages": 1,
+        "vulnerabilities": 1,
+        "adverse_statuses": 1
+      },
+      "vulnerabilities": [
+        {
+          "dependency": {
+            "name": "iniconfig",
+            "version": "2.0.0"
+          },
+          "id": "PYSEC-2023-0001",
+          "display_id": "PYSEC-2023-0001",
+          "aliases": [],
+          "summary": "A test vulnerability in iniconfig",
+          "description": null,
+          "link": "https://example.com/advisory/PYSEC-2023-0001",
+          "fix_versions": [
+            "2.1.0"
+          ],
+          "published": null,
+          "modified": "2026-01-01T00:00:00Z"
+        }
+      ],
+      "adverse_statuses": [
+        {
+          "name": "iniconfig",
+          "status": "archived",
+          "reason": null
+        }
+      ]
+    }
+
+    ----- stderr -----
+    "#);
 }

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -131,6 +131,9 @@ async fn audit_json_no_vulnerabilities() {
     exit_code: 0
     ----- stdout -----
     {
+      "schema": {
+        "version": "preview"
+      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 0,
@@ -174,6 +177,9 @@ async fn audit_json_preview_warning() {
     exit_code: 0
     ----- stdout -----
     {
+      "schema": {
+        "version": "preview"
+      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 0,
@@ -2195,6 +2201,9 @@ async fn audit_json_vulnerability_and_project_status() {
     exit_code: 1
     ----- stdout -----
     {
+      "schema": {
+        "version": "preview"
+      },
       "summary": {
         "audited_packages": 1,
         "vulnerabilities": 1,


### PR DESCRIPTION
## Summary

This adds `--output-format json` to `uv audit`. Like other subcommands that support JSON, we're keeping this in preview (so it's in double preview with `uv audit` itself). 

I'm not sure about the JSON layout itself yet.

See #18506.

## Test Plan

Added some integration coverage.