### PR TITLE
Continue uninstalling tools after encountering a tool environment with a missing receipt

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -137,11 +137,12 @@ async fn do_uninstall(
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
                     Ok(()) => {
+                        dangling = true;
                         writeln!(
                             printer.stderr(),
                             "Removed dangling environment for `{name}`"
                         )?;
-                        return Ok(());
+                        continue;
                     }
                     Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
                         if err.kind() == std::io::ErrorKind::NotFound =>

--- a/crates/uv/tests/it/tool_uninstall.rs
+++ b/crates/uv/tests/it/tool_uninstall.rs
@@ -188,3 +188,43 @@ fn tool_uninstall_all_missing_receipt() {
     Removed dangling environment for `black`
     ");
 }
+
+#[test]
+fn tool_uninstall_multiple_with_first_dangling() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black` and `ruff`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    // Remove the receipt for `black`, making it dangling
+    fs_err::remove_file(tool_dir.join("black").join("uv-receipt.toml")).unwrap();
+
+    // Uninstall both `black` (dangling) and `ruff` (valid)
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black").arg("ruff")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed dangling environment for `black`
+    Uninstalled 1 executable: ruff
+    ");
+}


### PR DESCRIPTION
## Summary

When uninstalling multiple tools (e.g. `uv tool uninstall black ruff`), if the first tool had a corrupt/missing receipt, the command would silently return after processing only the first tool — skipping all remaining tools.

## Root Cause

In `crates/uv/src/commands/tool/uninstall.rs` at line 144, the error path used `return Ok(())` instead of `continue`, exiting the loop entirely. The `--all` code path already handled this correctly with `dangling = true; continue;`.

## Fix

Changed `return Ok(())` to `dangling = true; continue;` so the loop proceeds to the next tool instead of aborting.

## Testing

Added `tool_uninstall_multiple_with_first_dangling` integration test that verifies both tools are processed when the first is dangling.

Fixes #19219