### PR TITLE
Support `--require-hashes` in `requirements.txt files`

### DIFF
--- a/crates/uv-configuration/src/hash.rs
+++ b/crates/uv-configuration/src/hash.rs
@@ -32,6 +32,15 @@ impl HashCheckingMode {
         }
     }
 
+    /// Apply the `--require-hashes` setting from a requirements file.
+    pub fn from_requirements_txt(mode: Option<Self>, require_hashes: bool) -> Option<Self> {
+        if require_hashes {
+            Some(Self::Require)
+        } else {
+            mode
+        }
+    }
+
     /// Returns `true` if the hash checking mode is `Require`.
     pub fn is_require(&self) -> bool {
         matches!(self, Self::Require)

--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -95,6 +95,8 @@ enum RequirementsTxtStatement {
     FindLinks(VerbatimUrl),
     /// `--no-index`
     NoIndex,
+    /// `--require-hashes`
+    RequireHashes,
     /// `--no-binary`
     NoBinary(NoBinary),
     /// `--only-binary`
@@ -158,6 +160,8 @@ pub struct RequirementsTxt {
     pub find_links: Vec<VerbatimUrl>,
     /// Whether to ignore the index, specified with `--no-index`.
     pub no_index: bool,
+    /// Whether all requirements must be hashed, specified with `--require-hashes`.
+    pub require_hashes: bool,
     /// Whether to disallow wheels, specified with `--no-binary`.
     pub no_binary: NoBinary,
     /// Whether to allow only wheels, specified with `--only-binary`.
@@ -542,6 +546,9 @@ impl RequirementsTxt {
                 RequirementsTxtStatement::NoIndex => {
                     data.no_index = true;
                 }
+                RequirementsTxtStatement::RequireHashes => {
+                    data.require_hashes = true;
+                }
                 RequirementsTxtStatement::NoBinary(no_binary) => {
                     data.no_binary.extend(no_binary);
                 }
@@ -592,6 +599,7 @@ impl RequirementsTxt {
             extra_index_urls,
             find_links,
             no_index,
+            require_hashes,
             no_binary,
             only_binary,
         } = other;
@@ -604,6 +612,7 @@ impl RequirementsTxt {
         self.extra_index_urls.extend(extra_index_urls);
         self.find_links.extend(find_links);
         self.no_index = self.no_index || no_index;
+        self.require_hashes = self.require_hashes || require_hashes;
         self.no_binary.extend(no_binary);
         self.only_binary.extend(only_binary);
     }
@@ -615,7 +624,6 @@ impl RequirementsTxt {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UnsupportedOption {
     PreferBinary,
-    RequireHashes,
     Pre,
     TrustedHost,
     UseFeature,
@@ -626,7 +634,6 @@ impl UnsupportedOption {
     fn name(self) -> &'static str {
         match self {
             Self::PreferBinary => "--prefer-binary",
-            Self::RequireHashes => "--require-hashes",
             Self::Pre => "--pre",
             Self::TrustedHost => "--trusted-host",
             Self::UseFeature => "--use-feature",
@@ -637,7 +644,6 @@ impl UnsupportedOption {
     fn cli(self) -> bool {
         match self {
             Self::PreferBinary => false,
-            Self::RequireHashes => true,
             Self::Pre => true,
             Self::TrustedHost => true,
             Self::UseFeature => false,
@@ -648,7 +654,6 @@ impl UnsupportedOption {
     fn iter() -> impl Iterator<Item = Self> {
         [
             Self::PreferBinary,
-            Self::RequireHashes,
             Self::Pre,
             Self::TrustedHost,
             Self::UseFeature,
@@ -811,6 +816,8 @@ fn parse_entry(
         RequirementsTxtStatement::ExtraIndexUrl(url.with_given(given))
     } else if s.eat_if("--no-index") {
         RequirementsTxtStatement::NoIndex
+    } else if s.eat_if("--require-hashes") {
+        RequirementsTxtStatement::RequireHashes
     } else if s.eat_if("--find-links") || s.eat_if("-f") {
         let given = parse_value("--find-links", content, s, |c: char| !is_terminal(c))?;
         let given = unquote(given)
@@ -2087,6 +2094,7 @@ mod test {
                 extra_index_urls: [],
                 find_links: [],
                 no_index: false,
+                require_hashes: false,
                 no_binary: None,
                 only_binary: None,
             }
@@ -2147,6 +2155,7 @@ mod test {
                 extra_index_urls: [],
                 find_links: [],
                 no_index: false,
+                require_hashes: false,
                 no_binary: Packages(
                     [
                         PackageName(
@@ -2253,6 +2262,7 @@ mod test {
                 extra_index_urls: [],
                 find_links: [],
                 no_index: true,
+                require_hashes: false,
                 no_binary: None,
                 only_binary: None,
             }
@@ -2503,6 +2513,7 @@ mod test {
                 extra_index_urls: [],
                 find_links: [],
                 no_index: false,
+                require_hashes: false,
                 no_binary: All,
                 only_binary: None,
             }
@@ -2863,6 +2874,7 @@ mod test {
                 extra_index_urls: [],
                 find_links: [],
                 no_index: false,
+                require_hashes: false,
                 no_binary: None,
                 only_binary: None,
             }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-basic.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-basic.txt.snap
@@ -185,6 +185,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -89,6 +89,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -69,6 +69,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-empty.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-empty.txt.snap
@@ -10,6 +10,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-for-poetry.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-for-poetry.txt.snap
@@ -124,6 +124,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-include-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-include-a.txt.snap
@@ -58,6 +58,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-include-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-include-b.txt.snap
@@ -29,6 +29,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -170,6 +170,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-small.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-small.txt.snap
@@ -69,6 +69,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-whitespace.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__line-endings-whitespace.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/uv-requirements-txt/src/lib.rs
-assertion_line: 1639
 expression: actual
 ---
 RequirementsTxt {
@@ -121,6 +120,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-basic.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-basic.txt.snap
@@ -185,6 +185,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-a.txt.snap
@@ -89,6 +89,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-constraints-b.txt.snap
@@ -69,6 +69,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-empty.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-empty.txt.snap
@@ -10,6 +10,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-for-poetry.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-for-poetry.txt.snap
@@ -124,6 +124,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-include-a.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-include-a.txt.snap
@@ -58,6 +58,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-include-b.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-include-b.txt.snap
@@ -29,6 +29,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -170,6 +170,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-small.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-small.txt.snap
@@ -69,6 +69,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-bare-url.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-bare-url.txt.snap
@@ -321,6 +321,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-editable.txt.snap
@@ -463,6 +463,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-whitespace.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-whitespace.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/uv-requirements-txt/src/lib.rs
-assertion_line: 1591
 expression: actual
 ---
 RequirementsTxt {
@@ -121,6 +120,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-bare-url.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-bare-url.txt.snap
@@ -321,6 +321,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-editable.txt.snap
@@ -463,6 +463,7 @@ RequirementsTxt {
     extra_index_urls: [],
     find_links: [],
     no_index: false,
+    require_hashes: false,
     no_binary: None,
     only_binary: None,
 }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -83,6 +83,8 @@ pub struct RequirementsSpecification {
     pub extra_index_urls: Vec<IndexUrl>,
     /// Whether to disallow index usage.
     pub no_index: bool,
+    /// Whether all requirements must be hashed.
+    pub require_hashes: bool,
     /// The `--find-links` locations to use for fetching packages.
     pub find_links: Vec<IndexUrl>,
     /// The `--no-binary` flags to enforce when selecting distributions.
@@ -240,6 +242,7 @@ impl RequirementsSpecification {
                 .collect(),
             no_binary: requirements_txt.no_binary,
             no_build: requirements_txt.only_binary,
+            require_hashes: requirements_txt.require_hashes,
             ..Self::default()
         }
     }
@@ -594,6 +597,7 @@ impl RequirementsSpecification {
             spec.find_links.extend(source.find_links);
             spec.no_binary.extend(source.no_binary);
             spec.no_build.extend(source.no_build);
+            spec.require_hashes |= source.require_hashes;
         }
 
         // Read all constraints, treating both requirements _and_ constraints as constraints.
@@ -633,6 +637,7 @@ impl RequirementsSpecification {
             spec.find_links.extend(source.find_links);
             spec.no_binary.extend(source.no_binary);
             spec.no_build.extend(source.no_build);
+            spec.require_hashes |= source.require_hashes;
         }
 
         // Read all overrides, treating both requirements _and_ overrides as overrides.
@@ -660,6 +665,7 @@ impl RequirementsSpecification {
             spec.find_links.extend(source.find_links);
             spec.no_binary.extend(source.no_binary);
             spec.no_build.extend(source.no_build);
+            spec.require_hashes |= source.require_hashes;
         }
 
         // Collect excludes.

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -213,6 +213,7 @@ pub(crate) async fn pip_compile(
         index_url,
         extra_index_urls,
         no_index,
+        require_hashes: _,
         find_links,
         no_binary,
         no_build,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -151,6 +151,7 @@ pub(crate) async fn pip_install(
         index_url,
         extra_index_urls,
         no_index,
+        require_hashes,
         find_links,
         no_binary,
         no_build,
@@ -167,6 +168,8 @@ pub(crate) async fn pip_install(
     .await?;
 
     override_dependencies.extend(overrides_from_workspace);
+
+    let hash_checking = HashCheckingMode::from_requirements_txt(hash_checking, require_hashes);
 
     if pylock.is_some() {
         if !preview.is_enabled(PreviewFeature::Pylock) {

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -122,6 +122,7 @@ pub(crate) async fn pip_sync(
         index_url,
         extra_index_urls,
         no_index,
+        require_hashes,
         find_links,
         no_binary,
         no_build,
@@ -136,6 +137,8 @@ pub(crate) async fn pip_sync(
         &client_builder,
     )
     .await?;
+
+    let hash_checking = HashCheckingMode::from_requirements_txt(hash_checking, require_hashes);
 
     if pylock.is_some() {
         if !preview.is_enabled(PreviewFeature::Pylock) {

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -3674,6 +3674,48 @@ fn require_hashes_missing_hash() -> Result<()> {
     Ok(())
 }
 
+/// Enable `--require-hashes` from the `requirements.txt`.
+#[test]
+fn require_hashes_in_requirements_txt() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(indoc! {r"
+        --require-hashes
+        anyio
+    "})?;
+
+    uv_snapshot!(context.pip_sync()
+        .arg("requirements.txt"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have their versions pinned with `==`, but found: anyio
+    "
+    );
+
+    requirements_txt.write_str(indoc! {r"
+        --require-hashes
+        iniconfig==2.0.0
+    "})?;
+
+    uv_snapshot!(context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--no-require-hashes"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: iniconfig==2.0.0
+    "
+    );
+
+    Ok(())
+}
+
 /// Omit the version with `--require-hashes`.
 #[test]
 fn require_hashes_missing_version() -> Result<()> {

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -1181,6 +1181,52 @@ fn install_unsupported_flag() -> Result<()> {
     Ok(())
 }
 
+/// Enable `--require-hashes` from the `requirements.txt`.
+#[test]
+fn install_require_hashes_in_requirements_txt() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(indoc! {r"
+        --require-hashes
+        iniconfig
+    "})?;
+
+    uv_snapshot!(context.pip_install()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have their versions pinned with `==`, but found: iniconfig
+    "
+    );
+
+    requirements_txt.write_str(indoc! {r"
+        --require-hashes
+        iniconfig==2.0.0
+    "})?;
+
+    uv_snapshot!(context.pip_install()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--no-require-hashes")
+        .arg("--strict"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: iniconfig==2.0.0
+    "
+    );
+
+    Ok(())
+}
+
 /// Install a requirements file with pins that conflict
 ///
 /// This is likely to occur in the real world when compiled on one platform then installed on another.


### PR DESCRIPTION
## Summary

Right now, we log a warning but proceed, which means we're effectively ignoring the `--require-hashes` directive (if you're not careful to watch for warnings).

This can be considered breaking because workflows that previously passed may now fail.
