### PR TITLE
Support PEP 794/Core Metadata 2.5: Import names and import namespaces

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -2,8 +2,9 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::{Deserialize, Deserializer};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, Bound};
+use std::collections::{BTreeMap, BTreeSet, Bound};
 use std::ffi::OsStr;
+use std::fmt::Display;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
@@ -19,7 +20,9 @@ use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::{
     ExtraOperator, MarkerExpression, MarkerTree, MarkerValueExtra, Requirement, VersionOrUrl,
 };
-use uv_pypi_types::{Keywords, Metadata23, ProjectUrls, VerbatimParsedUrl};
+use uv_pypi_types::{
+    Identifier, IdentifierParseError, Keywords, Metadata23, ProjectUrls, VerbatimParsedUrl,
+};
 
 use crate::serde_verbatim::SerdeVerbatim;
 use crate::{BuildBackendSettings, Error, error_on_venv};
@@ -71,6 +74,27 @@ pub enum ValidationError {
     LicenseFileNotUtf8(String),
     #[error("`project.classifiers` contains an invalid classifier: {0}")]
     InvalidClassifiers(String),
+    #[error("`project.import-namespaces` must not be empty")]
+    EmptyImportNamespaces,
+    #[error("`{field}` entry must not be empty")]
+    EmptyImportName { field: &'static str },
+    #[error("`{field}` entry `{value}` must end with `; private` or nothing, found `{suffix}`")]
+    InvalidImportSuffix {
+        field: &'static str,
+        value: String,
+        suffix: String,
+    },
+    #[error("`{field}` entry `{value}` has an invalid import name")]
+    InvalidImportName {
+        field: &'static str,
+        value: String,
+        #[source]
+        source: IdentifierParseError,
+    },
+    #[error(
+        "`project.import-names` and `project.import-namespaces` must not both contain `{name}`"
+    )]
+    DuplicateImportAcross { name: String },
 }
 
 /// The project is not compatible with a direct uv build.
@@ -91,6 +115,105 @@ pub enum DirectBuildIncompatibility {
     UrlRequirement,
     #[error("`uv_build{0}` is not a known compatible range")]
     IncompatibleRange(VersionSpecifiers),
+}
+
+#[derive(Debug, Clone)]
+struct ImportEntry {
+    base: String,
+    is_private: bool,
+}
+
+impl ImportEntry {
+    /// The special case where `import-names = []` in `pyproject.toml` is converted to an empty
+    /// `Import-Name` field.
+    fn empty() -> Self {
+        Self {
+            base: String::new(),
+            is_private: false,
+        }
+    }
+}
+
+impl Display for ImportEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.base.is_empty() {
+            Ok(())
+        } else if self.is_private {
+            write!(f, "{}; private", self.base)
+        } else {
+            write!(f, "{}", self.base)
+        }
+    }
+}
+
+fn parse_import_names(
+    import_names: Option<&[String]>,
+) -> Result<Option<Vec<ImportEntry>>, ValidationError> {
+    let Some(import_names) = import_names else {
+        return Ok(None);
+    };
+    if import_names.is_empty() {
+        return Ok(Some(vec![ImportEntry::empty()]));
+    }
+
+    let import_names = import_names
+        .iter()
+        .map(|value| parse_import_entry(value, "project.import-names"))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(import_names))
+}
+
+fn parse_import_namespaces(
+    import_namespaces: Option<&[String]>,
+) -> Result<Option<Vec<ImportEntry>>, ValidationError> {
+    let Some(import_namespaces) = import_namespaces else {
+        return Ok(None);
+    };
+    if import_namespaces.is_empty() {
+        return Err(ValidationError::EmptyImportNamespaces);
+    }
+
+    let import_namespaces = import_namespaces
+        .iter()
+        .map(|value| parse_import_entry(value, "project.import-namespaces"))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(import_namespaces))
+}
+
+fn parse_import_entry(value: &str, field: &'static str) -> Result<ImportEntry, ValidationError> {
+    let (name_part, suffix_part) = match value.split_once(';') {
+        Some((name, suffix)) => (name.trim_end(), Some(suffix.trim())),
+        None => (value, None),
+    };
+
+    if name_part.is_empty() {
+        return Err(ValidationError::EmptyImportName { field });
+    }
+
+    let is_private = match suffix_part {
+        Some("private") => true,
+        Some(suffix) => {
+            return Err(ValidationError::InvalidImportSuffix {
+                field,
+                value: value.to_string(),
+                suffix: suffix.to_string(),
+            });
+        }
+        None => false,
+    };
+
+    for segment in name_part.split('.') {
+        Identifier::from_str(segment).map_err(|source| ValidationError::InvalidImportName {
+            field,
+            value: name_part.to_string(),
+            source,
+        })?;
+    }
+
+    Ok(ImportEntry {
+        base: name_part.to_string(),
+        is_private,
+    })
 }
 
 /// Check if the build backend is matching the currently running uv version.
