### PR TITLE
Remove `wmi` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ dependencies = [
  "uv-pep440",
  "uv-platform-tags",
  "uv-static",
- "wmi",
+ "windows-registry",
 ]
 
 [[package]]
@@ -8178,20 +8178,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "wmi"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
-dependencies = [
- "futures",
- "log",
- "serde",
- "thiserror 2.0.18",
- "windows",
- "windows-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ dependencies = [
  "uv-pep440",
  "uv-platform-tags",
  "uv-static",
- "windows-registry",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,7 @@ webpki-root-certs = { version = "1" }
 which = { version = "8.0.0", features = ["regex"] }
 windows = { version = "0.61.0", features = [
   "std",
+  "Win32_Devices_DeviceAndDriverInstallation",
   "Win32_Foundation",
   "Win32_Globalization",
   "Win32_Security",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,6 @@ windows = { version = "0.61.0", features = [
 windows-registry = { version = "0.5.0" }
 windows-version = { version = "0.1.6" }
 wiremock = { version = "0.6.4" }
-wmi = { version = "0.18.3", default-features = false }
 xz2 = { version = "0.1.7", features = ["static"] }
 zeroize = { version = "1.8.1" }
 

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(all(target_os = "windows"))'.dependencies]
-wmi = { workspace = true }
+windows-registry = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-torch/Cargo.toml
+++ b/crates/uv-torch/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(all(target_os = "windows"))'.dependencies]
-windows-registry = { workspace = true }
+windows = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-torch/src/accelerator.rs
+++ b/crates/uv-torch/src/accelerator.rs
@@ -265,7 +265,7 @@ fn detect_intel_gpu_from_windows_devices() -> bool {
     // valid out pointer, and Configuration Manager writes only that scalar result here.
     let result = unsafe {
         CM_Get_Device_ID_List_SizeW(
-            &mut device_ids_len,
+            &raw mut device_ids_len,
             WINDOWS_DISPLAY_ADAPTER_CLASS_GUID,
             FLAGS,
         )

--- a/crates/uv-torch/src/accelerator.rs
+++ b/crates/uv-torch/src/accelerator.rs
@@ -7,9 +7,14 @@ use uv_pep440::Version;
 use uv_static::EnvVars;
 
 #[cfg(windows)]
-use serde::Deserialize;
-#[cfg(windows)]
-use wmi::WMIConnection;
+use windows_registry::LOCAL_MACHINE;
+
+// Constants used for PCI device detection.
+const PCI_BASE_CLASS_MASK: u32 = 0x00ff_0000;
+const PCI_BASE_CLASS_DISPLAY: u32 = 0x0003_0000;
+const PCI_VENDOR_ID_INTEL: u32 = 0x8086;
+#[cfg(any(windows, test))]
+const WINDOWS_DISPLAY_ADAPTER_CLASS_GUID: &str = "{4d36e968-e325-11ce-bfc1-08002be10318}";
 
 #[derive(Debug, thiserror::Error)]
 pub enum AcceleratorError {
@@ -65,13 +70,8 @@ impl Accelerator {
     /// 5. `nvidia-smi --query-gpu=driver_version --format=csv,noheader`.
     /// 6. `rocm_agent_enumerator`, which lists the AMD GPU architectures.
     /// 7. `/sys/bus/pci/devices`, filtering for the Intel GPU via PCI.
-    /// 8. Windows Managmeent Instrumentation (WMI), filtering for the Intel GPU via PCI.
+    /// 8. The Windows registry, filtering for the Intel GPU via PCI.
     pub fn detect() -> Result<Option<Self>, AcceleratorError> {
-        // Constants used for PCI device detection.
-        const PCI_BASE_CLASS_MASK: u32 = 0x00ff_0000;
-        const PCI_BASE_CLASS_DISPLAY: u32 = 0x0003_0000;
-        const PCI_VENDOR_ID_INTEL: u32 = 0x8086;
-
         // Read from `UV_CUDA_DRIVER_VERSION`.
         if let Ok(driver_version) = std::env::var(EnvVars::UV_CUDA_DRIVER_VERSION) {
             let driver_version = Version::from_str(&driver_version)?;
@@ -196,42 +196,10 @@ impl Accelerator {
             Err(e) => return Err(e.into()),
         }
 
-        // Detect Intel GPU via WMI on Windows
+        // Detect Intel GPU via the Windows registry.
         #[cfg(windows)]
-        {
-            #[derive(Deserialize, Debug)]
-            #[serde(rename = "Win32_VideoController")]
-            #[serde(rename_all = "PascalCase")]
-            struct VideoController {
-                #[serde(rename = "PNPDeviceID")]
-                pnp_device_id: Option<String>,
-                name: Option<String>,
-            }
-
-            match WMIConnection::new() {
-                Ok(wmi_connection) => match wmi_connection.query::<VideoController>() {
-                    Ok(gpu_controllers) => {
-                        for gpu_controller in gpu_controllers {
-                            if let Some(pnp_device_id) = &gpu_controller.pnp_device_id {
-                                if pnp_device_id.contains(&format!("VEN_{PCI_VENDOR_ID_INTEL:04X}"))
-                                {
-                                    debug!(
-                                        "Detected Intel GPU from WMI: PNPDeviceID={}, Name={:?}",
-                                        pnp_device_id, gpu_controller.name
-                                    );
-                                    return Ok(Some(Self::Xpu));
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        debug!("Failed to query WMI for video controllers: {e}");
-                    }
-                },
-                Err(e) => {
-                    debug!("Failed to create WMI connection: {e}");
-                }
-            }
+        if detect_intel_gpu_from_windows_registry() {
+            return Ok(Some(Self::Xpu));
         }
 
         debug!("Failed to detect GPU driver version");
@@ -278,6 +246,88 @@ fn parse_pci_device_ids(device_path: &Path) -> Result<(u32, u32), AcceleratorErr
     let pci_vendor = u32::from_str_radix(vendor_content.trim().trim_start_matches("0x"), 16)?;
 
     Ok((pci_class, pci_vendor))
+}
+
+#[cfg(windows)]
+fn detect_intel_gpu_from_windows_registry() -> bool {
+    let pci_devices = match LOCAL_MACHINE.open(r"SYSTEM\CurrentControlSet\Enum\PCI") {
+        Ok(pci_devices) => pci_devices,
+        Err(err) => {
+            debug!("Failed to open Windows PCI registry key: {err}");
+            return false;
+        }
+    };
+
+    let device_ids = match pci_devices.keys() {
+        Ok(device_ids) => device_ids,
+        Err(err) => {
+            debug!("Failed to enumerate Windows PCI registry devices: {err}");
+            return false;
+        }
+    };
+
+    for device_id in device_ids {
+        if !contains_intel_vendor_id(&device_id) {
+            continue;
+        }
+
+        let device = match pci_devices.open(&device_id) {
+            Ok(device) => device,
+            Err(err) => {
+                debug!("Failed to open Windows PCI registry device `{device_id}`: {err}");
+                continue;
+            }
+        };
+
+        let instance_ids = match device.keys() {
+            Ok(instance_ids) => instance_ids,
+            Err(err) => {
+                debug!(
+                    "Failed to enumerate Windows PCI registry instances for `{device_id}`: {err}"
+                );
+                continue;
+            }
+        };
+
+        for instance_id in instance_ids {
+            let instance = match device.open(&instance_id) {
+                Ok(instance) => instance,
+                Err(err) => {
+                    debug!(
+                        "Failed to open Windows PCI registry instance `{device_id}\\{instance_id}`: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            let class = instance.get_string("Class").ok();
+            let class_guid = instance.get_string("ClassGUID").ok();
+            if is_windows_display_adapter(class.as_deref(), class_guid.as_deref()) {
+                let name = instance.get_string("DeviceDesc").ok();
+                debug!(
+                    "Detected Intel GPU from Windows registry: DeviceID={device_id}, InstanceID={instance_id}, Name={name:?}"
+                );
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(any(windows, test))]
+fn contains_intel_vendor_id(pnp_device_id: &str) -> bool {
+    pnp_device_id
+        .split(['\\', '&'])
+        .any(|segment| segment.eq_ignore_ascii_case("VEN_8086"))
+}
+
+#[cfg(any(windows, test))]
+fn is_windows_display_adapter(class: Option<&str>, class_guid: Option<&str>) -> bool {
+    class.is_some_and(|class| class.eq_ignore_ascii_case("Display"))
+        || class_guid.is_some_and(|class_guid| {
+            class_guid.eq_ignore_ascii_case(WINDOWS_DISPLAY_ADAPTER_CLASS_GUID)
+        })
 }
 
 /// A GPU architecture for AMD GPUs.
@@ -375,5 +425,33 @@ mod tests {
             let version = Version::from_str(first_line.trim()).unwrap();
             assert_eq!(version, Version::from_str("572.60").unwrap());
         }
+    }
+
+    #[test]
+    fn intel_vendor_id_from_pnp_device_id() {
+        assert!(contains_intel_vendor_id(
+            r"PCI\VEN_8086&DEV_9A49&SUBSYS_00000000"
+        ));
+        assert!(contains_intel_vendor_id(
+            r"pci\ven_8086&dev_9a49&subsys_00000000"
+        ));
+        assert!(!contains_intel_vendor_id(
+            r"PCI\VEN_10DE&DEV_2504&SUBSYS_00000000"
+        ));
+        assert!(!contains_intel_vendor_id(r"PCI\DEV_8086&SUBSYS_00000000"));
+    }
+
+    #[test]
+    fn windows_display_adapter_registry_class() {
+        assert!(is_windows_display_adapter(Some("Display"), None));
+        assert!(is_windows_display_adapter(Some("display"), None));
+        assert!(is_windows_display_adapter(
+            None,
+            Some("{4D36E968-E325-11CE-BFC1-08002BE10318}")
+        ));
+        assert!(!is_windows_display_adapter(
+            Some("Net"),
+            Some("{4d36e972-e325-11ce-bfc1-08002be10318}")
+        ));
     }
 }

--- a/crates/uv-torch/src/accelerator.rs
+++ b/crates/uv-torch/src/accelerator.rs
@@ -7,14 +7,19 @@ use uv_pep440::Version;
 use uv_static::EnvVars;
 
 #[cfg(windows)]
-use windows_registry::LOCAL_MACHINE;
+use windows::Win32::Devices::DeviceAndDriverInstallation::{
+    CM_GETIDLIST_FILTER_CLASS, CM_GETIDLIST_FILTER_PRESENT, CM_Get_Device_ID_List_SizeW,
+    CM_Get_Device_ID_ListW, CR_SUCCESS,
+};
 
 // Constants used for PCI device detection.
 const PCI_BASE_CLASS_MASK: u32 = 0x00ff_0000;
 const PCI_BASE_CLASS_DISPLAY: u32 = 0x0003_0000;
 const PCI_VENDOR_ID_INTEL: u32 = 0x8086;
-#[cfg(any(windows, test))]
-const WINDOWS_DISPLAY_ADAPTER_CLASS_GUID: &str = "{4d36e968-e325-11ce-bfc1-08002be10318}";
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
+#[cfg(windows)]
+const WINDOWS_DISPLAY_ADAPTER_CLASS_GUID: windows::core::PCWSTR =
+    windows::core::w!("{4d36e968-e325-11ce-bfc1-08002be10318}");
 
 #[derive(Debug, thiserror::Error)]
 pub enum AcceleratorError {
@@ -70,7 +75,7 @@ impl Accelerator {
     /// 5. `nvidia-smi --query-gpu=driver_version --format=csv,noheader`.
     /// 6. `rocm_agent_enumerator`, which lists the AMD GPU architectures.
     /// 7. `/sys/bus/pci/devices`, filtering for the Intel GPU via PCI.
-    /// 8. The Windows registry, filtering for the Intel GPU via PCI.
+    /// 8. The Windows device tree, filtering for present Intel display adapters via PCI.
     pub fn detect() -> Result<Option<Self>, AcceleratorError> {
         // Read from `UV_CUDA_DRIVER_VERSION`.
         if let Ok(driver_version) = std::env::var(EnvVars::UV_CUDA_DRIVER_VERSION) {
@@ -196,9 +201,11 @@ impl Accelerator {
             Err(e) => return Err(e.into()),
         }
 
-        // Detect Intel GPU via the Windows registry.
+        // Detect Intel GPU via present Windows display adapters.
+        // TODO: Consider rejecting display adapters with disabled/problem devnode status.
+        // See: `CM_Locate_DevNodeW` + `CM_Get_DevNode_Status`
         #[cfg(windows)]
-        if detect_intel_gpu_from_windows_registry() {
+        if detect_intel_gpu_from_windows_devices() {
             return Ok(Some(Self::Xpu));
         }
 
@@ -249,66 +256,49 @@ fn parse_pci_device_ids(device_path: &Path) -> Result<(u32, u32), AcceleratorErr
 }
 
 #[cfg(windows)]
-fn detect_intel_gpu_from_windows_registry() -> bool {
-    let pci_devices = match LOCAL_MACHINE.open(r"SYSTEM\CurrentControlSet\Enum\PCI") {
-        Ok(pci_devices) => pci_devices,
-        Err(err) => {
-            debug!("Failed to open Windows PCI registry key: {err}");
-            return false;
-        }
+#[allow(unsafe_code)]
+fn detect_intel_gpu_from_windows_devices() -> bool {
+    const FLAGS: u32 = CM_GETIDLIST_FILTER_CLASS | CM_GETIDLIST_FILTER_PRESENT;
+
+    let mut device_ids_len = 0;
+    // SAFETY: The class GUID is a static null-terminated UTF-16 string, `device_ids_len` is a
+    // valid out pointer, and Configuration Manager writes only that scalar result here.
+    let result = unsafe {
+        CM_Get_Device_ID_List_SizeW(
+            &mut device_ids_len,
+            WINDOWS_DISPLAY_ADAPTER_CLASS_GUID,
+            FLAGS,
+        )
     };
+    if result != CR_SUCCESS {
+        debug!("Failed to query Windows display adapter device list length: {result:?}");
+        return false;
+    }
 
-    let device_ids = match pci_devices.keys() {
-        Ok(device_ids) => device_ids,
-        Err(err) => {
-            debug!("Failed to enumerate Windows PCI registry devices: {err}");
-            return false;
-        }
+    let Ok(device_ids_len) = usize::try_from(device_ids_len) else {
+        debug!("Windows display adapter device list length does not fit in memory");
+        return false;
     };
+    let mut encoded_device_ids = vec![0; device_ids_len];
 
-    for device_id in device_ids {
-        if !contains_intel_vendor_id(&device_id) {
-            continue;
-        }
+    // SAFETY: The class GUID is a static null-terminated UTF-16 string, and the writable buffer
+    // length matches the size returned by `CM_Get_Device_ID_List_SizeW` for the same filter.
+    let result = unsafe {
+        CM_Get_Device_ID_ListW(
+            WINDOWS_DISPLAY_ADAPTER_CLASS_GUID,
+            &mut encoded_device_ids,
+            FLAGS,
+        )
+    };
+    if result != CR_SUCCESS {
+        debug!("Failed to query present Windows display adapters: {result:?}");
+        return false;
+    }
 
-        let device = match pci_devices.open(&device_id) {
-            Ok(device) => device,
-            Err(err) => {
-                debug!("Failed to open Windows PCI registry device `{device_id}`: {err}");
-                continue;
-            }
-        };
-
-        let instance_ids = match device.keys() {
-            Ok(instance_ids) => instance_ids,
-            Err(err) => {
-                debug!(
-                    "Failed to enumerate Windows PCI registry instances for `{device_id}`: {err}"
-                );
-                continue;
-            }
-        };
-
-        for instance_id in instance_ids {
-            let instance = match device.open(&instance_id) {
-                Ok(instance) => instance,
-                Err(err) => {
-                    debug!(
-                        "Failed to open Windows PCI registry instance `{device_id}\\{instance_id}`: {err}"
-                    );
-                    continue;
-                }
-            };
-
-            let class = instance.get_string("Class").ok();
-            let class_guid = instance.get_string("ClassGUID").ok();
-            if is_windows_display_adapter(class.as_deref(), class_guid.as_deref()) {
-                let name = instance.get_string("DeviceDesc").ok();
-                debug!(
-                    "Detected Intel GPU from Windows registry: DeviceID={device_id}, InstanceID={instance_id}, Name={name:?}"
-                );
-                return true;
-            }
+    for device_id in windows_device_ids(&encoded_device_ids) {
+        if contains_intel_vendor_id(&device_id) {
+            debug!("Detected Intel GPU from present Windows display adapter: {device_id}");
+            return true;
         }
     }
 
@@ -323,10 +313,16 @@ fn contains_intel_vendor_id(pnp_device_id: &str) -> bool {
 }
 
 #[cfg(any(windows, test))]
-fn is_windows_display_adapter(class: Option<&str>, class_guid: Option<&str>) -> bool {
-    class.is_some_and(|class| class.eq_ignore_ascii_case("Display"))
-        || class_guid.is_some_and(|class_guid| {
-            class_guid.eq_ignore_ascii_case(WINDOWS_DISPLAY_ADAPTER_CLASS_GUID)
+fn windows_device_ids(encoded_device_ids: &[u16]) -> impl Iterator<Item = String> + '_ {
+    encoded_device_ids
+        .split(|code_unit| *code_unit == 0)
+        .filter(|device_id| !device_id.is_empty())
+        .filter_map(|device_id| match String::from_utf16(device_id) {
+            Ok(device_id) => Some(device_id),
+            Err(err) => {
+                debug!("Failed to decode Windows device instance ID: {err}");
+                None
+            }
         })
 }
 
@@ -442,16 +438,19 @@ mod tests {
     }
 
     #[test]
-    fn windows_display_adapter_registry_class() {
-        assert!(is_windows_display_adapter(Some("Display"), None));
-        assert!(is_windows_display_adapter(Some("display"), None));
-        assert!(is_windows_display_adapter(
-            None,
-            Some("{4D36E968-E325-11CE-BFC1-08002BE10318}")
-        ));
-        assert!(!is_windows_display_adapter(
-            Some("Net"),
-            Some("{4d36e972-e325-11ce-bfc1-08002be10318}")
-        ));
+    fn windows_device_instance_ids() {
+        let intel_gpu = r"PCI\VEN_8086&DEV_9A49&SUBSYS_00000000\3&11583659&0&10";
+        let nvidia_gpu = r"PCI\VEN_10DE&DEV_2504&SUBSYS_00000000\4&12AB34CD&0&0008";
+
+        let mut encoded_device_ids = Vec::new();
+        encoded_device_ids.extend(intel_gpu.encode_utf16());
+        encoded_device_ids.push(0);
+        encoded_device_ids.extend(nvidia_gpu.encode_utf16());
+        encoded_device_ids.extend([0, 0]);
+
+        assert_eq!(
+            windows_device_ids(&encoded_device_ids).collect::<Vec<_>>(),
+            vec![intel_gpu.to_string(), nvidia_gpu.to_string()]
+        );
     }
 }


### PR DESCRIPTION
## Summary

This is entirely written by Codex, but the intent is to use ~~`windows_registry`~~ the configuration manager APIs (from Win32) instead of `wmi` for Intel XPU detection. (We _only_ use `wmi` for this one use-case, which seems not-worth-it.)