### PR TITLE
Preserve `--locked` error message when `--quiet` is set

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -270,7 +270,7 @@ pub(crate) async fn lock(
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -374,7 +374,7 @@ pub(crate) async fn sync(
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{}",
                     ProjectError::LockMismatch(prev, cur, lock_source)
                         .to_string()
@@ -478,7 +478,7 @@ pub(crate) async fn sync(
         Outcome::Success(..) => Ok(ExitStatus::Success),
         Outcome::LockMismatch(prev, cur, lock_source) => {
             writeln!(
-                printer.stderr(),
+                printer.stderr_important(),
                 "{}",
                 ProjectError::LockMismatch(prev, cur, lock_source)
                     .to_string()

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -119,7 +119,7 @@ pub(crate) async fn metadata(
     {
         Ok(lock) => print_lock_as_metadata(virtual_project.workspace(), &lock.into_lock(), printer),
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -53,7 +53,6 @@ impl Printer {
     }
 
     /// Return the [`Stderr`] for this printer.
-    #[allow(dead_code)] // Only used with the optional self-update feature.
     pub(crate) fn stderr_important(self) -> Stderr {
         match self {
             Self::Silent => Stderr::Disabled,

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -98,6 +98,16 @@ fn locked() -> Result<()> {
     The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     ");
 
+    // `--quiet` must not suppress the error message (exit code 1, cause must be visible).
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
     let updated = context.read("uv.lock");
 
     // And the lockfile should be unchanged.


### PR DESCRIPTION
Fixes `uv sync --locked --quiet` and `uv lock --check --quiet` exiting with code 1 but printing no error when the lockfile is out of date.

The issue was that `Printer::Quiet` disables `stderr()`, so the `LockMismatch` message was being silenced under -q. These paths now use `stderr_important()`, which still prints under -q and is only suppressed by `-qq`.

Updated the affected call sites in sync.rs, lock.rs, and workspace/metadata.rs, and removed the now-unneeded `#[allow(dead_code)]` from printer.rs.

Added a regression test for `uv sync --locked --quiet` with an outdated lockfile, verifying the error is still shown on `stderr`.

Closes #19326.