@@ -355,6 +478,25 @@ impl PyProjectToml {
             return Err(ValidationError::Dynamic.into());
         }
 
+        let import_names = parse_import_names(self.project.import_names.as_deref())?;
+        let import_namespaces = parse_import_namespaces(self.project.import_namespaces.as_deref())?;
+
+        if let (Some(import_names), Some(import_namespaces)) = (&import_names, &import_namespaces) {
+            let import_name_set: BTreeSet<_> = import_names
+                .iter()
+                .map(|entry| entry.base.as_str())
+                .collect();
+            if let Some(overlap) = import_namespaces
+                .iter()
+                .find(|entry| import_name_set.contains(entry.base.as_str()))
+            {
+                return Err(ValidationError::DuplicateImportAcross {
+                    name: overlap.base.clone(),
+                }
+                .into());
+            }
+        }
+
         let author = self
             .project
             .authors
@@ -417,9 +559,13 @@ impl PyProjectToml {
             .filter(|maintainer_email| !maintainer_email.is_empty());
 
         // Using PEP 639 bumps the METADATA version
-        let metadata_version = if self.project.license_files.is_some()
-            || matches!(self.project.license, Some(License::Spdx(_)))
-        {
+        let uses_pep639 = self.project.license_files.is_some()
+            || matches!(self.project.license, Some(License::Spdx(_)));
+        let uses_pep794 = import_names.is_some() || import_namespaces.is_some();
+        let metadata_version = if uses_pep794 {
+            debug!("Found import name metadata declarations, using METADATA 2.5");
+            "2.5"
+        } else if uses_pep639 {
             debug!("Found PEP 639 license declarations, using METADATA 2.4");
             "2.4"
         } else {
@@ -463,6 +609,23 @@ impl PyProjectToml {
                 ))
                 .collect::<Vec<_>>();
 
+        let import_names = import_names
+            .map(|import_names| {
+                import_names
+                    .into_iter()
+                    .map(|entry| entry.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let import_namespaces = import_namespaces
+            .map(|import_namespaces| {
+                import_namespaces
+                    .into_iter()
+                    .map(|entry| entry.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(Metadata23 {
             metadata_version: metadata_version.to_string(),
             name: self.project.name.given.clone(),
@@ -492,7 +655,6 @@ impl PyProjectToml {
                 .cloned()
                 .map(Into::into)
                 .collect(),
-
             requires_dist: requires_dist.iter().map(ToString::to_string).collect(),
             provides_extra: extras.iter().map(ToString::to_string).collect(),
             // Not commonly set.
@@ -508,6 +670,8 @@ impl PyProjectToml {
             requires_external: vec![],
             project_urls,
             dynamic: vec![],
+            import_names,
+            import_namespaces,
         })
     }
 
@@ -805,6 +969,14 @@ struct Project {
     dependencies: Option<Vec<Requirement>>,
     /// The optional dependencies of the project.
     optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
+    /// Import names exclusively provided by the project.
+    ///
+    /// From PEP 794.
+    import_names: Option<Vec<String>>,
+    /// Import namespaces provided by the project.
+    ///
+    /// From PEP 794.
+    import_namespaces: Option<Vec<String>>,
     /// Specifies which fields listed by PEP 621 were intentionally unspecified so another tool
     /// can/will provide such metadata dynamically.
     ///
@@ -1219,6 +1391,114 @@ mod tests {
 
         [bar_group]
         foo-bar = foo:bar
+        ");
+    }
+
+    #[test]
+    fn import_names_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r#"
+            import-names = ["spam", "spam.eggs ; private", "mod.tools.cli"]
+            import-namespaces = ["mod", "mod.tools"]
+        "#});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let metadata = pyproject_toml.to_metadata(temp_dir.path()).unwrap();
+
+        assert_snapshot!(metadata.core_metadata_format(), @"
+        Metadata-Version: 2.5
+        Name: hello-world
+        Version: 0.1.0
+        Import-Name: spam
+        Import-Name: spam.eggs; private
+        Import-Name: mod.tools.cli
+        Import-Namespace: mod
+        Import-Namespace: mod.tools
+        ");
+    }
+
+    #[test]
+    fn import_names_empty_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r"
+            import-names = []
+        "});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let metadata = pyproject_toml.to_metadata(temp_dir.path()).unwrap();
+
+        assert_snapshot!(metadata.core_metadata_format(), @"
+        Metadata-Version: 2.5
+        Name: hello-world
+        Version: 0.1.0
+        Import-Name:
+        ");
+    }
+
+    #[test]
+    fn import_names_empty_string() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r#"
+            import-names = [""]
+        "#});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let err = pyproject_toml
+            .to_metadata(temp_dir.path())
+            .map(|_| ())
+            .unwrap_err();
+        assert_snapshot!(format_err(err), @"
+        Invalid project metadata
+          Caused by: `project.import-names` entry must not be empty
+        ");
+    }
+
+    #[test]
+    fn import_namespaces_empty_string() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r#"
+            import-namespaces = [""]
+        "#});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let err = pyproject_toml
+            .to_metadata(temp_dir.path())
+            .map(|_| ())
+            .unwrap_err();
+        assert_snapshot!(format_err(err), @"
+        Invalid project metadata
+          Caused by: `project.import-namespaces` entry must not be empty
+        ");
+    }
+
+    #[test]
+    fn import_names_dotted_without_prefix() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r#"
+            import-names = ["spam.eggs"]
+        "#});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let metadata = pyproject_toml.to_metadata(temp_dir.path()).unwrap();
+
+        assert_snapshot!(metadata.core_metadata_format(), @"
+        Metadata-Version: 2.5
+        Name: hello-world
+        Version: 0.1.0
+        Import-Name: spam.eggs
+        ");
+    }
+
+    #[test]
+    fn import_names_overlap() {
+        let temp_dir = TempDir::new().unwrap();
+        let contents = extend_project(indoc! {r#"
+            import-names = ["spam"]
+            import-namespaces = ["spam"]
+        "#});
+        let pyproject_toml: PyProjectToml = toml::from_str(&contents).unwrap();
+        let err = pyproject_toml
+            .to_metadata(temp_dir.path())
+            .map(|_| ())
+            .unwrap_err();
+        assert_snapshot!(format_err(err), @"
+        Invalid project metadata
+          Caused by: `project.import-names` and `project.import-namespaces` must not both contain `spam`
         ");
     }
 

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -180,6 +180,10 @@ fn parse_import_namespaces(
     Ok(Some(import_namespaces))
 }
 
+/// Parse `Import-Name` and `Import-Namespace` entries.
+///
+/// An import name(space) is a module path, consisting of identifiers with dots in between, and
+/// an optional `; private` suffix, e.g., `tqdm` or `foo.bar.baz ; private`.
 fn parse_import_entry(value: &str, field: &'static str) -> Result<ImportEntry, ValidationError> {
     let (name_part, suffix_part) = match value.split_once(';') {
         Some((name, suffix)) => (name.trim_end(), Some(suffix.trim())),

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -1179,6 +1179,22 @@ impl FormMetadata {
             .find(|hash| hash.algorithm == HashAlgorithm::Blake2b)
             .unwrap();
 
+        let metadata = metadata(file, filename).await?;
+
+        Ok(Self::from_metadata(
+            metadata,
+            filename,
+            sha256_hash,
+            blake2b_hash,
+        ))
+    }
+
+    fn from_metadata(
+        metadata: Metadata23,
+        filename: &DistFilename,
+        sha256_hash: &HashDigest,
+        blake2b_hash: &HashDigest,
+    ) -> Self {
         let Metadata23 {
             metadata_version,
             name,
@@ -1207,8 +1223,10 @@ impl FormMetadata {
             requires_external,
             project_urls,
             provides_extra,
+            import_names,
+            import_namespaces,
             dynamic,
-        } = metadata(file, filename).await?;
+        } = metadata;
 
         let mut form_metadata = vec![
             (":action", "file_upload".to_string()),
@@ -1269,10 +1287,12 @@ impl FormMetadata {
         add_vec("project_urls", project_urls.to_vec_str());
         add_vec("provides_dist", provides_dist);
         add_vec("provides_extra", provides_extra);
+        add_vec("import_names", import_names);
+        add_vec("import_namespaces", import_namespaces);
         add_vec("requires_dist", requires_dist);
         add_vec("requires_external", requires_external);
 
-        Ok(Self(form_metadata))
+        Self(form_metadata)
     }
 
     /// Returns an iterator over the metadata fields.
@@ -1512,6 +1532,7 @@ mod tests {
     use uv_auth::Credentials;
     use uv_client::{AuthIntegration, BaseClientBuilder, RedirectPolicy};
     use uv_distribution_filename::DistFilename;
+    use uv_pypi_types::{HashDigest, Metadata23};
     use uv_redacted::DisplaySafeUrl;
 
     use crate::{
@@ -1857,6 +1878,45 @@ mod tests {
             ]
             "#);
         }
+    }
+
+    #[test]
+    fn form_metadata_import_names() {
+        let filename = DistFilename::try_from_normalized_filename("pkg-1.0.0.tar.gz").unwrap();
+        let sha256_hash: HashDigest = "sha256:0123".parse().unwrap();
+        let blake2b_hash: HashDigest = "blake2b:4567".parse().unwrap();
+        let metadata = Metadata23 {
+            metadata_version: "2.5".to_string(),
+            name: "pkg".to_string(),
+            version: "1.0.0".to_string(),
+            requires_python: Some(">=3.12".to_string()),
+            import_names: vec!["spam".to_string(), "spam.eggs; private".to_string()],
+            import_namespaces: vec!["zope".to_string()],
+            ..Default::default()
+        };
+
+        let form_metadata =
+            FormMetadata::from_metadata(metadata, &filename, &sha256_hash, &blake2b_hash);
+        let formatted_metadata = form_metadata
+            .iter()
+            .map(|(key, value)| format!("{key}: {value}"))
+            .join("\n");
+
+        assert_snapshot!(formatted_metadata, @r###"
+        :action: file_upload
+        sha256_digest: 0123
+        blake2_256_digest: 4567
+        protocol_version: 1
+        metadata_version: 2.5
+        name: pkg
+        version: 1.0.0
+        filetype: sdist
+        pyversion: source
+        requires_python: >=3.12
+        import_names: spam
+        import_names: spam.eggs; private
+        import_namespaces: zope
+        "###);
     }
 
     /// Snapshot the data we send for an upload request for a source distribution.

--- a/crates/uv-pypi-types/src/metadata/metadata23.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata23.rs
@@ -162,7 +162,8 @@ impl Metadata23 {
         let provides_extra = headers.get_all_values("Provides-Extra").collect();
         let import_names: Vec<String> = headers.get_all_values("Import-Name").collect();
         let import_namespaces: Vec<String> = headers.get_all_values("Import-Namespace").collect();
-        // PEP 794 requires rejecting overlapping import names and namespaces.
+        // PEP 794 requires rejecting modules that are used both in import names and import
+        // namespaces. (Nesting is allowed, only exact matches are forbidden.)
         validate_import_name_overlap(&import_names, &import_namespaces)?;
         let description_content_type = headers.get_first_value("Description-Content-Type");
         let dynamic = headers.get_all_values("Dynamic").collect();

--- a/crates/uv-pypi-types/src/metadata/metadata23.rs
+++ b/crates/uv-pypi-types/src/metadata/metadata23.rs
@@ -1,4 +1,5 @@
 //! Vendored from <https://github.com/PyO3/python-pkginfo-rs>
+use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::Write;
 use std::str;
@@ -9,13 +10,13 @@ use indexmap::IndexMap;
 use crate::MetadataError;
 use crate::metadata::Headers;
 
-/// Code Metadata 2.3 as specified in
+/// Core Metadata 2.x as specified in
 /// <https://packaging.python.org/specifications/core-metadata/>.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Metadata23 {
-    /// Version of the file format; legal values are `1.0`, `1.1`, `1.2`, `2.1`, `2.2`, `2.3` and
-    /// `2.4`.
+    /// Version of the file format; legal values are `1.0`, `1.1`, `1.2`, `2.1`, `2.2`, `2.3`,
+    /// `2.4`, and `2.5`.
     pub metadata_version: String,
     /// The name of the distribution.
     pub name: String,
@@ -102,6 +103,14 @@ pub struct Metadata23 {
     /// May be used to make a dependency conditional on whether the optional feature has been
     /// requested.
     pub provides_extra: Vec<String>,
+    /// Import names exclusively provided by the project.
+    ///
+    /// Introduced by PEP 794, requires metadata version 2.5.
+    pub import_names: Vec<String>,
+    /// Import namespaces provided by the project.
+    ///
+    /// Introduced by PEP 794, requires metadata version 2.5.
+    pub import_namespaces: Vec<String>,
     /// A string containing the name of another core metadata field.
     pub dynamic: Vec<String>,
 }
@@ -151,6 +160,10 @@ impl Metadata23 {
         let requires_external = headers.get_all_values("Requires-External").collect();
         let project_urls = ProjectUrls::from_iter_str(headers.get_all_values("Project-URL"));
         let provides_extra = headers.get_all_values("Provides-Extra").collect();
+        let import_names: Vec<String> = headers.get_all_values("Import-Name").collect();
+        let import_namespaces: Vec<String> = headers.get_all_values("Import-Namespace").collect();
+        // PEP 794 requires rejecting overlapping import names and namespaces.
+        validate_import_name_overlap(&import_names, &import_namespaces)?;
         let description_content_type = headers.get_first_value("Description-Content-Type");
         let dynamic = headers.get_all_values("Dynamic").collect();
         Ok(Self {
@@ -180,6 +193,8 @@ impl Metadata23 {
             requires_external,
             project_urls,
             provides_extra,
+            import_names,
+            import_namespaces,
             dynamic,
         })
     }
@@ -274,6 +289,8 @@ impl Metadata23 {
         write_all(&mut writer, "Requires-External", &self.requires_external);
         write_all(&mut writer, "Project-URL", self.project_urls.to_vec_str());
         write_all(&mut writer, "Provides-Extra", &self.provides_extra);
+        write_all(&mut writer, "Import-Name", &self.import_names);
+        write_all(&mut writer, "Import-Namespace", &self.import_namespaces);
         write_opt_str(
             &mut writer,
             "Description-Content-Type",
@@ -287,6 +304,31 @@ impl Metadata23 {
         }
         writer
     }
+}
+
+fn import_name_base(value: &str) -> &str {
+    match value.split_once(';') {
+        Some((base, _suffix)) => base.trim_end(),
+        None => value,
+    }
+}
+
+fn validate_import_name_overlap(
+    import_names: &[String],
+    import_namespaces: &[String],
+) -> Result<(), MetadataError> {
+    let import_name_set: BTreeSet<_> = import_names
+        .iter()
+        .map(|import_name| import_name_base(import_name))
+        .collect();
+    if let Some(overlap) = import_namespaces
+        .iter()
+        .map(|import_namespace| import_name_base(import_namespace))
+        .find(|import_namespace| import_name_set.contains(import_namespace))
+    {
+        return Err(MetadataError::DuplicateImportName(overlap.to_string()));
+    }
+    Ok(())
 }
 
 impl FromStr for Metadata23 {
@@ -363,6 +405,7 @@ impl ProjectUrls {
 mod tests {
     use super::*;
     use crate::MetadataError;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_parse_from_str() {
@@ -392,5 +435,36 @@ mod tests {
         let meta: Metadata23 = s.parse().unwrap();
         assert_eq!(meta.author.as_deref(), Some("中文"));
         assert_eq!(meta.description.as_deref(), Some("一个 Python 包"));
+    }
+
+    #[test]
+    fn import_name_round_trip() {
+        let metadata = Metadata23 {
+            metadata_version: "2.5".to_string(),
+            name: "pkg".to_string(),
+            version: "1.0".to_string(),
+            import_names: vec!["spam.foo".to_string(), "spam.eggs; private".to_string()],
+            import_namespaces: vec!["spam".to_string(), "zope".to_string()],
+            ..Default::default()
+        };
+
+        let formatted = metadata.core_metadata_format();
+        assert_eq!(
+            formatted,
+            "Metadata-Version: 2.5\nName: pkg\nVersion: 1.0\nImport-Name: spam.foo\nImport-Name: spam.eggs; private\nImport-Namespace: spam\nImport-Namespace: zope\n"
+        );
+
+        let parsed: Metadata23 = formatted.parse().unwrap();
+        assert_eq!(parsed.import_names, metadata.import_names);
+        assert_eq!(parsed.import_namespaces, metadata.import_namespaces);
+    }
+
+    #[test]
+    fn import_name_overlap() {
+        let metadata = "Metadata-Version: 2.5\nName: pkg\nVersion: 1.0\nImport-Name: spam ; private\nImport-Namespace: spam\n";
+        assert_snapshot!(
+            Metadata23::parse(metadata.as_bytes()).unwrap_err(),
+            @"`Import-Name` and `Import-Namespace` must not both contain `spam`"
+        );
     }
 }

--- a/crates/uv-pypi-types/src/metadata/mod.rs
+++ b/crates/uv-pypi-types/src/metadata/mod.rs
@@ -52,6 +52,8 @@ pub enum MetadataError {
     InvalidName(#[from] InvalidNameError),
     #[error("Invalid `Metadata-Version` field: {0}")]
     InvalidMetadataVersion(String),
+    #[error("`Import-Name` and `Import-Namespace` must not both contain `{0}`")]
+    DuplicateImportName(String),
     #[error("Reading metadata from `PKG-INFO` requires Metadata 2.2 or later (found: {0})")]
     UnsupportedMetadataVersion(String),
     #[error("The following field was marked as dynamic: {0}")]

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -1375,6 +1375,8 @@ fn build_with_all_metadata() -> Result<()> {
       "download_url": null,
       "dynamic": [],
       "home_page": null,
+      "import_names": [],
+      "import_namespaces": [],
       "keywords": [
         "example",
         "test",


### PR DESCRIPTION
Support PEP 794 in the uv build backend, when publishing and when parsing metadata, while checking for the banned conditions from the PEP.

This is rebase of #16598 with additional fixes.