### PR TITLE
Remove usages of `zip` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "astral-version-ranges",
+ "astral_async_zip",
  "axoupdater",
  "backon",
  "base64 0.22.1",
@@ -6429,7 +6430,6 @@ dependencies = [
  "uv-warnings",
  "uv-workspace",
  "walkdir",
- "zip",
 ]
 
 [[package]]
@@ -6515,7 +6515,6 @@ dependencies = [
  "uv-static",
  "uv-warnings",
  "xz2",
- "zip",
 ]
 
 [[package]]
@@ -6752,7 +6751,6 @@ dependencies = [
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,8 +321,8 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.18-rc1"
-source = "git+https://github.com/astral-sh/rs-async-zip.git?branch=charlie%2Frestore-zip-writing#c4051722ee7d527ad008d03ea1b218e0aae5dfa1"
+version = "0.0.18-rc2"
+source = "git+https://github.com/astral-sh/rs-async-zip.git?tag=v0.0.18-rc2#8eb9ed214128e6db76dc753bca43908f71e569a9"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6498,6 +6498,7 @@ dependencies = [
  "astral_async_zip",
  "async-compression",
  "blake2",
+ "flate2",
  "fs-err",
  "futures",
  "md-5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,15 +321,14 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+version = "0.0.18-rc1"
+source = "git+https://github.com/astral-sh/rs-async-zip.git?branch=charlie%2Frestore-zip-writing#c4051722ee7d527ad008d03ea1b218e0aae5dfa1"
 dependencies = [
  "async-compression",
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -6013,10 +6012,12 @@ name = "uv-build-backend"
 version = "0.0.47"
 dependencies = [
  "astral-version-ranges",
+ "astral_async_zip",
  "base64 0.22.1",
  "csv",
  "flate2",
  "fs-err",
+ "futures-lite",
  "globset",
  "indexmap",
  "indoc",
@@ -7350,7 +7351,9 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "astral_async_zip",
  "fs-err",
+ "futures-lite",
  "goblin",
  "rcgen",
  "tempfile",
@@ -7358,7 +7361,6 @@ dependencies = [
  "uv-fs",
  "which",
  "windows",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ async-compression = { version = "0.4.12", features = [
 ] }
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.11.0", package = "astral_async_http_range_reader" }
-async_zip = { version = "0.0.17", package = "astral_async_zip", features = [
+async_zip = { git = "https://github.com/astral-sh/rs-async-zip.git", branch = "charlie/restore-zip-writing", package = "astral_async_zip", features = [
   "bzip2",
   "deflate",
   "lzma",
@@ -150,6 +150,7 @@ flate2 = { version = "1.0.33", default-features = false, features = [
 ] }
 fs-err = { version = "3.2.2", features = ["tokio"] }
 futures = { version = "0.3.30" }
+futures-lite = { version = "2.6.1" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.15" }
 globwalk = { version = "0.9.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ async-compression = { version = "0.4.12", features = [
 ] }
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.11.0", package = "astral_async_http_range_reader" }
-async_zip = { git = "https://github.com/astral-sh/rs-async-zip.git", branch = "charlie/restore-zip-writing", package = "astral_async_zip", features = [
+async_zip = { version = "0.0.18-rc2", git = "https://github.com/astral-sh/rs-async-zip.git", tag = "v0.0.18-rc2", package = "astral_async_zip", features = [
   "bzip2",
   "deflate",
   "lzma",

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -27,10 +27,12 @@ uv-pypi-types = { workspace = true }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
 
+async_zip = { workspace = true }
 base64 = { workspace = true }
 csv = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true }
+futures-lite = { workspace = true }
 globset = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
@@ -47,7 +49,6 @@ toml = { workspace = true }
 tracing = { workspace = true }
 version-ranges = { workspace = true }
 walkdir = { workspace = true }
-zip = { workspace = true }
 
 [lints]
 workspace = true
@@ -65,3 +66,4 @@ uv-preview = { workspace = true, features = ["testing"] }
 indoc = { workspace = true }
 insta = { workspace = true }
 regex = { workspace = true }
+zip = { workspace = true }

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -62,7 +62,7 @@ pub enum Error {
         err: walkdir::Error,
     },
     #[error("Failed to write wheel zip archive")]
-    Zip(#[from] zip::result::ZipError),
+    AsyncZip(#[from] async_zip::error::ZipError),
     #[error("Failed to write RECORD file")]
     Csv(#[from] csv::Error),
     #[error("Failed to write JSON metadata file")]
@@ -735,7 +735,7 @@ mod tests {
         // Check that the wheel is reproducible across platforms.
         assert_snapshot!(
             format!("{:x}", sha2::Sha256::digest(fs_err::read(&wheel_path).unwrap())),
-            @"dbe56fd8bd52184095b2e0ea3e83c95d1bc8b4aa53cf469cec5af62251b24abb"
+            @"cf5d6cdd49691afa93417491dd3376abc1211894b57cdbdc9d62d47658688cc5"
         );
         assert_snapshot!(build.wheel_contents.join("\n"), @"
         built_by_uv-0.1.0.data/data/

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -735,7 +735,7 @@ mod tests {
         // Check that the wheel is reproducible across platforms.
         assert_snapshot!(
             format!("{:x}", sha2::Sha256::digest(fs_err::read(&wheel_path).unwrap())),
-            @"cf5d6cdd49691afa93417491dd3376abc1211894b57cdbdc9d62d47658688cc5"
+            @"0affdf7d3fda7e0a27007f6bf61524cd58bf3fce8e456bafb58b4a22faf0d6d0"
         );
         assert_snapshot!(build.wheel_contents.join("\n"), @"
         built_by_uv-0.1.0.data/data/

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -1,15 +1,20 @@
+use async_zip::base::write::{EntryStreamWriter, ZipFileWriter};
+use async_zip::{Compression, ZipEntryBuilder};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD as base64};
 use fs_err::File;
+use futures_lite::future::block_on;
+use futures_lite::io::{AsyncWrite, AsyncWriteExt};
 use globset::{GlobSet, GlobSetBuilder};
 use rustc_hash::FxHashSet;
 use sha2::{Digest, Sha256};
 use std::fmt::{Display, Formatter};
-use std::io::{BufReader, Read, Seek, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::{Component, Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::{io, mem};
 use tracing::{debug, trace};
 use walkdir::WalkDir;
-use zip::{CompressionMethod, ZipWriter};
 
 use uv_distribution_filename::WheelFilename;
 use uv_fs::Simplified;
@@ -697,20 +702,75 @@ impl Display for WheelInfo {
     }
 }
 
-/// Zip archive (wheel) writer.
-struct ZipDirectoryWriter<W: Write + Seek> {
-    writer: ZipWriter<W>,
-    compression: CompressionMethod,
+/// ZIP archive (wheel) writer.
+struct ZipDirectoryWriter<W: AsyncWrite + Unpin> {
+    writer: ZipFileWriter<W>,
+    compression: Compression,
     /// The entries in the `RECORD` file.
     record: Vec<RecordEntry>,
 }
 
-impl<W: Write + Seek> ZipDirectoryWriter<W> {
+impl<W: AsyncWrite + Unpin> ZipDirectoryWriter<W> {
+    const REGULAR_FILE_MODE: u16 = 0o100_644;
+    const EXECUTABLE_FILE_MODE: u16 = 0o100_755;
+    const DIRECTORY_MODE: u16 = 0o040_755;
+
+    fn entry(path: &str, compression: Compression, mode: u16) -> ZipEntryBuilder {
+        ZipEntryBuilder::new(path.to_string().into(), compression).unix_permissions(mode)
+    }
+
+    /// Add a file with the given name and return a writer for it.
+    fn new_writer<'slf>(
+        &'slf mut self,
+        path: &str,
+        executable_bit: bool,
+    ) -> Result<EntryWriter<'slf, W>, Error> {
+        // Set file permissions: 644 (rw-r--r--) for regular files, 755 (rwxr-xr-x) for executables
+        let mode = if executable_bit {
+            Self::EXECUTABLE_FILE_MODE
+        } else {
+            Self::REGULAR_FILE_MODE
+        };
+        let entry = Self::entry(path, self.compression, mode);
+        let writer = block_on(self.writer.write_entry_stream(entry))?;
+        Ok(EntryWriter::new(writer))
+    }
+}
+
+struct SyncWriter<W> {
+    writer: W,
+}
+
+impl<W> SyncWriter<W> {
+    fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: Write + Unpin> AsyncWrite for SyncWriter<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(self.get_mut().writer.write(buffer))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(self.get_mut().writer.flush())
+    }
+
+    fn poll_close(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_flush(context)
+    }
+}
+
+impl<W: Write + Unpin> ZipDirectoryWriter<SyncWriter<W>> {
     /// A wheel writer with deflate compression.
     fn new_wheel(writer: W) -> Self {
         Self {
-            writer: ZipWriter::new(writer),
-            compression: CompressionMethod::Deflated,
+            writer: ZipFileWriter::new(SyncWriter::new(writer)),
+            compression: Compression::Deflate,
             record: Vec::new(),
         }
     }
@@ -721,39 +781,57 @@ impl<W: Write + Seek> ZipDirectoryWriter<W> {
     #[expect(dead_code)]
     fn new_editable(writer: W) -> Self {
         Self {
-            writer: ZipWriter::new(writer),
-            compression: CompressionMethod::Stored,
+            writer: ZipFileWriter::new(SyncWriter::new(writer)),
+            compression: Compression::Stored,
             record: Vec::new(),
         }
     }
+}
 
-    /// Add a file with the given name and return a writer for it.
-    fn new_writer<'slf>(
-        &'slf mut self,
-        path: &str,
-        executable_bit: bool,
-    ) -> Result<Box<dyn Write + 'slf>, Error> {
-        // Set file permissions: 644 (rw-r--r--) for regular files, 755 (rwxr-xr-x) for executables
-        let permissions = if executable_bit { 0o755 } else { 0o644 };
-        let options = zip::write::SimpleFileOptions::default()
-            .system(zip::System::Unix)
-            .unix_permissions(permissions)
-            .compression_method(self.compression);
-        self.writer.start_file(path, options)?;
-        Ok(Box::new(&mut self.writer))
+struct EntryWriter<'writer, W: AsyncWrite + Unpin> {
+    writer: Option<EntryStreamWriter<'writer, W>>,
+}
+
+impl<'writer, W: AsyncWrite + Unpin> EntryWriter<'writer, W> {
+    fn new(writer: EntryStreamWriter<'writer, W>) -> Self {
+        Self {
+            writer: Some(writer),
+        }
+    }
+
+    fn close(mut self) -> Result<(), Error> {
+        let Some(writer) = self.writer.take() else {
+            return Ok(());
+        };
+        block_on(writer.close())?;
+        Ok(())
     }
 }
 
-impl<W: Write + Seek> DirectoryWriter for ZipDirectoryWriter<W> {
+impl<W: AsyncWrite + Unpin> Write for EntryWriter<'_, W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let Some(writer) = self.writer.as_mut() else {
+            return Err(io::Error::other(
+                "wheel ZIP entry writer was already closed",
+            ));
+        };
+        block_on(writer.write(buffer))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let Some(writer) = self.writer.as_mut() else {
+            return Ok(());
+        };
+        block_on(writer.flush())
+    }
+}
+
+impl<W: AsyncWrite + Unpin> DirectoryWriter for ZipDirectoryWriter<W> {
     fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error> {
         trace!("Adding {}", path);
         // Set appropriate permissions for metadata files (644 = rw-r--r--)
-        let options = zip::write::SimpleFileOptions::default()
-            .system(zip::System::Unix)
-            .unix_permissions(0o644)
-            .compression_method(self.compression);
-        self.writer.start_file(path, options)?;
-        self.writer.write_all(bytes)?;
+        let entry = Self::entry(path, self.compression, Self::REGULAR_FILE_MODE);
+        block_on(self.writer.write_entry_whole(entry, bytes))?;
 
         let hash = base64.encode(Sha256::new().chain_update(bytes).finalize());
         self.record.push(RecordEntry {
@@ -779,17 +857,21 @@ impl<W: Write + Seek> DirectoryWriter for ZipDirectoryWriter<W> {
         let executable_bit = false;
         let mut writer = self.new_writer(path, executable_bit)?;
         let record = write_hashed(path, &mut reader, &mut writer)?;
-        drop(writer);
+        writer.close()?;
         self.record.push(record);
         Ok(())
     }
 
     fn write_directory(&mut self, directory: &str) -> Result<(), Error> {
         trace!("Adding directory {}", directory);
-        let options = zip::write::SimpleFileOptions::default()
-            .compression_method(self.compression)
-            .system(zip::System::Unix);
-        Ok(self.writer.add_directory(directory, options)?)
+        let directory = if directory.ends_with('/') {
+            directory.to_string()
+        } else {
+            format!("{directory}/")
+        };
+        let entry = Self::entry(&directory, Compression::Stored, Self::DIRECTORY_MODE);
+        block_on(self.writer.write_entry_whole(entry, &[]))?;
+        Ok(())
     }
 
     /// Write the `RECORD` file and the central directory.
@@ -797,14 +879,13 @@ impl<W: Write + Seek> DirectoryWriter for ZipDirectoryWriter<W> {
         let record_path = format!("{dist_info_dir}/RECORD");
         trace!("Adding {record_path}");
         let record = mem::take(&mut self.record);
-        write_record(
-            &mut self.new_writer(&record_path, false)?,
-            dist_info_dir,
-            record,
-        )?;
+        let mut record_bytes = Vec::new();
+        write_record(&mut record_bytes, dist_info_dir, record)?;
+        let entry = Self::entry(&record_path, self.compression, Self::REGULAR_FILE_MODE);
+        block_on(self.writer.write_entry_whole(entry, &record_bytes))?;
 
         trace!("Adding central directory");
-        self.writer.finish()?;
+        block_on(self.writer.close())?;
         Ok(())
     }
 }

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -711,6 +711,9 @@ struct ZipDirectoryWriter<W: AsyncWrite + Unpin> {
 }
 
 impl<W: AsyncWrite + Unpin> ZipDirectoryWriter<W> {
+    // Include the Unix file type bits because `async_zip` writes this mode
+    // directly to the ZIP external attributes. The sync `zip` crate adds
+    // those bits internally when starting file and directory entries.
     const REGULAR_FILE_MODE: u16 = 0o100_644;
     const EXECUTABLE_FILE_MODE: u16 = 0o100_755;
     const DIRECTORY_MODE: u16 = 0o040_755;

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -60,7 +60,6 @@ toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
-zip = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use owo_colors::OwoColorize;
 use tokio::task::JoinError;
-use zip::result::ZipError;
 
 use crate::metadata::MetadataError;
 use uv_cache::Error as CacheError;
@@ -125,8 +124,6 @@ pub enum Error {
     WheelMetadata(PathBuf, #[source] Box<uv_metadata::Error>),
     #[error("Failed to read metadata from installed package `{0}`")]
     ReadInstalled(Box<InstalledDist>, #[source] InstalledDistError),
-    #[error("Failed to read zip archive from built wheel")]
-    Zip(#[from] ZipError),
     #[error("Failed to extract archive: {0}")]
     Extract(String, #[source] uv_extract::Error),
     #[error("The source distribution is missing a `PKG-INFO` file")]

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -20,7 +20,6 @@ use reqwest::{Response, StatusCode};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{Instrument, debug, info_span, instrument, warn};
 use url::Url;
-use zip::ZipArchive;
 
 use uv_auth::CredentialsCache;
 use uv_cache::{Cache, CacheBucket, CacheEntry, CacheShard, Removal, WheelCache};
@@ -3161,8 +3160,7 @@ fn read_wheel_metadata(
 ) -> Result<ResolutionMetadata, Error> {
     let file = fs_err::File::open(wheel).map_err(Error::CacheRead)?;
     let reader = std::io::BufReader::new(file);
-    let mut archive = ZipArchive::new(reader)?;
-    let dist_info = read_archive_metadata(filename, &mut archive)
+    let dist_info = read_archive_metadata(filename, reader)
         .map_err(|err| Error::WheelMetadata(wheel.to_path_buf(), Box::new(err)))?;
     Ok(ResolutionMetadata::parse_metadata(&dist_info)?)
 }

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -39,7 +39,6 @@ tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 xz2 = { workspace = true }
-zip = { workspace = true }
 
 [features]
 default = []

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -26,6 +26,7 @@ astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd", "xz"] }
 async_zip = { workspace = true }
 blake2 = { workspace = true }
+flate2 = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 md-5 = { workspace = true }
@@ -46,4 +47,7 @@ default = []
 static = ["xz2/static"]
 
 [package.metadata.cargo-shear]
-ignored = ["xz2"]
+# NOTE: `async-compression` owns the actual Deflate codec, but we need to
+# explicitly declare `flate2` here so the workspace's `zlib-rs` backend stays
+# selected after removing the synchronous `zip` dependency.
+ignored = ["flate2", "xz2"]

--- a/crates/uv-extract/src/error.rs
+++ b/crates/uv-extract/src/error.rs
@@ -4,8 +4,6 @@ use std::{ffi::OsString, path::PathBuf};
 pub enum Error {
     #[error("I/O operation failed during extraction")]
     Io(#[source] std::io::Error),
-    #[error("Invalid zip file")]
-    Zip(#[from] zip::result::ZipError),
     #[error("Invalid zip file structure")]
     AsyncZip(#[from] async_zip::error::ZipError),
     #[error("Invalid tar file")]
@@ -113,11 +111,6 @@ impl Error {
             Ok(zip_err) => return Self::AsyncZip(zip_err),
             Err(err) => err,
         };
-        let err = match err.downcast::<zip::result::ZipError>() {
-            Ok(zip_err) => return Self::Zip(zip_err),
-            Err(err) => err,
-        };
-
         Self::Io(err)
     }
 

--- a/crates/uv-extract/src/lib.rs
+++ b/crates/uv-extract/src/lib.rs
@@ -58,20 +58,6 @@ impl From<async_zip::Compression> for CompressionMethod {
     }
 }
 
-impl From<zip::CompressionMethod> for CompressionMethod {
-    fn from(value: zip::CompressionMethod) -> Self {
-        match value {
-            zip::CompressionMethod::Stored => Self::Stored,
-            zip::CompressionMethod::Deflated => Self::Deflated,
-            zip::CompressionMethod::Zstd => Self::Zstd,
-            zip::CompressionMethod::Bzip2 => Self::Deprecated("bzip2"),
-            zip::CompressionMethod::Lzma => Self::Deprecated("lzma"),
-            zip::CompressionMethod::Xz => Self::Deprecated("xz"),
-            _ => Self::Deprecated("unknown"),
-        }
-    }
-}
-
 /// Validate that a given filename (e.g. reported by a ZIP archive's
 /// local file entries or central directory entries) is "safe" to use.
 ///

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -16,6 +16,26 @@ use crate::{CompressionMethod, Error, insecure_no_validate, validate_archive_mem
 
 const DEFAULT_BUF_SIZE: usize = 128 * 1024;
 
+/// Ensure the file path is safe to use as a [`Path`].
+///
+/// See: <https://docs.rs/zip/latest/zip/read/struct.ZipFile.html#method.enclosed_name>
+pub(crate) fn enclosed_name(file_name: &str) -> Option<PathBuf> {
+    if file_name.contains('\0') {
+        return None;
+    }
+    let path = PathBuf::from(file_name);
+    let mut depth = 0usize;
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => return None,
+            Component::ParentDir => depth = depth.checked_sub(1)?,
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => (),
+        }
+    }
+    Some(path)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LocalHeaderEntry {
     /// The relative path of the entry, as computed from the local file header.
@@ -55,26 +75,6 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<Vec<(PathBuf, u64)>, Error> {
-    /// Ensure the file path is safe to use as a [`Path`].
-    ///
-    /// See: <https://docs.rs/zip/latest/zip/read/struct.ZipFile.html#method.enclosed_name>
-    pub(crate) fn enclosed_name(file_name: &str) -> Option<PathBuf> {
-        if file_name.contains('\0') {
-            return None;
-        }
-        let path = PathBuf::from(file_name);
-        let mut depth = 0usize;
-        for component in path.components() {
-            match component {
-                Component::Prefix(_) | Component::RootDir => return None,
-                Component::ParentDir => depth = depth.checked_sub(1)?,
-                Component::Normal(_) => depth += 1,
-                Component::CurDir => (),
-            }
-        }
-        Some(path)
-    }
-
     // Determine whether ZIP validation is disabled.
     let skip_validation = insecure_no_validate();
 

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -3,12 +3,15 @@ use std::sync::Mutex;
 
 use crate::vendor::CloneableSeekableReader;
 use crate::{CompressionMethod, Error, insecure_no_validate, validate_archive_member_name};
+use async_zip::base::read::seek::ZipFileReader;
+use async_zip::error::ZipError;
+use futures::executor::block_on;
+use futures::io::{AllowStdIo, AsyncReadExt, AsyncWriteExt};
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use tracing::warn;
 use uv_configuration::initialize_rayon_once;
 use uv_warnings::warn_user_once;
-use zip::ZipArchive;
 
 /// Unzip a `.zip` archive into the target directory.
 ///
@@ -16,20 +19,31 @@ use zip::ZipArchive;
 pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>, Error> {
     let (reader, filename) = reader.into_parts();
 
-    // Unzip in parallel.
-    let reader = std::io::BufReader::new(reader);
-    let archive = ZipArchive::new(CloneableSeekableReader::new(reader))?;
+    // Parse the central directory once, then clone the archive reader per Rayon worker so
+    // extraction stays parallel for already-downloaded wheels.
+    let archive = block_on(ZipFileReader::new(AllowStdIo::new(
+        CloneableSeekableReader::new(reader),
+    )))?;
     let directories = Mutex::new(FxHashSet::default());
     let skip_validation = insecure_no_validate();
     // Initialize the threadpool with the user settings.
     initialize_rayon_once();
-    (0..archive.len())
+    (0..archive.file().entries().len())
         .into_par_iter()
         .map(|file_number| {
             let mut archive = archive.clone();
-            let mut file = archive.by_index(file_number)?;
+            let entry = archive.file().entries()[file_number].clone();
+            let file_name = match entry.filename().as_str() {
+                Ok(file_name) => file_name,
+                Err(ZipError::StringNotUtf8) => {
+                    return Err(Error::CentralDirectoryEntryNotUtf8 {
+                        index: file_number as u64,
+                    });
+                }
+                Err(err) => return Err(err.into()),
+            };
 
-            let compression = CompressionMethod::from(file.compression());
+            let compression = CompressionMethod::from(entry.compression());
             if !compression.is_well_known() {
                 warn_user_once!(
                     "One or more file entries in '{filename}' use the '{compression}' compression method, which is not widely supported. A future version of uv will reject ZIP archives containing entries compressed with this method. Entries must be compressed with the '{stored}', '{deflate}', or '{zstd}' compression methods.",
@@ -40,22 +54,26 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
                 );
             }
 
-            if let Err(e) = validate_archive_member_name(file.name()) {
+            if let Err(e) = validate_archive_member_name(file_name) {
                 if !skip_validation {
                     return Err(e);
                 }
             }
 
             // Determine the path of the file within the wheel.
-            let Some(enclosed_name) = file.enclosed_name() else {
-                warn!("Skipping unsafe file name: {}", file.name());
+            let Some(enclosed_name) = crate::stream::enclosed_name(file_name) else {
+                warn!("Skipping unsafe file name: {file_name}");
                 return Ok(None);
             };
 
             // Create necessary parent directories.
             let path = target.join(&enclosed_name);
-            if file.is_dir() {
-                let mut directories = directories.lock().unwrap();
+            if entry.dir()? {
+                let mut directories = directories.lock().map_err(|_| {
+                    Error::Io(std::io::Error::other(
+                        "ZIP extraction directory tracker mutex was poisoned",
+                    ))
+                })?;
                 if directories.insert(path.clone()) {
                     fs_err::create_dir_all(path).map_err(Error::Io)?;
                 }
@@ -63,7 +81,11 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
             }
 
             if let Some(parent) = path.parent() {
-                let mut directories = directories.lock().unwrap();
+                let mut directories = directories.lock().map_err(|_| {
+                    Error::Io(std::io::Error::other(
+                        "ZIP extraction directory tracker mutex was poisoned",
+                    ))
+                })?;
                 if directories.insert(parent.to_path_buf()) {
                     fs_err::create_dir_all(parent).map_err(Error::Io)?;
                 }
@@ -71,14 +93,46 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
 
             // Copy the file contents.
             let outfile = fs_err::File::create(&path).map_err(Error::Io)?;
-            let size = file.size();
-            if size > 0 {
-                let mut writer = if let Ok(size) = usize::try_from(size) {
-                    std::io::BufWriter::with_capacity(std::cmp::min(size, 1024 * 1024), outfile)
-                } else {
-                    std::io::BufWriter::new(outfile)
-                };
-                std::io::copy(&mut file, &mut writer).map_err(Error::io_or_compression)?;
+            let size = entry.uncompressed_size();
+            let writer = if let Ok(size) = usize::try_from(size) {
+                std::io::BufWriter::with_capacity(std::cmp::min(size, 1024 * 1024), outfile)
+            } else {
+                std::io::BufWriter::new(outfile)
+            };
+            let (copied, computed_crc32) = block_on(async {
+                let mut file = archive.reader_with_entry(file_number).await?;
+                let mut writer = AllowStdIo::new(writer);
+                let mut copied = 0;
+                let mut buffer = vec![0; 128 * 1024];
+                loop {
+                    let read = file
+                        .read(&mut buffer)
+                        .await
+                        .map_err(Error::io_or_compression)?;
+                    if read == 0 {
+                        break;
+                    }
+                    writer.write_all(&buffer[..read]).await.map_err(Error::Io)?;
+                    copied += read as u64;
+                }
+                writer.flush().await.map_err(Error::Io)?;
+                Ok::<_, Error>((copied, file.compute_hash()))
+            })?;
+
+            if copied != size && !skip_validation {
+                return Err(Error::BadUncompressedSize {
+                    path: enclosed_name.clone(),
+                    computed: copied,
+                    expected: size,
+                });
+            }
+
+            if computed_crc32 != entry.crc32() && !skip_validation {
+                return Err(Error::BadCrc32 {
+                    path: enclosed_name.clone(),
+                    computed: computed_crc32,
+                    expected: entry.crc32(),
+                });
             }
 
             // See `uv_extract::stream::unzip`. For simplicity, this is identical with the code there except for being
@@ -88,7 +142,7 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
                 use std::fs::Permissions;
                 use std::os::unix::fs::PermissionsExt;
 
-                if let Some(mode) = file.unix_mode() {
+                if let Some(mode) = entry.unix_permissions() {
                     // https://github.com/pypa/pip/blob/3898741e29b7279e7bffe044ecfbe20f6a438b1e/src/pip/_internal/utils/unpacking.py#L88-L100
                     let has_any_executable_bit = mode & 0o111;
                     if has_any_executable_bit != 0 {

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -69,11 +69,7 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
             // Create necessary parent directories.
             let path = target.join(&enclosed_name);
             if entry.dir()? {
-                let mut directories = directories.lock().map_err(|_| {
-                    Error::Io(std::io::Error::other(
-                        "ZIP extraction directory tracker mutex was poisoned",
-                    ))
-                })?;
+                let mut directories = directories.lock().unwrap();
                 if directories.insert(path.clone()) {
                     fs_err::create_dir_all(path).map_err(Error::Io)?;
                 }
@@ -81,11 +77,7 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
             }
 
             if let Some(parent) = path.parent() {
-                let mut directories = directories.lock().map_err(|_| {
-                    Error::Io(std::io::Error::other(
-                        "ZIP extraction directory tracker mutex was poisoned",
-                    ))
-                })?;
+                let mut directories = directories.lock().unwrap();
                 if directories.insert(parent.to_path_buf()) {
                     fs_err::create_dir_all(parent).map_err(Error::Io)?;
                 }

--- a/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
+++ b/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
@@ -9,9 +9,11 @@
 #![expect(clippy::cast_sign_loss)]
 
 use std::{
-    io::{BufReader, Cursor, Read, Seek, SeekFrom},
+    io::{BufRead, BufReader, Cursor, Read, Seek, SeekFrom},
     sync::{Arc, Mutex},
 };
+
+const BUFFER_SIZE: usize = 64 * 1024;
 
 /// A trait to represent some reader which has a total length known in
 /// advance. This is roughly equivalent to the nightly
@@ -30,6 +32,9 @@ pub(crate) struct CloneableSeekableReader<R: Read + Seek + HasLength> {
     pos: u64,
     // TODO determine and store this once instead of per cloneable file
     file_length: Option<u64>,
+    buffer: Box<[u8; BUFFER_SIZE]>,
+    buffer_position: usize,
+    buffer_length: usize,
 }
 
 impl<R: Read + Seek + HasLength> Clone for CloneableSeekableReader<R> {
@@ -38,6 +43,9 @@ impl<R: Read + Seek + HasLength> Clone for CloneableSeekableReader<R> {
             file: self.file.clone(),
             pos: self.pos,
             file_length: self.file_length,
+            buffer: Box::new([0; BUFFER_SIZE]),
+            buffer_position: 0,
+            buffer_length: 0,
         }
     }
 }
@@ -53,22 +61,60 @@ impl<R: Read + Seek + HasLength> CloneableSeekableReader<R> {
             file: Arc::new(Mutex::new(file)),
             pos: 0u64,
             file_length: None,
+            buffer: Box::new([0; BUFFER_SIZE]),
+            buffer_position: 0,
+            buffer_length: 0,
         }
     }
 
     /// Determine the length of the underlying stream.
     fn ascertain_file_length(&mut self) -> u64 {
         self.file_length.unwrap_or_else(|| {
-            let len = self.file.lock().unwrap().len();
+            let len = self
+                .file
+                .lock()
+                .expect("cloneable seekable reader mutex should not be poisoned")
+                .len();
             self.file_length = Some(len);
             len
         })
+    }
+
+    fn buffered_len(&self) -> usize {
+        self.buffer_length.saturating_sub(self.buffer_position)
+    }
+
+    fn consume_buffer(&mut self, amount: usize) {
+        let amount = amount.min(self.buffered_len());
+        self.buffer_position += amount;
+        self.pos += amount as u64;
+
+        if self.buffer_position == self.buffer_length {
+            self.buffer_position = 0;
+            self.buffer_length = 0;
+        }
+    }
+
+    fn clear_buffer(&mut self) {
+        self.buffer_position = 0;
+        self.buffer_length = 0;
     }
 }
 
 impl<R: Read + Seek + HasLength> Read for CloneableSeekableReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut underlying_file = self.file.lock().expect("Unable to get underlying file");
+        if self.buffered_len() > 0 {
+            let amount = buf.len().min(self.buffered_len());
+            buf[..amount]
+                .copy_from_slice(&self.buffer[self.buffer_position..self.buffer_position + amount]);
+            self.consume_buffer(amount);
+            return Ok(amount);
+        }
+
+        let mut underlying_file = self
+            .file
+            .lock()
+            .map_err(|_| std::io::Error::other("cloneable seekable reader mutex was poisoned"))?;
         // TODO share an object which knows current position to avoid unnecessary
         // seeks
         underlying_file.seek(SeekFrom::Start(self.pos))?;
@@ -106,7 +152,27 @@ impl<R: Read + Seek + HasLength> Seek for CloneableSeekableReader<R> {
             }
         };
         self.pos = new_pos;
+        self.clear_buffer();
         Ok(new_pos)
+    }
+}
+
+impl<R: Read + Seek + HasLength> BufRead for CloneableSeekableReader<R> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if self.buffered_len() == 0 {
+            let mut underlying_file = self.file.lock().map_err(|_| {
+                std::io::Error::other("cloneable seekable reader mutex was poisoned")
+            })?;
+            underlying_file.seek(SeekFrom::Start(self.pos))?;
+            self.buffer_length = underlying_file.read(&mut *self.buffer)?;
+            self.buffer_position = 0;
+        }
+
+        Ok(&self.buffer[self.buffer_position..self.buffer_length])
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.consume_buffer(amount);
     }
 }
 

--- a/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
+++ b/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
@@ -70,11 +70,7 @@ impl<R: Read + Seek + HasLength> CloneableSeekableReader<R> {
     /// Determine the length of the underlying stream.
     fn ascertain_file_length(&mut self) -> u64 {
         self.file_length.unwrap_or_else(|| {
-            let len = self
-                .file
-                .lock()
-                .expect("cloneable seekable reader mutex should not be poisoned")
-                .len();
+            let len = self.file.lock().unwrap().len();
             self.file_length = Some(len);
             len
         })
@@ -111,10 +107,7 @@ impl<R: Read + Seek + HasLength> Read for CloneableSeekableReader<R> {
             return Ok(amount);
         }
 
-        let mut underlying_file = self
-            .file
-            .lock()
-            .map_err(|_| std::io::Error::other("cloneable seekable reader mutex was poisoned"))?;
+        let mut underlying_file = self.file.lock().unwrap();
         // TODO share an object which knows current position to avoid unnecessary
         // seeks
         underlying_file.seek(SeekFrom::Start(self.pos))?;
@@ -160,9 +153,7 @@ impl<R: Read + Seek + HasLength> Seek for CloneableSeekableReader<R> {
 impl<R: Read + Seek + HasLength> BufRead for CloneableSeekableReader<R> {
     fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
         if self.buffered_len() == 0 {
-            let mut underlying_file = self.file.lock().map_err(|_| {
-                std::io::Error::other("cloneable seekable reader mutex was poisoned")
-            })?;
+            let mut underlying_file = self.file.lock().unwrap();
             underlying_file.seek(SeekFrom::Start(self.pos))?;
             self.buffer_length = underlying_file.read(&mut *self.buffer)?;
             self.buffer_position = 0;

--- a/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
+++ b/crates/uv-extract/src/vendor/cloneable_seekable_reader.rs
@@ -13,6 +13,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+// Chosen from extraction benchmarks to reduce read calls without adding too
+// much per-clone buffering.
 const BUFFER_SIZE: usize = 64 * 1024;
 
 /// A trait to represent some reader which has a total length known in

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-zip = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-metadata/src/lib.rs
+++ b/crates/uv-metadata/src/lib.rs
@@ -3,8 +3,9 @@
 //! This module reads all fields exhaustively. The fields are defined in the [Core metadata
 //! specification](https://packaging.python.org/en/latest/specifications/core-metadata/).
 
+use futures::executor::block_on;
+use futures::io::AllowStdIo;
 use std::io;
-use std::io::{Read, Seek};
 use std::path::Path;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
@@ -12,7 +13,6 @@ use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use uv_distribution_filename::WheelFilename;
 use uv_normalize::{DistInfoName, InvalidNameError};
 use uv_pypi_types::ResolutionMetadata;
-use zip::ZipArchive;
 
 /// The caller is responsible for attaching the path or url we failed to read.
 #[derive(Debug, Error)]
@@ -39,8 +39,6 @@ pub enum Error {
         computed: u32,
         expected: u32,
     },
-    #[error("Failed to read from zip file")]
-    Zip(#[from] zip::result::ZipError),
     #[error("Failed to read from zip file")]
     AsyncZip(#[from] async_zip::error::ZipError),
     // No `#[from]` to enforce manual review of `io::Error` sources.
@@ -133,18 +131,31 @@ pub fn is_metadata_entry(path: &str, filename: &WheelFilename) -> Result<bool, E
 /// Given an archive, read the `METADATA` from the `.dist-info` directory.
 pub fn read_archive_metadata(
     filename: &WheelFilename,
-    archive: &mut ZipArchive<impl Read + Seek + Sized>,
+    reader: impl std::io::BufRead + std::io::Seek + Unpin,
 ) -> Result<Vec<u8>, Error> {
-    let dist_info_prefix =
-        find_archive_dist_info(filename, archive.file_names().map(|name| (name, name)))?.1;
+    block_on(async {
+        let mut zip_reader =
+            async_zip::base::read::seek::ZipFileReader::new(AllowStdIo::new(reader)).await?;
 
-    let mut file = archive.by_name(&format!("{dist_info_prefix}.dist-info/METADATA"))?;
+        let (metadata_index, _dist_info_prefix) = find_archive_dist_info(
+            filename,
+            zip_reader
+                .file()
+                .entries()
+                .iter()
+                .enumerate()
+                .filter_map(|(index, entry)| Some((index, entry.filename().as_str().ok()?))),
+        )?;
 
-    #[expect(clippy::cast_possible_truncation)]
-    let mut buffer = Vec::with_capacity(file.size() as usize);
-    file.read_to_end(&mut buffer).map_err(Error::Io)?;
+        let mut buffer = Vec::new();
+        zip_reader
+            .reader_with_entry(metadata_index)
+            .await?
+            .read_to_end_checked(&mut buffer)
+            .await?;
 
-    Ok(buffer)
+        Ok(buffer)
+    })
 }
 
 /// Find the `.dist-info` directory in an unzipped wheel.

--- a/crates/uv-trampoline-builder/Cargo.toml
+++ b/crates/uv-trampoline-builder/Cargo.toml
@@ -31,9 +31,10 @@ fs-err = {workspace = true }
 goblin = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-zip = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+async_zip = { workspace = true }
+futures-lite = { workspace = true }
 windows = { workspace = true }
 
 [dev-dependencies]

--- a/crates/uv-trampoline-builder/src/lib.rs
+++ b/crates/uv-trampoline-builder/src/lib.rs
@@ -230,6 +230,9 @@ pub enum Error {
     NotWindows,
     #[error("Cannot process launcher metadata from resource")]
     UnprocessableMetadata,
+    #[cfg(windows)]
+    #[error("Failed to write Windows launcher ZIP payload")]
+    AsyncZip(#[from] async_zip::error::ZipError),
     #[error("Resources over 2^32 bytes are not supported")]
     ResourceTooLarge,
     #[error("Failed to update Windows PE resources: {}", path.user_display())]
@@ -380,30 +383,22 @@ pub fn windows_script_launcher(
     is_gui: bool,
     python_executable: impl AsRef<Path>,
 ) -> Result<Vec<u8>, Error> {
-    use std::io::{Cursor, Write};
-
-    use zip::ZipWriter;
-    use zip::write::SimpleFileOptions;
+    use async_zip::base::write::ZipFileWriter;
+    use async_zip::{Compression, ZipEntryBuilder};
+    use futures_lite::future::block_on;
+    use futures_lite::io::Cursor;
 
     use uv_fs::Simplified;
 
     let launcher_bin: &[u8] = get_launcher_bin(is_gui)?;
 
-    let mut payload: Vec<u8> = Vec::new();
-    {
-        // We're using the zip writer, but with stored compression
-        // https://github.com/njsmith/posy/blob/04927e657ca97a5e35bb2252d168125de9a3a025/src/trampolines/mod.rs#L75-L82
-        // https://github.com/pypa/distlib/blob/8ed03aab48add854f377ce392efffb79bb4d6091/PC/launcher.c#L259-L271
-        let stored =
-            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
-        let mut archive = ZipWriter::new(Cursor::new(&mut payload));
-        let error_msg = "Writing to Vec<u8> should never fail";
-        archive.start_file("__main__.py", stored).expect(error_msg);
-        archive
-            .write_all(launcher_python_script.as_bytes())
-            .expect(error_msg);
-        archive.finish().expect(error_msg);
-    }
+    // Store the launcher script without compression.
+    // https://github.com/njsmith/posy/blob/04927e657ca97a5e35bb2252d168125de9a3a025/src/trampolines/mod.rs#L75-L82
+    // https://github.com/pypa/distlib/blob/8ed03aab48add854f377ce392efffb79bb4d6091/PC/launcher.c#L259-L271
+    let mut archive = ZipFileWriter::new(Cursor::new(Vec::new()));
+    let entry = ZipEntryBuilder::new("__main__.py".to_string().into(), Compression::Stored);
+    block_on(archive.write_entry_whole(entry, launcher_python_script.as_bytes()))?;
+    let payload = block_on(archive.close())?.into_inner();
 
     let python = python_executable.as_ref();
     let python_path = python.simplified_display().to_string();

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -69,6 +69,7 @@ uv-workspace = { workspace = true, features = ["clap"] }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }
+async_zip = { workspace = true }
 axoupdater = { workspace = true, features = [
   "github_releases",
   "tokio",
@@ -113,7 +114,6 @@ uuid = { workspace = true, features = ["v4"] }
 version-ranges = { workspace = true }
 walkdir = { workspace = true }
 which = { workspace = true }
-zip = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 self-replace = { workspace = true }

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -382,7 +382,7 @@ async fn build_impl(
             preview,
         );
         async {
-            let result = future.await;
+            let result = Box::pin(future).await;
             (source, result)
         }
     }))

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -142,7 +142,7 @@ pub(crate) async fn init(
                 }
             };
 
-            init_project(
+            Box::pin(init_project(
                 &path,
                 &name,
                 package,
@@ -165,7 +165,7 @@ pub(crate) async fn init(
                 cache,
                 printer,
                 preview,
-            )
+            ))
             .await?;
 
             // Create the `README.md` if it does not already exist.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -2005,9 +2005,26 @@ async fn resolve_gist_url(
 /// Returns `true` if the target is a ZIP archive containing a `__main__.py` file.
 fn is_python_zipapp(target: &Path) -> bool {
     if let Ok(file) = fs_err::File::open(target) {
-        if let Ok(mut archive) = zip::ZipArchive::new(file) {
-            return archive.by_name("__main__.py").is_ok_and(|f| f.is_file());
-        }
+        let reader = std::io::BufReader::new(file);
+        return futures::executor::block_on(async {
+            let archive = async_zip::base::read::seek::ZipFileReader::new(
+                futures::io::AllowStdIo::new(reader),
+            )
+            .await
+            .ok()?;
+            archive
+                .file()
+                .entries()
+                .iter()
+                .find(|entry| {
+                    entry
+                        .filename()
+                        .as_str()
+                        .is_ok_and(|name| name == "__main__.py")
+                })
+                .map(|entry| entry.dir().is_ok_and(|is_dir| !is_dir))
+        })
+        .unwrap_or(false);
     }
     false
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -646,7 +646,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 groups: args.settings.groups,
             };
 
-            commands::pip_compile(
+            Box::pin(commands::pip_compile(
                 &requirements,
                 &constraints,
                 &overrides,
@@ -709,7 +709,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 workspace_cache,
                 printer,
                 globals.preview,
-            )
+            ))
             .await
         }
         Commands::Pip(PipNamespace {
@@ -753,7 +753,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 groups: args.settings.groups,
             };
 
-            commands::pip_sync(
+            Box::pin(commands::pip_sync(
                 &requirements,
                 &constraints,
                 &build_constraints,
@@ -796,7 +796,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.dry_run,
                 printer,
                 globals.preview,
-            )
+            ))
             .await
         }
         Commands::Pip(PipNamespace {
@@ -1264,7 +1264,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.no_clear,
             );
 
-            commands::venv(
+            Box::pin(commands::venv(
                 &project_dir,
                 args.path,
                 python_request,
@@ -1294,7 +1294,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                         .is_enabled(PreviewFeature::RelocatableEnvsDefault)
                         && !args.no_relocatable),
                 globals.preview,
-            )
+            ))
             .await
         }
         Commands::Project(project) => {
@@ -1836,7 +1836,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache.init().await?;
 
-            commands::python_pin(
+            Box::pin(commands::python_pin(
                 &project_dir,
                 args.request,
                 args.resolved,
@@ -1851,7 +1851,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &workspace_cache,
                 printer,
                 globals.preview,
-            )
+            ))
             .await
         }
         Commands::Python(PythonNamespace {
@@ -2113,7 +2113,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache.init().await?;
 
-            commands::init(
+            Box::pin(commands::init(
                 project_dir,
                 args.path,
                 args.name,
@@ -2137,7 +2137,7 @@ async fn run_project(
                 &cache,
                 printer,
                 globals.preview,
-            )
+            ))
             .await
         }
         ProjectCommand::Run(args) => {

--- a/crates/uv/tests/it/extract.rs
+++ b/crates/uv/tests/it/extract.rs
@@ -27,6 +27,36 @@ async fn unzip(url: &str) -> anyhow::Result<(), uv_extract::Error> {
     Ok(())
 }
 
+async fn unzip_seekable(url: &str) -> anyhow::Result<(), uv_extract::Error> {
+    let backoff = backon::ExponentialBuilder::default()
+        .with_min_delay(std::time::Duration::from_millis(500))
+        .with_max_times(5)
+        .build();
+
+    let download = || async {
+        let response = reqwest::get(url).await?;
+        Ok::<_, reqwest::Error>(response)
+    };
+
+    let response = download.retry(backoff).await.unwrap();
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(std::io::Error::other)
+        .map_err(uv_extract::Error::Io)?;
+
+    let archive = tempfile::NamedTempFile::new().map_err(uv_extract::Error::Io)?;
+    fs_err::write(archive.path(), bytes).map_err(uv_extract::Error::Io)?;
+    let archive = fs_err::File::open(archive.path()).map_err(uv_extract::Error::Io)?;
+
+    let target = tempfile::TempDir::new().map_err(uv_extract::Error::Io)?;
+    let target_path = target.path().to_path_buf();
+    tokio::task::spawn_blocking(move || uv_extract::unzip(archive, &target_path))
+        .await
+        .expect("seekable ZIP extraction task should not panic")?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn malo_accept_comment() {
     unzip("https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/0723f54ceb33a4fdc7f2eddc19635cd704d61c84/accept/comment.zip").await.unwrap();
@@ -48,6 +78,12 @@ async fn malo_accept_data_descriptor() {
 #[tokio::test]
 async fn malo_accept_deflate() {
     unzip("https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/0723f54ceb33a4fdc7f2eddc19635cd704d61c84/accept/deflate.zip").await.unwrap();
+    insta::assert_debug_snapshot!((), @"()");
+}
+
+#[tokio::test]
+async fn malo_seekable_accept_deflate() {
+    unzip_seekable("https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/0723f54ceb33a4fdc7f2eddc19635cd704d61c84/accept/deflate.zip").await.unwrap();
     insta::assert_debug_snapshot!((), @"()");
 }
 
@@ -229,6 +265,18 @@ async fn malo_reject_data_descriptor_bad_crc() {
         path: "fixme",
         computed: 907060870,
         expected: 1,
+    }
+    "#);
+}
+
+#[tokio::test]
+async fn malo_seekable_malicious_short_usize() {
+    let result = unzip_seekable("https://pub-c6f28d316acd406eae43501e51ad30fa.r2.dev/0723f54ceb33a4fdc7f2eddc19635cd704d61c84/malicious/short_usize.zip").await.unwrap_err();
+    insta::assert_debug_snapshot!(result, @r#"
+    BadUncompressedSize {
+        path: "file",
+        computed: 51,
+        expected: 9,
     }
     "#);
 }


### PR DESCRIPTION
## Summary

Historically, we've relied on both the synchronous `zip` crate and our own `rs-async-zip` fork. The async variant is used for streaming (i.e., unzipping a wheel as it's downloaded), while the sync variant is used to parallel-unzip local files, which turns out to be very fast.

This PR removes all usages of the `zip` crate (apart from in development dependencies), in favor of using `rs-async-zip` everywhere. This appears to both reduce crate size _and_ improve performance while also cutting off a source of CVEs. (The `rs-async-zip` crate is, of course, also vulnerable to potential CVEs, but having _two_ crates is strictly greater exposure for us.)

Per Codex, the parallel unzip is now a bit faster:

```
- 55 KB wheel: async -1.0%
- 393 KB wheel: async -7.8%
- 11.4 MB shellcheck wheel: async -3.8%
- 12.5 MB Ruff wheel: async -9.1%
- 21.3 MB NumPy wheel: async -11.0%
- 66.5 MB pandas wheel: async -4.3%
```

Per Codex, the `uv` and `uv-build` binaries are both smaller:

```
  ┌──────────┬──────────────┬──────────────┬─────────────────────────────────┐
  │ Binary   │         main │       branch │                           delta │
  ├──────────┼──────────────┼──────────────┼─────────────────────────────────┤
  │ uv       │ 16,422,784 B │ 16,274,608 B │ -148,176 B (-144.7 KiB, -0.90%) │
  │ uv-build │  2,683,584 B │  2,652,512 B │   -31,072 B (-30.3 KiB, -1.16%) │
  └──────────┴──────────────┴──────────────┴─────────────────────────────────┘
```

Closes https://github.com/astral-sh/uv/issues/19363.