### PR TITLE
Avoid applying `.env` files in parent process

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -82,6 +82,99 @@ impl Display for ToolRunCommand {
     }
 }
 
+/// Read dotenv files into an overlay for the spawned tool process.
+///
+/// These values intentionally do not mutate uv's process environment: internal settings like
+/// `UV_TOOL_DIR` must already be fixed before `.env` values are exposed to the requested tool.
+fn read_env_files(
+    env_file: &[PathBuf],
+    no_env_file: bool,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let mut environment = Vec::new();
+
+    if no_env_file {
+        return Ok(environment);
+    }
+
+    for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
+        let iter = match dotenvy::from_path_iter(env_file_path) {
+            Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                bail!(
+                    "No environment file found at: `{}`",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::Io(err)) => {
+                bail!(
+                    "Failed to read environment file `{}`: {err}",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::LineParse(content, position)) => {
+                warn_user!(
+                    "Failed to parse environment file `{}` at position {position}: {content}",
+                    env_file_path.simplified_display(),
+                );
+                continue;
+            }
+            Err(err) => {
+                warn_user!(
+                    "Failed to parse environment file `{}`: {err}",
+                    env_file_path.simplified_display(),
+                );
+                continue;
+            }
+            Ok(iter) => iter,
+        };
+
+        let mut parsed = true;
+        for item in iter {
+            match item {
+                Ok((key, value)) => {
+                    if std::env::var(&key).is_err() {
+                        environment.push((key, value));
+                    }
+                }
+                Err(dotenvy::Error::Io(err)) => {
+                    bail!(
+                        "Failed to read environment file `{}`: {err}",
+                        env_file_path.simplified_display()
+                    );
+                }
+                Err(dotenvy::Error::LineParse(content, position)) => {
+                    warn_user!(
+                        "Failed to parse environment file `{}` at position {position}: {content}",
+                        env_file_path.simplified_display(),
+                    );
+                    parsed = false;
+                    break;
+                }
+                Err(err) => {
+                    warn_user!(
+                        "Failed to parse environment file `{}`: {err}",
+                        env_file_path.simplified_display(),
+                    );
+                    parsed = false;
+                    break;
+                }
+            }
+        }
+
+        if parsed {
+            debug!(
+                "Read environment file at: `{}`",
+                env_file_path.simplified_display()
+            );
+        }
+    }
+
+    // `dotenvy::from_path` preserves the first loaded value, while `Command::envs` preserves the
+    // last value set for the child process.
+    environment.reverse();
+
+    Ok(environment)
+}
+
 /// Check if the given arguments contain a verbose flag (e.g., `--verbose`, `-v`, `-vv`, etc.)
 fn find_verbose_flag(args: &[std::ffi::OsString]) -> Option<&str> {
     args.iter().find_map(|arg| {
@@ -138,43 +231,7 @@ pub(crate) async fn run(
         );
     }
 
-    // Read from the `.env` file, if necessary.
-    if !no_env_file {
-        for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
-            match dotenvy::from_path(env_file_path) {
-                Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                    bail!(
-                        "No environment file found at: `{}`",
-                        env_file_path.simplified_display()
-                    );
-                }
-                Err(dotenvy::Error::Io(err)) => {
-                    bail!(
-                        "Failed to read environment file `{}`: {err}",
-                        env_file_path.simplified_display()
-                    );
-                }
-                Err(dotenvy::Error::LineParse(content, position)) => {
-                    warn_user!(
-                        "Failed to parse environment file `{}` at position {position}: {content}",
-                        env_file_path.simplified_display(),
-                    );
-                }
-                Err(err) => {
-                    warn_user!(
-                        "Failed to parse environment file `{}`: {err}",
-                        env_file_path.simplified_display(),
-                    );
-                }
-                Ok(()) => {
-                    debug!(
-                        "Read environment file at: `{}`",
-                        env_file_path.simplified_display()
-                    );
-                }
-            }
-        }
-    }
+    let env_file_environment = read_env_files(&env_file, no_env_file)?;
 
     let Some(command) = command else {
         // When a command isn't provided, we'll show a brief help including available tools
@@ -403,6 +460,7 @@ pub(crate) async fn run(
     };
 
     process.args(args);
+    process.envs(env_file_environment);
 
     // Construct the `PATH` environment variable.
     let new_path = std::env::join_paths(

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -84,8 +84,8 @@ impl Display for ToolRunCommand {
 
 /// Read dotenv files into an overlay for the spawned tool process.
 ///
-/// These values intentionally do not mutate uv's process environment: internal settings like
-/// `UV_TOOL_DIR` must already be fixed before `.env` values are exposed to the requested tool.
+/// These values intentionally do not mutate uv's process environment and cannot mutate
+/// the current uv process' settings.
 fn read_env_files(
     env_file: &[PathBuf],
     no_env_file: bool,

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1,6 +1,11 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
+#[cfg(unix)]
+use fs_err::{metadata, set_permissions};
 use indoc::indoc;
 use uv_fs::copy_dir_all;
 use uv_static::EnvVars;
@@ -2671,6 +2676,59 @@ fn run_with_env_file() -> anyhow::Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     ");
+
+    let evil_tools = context.temp_dir.child(".evil-tools");
+    let evil_tool = evil_tools.child("foo");
+    let evil_python = if cfg!(windows) {
+        let scripts = evil_tool.child("Scripts");
+        scripts.create_dir_all()?;
+        scripts.child("python.exe")
+    } else {
+        let bin = evil_tool.child("bin");
+        bin.create_dir_all()?;
+        bin.child("python3")
+    };
+    evil_python.write_str(indoc! { r"
+        #!/bin/sh
+        echo queried > queried.txt
+        exit 1
+    " })?;
+
+    #[cfg(unix)]
+    {
+        let mut permissions = metadata(evil_python.path())?.permissions();
+        permissions.set_mode(0o755);
+        set_permissions(evil_python.path(), permissions)?;
+    }
+
+    context.temp_dir.child(".file").write_str(indoc! { "
+        UV_TOOL_DIR=.evil-tools
+        THE_EMPIRE_VARIABLE=palpatine
+        REBEL_1=leia_organa
+        REBEL_2=obi_wan_kenobi
+        REBEL_3=C3PO
+       "
+    })?;
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg("./foo")
+        .arg("script")
+        .env(EnvVars::UV_ENV_FILE, ".file")
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    palpatine
+    leia_organa
+    obi_wan_kenobi
+    C3PO
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    ");
+
+    assert!(!context.temp_dir.child("queried.txt").exists());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Our support for `.env` files is intended to be limited to the process we execute in `uv run` or `uv tool run` (or `uvx`), i.e., we don't intend to support setting uv-specific environment variables via `.env`. As-is, though, some environment variables like `UV_TOOL_DIR` _can_ be set due to order of operations. This PR modifies our loading to avoid reading the `.env` into the parent process. Instead, we use `dotenvy` to read the values, but set them explicitly on the child process.