### PR TITLE
Fix bug from inconsistent workflow name in GHA-PyPI guide example

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -356,7 +356,7 @@ functional and we didn't miss any files. This step is recommended, but optional.
 
 First, add a release workflow to your project:
 
-```yaml title=".github/workflows/publish.yml"
+```yaml title=".github/workflows/release.yml"
 name: "Publish"
 
 on:

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -357,7 +357,7 @@ functional and we didn't miss any files. This step is recommended, but optional.
 First, add a release workflow to your project:
 
 ```yaml title=".github/workflows/release.yml"
-name: "Publish"
+name: "Publish release to PyPI"
 
 on:
   push:


### PR DESCRIPTION
This is a very minor doc change but fixes a bug for diligent but unknowing new users following the guide.

The UV guide on publishing to PyPI from GHA has a screenshot showing that users reference a "release.yml" GHA workflow file when setting up a new Trusted Publisher in PyPI. But the guide had users create a "publish.yml" workflow file in their GitHub repository before this. PyPI won't grant the expected token because the workflow names don't match exactly across PyPI and GH, so the example bombs pretty hard.

Love all your work. Thanks for your help.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
