### PR TITLE
Avoid parsing JSON manifest when local Python is available

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -176,6 +176,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ inputs.save-rust-cache == 'true' }}
+          cache-bin: false
       - name: "Build"
         run: cargo build --profile no-debug --bin uv --bin uvx
 

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -152,6 +152,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ inputs.save-rust-cache == 'true' }}
+          cache-bin: false
       - name: "Build"
         run: cargo build --profile no-debug --bin uv --bin uvx
 

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1,7 +1,6 @@
 use itertools::{Either, Itertools};
 use owo_colors::AnsiColors;
 use regex::Regex;
-use reqwest_retry::policies::ExponentialBackoff;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use same_file::is_same_file;
 use std::borrow::Cow;
@@ -12,7 +11,7 @@ use std::{path::Path, path::PathBuf, str::FromStr};
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use uv_cache::Cache;
-use uv_client::BaseClient;
+use uv_client::BaseClientBuilder;
 use uv_distribution_types::RequiresPython;
 use uv_fs::Simplified;
 use uv_fs::which::is_executable;
@@ -1391,19 +1390,19 @@ pub(crate) async fn find_best_python_installation(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     downloads_enabled: bool,
-    download_list: &ManagedPythonDownloadList,
-    client: &BaseClient,
-    retry_policy: &ExponentialBackoff,
+    client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
     reporter: Option<&dyn crate::downloads::Reporter>,
     python_install_mirror: Option<&str>,
     pypy_install_mirror: Option<&str>,
+    python_downloads_json_url: Option<&str>,
     preview: Preview,
 ) -> Result<PythonInstallation, crate::Error> {
     debug!("Starting Python discovery for {request}");
     let original_request = request;
 
     let mut previous_fetch_failed = false;
+    let mut download_state = None;
 
     let request_without_patch = match request {
         PythonRequest::Version(version) => {
@@ -1449,6 +1448,24 @@ pub(crate) async fn find_best_python_installation(
             && !previous_fetch_failed
             && let Some(download_request) = PythonDownloadRequest::from_request(request)
         {
+            let (client, retry_policy, download_list) =
+                if let Some(download_state) = &mut download_state {
+                    download_state
+                } else {
+                    let download_list_client = client_builder.build()?;
+                    let download_list = ManagedPythonDownloadList::new(
+                        &download_list_client,
+                        python_downloads_json_url,
+                    )
+                    .await?;
+                    let retry_policy = client_builder.retry_policy();
+
+                    // Python downloads are performing their own retries to catch stream errors, disable
+                    // the default retries to avoid the middleware performing uncontrolled retries.
+                    let client = client_builder.clone().retries(0).build()?;
+                    download_state.insert((client, retry_policy, download_list))
+                };
+
             let download = download_request
                 .clone()
                 .fill()

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -148,18 +148,13 @@ impl PythonInstallation {
 
         let err = match Self::find_existing(request, environments, preference, cache, preview) {
             Ok(installation) => {
-                if installation
-                    .outdated_prerelease_download_request(request)
-                    .is_some()
-                {
-                    // Python downloads are performing their own retries to catch stream errors,
-                    // disable the default retries to avoid the middleware performing uncontrolled
-                    // retries.
-                    let client = client_builder.clone().retries(0).build()?;
-                    let download_list =
-                        ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
-                    installation.warn_if_outdated_prerelease(request, &download_list);
-                }
+                installation
+                    .warn_if_outdated_prerelease_if_needed(
+                        request,
+                        client_builder,
+                        python_downloads_json_url,
+                    )
+                    .await?;
                 return Ok(installation);
             }
             Err(err) => err,
@@ -421,6 +416,8 @@ impl PythonInstallation {
         self.interpreter
     }
 
+    /// Return the stable-download request used to check whether an installed managed prerelease
+    /// should emit an upgrade warning.
     fn outdated_prerelease_download_request(
         &self,
         request: &PythonRequest,
@@ -464,14 +461,44 @@ impl PythonInstallation {
         request: &PythonRequest,
         download_list: &ManagedPythonDownloadList,
     ) {
+        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
+            return;
+        };
+
+        self.warn_if_outdated_prerelease_download(download_request, download_list);
+    }
+
+    /// Load download metadata only when a managed prerelease may need an upgrade warning.
+    async fn warn_if_outdated_prerelease_if_needed(
+        &self,
+        request: &PythonRequest,
+        client_builder: &BaseClientBuilder<'_>,
+        python_downloads_json_url: Option<&str>,
+    ) -> Result<(), Error> {
+        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
+            return Ok(());
+        };
+
+        // Python downloads are performing their own retries to catch stream errors, disable the
+        // default retries to avoid the middleware performing uncontrolled retries.
+        let client = client_builder.clone().retries(0).build()?;
+        let download_list =
+            ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
+        self.warn_if_outdated_prerelease_download(download_request, &download_list);
+
+        Ok(())
+    }
+
+    /// Emit the managed-prerelease warning when the provided download request has a stable match.
+    fn warn_if_outdated_prerelease_download(
+        &self,
+        download_request: PythonDownloadRequest,
+        download_list: &ManagedPythonDownloadList,
+    ) {
         let interpreter = self.interpreter();
         let version = interpreter.python_version();
 
         let release = version.only_release();
-
-        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
-            return;
-        };
 
         let has_stable_download = {
             let mut downloads = download_list.iter_matching(&download_request);

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -148,13 +148,15 @@ impl PythonInstallation {
 
         let err = match Self::find_existing(request, environments, preference, cache, preview) {
             Ok(installation) => {
-                installation
-                    .warn_if_outdated_prerelease_if_needed(
-                        request,
-                        client_builder,
-                        python_downloads_json_url,
-                    )
-                    .await?;
+                if installation.should_check_outdated_prerelease_warning(request) {
+                    // Python downloads are performing their own retries to catch stream errors,
+                    // disable the default retries to avoid the middleware performing uncontrolled
+                    // retries.
+                    let client = client_builder.clone().retries(0).build()?;
+                    let download_list =
+                        ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
+                    installation.warn_if_outdated_prerelease(request, &download_list);
+                }
                 return Ok(installation);
             }
             Err(err) => err,
@@ -416,24 +418,20 @@ impl PythonInstallation {
         self.interpreter
     }
 
-    /// Return the stable-download request used to check whether an installed managed prerelease
-    /// should emit an upgrade warning.
-    fn outdated_prerelease_download_request(
-        &self,
-        request: &PythonRequest,
-    ) -> Option<PythonDownloadRequest> {
+    /// Return `true` when checking for an outdated managed prerelease warning may be necessary.
+    fn should_check_outdated_prerelease_warning(&self, request: &PythonRequest) -> bool {
         if request.allows_prereleases() {
-            return None;
+            return false;
         }
 
         let interpreter = self.interpreter();
 
         if interpreter.python_version().pre().is_none() {
-            return None;
+            return false;
         }
 
         if !interpreter.is_managed() {
-            return None;
+            return false;
         }
 
         // Transparent upgrades only exist for CPython, so skip the warning for other
@@ -444,14 +442,10 @@ impl PythonInstallation {
             .implementation_name()
             .eq_ignore_ascii_case("cpython")
         {
-            return None;
+            return false;
         }
 
-        Some(
-            PythonDownloadRequest::try_from(&interpreter.key())
-                .ok()?
-                .with_prereleases(false),
-        )
+        true
     }
 
     /// Emit a warning when the interpreter is a managed prerelease and a matching stable
@@ -461,44 +455,20 @@ impl PythonInstallation {
         request: &PythonRequest,
         download_list: &ManagedPythonDownloadList,
     ) {
-        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
+        if !self.should_check_outdated_prerelease_warning(request) {
             return;
-        };
+        }
 
-        self.warn_if_outdated_prerelease_download(download_request, download_list);
-    }
-
-    /// Load download metadata only when a managed prerelease may need an upgrade warning.
-    async fn warn_if_outdated_prerelease_if_needed(
-        &self,
-        request: &PythonRequest,
-        client_builder: &BaseClientBuilder<'_>,
-        python_downloads_json_url: Option<&str>,
-    ) -> Result<(), Error> {
-        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
-            return Ok(());
-        };
-
-        // Python downloads are performing their own retries to catch stream errors, disable the
-        // default retries to avoid the middleware performing uncontrolled retries.
-        let client = client_builder.clone().retries(0).build()?;
-        let download_list =
-            ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
-        self.warn_if_outdated_prerelease_download(download_request, &download_list);
-
-        Ok(())
-    }
-
-    /// Emit the managed-prerelease warning when the provided download request has a stable match.
-    fn warn_if_outdated_prerelease_download(
-        &self,
-        download_request: PythonDownloadRequest,
-        download_list: &ManagedPythonDownloadList,
-    ) {
         let interpreter = self.interpreter();
         let version = interpreter.python_version();
 
         let release = version.only_release();
+
+        let Ok(download_request) = PythonDownloadRequest::try_from(&interpreter.key()) else {
+            return;
+        };
+
+        let download_request = download_request.with_prereleases(false);
 
         let has_stable_download = {
             let mut downloads = download_list.iter_matching(&download_request);

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -71,6 +71,7 @@ impl PythonInstallation {
         Ok(installation)
     }
 
+    /// Find an existing [`PythonInstallation`].
     fn find_existing(
         request: &PythonRequest,
         environments: EnvironmentPreference,
@@ -148,26 +149,20 @@ impl PythonInstallation {
 
         let err = match Self::find_existing(request, environments, preference, cache, preview) {
             Ok(installation) => {
+                // Avoid parsing the download list unless we need it to surface a warning.
                 if installation.should_check_outdated_prerelease_warning(request) {
-                    // Python downloads are performing their own retries to catch stream errors,
-                    // disable the default retries to avoid the middleware performing uncontrolled
-                    // retries.
-                    let client = client_builder.clone().retries(0).build()?;
-                    let download_list =
-                        ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
+                    let download_list_client = client_builder.build()?;
+                    let download_list = ManagedPythonDownloadList::new(
+                        &download_list_client,
+                        python_downloads_json_url,
+                    )
+                    .await?;
                     installation.warn_if_outdated_prerelease(request, &download_list);
                 }
                 return Ok(installation);
             }
             Err(err) => err,
         };
-
-        // Python downloads are performing their own retries to catch stream errors, disable the
-        // default retries to avoid the middleware performing uncontrolled retries.
-        let retry_policy = client_builder.retry_policy();
-        let client = client_builder.clone().retries(0).build()?;
-        let download_list =
-            ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
 
         match err {
             // If Python is missing, we should attempt a download
@@ -182,6 +177,11 @@ impl PythonInstallation {
         let Some(download_request) = PythonDownloadRequest::from_request(request) else {
             return Err(err);
         };
+
+        let download_list_client = client_builder.build()?;
+        let download_list =
+            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
+                .await?;
 
         let downloads_enabled = preference.allows_managed()
             && python_downloads.is_automatic()
@@ -269,9 +269,14 @@ impl PythonInstallation {
             return Err(err);
         }
 
+        // Python downloads are performing their own retries to catch stream errors, disable the
+        // default retries to avoid the middleware performing uncontrolled retries.
+        let retry_policy = client_builder.retry_policy();
+        let download_client = client_builder.clone().retries(0).build()?;
+
         let installation = Self::fetch(
             download,
-            &client,
+            &download_client,
             &retry_policy,
             cache,
             reporter,

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -72,7 +72,7 @@ impl PythonInstallation {
     }
 
     /// Find an existing [`PythonInstallation`].
-    fn find_existing(
+    pub fn find_existing(
         request: &PythonRequest,
         environments: EnvironmentPreference,
         preference: PythonPreference,
@@ -149,16 +149,13 @@ impl PythonInstallation {
 
         let err = match Self::find_existing(request, environments, preference, cache, preview) {
             Ok(installation) => {
-                // Avoid parsing the download list unless we need it to surface a warning.
-                if installation.should_check_outdated_prerelease_warning(request) {
-                    let download_list_client = client_builder.build()?;
-                    let download_list = ManagedPythonDownloadList::new(
-                        &download_list_client,
+                installation
+                    .download_and_warn_if_outdated_prerelease(
+                        request,
+                        client_builder,
                         python_downloads_json_url,
                     )
                     .await?;
-                    installation.warn_if_outdated_prerelease(request, &download_list);
-                }
                 return Ok(installation);
             }
             Err(err) => err,
@@ -504,6 +501,30 @@ impl PythonInstallation {
                 version,
             );
         }
+    }
+
+    /// Emit a warning when the interpreter is a managed prerelease and a matching stable
+    /// build can be installed via `uv python upgrade`.
+    ///
+    /// Avoids loading the Python download list unless the discovered interpreter could require
+    /// the warning.
+    pub async fn download_and_warn_if_outdated_prerelease(
+        &self,
+        request: &PythonRequest,
+        client_builder: &BaseClientBuilder<'_>,
+        python_downloads_json_url: Option<&str>,
+    ) -> Result<(), Error> {
+        if !self.should_check_outdated_prerelease_warning(request) {
+            return Ok(());
+        }
+
+        let download_list_client = client_builder.build()?;
+        let download_list =
+            ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url)
+                .await?;
+        self.warn_if_outdated_prerelease(request, &download_list);
+
+        Ok(())
     }
 }
 

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -66,10 +66,25 @@ impl PythonInstallation {
         cache: &Cache,
         preview: Preview,
     ) -> Result<Self, Error> {
-        let installation =
-            find_python_installation(request, environments, preference, cache, preview)??;
+        let installation = Self::find_existing(request, environments, preference, cache, preview)?;
         installation.warn_if_outdated_prerelease(request, download_list);
         Ok(installation)
+    }
+
+    fn find_existing(
+        request: &PythonRequest,
+        environments: EnvironmentPreference,
+        preference: PythonPreference,
+        cache: &Cache,
+        preview: Preview,
+    ) -> Result<Self, Error> {
+        Ok(find_python_installation(
+            request,
+            environments,
+            preference,
+            cache,
+            preview,
+        )??)
     }
 
     /// Find or download a [`PythonInstallation`] that satisfies a requested version, if the request
@@ -131,25 +146,31 @@ impl PythonInstallation {
     ) -> Result<Self, Error> {
         let request = request.unwrap_or(&PythonRequest::Default);
 
+        let err = match Self::find_existing(request, environments, preference, cache, preview) {
+            Ok(installation) => {
+                if installation
+                    .outdated_prerelease_download_request(request)
+                    .is_some()
+                {
+                    // Python downloads are performing their own retries to catch stream errors,
+                    // disable the default retries to avoid the middleware performing uncontrolled
+                    // retries.
+                    let client = client_builder.clone().retries(0).build()?;
+                    let download_list =
+                        ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
+                    installation.warn_if_outdated_prerelease(request, &download_list);
+                }
+                return Ok(installation);
+            }
+            Err(err) => err,
+        };
+
         // Python downloads are performing their own retries to catch stream errors, disable the
         // default retries to avoid the middleware performing uncontrolled retries.
         let retry_policy = client_builder.retry_policy();
         let client = client_builder.clone().retries(0).build()?;
         let download_list =
             ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
-
-        // Search for the installation
-        let err = match Self::find(
-            request,
-            environments,
-            preference,
-            &download_list,
-            cache,
-            preview,
-        ) {
-            Ok(installation) => return Ok(installation),
-            Err(err) => err,
-        };
 
         match err {
             // If Python is missing, we should attempt a download
@@ -400,26 +421,22 @@ impl PythonInstallation {
         self.interpreter
     }
 
-    /// Emit a warning when the interpreter is a managed prerelease and a matching stable
-    /// build can be installed via `uv python upgrade`.
-    pub(crate) fn warn_if_outdated_prerelease(
+    fn outdated_prerelease_download_request(
         &self,
         request: &PythonRequest,
-        download_list: &ManagedPythonDownloadList,
-    ) {
+    ) -> Option<PythonDownloadRequest> {
         if request.allows_prereleases() {
-            return;
+            return None;
         }
 
         let interpreter = self.interpreter();
-        let version = interpreter.python_version();
 
-        if version.pre().is_none() {
-            return;
+        if interpreter.python_version().pre().is_none() {
+            return None;
         }
 
         if !interpreter.is_managed() {
-            return;
+            return None;
         }
 
         // Transparent upgrades only exist for CPython, so skip the warning for other
@@ -430,16 +447,31 @@ impl PythonInstallation {
             .implementation_name()
             .eq_ignore_ascii_case("cpython")
         {
-            return;
+            return None;
         }
+
+        Some(
+            PythonDownloadRequest::try_from(&interpreter.key())
+                .ok()?
+                .with_prereleases(false),
+        )
+    }
+
+    /// Emit a warning when the interpreter is a managed prerelease and a matching stable
+    /// build can be installed via `uv python upgrade`.
+    pub(crate) fn warn_if_outdated_prerelease(
+        &self,
+        request: &PythonRequest,
+        download_list: &ManagedPythonDownloadList,
+    ) {
+        let interpreter = self.interpreter();
+        let version = interpreter.python_version();
 
         let release = version.only_release();
 
-        let Ok(download_request) = PythonDownloadRequest::try_from(&interpreter.key()) else {
+        let Some(download_request) = self.outdated_prerelease_download_request(request) else {
             return;
         };
-
-        let download_request = download_request.with_prereleases(false);
 
         let has_stable_download = {
             let mut downloads = download_list.iter_matching(&download_request);

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -103,10 +103,6 @@ impl PythonInstallation {
         python_downloads_json_url: Option<&str>,
         preview: Preview,
     ) -> Result<Self, Error> {
-        let retry_policy = client_builder.retry_policy();
-        let client = client_builder.clone().retries(0).build()?;
-        let download_list =
-            ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
         let downloads_enabled = preference.allows_managed()
             && python_downloads.is_automatic()
             && client_builder.connectivity.is_online();
@@ -115,17 +111,22 @@ impl PythonInstallation {
             environments,
             preference,
             downloads_enabled,
-            &download_list,
-            &client,
-            &retry_policy,
+            client_builder,
             cache,
             reporter,
             python_install_mirror,
             pypy_install_mirror,
+            python_downloads_json_url,
             preview,
         )
         .await?;
-        installation.warn_if_outdated_prerelease(request, &download_list);
+        installation
+            .download_and_warn_if_outdated_prerelease(
+                request,
+                client_builder,
+                python_downloads_json_url,
+            )
+            .await?;
         Ok(installation)
     }
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -146,9 +146,8 @@ mod tests {
 
     use crate::{
         PythonDownloads, PythonNotFound, PythonRequest, PythonSource, PythonVersion,
-        downloads::ManagedPythonDownloadList, implementation::ImplementationName,
-        installation::PythonInstallation, managed::ManagedPythonInstallations,
-        virtualenv::virtualenv_python_executable,
+        implementation::ImplementationName, installation::PythonInstallation,
+        managed::ManagedPythonInstallations, virtualenv::virtualenv_python_executable,
     };
     use crate::{
         PythonPreference,
@@ -1052,12 +1051,6 @@ mod tests {
         preview: Preview,
     ) -> Result<PythonInstallation, crate::Error> {
         let client_builder = BaseClientBuilder::default();
-        let download_list = ManagedPythonDownloadList::new_only_embedded()?;
-        let client = client_builder
-            .clone()
-            .retries(0)
-            .build()
-            .expect("failed to build base client");
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1067,10 +1060,9 @@ mod tests {
                 environments,
                 preference,
                 false,
-                &download_list,
-                &client,
-                &client_builder.retry_policy(),
+                &client_builder,
                 cache,
+                None,
                 None,
                 None,
                 None,

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -145,7 +145,7 @@ mod tests {
     use uv_cache::Cache;
 
     use crate::{
-        PythonNotFound, PythonRequest, PythonSource, PythonVersion,
+        PythonDownloads, PythonNotFound, PythonRequest, PythonSource, PythonVersion,
         downloads::ManagedPythonDownloadList, implementation::ImplementationName,
         installation::PythonInstallation, managed::ManagedPythonInstallations,
         virtualenv::virtualenv_python_executable,
@@ -647,6 +647,52 @@ mod tests {
                 }
             ),
             "We should find the valid executable; got {interpreter:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_or_download_skips_download_metadata_when_python_is_found() -> Result<()> {
+        let mut context = TestContext::new()?;
+        context.add_python_versions(&["3.12.1"])?;
+        let missing_downloads = context.tempdir.child("missing-downloads.json");
+
+        let interpreter = context.run(|| {
+            let client_builder = BaseClientBuilder::default();
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to build runtime")
+                .block_on(PythonInstallation::find_or_download(
+                    None,
+                    EnvironmentPreference::OnlySystem,
+                    PythonPreference::OnlySystem,
+                    PythonDownloads::Never,
+                    &client_builder,
+                    &context.cache,
+                    None,
+                    None,
+                    None,
+                    missing_downloads.path().to_str(),
+                    Preview::default(),
+                ))
+        })?;
+
+        assert!(
+            matches!(
+                interpreter,
+                PythonInstallation {
+                    source: PythonSource::SearchPathFirst,
+                    interpreter: _
+                }
+            ),
+            "We should find the local Python without reading download metadata; got {interpreter:?}"
+        );
+        assert_eq!(
+            &interpreter.interpreter().python_full_version().to_string(),
+            "3.12.1",
+            "We should find the local interpreter"
         );
 
         Ok(())

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -656,6 +656,8 @@ mod tests {
     fn find_or_download_skips_download_metadata_when_python_is_found() -> Result<()> {
         let mut context = TestContext::new()?;
         context.add_python_versions(&["3.12.1"])?;
+        // Pass a missing metadata file to assert that an already-installed Python can
+        // be returned without reading the download list.
         let missing_downloads = context.tempdir.child("missing-downloads.json");
 
         let interpreter = context.run(|| {

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -7,7 +7,6 @@ use uv_client::BaseClientBuilder;
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_fs::Simplified;
 use uv_preview::Preview;
-use uv_python::downloads::ManagedPythonDownloadList;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
 };
@@ -78,18 +77,21 @@ pub(crate) async fn find(
     )
     .await?;
 
-    let download_list_client = client_builder.build()?;
-    let download_list =
-        ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url).await?;
-
-    let python = PythonInstallation::find(
-        &python_request.unwrap_or_default(),
+    let python_request = python_request.unwrap_or_default();
+    let python = PythonInstallation::find_existing(
+        &python_request,
         environment_preference,
         python_preference,
-        &download_list,
         cache,
         preview,
     )?;
+    python
+        .download_and_warn_if_outdated_prerelease(
+            &python_request,
+            client_builder,
+            python_downloads_json_url,
+        )
+        .await?;
 
     // Warn if the discovered Python version is incompatible with the current workspace
     if let Some(requires_python) = requires_python {

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -78,8 +78,9 @@ pub(crate) async fn find(
     )
     .await?;
 
-    let client = client_builder.clone().retries(0).build()?;
-    let download_list = ManagedPythonDownloadList::new(&client, python_downloads_json_url).await?;
+    let download_list_client = client_builder.build()?;
+    let download_list =
+        ManagedPythonDownloadList::new(&download_list_client, python_downloads_json_url).await?;
 
     let python = PythonInstallation::find(
         &python_request.unwrap_or_default(),

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -93,20 +93,30 @@ pub(crate) async fn pin(
     let Some(request) = request else {
         // Display the current pinned Python version
         if let Some(file) = version_file? {
-            for pin in file.versions() {
-                writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
-                if let Some(virtual_project) = &virtual_project {
-                    let download_list_client = client_builder.build()?;
-                    let download_list = ManagedPythonDownloadList::new(
+            let mut pins = file.versions().peekable();
+            let download_list = if virtual_project.is_some() && pins.peek().is_some() {
+                let download_list_client = client_builder.build()?;
+                Some(
+                    ManagedPythonDownloadList::new(
                         &download_list_client,
                         install_mirrors.python_downloads_json_url.as_deref(),
                     )
-                    .await?;
+                    .await?,
+                )
+            } else {
+                None
+            };
+
+            for pin in pins {
+                writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
+                if let Some(virtual_project) = &virtual_project
+                    && let Some(download_list) = &download_list
+                {
                     warn_if_existing_pin_incompatible_with_project(
                         pin,
                         virtual_project,
                         python_preference,
-                        &download_list,
+                        download_list,
                         cache,
                         preview,
                     );

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -96,9 +96,9 @@ pub(crate) async fn pin(
             for pin in file.versions() {
                 writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
                 if let Some(virtual_project) = &virtual_project {
-                    let client = client_builder.clone().retries(0).build()?;
+                    let download_list_client = client_builder.build()?;
                     let download_list = ManagedPythonDownloadList::new(
-                        &client,
+                        &download_list_client,
                         install_mirrors.python_downloads_json_url.as_deref(),
                     )
                     .await?;
@@ -268,8 +268,8 @@ fn warn_if_existing_pin_incompatible_with_project(
         }
     }
 
-    // If there is not a version in the pinned request, attempt to resolve the pin into an
-    // interpreter to check for compatibility on the current system.
+    // If the request itself didn't prove an incompatibility, resolve the pin into an
+    // interpreter to check the concrete version on the current system.
     match PythonInstallation::find(
         pin,
         EnvironmentPreference::OnlySystem,

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -151,6 +151,24 @@ fn python_find() {
 }
 
 #[test]
+fn python_find_skips_download_metadata_when_python_is_found() {
+    let context = uv_test::test_context_with_versions!(&["3.12"]);
+    let missing_downloads = context.temp_dir.child("missing-downloads.json");
+
+    uv_snapshot!(context.filters(), context
+        .python_find()
+        .arg("--python-downloads-json-url")
+        .arg(missing_downloads.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-3.12]
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn python_find_pin() {
     let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
 

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -8,6 +8,7 @@ use uv_platform::{Arch, Os};
 use uv_python::{PYTHON_VERSION_FILENAME, PYTHON_VERSIONS_FILENAME};
 use uv_static::EnvVars;
 use uv_test::uv_snapshot;
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
 
 #[test]
 fn python_pin() {
@@ -201,6 +202,49 @@ fn python_pin_uses_python_downloads_json_url() {
     ----- stderr -----
     error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
     ");
+}
+
+#[tokio::test]
+async fn python_pin_downloads_metadata_once_for_multiple_pins() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);
+
+    context.temp_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+        dependencies = []
+        "#,
+    )?;
+
+    context
+        .temp_dir
+        .child(PYTHON_VERSION_FILENAME)
+        .write_str("3.11\n3.12\n")?;
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("{}", "application/json"))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .python_pin()
+        .arg("--python-downloads-json-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11
+    3.12
+
+    ----- stderr -----
+    ");
+
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+
+    Ok(())
 }
 
 // If there is no project-level `.python-version` file, respect the global pin.


### PR DESCRIPTION
## Summary

Right now, it appears that we parse the JSON manifest for ~every lock and sync (I _think_ this regressed in b9826778b). By avoiding that work, this PR improves (warm) `uv lock` from 38.94ms to 24.06ms (38.2% faster!), and (warm) `uv sync` from 146.96ms to 129.80ms.

Note that we _do_ need to read it if you're using a pre-release, since we have this dedicated pre-release warning.

Closes https://github.com/astral-sh/uv/issues/19397.
