### PR TITLE
Fix JUnit upload on Windows runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,6 +288,6 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: junit-results-windows-${{ matrix.partition }}
-          path: target/nextest/ci*/junit.xml
+          path: ${{ env.UV_WORKSPACE }}/target/nextest/ci*/junit.xml
           if-no-files-found: ignore
           retention-days: 14


### PR DESCRIPTION
## Summary

This was an oversight from #19330. We're running our tests on Windows in a Dev Drive, so we need to fixup the path rather than assuming that CWD has a `target` dir.

## Test Plan

NFC.