### PR TITLE
Fix `uv tree` showing extra-conditional deps for packages required without extras

### DIFF
--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -423,7 +423,7 @@ impl<'env> TreeDisplay<'env> {
         &'env self,
         cursor: Cursor,
         visited: &mut FxHashMap<VisitedNode<'env>, Vec<&'env PackageId>>,
-        path: &mut Vec<&'env PackageId>,
+        path: &mut Vec<VisitedNode<'env>>,
     ) -> Vec<String> {
         // Short-circuit if the current path is longer than the provided depth.
         if path.len() > self.depth {
@@ -487,7 +487,7 @@ impl<'env> TreeDisplay<'env> {
         // Skip the traversal if:
         // 1. The package is in the current traversal path (i.e., a dependency cycle).
         // 2. The package has been visited and de-duplication is enabled (default).
-        if path.contains(&package_id) {
+        if path.contains(&visited_node) {
             return vec![format!("{line} (*)")];
         }
         if !self.no_dedupe
@@ -541,7 +541,7 @@ impl<'env> TreeDisplay<'env> {
         // Only mark as visited if we're going to expand children (not at depth limit).
         if path.len() < self.depth {
             visited.insert(
-                visited_node,
+                visited_node.clone(),
                 dependencies
                     .iter()
                     .filter_map(|node| match self.graph[node.node()] {
@@ -551,7 +551,7 @@ impl<'env> TreeDisplay<'env> {
                     .collect(),
             );
         }
-        path.push(package_id);
+        path.push(visited_node);
 
         for (index, dep) in dependencies.iter().enumerate() {
             // For sub-visited packages, add the prefix to make the tree display user-friendly.

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -16,7 +16,7 @@ use uv_pep440::Version;
 use uv_pep508::MarkerTree;
 use uv_pypi_types::ResolverMarkerEnvironment;
 
-use crate::lock::PackageId;
+use crate::lock::{Package, PackageId};
 use crate::{Lock, PackageMap};
 
 #[derive(Debug)]
@@ -422,7 +422,7 @@ impl<'env> TreeDisplay<'env> {
     fn visit(
         &'env self,
         cursor: Cursor,
-        visited: &mut FxHashMap<&'env PackageId, Vec<&'env PackageId>>,
+        visited: &mut FxHashMap<VisitedNode<'env>, Vec<&'env PackageId>>,
         path: &mut Vec<&'env PackageId>,
     ) -> Vec<String> {
         // Short-circuit if the current path is longer than the provided depth.
@@ -434,6 +434,13 @@ impl<'env> TreeDisplay<'env> {
             return Vec::new();
         };
         let edge = cursor.edge().map(|edge_id| &self.graph[edge_id]);
+        let package = self.lock.find_by_id(package_id);
+
+        let expanded_extras = self.expanded_extras(package, edge);
+        let visited_node = VisitedNode {
+            package_id,
+            expanded_extras: expanded_extras.clone(),
+        };
 
         let line = {
             let mut line = format!("{}", package_id.name);
@@ -467,7 +474,6 @@ impl<'env> TreeDisplay<'env> {
             // Append compressed wheel size, if available in the lockfile.
             // Keep it simple: use the first wheel entry that includes a size.
             if self.show_sizes {
-                let package = self.lock.find_by_id(package_id);
                 if let Some(size_bytes) = package.wheels.iter().find_map(|wheel| wheel.size) {
                     let (bytes, unit) = human_readable_bytes(size_bytes);
                     line.push(' ');
@@ -481,14 +487,17 @@ impl<'env> TreeDisplay<'env> {
         // Skip the traversal if:
         // 1. The package is in the current traversal path (i.e., a dependency cycle).
         // 2. The package has been visited and de-duplication is enabled (default).
-        if let Some(requirements) = visited.get(package_id) {
-            if !self.no_dedupe || path.contains(&package_id) {
-                return if requirements.is_empty() {
-                    vec![line]
-                } else {
-                    vec![format!("{line} (*)")]
-                };
-            }
+        if path.contains(&package_id) {
+            return vec![format!("{line} (*)")];
+        }
+        if !self.no_dedupe
+            && let Some(requirements) = visited.get(&visited_node)
+        {
+            return if requirements.is_empty() {
+                vec![line]
+            } else {
+                vec![format!("{line} (*)")]
+            };
         }
 
         // Incorporate the latest version of the package, if known.
@@ -496,19 +505,6 @@ impl<'env> TreeDisplay<'env> {
             format!("{line} {}", format!("(latest: v{version})").bold().cyan())
         } else {
             line
-        };
-
-        // Determine which extras are activated for the current node based on the incoming edge.
-        // `None` means a root context (e.g., workspace members reached directly from the
-        // synthetic root), where all optional children are displayed. `Some(set)` restricts
-        // optional dependencies to those whose activating extra appears in `set`.
-        //
-        // In inverted mode the graph edges are reversed, so an `Optional` outgoing edge means
-        // "this package is required by X via extra Y" — the filter does not apply there.
-        let activated_extras = if self.invert {
-            None
-        } else {
-            edge.and_then(Edge::extras)
         };
 
         let mut dependencies = self
@@ -519,8 +515,10 @@ impl<'env> TreeDisplay<'env> {
                 Node::Package(_) => {
                     // Only include extra-conditional dependencies if the activating extra is
                     // enabled in the current context.
-                    if let Edge::Optional(required_extra, _) = &self.graph[edge.id()] {
-                        if activated_extras.is_some_and(|extras| !extras.contains(required_extra)) {
+                    if !self.invert
+                        && let Edge::Optional(required_extra, _) = &self.graph[edge.id()]
+                    {
+                        if !expanded_extras.contains(required_extra) {
                             return None;
                         }
                     }
@@ -543,7 +541,7 @@ impl<'env> TreeDisplay<'env> {
         // Only mark as visited if we're going to expand children (not at depth limit).
         if path.len() < self.depth {
             visited.insert(
-                package_id,
+                visited_node,
                 dependencies
                     .iter()
                     .filter_map(|node| match self.graph[node.node()] {
@@ -625,6 +623,36 @@ impl<'env> TreeDisplay<'env> {
 
         lines
     }
+
+    /// Return the extras that can change this package's rendered child list.
+    fn expanded_extras(
+        &self,
+        package: &'env Package,
+        edge: Option<&Edge<'env>>,
+    ) -> BTreeSet<&'env ExtraName> {
+        if self.invert {
+            // In inverted mode, optional edges are reverse "required by extra" relationships.
+            // They do not select this package's outgoing dependencies, so de-dupe stays
+            // package-only.
+            return BTreeSet::default();
+        }
+
+        let Some(requested_extras) = edge.and_then(Edge::extras) else {
+            // Roots are rendered with all optional dependency groups expanded.
+            return package.optional_dependencies.keys().collect();
+        };
+
+        requested_extras
+            .iter()
+            .filter(|extra| package.optional_dependencies.contains_key(*extra))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct VisitedNode<'env> {
+    package_id: &'env PackageId,
+    expanded_extras: BTreeSet<&'env ExtraName>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -31,6 +31,8 @@ pub struct TreeDisplay<'env> {
     depth: usize,
     /// Whether to de-duplicate the displayed dependencies.
     no_dedupe: bool,
+    /// Whether the graph edges have been reversed (i.e., `--invert` mode).
+    invert: bool,
     /// Reference to the lock to look up additional metadata (e.g., wheel sizes).
     lock: &'env Lock,
     /// Whether to show sizes in the rendered output.
@@ -410,6 +412,7 @@ impl<'env> TreeDisplay<'env> {
             latest,
             depth,
             no_dedupe,
+            invert,
             lock,
             show_sizes,
         }
@@ -495,12 +498,34 @@ impl<'env> TreeDisplay<'env> {
             line
         };
 
+        // Determine which extras are activated for the current node based on the incoming edge.
+        // `None` means a root context (e.g., workspace members reached directly from the
+        // synthetic root), where all optional children are displayed. `Some(set)` restricts
+        // optional dependencies to those whose activating extra appears in `set`.
+        //
+        // In inverted mode the graph edges are reversed, so an `Optional` outgoing edge means
+        // "this package is required by X via extra Y" — the filter does not apply there.
+        let activated_extras = if self.invert {
+            None
+        } else {
+            edge.and_then(Edge::extras)
+        };
+
         let mut dependencies = self
             .graph
             .edges_directed(cursor.node(), Direction::Outgoing)
             .filter_map(|edge| match self.graph[edge.target()] {
                 Node::Root => None,
-                Node::Package(_) => Some(Cursor::new(edge.target(), edge.id())),
+                Node::Package(_) => {
+                    // Only include extra-conditional dependencies if the activating extra is
+                    // enabled in the current context.
+                    if let Edge::Optional(required_extra, _) = &self.graph[edge.id()] {
+                        if activated_extras.is_some_and(|extras| !extras.contains(required_extra)) {
+                            return None;
+                        }
+                    }
+                    Some(Cursor::new(edge.target(), edge.id()))
+                }
             })
             .collect::<Vec<_>>();
         dependencies.sort_by_key(|cursor| {

--- a/crates/uv/tests/it/tree.rs
+++ b/crates/uv/tests/it/tree.rs
@@ -797,6 +797,88 @@ fn optional_dependencies_inverted() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for <https://github.com/astral-sh/uv/issues/19327>.
+///
+/// When a package is required both as a plain dep and as a dep with extras (e.g., from a
+/// dependency group), `uv tree` should not display extra-conditional dependencies for the plain
+/// occurrence.
+#[test]
+fn dep_and_group_extras() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["flask"]
+
+        [dependency-groups]
+        dev = ["flask[dotenv]"]
+    "#,
+    )?;
+
+    // Plain `flask` should not show `python-dotenv` (which belongs to the `dotenv` extra).
+    // `flask[dotenv]` should be deduplicated as `(*)` because `flask` was already rendered above.
+    uv_snapshot!(context.filters(), context.tree().arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project v0.1.0
+    ├── flask v3.0.2
+    │   ├── blinker v1.7.0
+    │   ├── click v8.1.7
+    │   │   └── colorama v0.4.6
+    │   ├── itsdangerous v2.1.2
+    │   ├── jinja2 v3.1.3
+    │   │   └── markupsafe v2.1.5
+    │   └── werkzeug v3.0.1
+    │       └── markupsafe v2.1.5
+    └── flask[dotenv] v3.0.2 (group: dev) (*)
+    (*) Package tree already displayed
+
+    ----- stderr -----
+    Resolved 10 packages in [TIME]
+    "
+    );
+
+    // With `--no-dedupe`, `flask[dotenv]` is expanded and shows `python-dotenv` as an extra dep,
+    // while plain `flask` still does not show it.
+    uv_snapshot!(context.filters(), context.tree().arg("--universal").arg("--no-dedupe"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project v0.1.0
+    ├── flask v3.0.2
+    │   ├── blinker v1.7.0
+    │   ├── click v8.1.7
+    │   │   └── colorama v0.4.6
+    │   ├── itsdangerous v2.1.2
+    │   ├── jinja2 v3.1.3
+    │   │   └── markupsafe v2.1.5
+    │   └── werkzeug v3.0.1
+    │       └── markupsafe v2.1.5
+    └── flask[dotenv] v3.0.2 (group: dev)
+        ├── blinker v1.7.0
+        ├── click v8.1.7
+        │   └── colorama v0.4.6
+        ├── itsdangerous v2.1.2
+        ├── jinja2 v3.1.3
+        │   └── markupsafe v2.1.5
+        ├── werkzeug v3.0.1
+        │   └── markupsafe v2.1.5
+        └── python-dotenv v1.0.1 (extra: dotenv)
+
+    ----- stderr -----
+    Resolved 10 packages in [TIME]
+    "
+    );
+
+    Ok(())
+}
+
 #[test]
 fn package() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/it/tree.rs
+++ b/crates/uv/tests/it/tree.rs
@@ -952,6 +952,86 @@ fn dep_and_group_extras_with_extra_only_dependency() -> Result<()> {
 }
 
 #[test]
+fn dep_and_group_extras_with_different_extras_in_path() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let leaf = context.temp_dir.child("leaf");
+    fs_err::create_dir_all(leaf.path())?;
+    leaf.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "leaf"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+    let leaf_url = Url::from_file_path(leaf.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert leaf path to URL"))?;
+
+    let a = context.temp_dir.child("a");
+    fs_err::create_dir_all(a.path())?;
+    let b = context.temp_dir.child("b");
+    fs_err::create_dir_all(b.path())?;
+    let b_url = Url::from_file_path(b.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert b path to URL"))?;
+    a.child("pyproject.toml").write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["b[extra2] @ {}"]
+        "#,
+        b_url,
+    })?;
+    let a_url = Url::from_file_path(a.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert a path to URL"))?;
+
+    b.child("pyproject.toml").write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        extra1 = ["a @ {}"]
+        extra2 = ["leaf @ {}"]
+        "#,
+        a_url,
+        leaf_url,
+    })?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["b[extra1] @ {}"]
+        "#,
+        b_url,
+    })?;
+
+    uv_snapshot!(context.filters(), context.tree(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project v0.1.0
+    └── b[extra1] v0.1.0
+        └── a v0.1.0 (extra: extra1)
+            └── b[extra2] v0.1.0
+                └── leaf v0.1.0 (extra: extra2)
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn package() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/it/tree.rs
+++ b/crates/uv/tests/it/tree.rs
@@ -820,8 +820,8 @@ fn dep_and_group_extras() -> Result<()> {
     "#,
     )?;
 
-    // Plain `flask` should not show `python-dotenv` (which belongs to the `dotenv` extra).
-    // `flask[dotenv]` should be deduplicated as `(*)` because `flask` was already rendered above.
+    // Plain `flask` should not show `python-dotenv` (which belongs to the `dotenv` extra),
+    // but the `flask[dotenv]` occurrence should still be expanded in its own extra context.
     uv_snapshot!(context.filters(), context.tree().arg("--universal"), @"
     success: true
     exit_code: 0
@@ -836,7 +836,13 @@ fn dep_and_group_extras() -> Result<()> {
     │   │   └── markupsafe v2.1.5
     │   └── werkzeug v3.0.1
     │       └── markupsafe v2.1.5
-    └── flask[dotenv] v3.0.2 (group: dev) (*)
+    └── flask[dotenv] v3.0.2 (group: dev)
+        ├── blinker v1.7.0
+        ├── click v8.1.7 (*)
+        ├── itsdangerous v2.1.2
+        ├── jinja2 v3.1.3 (*)
+        ├── werkzeug v3.0.1 (*)
+        └── python-dotenv v1.0.1 (extra: dotenv)
     (*) Package tree already displayed
 
     ----- stderr -----
@@ -875,6 +881,72 @@ fn dep_and_group_extras() -> Result<()> {
     Resolved 10 packages in [TIME]
     "
     );
+
+    Ok(())
+}
+
+#[test]
+fn dep_and_group_extras_with_extra_only_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let leaf = context.temp_dir.child("leaf");
+    fs_err::create_dir_all(leaf.path())?;
+    leaf.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "leaf"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+    let leaf_url = Url::from_file_path(leaf.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert leaf path to URL"))?;
+
+    let child = context.temp_dir.child("child");
+    fs_err::create_dir_all(child.path())?;
+    child.child("pyproject.toml").write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        extra = ["leaf @ {}"]
+        "#,
+        leaf_url,
+    })?;
+    let child_url = Url::from_file_path(child.path())
+        .map_err(|()| anyhow::anyhow!("failed to convert child path to URL"))?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["child @ {}"]
+
+        [dependency-groups]
+        dev = ["child[extra] @ {}"]
+        "#,
+        child_url,
+        child_url,
+    })?;
+
+    uv_snapshot!(context.filters(), context.tree(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    project v0.1.0
+    ├── child v0.1.0
+    └── child[extra] v0.1.0 (group: dev)
+        └── leaf v0.1.0 (extra: extra)
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
When a package is required both as a plain dependency and as `pkg[extra]` in a group, `uv tree` can show the extra's dependencies under the plain occurrence too. This updates `TreeDisplay::visit` to only traverse optional outgoing edges when the incoming edge actually activates the matching extra, while leaving `--invert` unchanged since the edge direction is reversed there.

Added `dep_and_group_extras` in `crates/uv/tests/it/tree.rs`. All existing tree tests pass.

Closes #19327