### PR TITLE
Move Bazel auth helper setup into integration guide

### DIFF
--- a/docs/concepts/authentication/cli.md
+++ b/docs/concepts/authentication/cli.md
@@ -87,36 +87,8 @@ If no credentials are found, uv will return an empty set of headers:
     `uv auth helper` is experimental. Use `--preview-features auth-helper` or
     `UV_PREVIEW_FEATURES=auth-helper` to disable the warning.
 
-### Bazel
-
-Bazel 7 and newer supports credential helpers via the `--credential_helper` option. First,
-authenticate uv with the service that hosts the files Bazel needs to fetch:
-
-```console
-$ uv auth login https://packages.example.com
-```
-
-Then, configure Bazel to invoke uv for matching hosts:
-
-```text title=".bazelrc"
-common --credential_helper=packages.example.com=%workspace%/bazel/uv-auth-helper
-common --credential_helper=files.example.com=%workspace%/bazel/uv-auth-helper
-```
-
-Replace the host patterns with the hosts that serve the index and files Bazel will fetch.
-
-Finally, add the wrapper script referenced by `.bazelrc`:
-
-```bash title="bazel/uv-auth-helper"
-#!/usr/bin/env bash
-exec uv --preview-features auth-helper auth helper --protocol=bazel "$@"
-```
-
-The script must be executable:
-
-```console
-$ chmod +x bazel/uv-auth-helper
-```
+The [Bazel integration guide](../../guides/integration/bazel.md) explains how to use this command
+with Bazel.
 
 ## Configuring the storage backend
 

--- a/docs/guides/integration/bazel.md
+++ b/docs/guides/integration/bazel.md
@@ -1,0 +1,44 @@
+---
+title: Using uv with Bazel
+description:
+  Using uv to power package resolution with Bazel
+---
+
+# Using uv with Bazel
+
+For broader Bazel workflows with uv, see the
+[`rules_py` uv guide](https://github.com/aspect-build/rules_py#dependency-resolution-with-uv)
+or the
+[`rules_python` uv guide](https://rules-python.readthedocs.io/en/latest/pypi/lock.html#uv-pip-compile-bzlmod-only).
+
+## Authentication
+
+Bazel 7 and newer supports credential helpers via the `--credential_helper` option. To use
+credentials stored by uv for Bazel fetches, first authenticate uv with the service that hosts the
+files Bazel needs to fetch:
+
+```console
+$ uv auth login https://packages.example.com
+```
+
+Then, configure Bazel to invoke `uv auth helper` for matching hosts:
+
+```text title=".bazelrc"
+common --credential_helper=packages.example.com=%workspace%/bazel/uv-auth-helper
+common --credential_helper=files.example.com=%workspace%/bazel/uv-auth-helper
+```
+
+Replace the host patterns with the hosts that serve the index and files Bazel will fetch.
+
+Finally, add the wrapper script referenced by `.bazelrc`:
+
+```bash title="bazel/uv-auth-helper"
+#!/usr/bin/env bash
+exec uv --preview-features auth-helper auth helper --protocol=bazel "$@"
+```
+
+The script must be executable:
+
+```console
+$ chmod +x bazel/uv-auth-helper
+```

--- a/docs/guides/integration/bazel.md
+++ b/docs/guides/integration/bazel.md
@@ -21,7 +21,9 @@ files Bazel needs to fetch:
 $ uv auth login https://packages.example.com
 ```
 
-Then, configure Bazel to invoke `uv auth helper` for matching hosts:
+Then, configure Bazel to invoke
+[`uv auth helper`](../../concepts/authentication/cli.md#using-credentials-with-external-tools) for
+matching hosts:
 
 ```text title=".bazelrc"
 common --credential_helper=packages.example.com=%workspace%/bazel/uv-auth-helper

--- a/docs/guides/integration/bazel.md
+++ b/docs/guides/integration/bazel.md
@@ -1,14 +1,12 @@
 ---
 title: Using uv with Bazel
-description:
-  Using uv to power package resolution with Bazel
+description: Using uv to power package resolution with Bazel
 ---
 
 # Using uv with Bazel
 
 For broader Bazel workflows with uv, see the
-[`rules_py` uv guide](https://github.com/aspect-build/rules_py#dependency-resolution-with-uv)
-or the
+[`rules_py` uv guide](https://github.com/aspect-build/rules_py#dependency-resolution-with-uv) or the
 [`rules_python` uv guide](https://rules-python.readthedocs.io/en/latest/pypi/lock.html#uv-pip-compile-bzlmod-only).
 
 ## Authentication

--- a/docs/guides/integration/index.md
+++ b/docs/guides/integration/index.md
@@ -10,6 +10,7 @@ Learn how to integrate uv with other software:
 - [Using in GitLab CI/CD](./gitlab.md)
 - [Installing PyTorch](./pytorch.md)
 - [Building a FastAPI application](./fastapi.md)
+- [Using with Bazel](./bazel.md)
 - [Using with Azure Artifacts](./azure.md)
 - [Using with Google Artifact Registry](./google.md)
 - [Using with AWS CodeArtifact](./aws.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ plugins:
           - guides/integration/pre-commit.md
           - guides/integration/pytorch.md
           - guides/integration/fastapi.md
+          - guides/integration/bazel.md
           - guides/integration/azure.md
           - guides/integration/google.md
           - guides/integration/aws.md
@@ -203,6 +204,7 @@ nav:
           - Pre-commit: guides/integration/pre-commit.md
           - PyTorch: guides/integration/pytorch.md
           - FastAPI: guides/integration/fastapi.md
+          - Bazel: guides/integration/bazel.md
           - Azure Artifacts: guides/integration/azure.md
           - Google Artifact Registry: guides/integration/google.md
           - AWS CodeArtifact: guides/integration/aws.md


### PR DESCRIPTION
Make a new Bazel guide, that links to two of the most popular Bazel rulesets that support uv. Move the Bazel specific authentication setup to this new guide.

This is a followup to #19358 