### PR TITLE
fix: show lock mismatch error with --quiet/--check

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -270,7 +270,7 @@ pub(crate) async fn lock(
         // Lock mismatches from `--check`/`--locked` are expected validation failures.
         // Handle them here so we return exit code 1 instead of bubbling up as an error (exit code 2).
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -374,7 +374,7 @@ pub(crate) async fn sync(
                 Outcome::LockMismatch(prev, cur, lock_source)
             } else {
                 writeln!(
-                    printer.stderr(),
+                    printer.stderr_important(),
                     "{}",
                     ProjectError::LockMismatch(prev, cur, lock_source)
                         .to_string()
@@ -478,7 +478,7 @@ pub(crate) async fn sync(
         Outcome::Success(..) => Ok(ExitStatus::Success),
         Outcome::LockMismatch(prev, cur, lock_source) => {
             writeln!(
-                printer.stderr(),
+                printer.stderr_important(),
                 "{}",
                 ProjectError::LockMismatch(prev, cur, lock_source)
                     .to_string()

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -119,7 +119,7 @@ pub(crate) async fn metadata(
     {
         Ok(lock) => print_lock_as_metadata(virtual_project.workspace(), &lock.into_lock(), printer),
         Err(err @ ProjectError::LockMismatch(..)) => {
-            writeln!(printer.stderr(), "{}", err.to_string().bold())?;
+            writeln!(printer.stderr_important(), "{}", err.to_string().bold())?;
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(err)) => {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -15096,6 +15096,51 @@ fn check_outdated_lock() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that `uv lock --check --quiet` still shows the error message when the lockfile is outdated.
+///
+/// See: <https://github.com/astral-sh/uv/issues/19326>
+#[test]
+fn check_outdated_lock_quiet() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+        "#,
+    )?;
+
+    // Lock the initial requirements.
+    context.lock().assert().success();
+
+    // Update the requirements.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    // Running with `--check --quiet` should still show the error message.
+    uv_snapshot!(context.filters(), context.lock().arg("--check").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--check` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 /// This checks that markers that normalize to 'false', which are serialized
 /// to the lockfile as `python_full_version < '0'`, get read back as false.
 /// Otherwise `uv lock --check` will always fail.

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -106,6 +106,51 @@ fn locked() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that `--locked --quiet` still shows the error message when the lockfile is outdated.
+///
+/// See: <https://github.com/astral-sh/uv/issues/19326>
+#[test]
+fn locked_quiet() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+        "#,
+    )?;
+
+    // Lock the initial requirements.
+    context.lock().assert().success();
+
+    // Update the requirements.
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+        "#,
+    )?;
+
+    // Running with `--locked --quiet` should still show the error message.
+    uv_snapshot!(context.filters(), context.sync().arg("--locked").arg("--quiet"), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn frozen() -> Result<()> {
     let context = uv_test::test_context!("3.12");


### PR DESCRIPTION
Fixes #19326.

`uv lock --check --quiet` and `uv sync --locked --quiet` silently swallowed the lock-mismatch diagnostic, returning exit code 1 with no output. This made CI failures opaque.

Switched to `stderr_important()` so the diagnostic prints regardless of verbosity level. Adds regression tests for both code paths.