### PR TITLE
fix: show LockMismatch error with --quiet flag (#19326)

### DIFF
--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -374,7 +374,7 @@ pub(crate) async fn sync(
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{}",
                     ProjectError::LockMismatch(prev, cur, lock_source)
                         .to_string()
@@ -478,7 +478,7 @@ pub(crate) async fn sync(
         Outcome::Success(..) => Ok(ExitStatus::Success),
         Outcome::LockMismatch(prev, cur, lock_source) => {
             writeln!(
-                printer.stderr(),
+                printer.stderr_important(),
                 "{}",
                 ProjectError::LockMismatch(prev, cur, lock_source)
                     .to_string()

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -107,6 +107,51 @@ fn locked() -> Result<()> {
 }
 
 #[test]
+fn locked_error_shows_with_quiet() -> Result<()> {
+    // Regression test for https://github.com/astral-sh/uv/issues/19326
+    // When `--locked` fails due to lockfile mismatch with `--quiet`, the error
+    // should still be displayed (since it's an error, not normal output).
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+        "#,
+    )?;
+
+    // Create the initial lockfile.
+    context.lock().assert().success();
+
+    // Update the requirements to create a lockfile mismatch.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    // Running with `--locked --quiet` should show the error message.
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
## Summary
When `uv sync --locked` fails due to a lockfile mismatch and `--quiet` is also passed, the error message was silently suppressed because `printer.stderr()` returns `Disabled` in quiet mode.

## Root cause
In `crates/uv/src/commands/project/sync.rs`, the `LockMismatch` error output used `printer.stderr()`, which is disabled in quiet mode. Error messages should not be silently suppressed.

## Fix
Change both `LockMismatch` error output locations from `writeln!(printer.stderr(), ...)` to `writeln!(printer.stderr_important(), ...)`. The `stderr_important()` writer remains enabled even in quiet mode, which is appropriate for error messages that must always be displayed.

## Validation
- Build succeeded: `cargo build -p uv`
- Added regression test `locked_error_shows_with_quiet` in `crates/uv/tests/it/sync.rs`

## Before
`uv sync --dev --locked --quiet` would silently fail with no error message shown.

## After
`uv sync --dev --locked --quiet` now shows: `The lockfile at 'uv.lock' needs to be updated, but '--locked' was provided. To update the lockfile, run 'uv lock'.`

Fixes #19326