### PR TITLE
Normalize second-less TOML datetimes for TOML 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7278,6 +7278,7 @@ dependencies = [
 name = "uv-toml"
 version = "0.0.40"
 dependencies = [
+ "toml_datetime",
  "toml_parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7276,7 +7276,7 @@ dependencies = [
 
 [[package]]
 name = "uv-toml"
-version = "0.0.40"
+version = "0.0.45"
 dependencies = [
  "toml_datetime",
  "toml_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,7 @@ tokio = { version = "1.40.0", features = [
 tokio-stream = { version = "0.1.16" }
 tokio-util = { version = "0.7.12", features = ["compat", "io"] }
 toml = { version = "1.1.0", features = ["fast_hash"] }
+toml_datetime = { version = "1.1.0" }
 toml_edit = { version = "0.25.8", features = ["serde"] }
 toml_parser = { version = "1.1.0" }
 tracing = { version = "0.1.40" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ uv-small-str = { version = "0.0.45", path = "crates/uv-small-str" }
 uv-state = { version = "0.0.45", path = "crates/uv-state" }
 uv-static = { version = "0.0.45", path = "crates/uv-static" }
 uv-test = { version = "0.0.45", path = "crates/uv-test" }
-uv-toml = { version = "0.0.40", path = "crates/uv-toml" }
+uv-toml = { version = "0.0.45", path = "crates/uv-toml" }
 uv-tool = { version = "0.0.45", path = "crates/uv-tool" }
 uv-torch = { version = "0.0.45", path = "crates/uv-torch" }
 uv-trampoline-builder = { version = "0.0.45", path = "crates/uv-trampoline-builder" }

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -1885,6 +1885,9 @@ mod tests {
                 { name = "Platypus", email = "platypus@example.com", },
             ]
 
+            [tool.foo]
+            when = 1969-06-20T20:17Z
+
             [build-system]
             requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
@@ -1949,6 +1952,9 @@ mod tests {
         [[project.authors]]
         name = "Platypus"
         email = "platypus@example.com"
+
+        [tool.foo]
+        when = 1969-06-20T20:17:00Z
 
         [build-system]
         requires = ["uv_build>=0.5.15,<0.6.0"]
@@ -1976,6 +1982,9 @@ mod tests {
                 { name = "Platypus", email = "platypus@example.com", },
             ]
 
+            [tool.foo]
+            when = 1969-06-20T20:17Z
+
             [build-system]
             requires = ["uv_build>=0.5.15,<0.6.0"]
             build-backend = "uv_build"
@@ -2040,6 +2049,9 @@ mod tests {
         [[project.authors]]
         name = "Platypus"
         email = "platypus@example.com"
+
+        [tool.foo]
+        when = 1969-06-20T20:17:00Z
 
         [build-system]
         requires = ["uv_build>=0.5.15,<0.6.0"]

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -257,9 +257,10 @@ fn write_source_dist(
             false
         };
     if toml_backwards_compatibility {
-        let pyproject_value: toml::Value = toml::from_str(&pyproject_contents)
+        let mut pyproject_value: toml::Value = toml::from_str(&pyproject_contents)
             .map_err(|err| Error::Toml(pyproject_path.clone(), err))?;
         // See https://github.com/toml-rs/toml/issues/1088 for `to_string_pretty`.
+        normalize_toml10_datetimes(&mut pyproject_value);
         let pyproject_rewritten =
             toml::to_string_pretty(&pyproject_value).map_err(Error::TomlSerialize)?;
         writer.write_bytes(
@@ -362,6 +363,32 @@ impl<W: Write> TarGzWriter<W> {
         let enc = GzEncoder::new(writer, Compression::default());
         let tar = tar::Builder::new(enc);
         Self { path, tar }
+    }
+}
+
+fn normalize_toml10_datetimes(value: &mut toml::Value) {
+    match value {
+        toml::Value::Datetime(datetime) => {
+            if let Some(time) = datetime.time.as_mut()
+                && time.second.is_none()
+            {
+                time.second = Some(0);
+            }
+        }
+        toml::Value::Array(values) => {
+            for value in values {
+                normalize_toml10_datetimes(value);
+            }
+        }
+        toml::Value::Table(values) => {
+            for (_, value) in values.iter_mut() {
+                normalize_toml10_datetimes(value);
+            }
+        }
+        toml::Value::String(_)
+        | toml::Value::Integer(_)
+        | toml::Value::Float(_)
+        | toml::Value::Boolean(_) => {}
     }
 }
 

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -16,4 +16,5 @@ doctest = false
 workspace = true
 
 [dependencies]
+toml_datetime = { workspace = true }
 toml_parser = { workspace = true }

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-toml"
-version = "0.0.40"
+version = "0.0.45"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-toml/README.md
+++ b/crates/uv-toml/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.40) is a component of [uv 0.11.12](https://crates.io/crates/uv/0.11.12). The
+This version (0.0.45) is a component of [uv 0.11.12](https://crates.io/crates/uv/0.11.12). The
 source can be found [here](https://github.com/astral-sh/uv/blob/0.11.12/crates/uv-toml).
 
 See uv's

--- a/crates/uv-toml/src/lib.rs
+++ b/crates/uv-toml/src/lib.rs
@@ -1,3 +1,4 @@
+use toml_datetime::Datetime;
 use toml_parser::decoder::Encoding;
 use toml_parser::lexer::Token;
 use toml_parser::parser::{EventReceiver, parse_document};
@@ -121,6 +122,9 @@ impl EventReceiver for DetectToml11<'_> {
                 // TOML 1.1 introduces new escape sequences
                 self.flag_11();
             }
+        } else if has_toml11_optional_second_time(self.raw_at(span)) {
+            // TOML 1.1 makes seconds optional in times and datetimes.
+            self.flag_11();
         }
     }
 
@@ -149,6 +153,19 @@ fn has_toml11_escapes(raw: &str) -> bool {
         }
     }
     false
+}
+
+/// Scan for the TOML 1.1 optional-second time syntax, such as `12:34` and `1969-06-20T20:17Z`.
+fn has_toml11_optional_second_time(raw: &str) -> bool {
+    // Non-datetime scalars, such as booleans and integers, fail to parse as date and/or time.
+    let Ok(datetime) = raw.parse::<Datetime>() else {
+        return false;
+    };
+
+    datetime
+        .time
+        .as_ref()
+        .is_some_and(|time| time.second.is_none())
 }
 
 #[cfg(test)]
@@ -257,5 +274,22 @@ mod tests {
     #[test]
     fn features_trailing_comma_in_array_is_not_11() {
         assert!(!has_toml11_features("x = [1, 2, 3,]\n"));
+    }
+
+    #[test]
+    fn features_optional_second_time_values() {
+        assert!(has_toml11_features("x = 20:17\n"));
+        assert!(has_toml11_features("x = 1969-06-20T20:17\n"));
+        assert!(has_toml11_features("x = 1969-06-20 20:17\n"));
+        assert!(has_toml11_features("x = 1969-06-20T20:17Z\n"));
+        assert!(has_toml11_features("x = 1969-06-20T20:17z\n"));
+        assert!(has_toml11_features("x = 1969-06-20T20:17-07:00\n"));
+    }
+
+    #[test]
+    fn features_toml10_time_values_are_not_11() {
+        assert!(!has_toml11_features("x = 20:17:00\n"));
+        assert!(!has_toml11_features("x = 1969-06-20T20:17:00Z\n"));
+        assert!(!has_toml11_features("x = 1969-06-20\n"));
     }
 }

--- a/crates/uv-toml/src/lib.rs
+++ b/crates/uv-toml/src/lib.rs
@@ -110,8 +110,15 @@ impl EventReceiver for DetectToml11<'_> {
         self.state.pop();
     }
 
-    fn simple_key(&mut self, _span: Span, _kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
+    fn simple_key(&mut self, span: Span, kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
         self.set_sep(false);
+
+        if matches!(kind, Some(Encoding::BasicString | Encoding::MlBasicString))
+            && has_toml11_escapes(self.raw_at(span))
+        {
+            // TOML 1.1 introduces new escape sequences
+            self.flag_11();
+        }
     }
 
     fn scalar(&mut self, span: Span, kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
@@ -249,6 +256,16 @@ mod tests {
     #[test]
     fn features_hex_escape() {
         assert!(has_toml11_features("x = \"val \\x41\"\n"));
+    }
+
+    #[test]
+    fn features_hex_escape_in_quoted_key() {
+        assert!(has_toml11_features("\"\\x62ar\" = \"baz\"\n"));
+    }
+
+    #[test]
+    fn features_hex_escape_in_dotted_quoted_key() {
+        assert!(has_toml11_features("foo.\"\\x62ar\" = \"baz\"\n"));
     }
 
     #[test]

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -205,9 +205,11 @@ By default, uv excludes `__pycache__`, `*.pyc`, and `*.pyo`.
 
 When building a source distribution, the following files and directories are included:
 
-- The `pyproject.toml`. With the `toml-backwards-compatibility` preview feature enabled, the
-  `pyproject.toml` is reformatted for backwards compatibility, and the original file is preserved as
-  `pyproject.toml.orig`. This will be automatically enabled in the next breaking release.
+- The `pyproject.toml`. If uv detects TOML 1.1-only syntax, it issues a warning and automatically
+  enables the `toml-backwards-compatibility` preview feature: the `pyproject.toml` is reformatted
+  for backwards compatibility, and the original file is preserved as `pyproject.toml.orig`. Pass
+  `--preview-feature toml-backwards-compatibility` to enable the feature explicitly and suppress the
+  warning.
 - The [module](#modules) under
   [`tool.uv.build-backend.module-root`](../reference/settings.md#build-backend_module-root).
 - The files referenced by `project.license-files` and `project.readme`.


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/pull/18741 not handled by `to_string_pretty`.
