### PR TITLE
Clarify rollback after tool install executable conflicts

### DIFF
--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -19,7 +19,7 @@ use crate::commands::project::ProjectError;
 use crate::commands::project::remove::DependencyNotFoundError;
 use crate::commands::project::run::RecursionLimitError;
 use crate::commands::project::version::MissingProjectVersionError;
-use crate::commands::tool::common::NoExecutablesError;
+use crate::commands::tool::common::{ExecutableConflictError, NoExecutablesError};
 use crate::commands::tool::run::ToolRunScriptError;
 use crate::printer::Printer;
 
@@ -251,6 +251,7 @@ pub(crate) fn hints_for_error(err: &anyhow::Error) -> Hints<'static> {
         collect_hint::<ExtrasWithoutSourceError>(cause, &mut hints);
         collect_hint::<ProjectError>(cause, &mut hints);
         collect_hint::<NoExecutablesError>(cause, &mut hints);
+        collect_hint::<ExecutableConflictError>(cause, &mut hints);
         collect_hint::<ExternallyManagedError>(cause, &mut hints);
         collect_hint::<MissingProjectVersionError>(cause, &mut hints);
         collect_hint::<crate::commands::build_frontend::Error>(cause, &mut hints);

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -111,6 +111,41 @@ impl Hint for NoExecutablesError {
         hints
     }
 }
+
+/// An error raised when a tool's executables conflict with existing executables.
+///
+/// The tool environment is removed before raising this error, so the tool is not installed.
+#[derive(Debug, Error)]
+pub(crate) struct ExecutableConflictError {
+    /// The names of the conflicting executables.
+    names: Vec<String>,
+    /// The name of the tool being installed.
+    name: PackageName,
+}
+
+impl std::fmt::Display for ExecutableConflictError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (s, exists) = if self.names.len() == 1 {
+            ("", "exists")
+        } else {
+            ("s", "exist")
+        };
+        write!(
+            f,
+            "Executable{s} already {exists}: {} (use `--force` to overwrite)",
+            self.names.iter().map(|name| name.bold()).join(", ")
+        )
+    }
+}
+
+impl Hint for ExecutableConflictError {
+    fn hints(&self) -> Hints<'_> {
+        Hints::from(format!(
+            "The tool environment was removed, so `{}` is not installed.",
+            self.name.cyan()
+        ))
+    }
+}
 use crate::commands::project::{
     EnvironmentSpecification, PlatformState, PreferenceLocation, ProjectError, PythonRequestSource,
     lock::ValidatedLock,
@@ -873,20 +908,15 @@ pub(crate) fn finalize_tool_install(
 
                 let existing_entrypoints = existing_entrypoints
                     // SAFETY: We know the target has a filename because we just constructed it above
-                    .map(|(_, _, target)| target.file_name().unwrap().to_string_lossy())
+                    .map(|(_, _, target)| {
+                        target.file_name().unwrap().to_string_lossy().into_owned()
+                    })
                     .collect::<Vec<_>>();
-                let (s, exists) = if existing_entrypoints.len() == 1 {
-                    ("", "exists")
-                } else {
-                    ("s", "exist")
-                };
-                bail!(
-                    "Executable{s} already {exists}: {} (use `--force` to overwrite)",
-                    existing_entrypoints
-                        .iter()
-                        .map(|name| name.bold())
-                        .join(", ")
-                )
+                return Err(ExecutableConflictError {
+                    names: existing_entrypoints,
+                    name: name.clone(),
+                }
+                .into());
             }
         }
 

--- a/crates/uv/tests/tool/tool_install.rs
+++ b/crates/uv/tests/tool/tool_install.rs
@@ -2705,6 +2705,8 @@ fn tool_install_force() {
      + pathspec==0.12.1
      + platformdirs==4.2.0
     error: Executable already exists: black (use `--force` to overwrite)
+
+    hint: The tool environment was removed, so `black` is not installed.
     ");
 
     // We should delete the virtual environment
@@ -2741,6 +2743,8 @@ fn tool_install_force() {
      + pathspec==0.12.1
      + platformdirs==4.2.0
     error: Executable already exists: black (use `--force` to overwrite)
+
+    hint: The tool environment was removed, so `black` is not installed.
     ");
 
     // We should not create a virtual environment
@@ -2778,6 +2782,8 @@ fn tool_install_force() {
      + pathspec==0.12.1
      + platformdirs==4.2.0
     error: Executables already exist: black, blackd (use `--force` to overwrite)
+
+    hint: The tool environment was removed, so `black` is not installed.
     ");
 
     // Install `black` with `--force`


### PR DESCRIPTION
## Summary

When `uv tool install` fails because the target executable already exists, uv removes the tool environment before returning the error. Doing `uv tool uninstall <name>` afterwards shows that the tool is not installed, which is confusing after the install output has already shown packages being installed.

This just adds a short hint explaining that the tool environment was removed.

Closes #18854.

## Test Plan

```console
cargo fmt --all --check
cargo nextest run --cargo-profile fast-build --package uv --test it -E 'test(tool_install_force)'
```
Both passed