### PR TITLE
Respect `--require-hashes` when installing from `pylock.toml` files

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -523,6 +523,7 @@ pub(crate) async fn pip_install(
             &extras,
             &groups,
             &build_options,
+            hash_checking,
         )?
     } else {
         // When resolving, don't take any external preferences into account.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -432,6 +432,7 @@ pub(crate) async fn pip_sync(
             &extras,
             &groups,
             &build_options,
+            hash_checking,
         )?
     } else {
         // When resolving, don't take any external preferences into account.

--- a/crates/uv/src/commands/pylock.rs
+++ b/crates/uv/src/commands/pylock.rs
@@ -1,5 +1,5 @@
 //! Shared helpers for reading `pylock.toml` (PEP 751) files and deriving a [`Resolution`] and
-//! verifying [`HashStrategy`] from them, used by `uv pip install` and `uv pip sync`.
+//! [`HashStrategy`] from them, used by `uv pip install` and `uv pip sync`.
 
 use std::path::{Path, PathBuf};
 
@@ -55,8 +55,8 @@ pub(crate) async fn read_pylock_toml(
     Ok((install_path, lock))
 }
 
-/// Verify Python compatibility and convert a parsed [`PylockToml`] into a [`Resolution`] with a
-/// verifying [`HashStrategy`].
+/// Verify Python compatibility and convert a parsed [`PylockToml`] into a [`Resolution`] with its
+/// [`HashStrategy`].
 pub(crate) fn resolve_pylock_toml(
     lock: PylockToml,
     install_path: &Path,
@@ -66,6 +66,7 @@ pub(crate) fn resolve_pylock_toml(
     extras: &[ExtraName],
     groups: &[GroupName],
     build_options: &BuildOptions,
+    hash_checking: Option<HashCheckingMode>,
 ) -> anyhow::Result<(Resolution, HashStrategy)> {
     if let Some(requires_python) = lock.requires_python.as_ref() {
         if !requires_python.contains(interpreter.python_version()) {
@@ -88,7 +89,11 @@ pub(crate) fn resolve_pylock_toml(
         &tags,
         build_options,
     )?;
-    let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
+    let hasher = if let Some(hash_checking) = hash_checking {
+        HashStrategy::from_resolution(&resolution, hash_checking)?
+    } else {
+        HashStrategy::None
+    };
 
     Ok((resolution, hasher))
 }

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -12149,6 +12149,61 @@ fn pep_751_install_directory() -> Result<()> {
 }
 
 #[test]
+fn pep_751_install_require_hashes_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("foo").child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("foo")
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()?;
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        directory = { path = "foo" }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("-r")
+        .arg("pylock.toml")
+        .arg("--require-hashes"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: foo
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-git")]
 fn pep_751_install_git() -> Result<()> {
     let context = uv_test::test_context!("3.12");

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -5977,6 +5977,60 @@ fn pep_751() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn pep_751_require_hashes_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("foo").child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("foo")
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()?;
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "uv"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        directory = { path = "foo" }
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml")
+        .arg("--require-hashes"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: foo
+    "
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn pep_751_remote() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

Right now, we always use the `--verify-hashes` policy even if the user opts-in to a stricter setting.