### PR TITLE
Use the crates.io version of `astral_async_zip`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,8 +321,9 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.18-rc2"
-source = "git+https://github.com/astral-sh/rs-async-zip.git?tag=v0.0.18-rc2#8eb9ed214128e6db76dc753bca43908f71e569a9"
+version = "0.0.18-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f773362bd6d5b14e1cb03473e26a1932884107f98f77f45c443e7ca85c9d6c43"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ async-compression = { version = "0.4.12", features = [
 ] }
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.11.0", package = "astral_async_http_range_reader" }
-async_zip = { version = "0.0.18-rc2", git = "https://github.com/astral-sh/rs-async-zip.git", tag = "v0.0.18-rc2", package = "astral_async_zip", features = [
+async_zip = { version = "0.0.18-rc3", package = "astral_async_zip", features = [
   "bzip2",
   "deflate",
   "lzma",

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -735,7 +735,7 @@ mod tests {
         // Check that the wheel is reproducible across platforms.
         assert_snapshot!(
             format!("{:x}", sha2::Sha256::digest(fs_err::read(&wheel_path).unwrap())),
-            @"0affdf7d3fda7e0a27007f6bf61524cd58bf3fce8e456bafb58b4a22faf0d6d0"
+            @"17d4946da272e3fee31f9e8261472f06f115cc3c2178e0a5cddbebb83e91fd04"
         );
         assert_snapshot!(build.wheel_contents.join("\n"), @"
         built_by_uv-0.1.0.data/data/


### PR DESCRIPTION
## Summary

A staged change that I forgot to push prior to https://github.com/astral-sh/uv/pull/19365.