### PR TITLE
Include data files in editable builds

### DIFF
--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -229,37 +229,12 @@ fn write_wheel(
         )?;
     }
 
-    // Add the data files
-    for (name, directory) in settings.data.iter() {
-        debug!(
-            "Adding {name} data files from: {}",
-            directory.user_display()
-        );
-        if directory
-            .components()
-            .next()
-            .is_some_and(|component| !matches!(component, Component::CurDir | Component::Normal(_)))
-        {
-            return Err(Error::InvalidDataRoot {
-                name: name.to_string(),
-                path: directory.to_path_buf(),
-            });
-        }
-        let data_dir = format!(
-            "{}-{}.data/{}/",
-            pyproject_toml.name().as_dist_info_name(),
-            pyproject_toml.version(),
-            name
-        );
-
-        wheel_subdir_from_globs(
-            &source_tree.join(directory),
-            &data_dir,
-            &["**".to_string()],
-            &mut wheel_writer,
-            &format!("tool.uv.build-backend.data.{name}"),
-        )?;
-    }
+    write_data_files(
+        source_tree,
+        pyproject_toml,
+        settings.data.iter(),
+        &mut wheel_writer,
+    )?;
 
     debug!("Adding metadata files to wheel");
     let dist_info_dir = write_dist_info(
@@ -330,6 +305,13 @@ pub fn build_editable(
         src_root.as_os_str().as_encoded_bytes(),
     )?;
 
+    write_data_files(
+        source_tree,
+        &pyproject_toml,
+        settings.data.iter(),
+        &mut wheel_writer,
+    )?;
+
     debug!("Adding metadata files to: {}", wheel_path.user_display());
     let dist_info_dir = write_dist_info(
         &mut wheel_writer,
@@ -345,6 +327,47 @@ pub fn build_editable(
         .map_err(|err| Error::Persist(wheel_path.clone(), err.error))?;
 
     Ok(filename)
+}
+
+/// Add files configured via `tool.uv.build-backend.data` to a wheel.
+fn write_data_files<'data>(
+    source_tree: &Path,
+    pyproject_toml: &PyProjectToml,
+    data: impl Iterator<Item = (&'static str, &'data Path)>,
+    wheel_writer: &mut impl DirectoryWriter,
+) -> Result<(), Error> {
+    for (name, directory) in data {
+        debug!(
+            "Adding {name} data files from: {}",
+            directory.user_display()
+        );
+        if directory
+            .components()
+            .next()
+            .is_some_and(|component| !matches!(component, Component::CurDir | Component::Normal(_)))
+        {
+            return Err(Error::InvalidDataRoot {
+                name: name.to_string(),
+                path: directory.to_path_buf(),
+            });
+        }
+        let data_dir = format!(
+            "{}-{}.data/{}/",
+            pyproject_toml.name().as_dist_info_name(),
+            pyproject_toml.version(),
+            name
+        );
+
+        wheel_subdir_from_globs(
+            &source_tree.join(directory),
+            &data_dir,
+            &["**".to_string()],
+            wheel_writer,
+            &format!("tool.uv.build-backend.data.{name}"),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Write the dist-info directory to the output directory without building the wheel.

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -14530,6 +14530,107 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
     Ok(())
 }
 
+/// Test that `tool.uv.build-backend.data` files are installed for editable builds.
+///
+/// See <https://github.com/astral-sh/uv/issues/19258>.
+#[test]
+fn install_editable_uv_build_data() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+
+        [tool.uv.build-backend.data]
+        purelib = "purelib"
+        platlib = "platlib"
+        scripts = "scripts"
+        headers = "headers"
+        data = "data"
+    "#})?;
+
+    context.temp_dir.child("src/project/__init__.py").touch()?;
+    context
+        .temp_dir
+        .child("purelib/project-data.txt")
+        .write_str("project data")?;
+    context
+        .temp_dir
+        .child("platlib/project-platform-data.txt")
+        .write_str("project platform data")?;
+    context
+        .temp_dir
+        .child("scripts/project-script")
+        .write_str(indoc! {r#"
+            #!python
+            print("Hello from project script")
+        "#})?;
+    context
+        .temp_dir
+        .child("headers/project.h")
+        .write_str("#include <stdio.h>")?;
+    context
+        .temp_dir
+        .child("data/project-config.txt")
+        .write_str("project config")?;
+    uv_snapshot!(context.filters(), context.pip_install().arg("-e").arg("."), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
+    ");
+
+    assert_snapshot!(
+        fs::read_to_string(context.site_packages().join("project-data.txt"))?,
+        @"project data"
+    );
+    assert_snapshot!(
+        fs::read_to_string(context.site_packages().join("project-platform-data.txt"))?,
+        @"project platform data"
+    );
+
+    let project_script = fs::read_to_string(venv_bin_path(&context.venv).join("project-script"))?;
+    let normalized_project_script = if let Some(index) = project_script.find('\n') {
+        format!("#![PYTHON]{}", &project_script[index..])
+    } else {
+        project_script
+    };
+    assert_snapshot!(
+        normalized_project_script,
+        @r#"
+        #![PYTHON]
+        print("Hello from project script")
+        "#
+    );
+
+    let record = fs::read_to_string(
+        context
+            .site_packages()
+            .join("project-0.1.0.dist-info")
+            .join("RECORD"),
+    )?;
+    assert!(record.lines().any(|line| line.contains("/project-script")));
+    assert!(record.lines().any(|line| line.contains("/project.h")));
+    assert!(
+        record
+            .lines()
+            .any(|line| line.contains("/project-config.txt"))
+    );
+
+    Ok(())
+}
+
 /// Test that RECORD entries use forward slashes on all platforms.
 ///
 /// See <https://github.com/astral-sh/uv/issues/14446>.


### PR DESCRIPTION
## Summary

PEP 660 doesn't appear to be explicit about the treatment of `.data` directories, beyond the following:

> With regard to the wheel .data directory, this PEP focuses on making the purelib and platlib categories (installed into site-packages) “editable”. It does not make special provision for the other categories such as headers, data and scripts. Package authors are encouraged to use console_scripts, make their scripts tiny wrappers around library functionality, or manage these from the source checkout during development.

Other build backends seem to snapshot them, which seems reasonable to me.

Closes https://github.com/astral-sh/uv/issues/19258.
