### PR TITLE
Verify created junctions

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -78,6 +78,63 @@ pub async fn read_to_string_transcode(path: impl AsRef<Path>) -> std::io::Result
     Ok(buf)
 }
 
+/// Create a junction at `path` pointing to `target`.
+///
+/// Junctions can be silently broken when involving network paths or non-NTFS filesystems.
+///
+/// If creation fails but leaves behind an empty directory, it is cleaned up and the original
+/// creation error is propagated.
+#[cfg(windows)]
+fn create_junction(target: &Path, path: &Path) -> std::io::Result<()> {
+    use windows::Win32::Foundation::{
+        ERROR_ALREADY_EXISTS, ERROR_INVALID_NAME, ERROR_INVALID_PARAMETER,
+        ERROR_INVALID_REPARSE_DATA, ERROR_NOT_A_REPARSE_POINT, WIN32_ERROR,
+    };
+
+    let create_result = junction::create(target, path);
+
+    match path.metadata() {
+        Ok(_) if create_result.is_ok() => Ok(()),
+        Ok(_) => {
+            // Creation failed but left behind an empty directory. Only clean
+            // it up if the directory wasn't already there before we tried.
+            if let Err(ref create_err) = create_result {
+                if !matches!(
+                    create_err
+                        .raw_os_error()
+                        .map(|err| WIN32_ERROR(err.cast_unsigned())),
+                    Some(ERROR_ALREADY_EXISTS)
+                ) {
+                    // Not a junction (metadata succeeded normally), just
+                    // an empty directory left behind by junction::create.
+                    let _ = fs_err::remove_dir(path);
+                }
+            }
+            create_result
+        }
+        Err(err)
+            if matches!(
+                err.raw_os_error()
+                    .map(|err| WIN32_ERROR(err.cast_unsigned())),
+                Some(
+                    ERROR_INVALID_PARAMETER
+                        | ERROR_INVALID_NAME
+                        | ERROR_NOT_A_REPARSE_POINT
+                        | ERROR_INVALID_REPARSE_DATA
+                )
+            ) =>
+        {
+            // Broken reparse point. Once junction::delete strips the reparse data, only an empty
+            // directory shell remains.
+            if junction::delete(path).is_ok() {
+                let _ = fs_err::remove_dir(path);
+            }
+            Err(create_result.err().unwrap_or(err))
+        }
+        Err(err) => Err(create_result.err().unwrap_or(err)),
+    }
+}
+
 /// Create a directory link at `dst` pointing to `src`, replacing any existing link.
 ///
 /// On Windows, this normally creates an NTFS junction, since junctions don't
@@ -128,7 +185,7 @@ fn replace_with_junction(src: &Path, dst: &Path) -> std::io::Result<()> {
     }
 
     // Replace it with a new junction.
-    junction::create(dunce::simplified(src), dunce::simplified(dst))
+    create_junction(src, dst)
 }
 
 #[cfg(windows)]
@@ -218,7 +275,7 @@ pub fn create_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::
     if uv_windows::is_wine() {
         fs_err::os::windows::fs::symlink_dir(dunce::simplified(src), dunce::simplified(dst))
     } else {
-        junction::create(dunce::simplified(src), dunce::simplified(dst))
+        create_junction(src, dst)
     }
 }
 


### PR DESCRIPTION
## Summary

Verify Windows junction creation after `junction::create`.

If junction creation leaves behind a broken reparse point or empty directory, clean it up and return the original creation error instead of leaving a broken link behind.

## Test Plan

Tested manually on windows, requires setting up a network or WINFSP drive to really test. Planning on actually making that happen in CI.