### PR TITLE
Detect quoted keys with TOML 1.1 escapes in them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7276,7 +7276,7 @@ dependencies = [
 
 [[package]]
 name = "uv-toml"
-version = "0.0.40"
+version = "0.0.45"
 dependencies = [
  "toml_datetime",
  "toml_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ uv-small-str = { version = "0.0.45", path = "crates/uv-small-str" }
 uv-state = { version = "0.0.45", path = "crates/uv-state" }
 uv-static = { version = "0.0.45", path = "crates/uv-static" }
 uv-test = { version = "0.0.45", path = "crates/uv-test" }
-uv-toml = { version = "0.0.40", path = "crates/uv-toml" }
+uv-toml = { version = "0.0.45", path = "crates/uv-toml" }
 uv-tool = { version = "0.0.45", path = "crates/uv-tool" }
 uv-torch = { version = "0.0.45", path = "crates/uv-torch" }
 uv-trampoline-builder = { version = "0.0.45", path = "crates/uv-trampoline-builder" }

--- a/crates/uv-toml/Cargo.toml
+++ b/crates/uv-toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-toml"
-version = "0.0.40"
+version = "0.0.45"
 description = "This is an internal component crate of uv"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/uv-toml/README.md
+++ b/crates/uv-toml/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [uv](https://crates.io/crates/uv). The Rust API exposed here
 is unstable and will have frequent breaking changes.
 
-This version (0.0.40) is a component of [uv 0.11.12](https://crates.io/crates/uv/0.11.12). The
+This version (0.0.45) is a component of [uv 0.11.12](https://crates.io/crates/uv/0.11.12). The
 source can be found [here](https://github.com/astral-sh/uv/blob/0.11.12/crates/uv-toml).
 
 See uv's

--- a/crates/uv-toml/src/lib.rs
+++ b/crates/uv-toml/src/lib.rs
@@ -110,8 +110,15 @@ impl EventReceiver for DetectToml11<'_> {
         self.state.pop();
     }
 
-    fn simple_key(&mut self, _span: Span, _kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
+    fn simple_key(&mut self, span: Span, kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
         self.set_sep(false);
+
+        if matches!(kind, Some(Encoding::BasicString | Encoding::MlBasicString))
+            && has_toml11_escapes(self.raw_at(span))
+        {
+            // TOML 1.1 introduces new escape sequences
+            self.flag_11();
+        }
     }
 
     fn scalar(&mut self, span: Span, kind: Option<Encoding>, _error: &mut dyn ErrorSink) {
@@ -249,6 +256,16 @@ mod tests {
     #[test]
     fn features_hex_escape() {
         assert!(has_toml11_features("x = \"val \\x41\"\n"));
+    }
+
+    #[test]
+    fn features_hex_escape_in_quoted_key() {
+        assert!(has_toml11_features("\"\\x62ar\" = \"baz\"\n"));
+    }
+
+    #[test]
+    fn features_hex_escape_in_dotted_quoted_key() {
+        assert!(has_toml11_features("foo.\"\\x62ar\" = \"baz\"\n"));
     }
 
     #[test]

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -205,9 +205,11 @@ By default, uv excludes `__pycache__`, `*.pyc`, and `*.pyo`.
 
 When building a source distribution, the following files and directories are included:
 
-- The `pyproject.toml`. With the `toml-backwards-compatibility` preview feature enabled, the
-  `pyproject.toml` is reformatted for backwards compatibility, and the original file is preserved as
-  `pyproject.toml.orig`. This will be automatically enabled in the next breaking release.
+- The `pyproject.toml`. If uv detects TOML 1.1-only syntax, it issues a warning and automatically
+  enables the `toml-backwards-compatibility` preview feature: the `pyproject.toml` is reformatted
+  for backwards compatibility, and the original file is preserved as `pyproject.toml.orig`. Pass
+  `--preview-feature toml-backwards-compatibility` to enable the feature explicitly and suppress the
+  warning.
 - The [module](#modules) under
   [`tool.uv.build-backend.module-root`](../reference/settings.md#build-backend_module-root).
 - The files referenced by `project.license-files` and `project.readme`.


### PR DESCRIPTION
Stacked on #18741 and #19338.

Fix up the documentation, fix up the uv-toml package version, and detect TOML 1.1 escapes inside quoted keys.