### PR TITLE
fix: --isolated flag for PEP 723 scripts with lockfile (#15919)

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -237,23 +237,59 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
             debug!("Found existing lockfile for script");
 
             // Discover the interpreter for the script.
-            let environment = ScriptEnvironment::get_or_init(
-                (&script).into(),
-                python.as_deref().map(PythonRequest::parse),
-                &client_builder,
-                python_preference,
-                python_downloads,
-                &install_mirrors,
-                no_sync,
-                no_config,
-                active.map_or(Some(false), Some),
-                &cache,
-                DryRun::Disabled,
-                printer,
-                preview,
-            )
-            .await?
-            .into_environment()?;
+            let environment = if isolated {
+                // If `--isolated`, create a temporary virtual environment rather than reusing
+                // the cached script environment.
+                debug!("Creating isolated virtual environment for script");
+                let interpreter = ScriptInterpreter::discover(
+                    (&script).into(),
+                    python.as_deref().map(PythonRequest::parse),
+                    &client_builder,
+                    python_preference,
+                    python_downloads,
+                    &install_mirrors,
+                    no_sync,
+                    no_config,
+                    active.map_or(Some(false), Some),
+                    &cache,
+                    printer,
+                    preview,
+                )
+                .await?
+                .into_interpreter();
+
+                temp_dir = cache.venv_dir()?;
+                uv_virtualenv::create_venv(
+                    temp_dir.path(),
+                    interpreter,
+                    uv_virtualenv::Prompt::None,
+                    false,
+                    uv_virtualenv::OnExisting::Remove(
+                        uv_virtualenv::RemovalReason::TemporaryEnvironment,
+                    ),
+                    false,
+                    false,
+                    false,
+                )?
+            } else {
+                ScriptEnvironment::get_or_init(
+                    (&script).into(),
+                    python.as_deref().map(PythonRequest::parse),
+                    &client_builder,
+                    python_preference,
+                    python_downloads,
+                    &install_mirrors,
+                    no_sync,
+                    no_config,
+                    active.map_or(Some(false), Some),
+                    &cache,
+                    DryRun::Disabled,
+                    printer,
+                    preview,
+                )
+                .await?
+                .into_environment()?
+            };
 
             let _lock = environment
                 .lock()
@@ -407,23 +443,59 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     client_builder.credentials_cache(),
                 )?
                 .into_inner();
-                let environment = ScriptEnvironment::get_or_init(
-                    (&script).into(),
-                    python.as_deref().map(PythonRequest::parse),
-                    &client_builder,
-                    python_preference,
-                    python_downloads,
-                    &install_mirrors,
-                    no_sync,
-                    no_config,
-                    active.map_or(Some(false), Some),
-                    &cache,
-                    DryRun::Disabled,
-                    printer,
-                    preview,
-                )
-                .await?
-                .into_environment()?;
+                let environment = if isolated {
+                    // If `--isolated`, create a temporary virtual environment rather than
+                    // reusing the cached script environment.
+                    debug!("Creating isolated virtual environment for script");
+                    let interpreter = ScriptInterpreter::discover(
+                        (&script).into(),
+                        python.as_deref().map(PythonRequest::parse),
+                        &client_builder,
+                        python_preference,
+                        python_downloads,
+                        &install_mirrors,
+                        no_sync,
+                        no_config,
+                        active.map_or(Some(false), Some),
+                        &cache,
+                        printer,
+                        preview,
+                    )
+                    .await?
+                    .into_interpreter();
+
+                    temp_dir = cache.venv_dir()?;
+                    uv_virtualenv::create_venv(
+                        temp_dir.path(),
+                        interpreter,
+                        uv_virtualenv::Prompt::None,
+                        false,
+                        uv_virtualenv::OnExisting::Remove(
+                            uv_virtualenv::RemovalReason::TemporaryEnvironment,
+                        ),
+                        false,
+                        false,
+                        false,
+                    )?
+                } else {
+                    ScriptEnvironment::get_or_init(
+                        (&script).into(),
+                        python.as_deref().map(PythonRequest::parse),
+                        &client_builder,
+                        python_preference,
+                        python_downloads,
+                        &install_mirrors,
+                        no_sync,
+                        no_config,
+                        active.map_or(Some(false), Some),
+                        &cache,
+                        DryRun::Disabled,
+                        printer,
+                        preview,
+                    )
+                    .await?
+                    .into_environment()?
+                };
 
                 let build_constraints = script
                     .metadata()

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -1169,6 +1169,60 @@ fn run_pep723_script_lock() -> Result<()> {
     Ok(())
 }
 
+/// Run a PEP 723 script with `--isolated` should ignore an existing lockfile and use a
+/// temporary virtual environment instead.
+#[test]
+fn run_pep723_script_with_isolated() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "cachetools",
+        # ]
+        # ///
+
+        import cachetools
+        print("Hello from isolated script!")
+        print(cachetools.__version__)
+    "# })?;
+
+    // Create an existing lockfile to simulate the bug scenario.
+    uv_snapshot!(context.filters(), context.lock().arg("--script").arg("main.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    ");
+
+    // Verify the lockfile exists.
+    assert!(context.temp_dir.child("main.py.lock").exists());
+
+    // Running with `--isolated` should use a temporary environment, not the cached one.
+    // The key check is that no lockfile operations happen and a temp venv is used.
+    uv_snapshot!(context.filters(), context.run().arg("--isolated").arg("main.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hello from isolated script!
+    [VERSION]
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtual environment at: [TEMP_DIR]/.tmp[A-Z0-9]+
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + cachetools==[VERSION]
+    ");
+
+    Ok(())
+}
+
 /// With `managed = false`, we should avoid installing the project itself.
 #[test]
 fn run_managed_false() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #15919 - When running a PEP 723 script with an existing lockfile and the `--isolated` flag, `uv` now creates a temporary virtual environment instead of reusing the cached script environment.

## Changes

- **crates/uv/src/commands/project/run.rs**: Check the `isolated` flag before selecting the environment strategy for scripts with lockfiles. When isolated is true, create a temporary venv using `ScriptInterpreter::discover` + `uv_virtualenv::create_venv`.

- **crates/uv/tests/it/run.rs**: Added integration test `run_pep723_script_with_isolated` that verifies the behavior.

## Before this fix

```
$ uv lock --script my_script.py  # creates main.py.lock
$ uv --isolated run my_script.py  # BUG: ignores --isolated, uses cached env
```

## After this fix

```
$ uv lock --script my_script.py  # creates main.py.lock
$ uv --isolated run my_script.py  # Creates temp venv, no lockfile ops
```

## Testing

- cargo clippy -p uv --lib --tests passes
- cargo fmt -- --check passes
- Integration test added

## Checklist

- [ ] Tests pass
- [ ] Documentation updated (if needed)