### PR TITLE
Vendor netrc parser crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6717,6 +6717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-netrc"
+version = "0.0.47"
+dependencies = [
+ "fs-err",
+ "shellexpand",
+ "temp-env",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "uv-normalize"
 version = "0.0.47"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -227,7 +227,7 @@ dependencies = [
  "log",
  "priority-queue",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ dependencies = [
  "http",
  "reqwest",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tower-service",
 ]
 
@@ -260,7 +260,7 @@ dependencies = [
  "hyper",
  "reqwest",
  "retry-policies",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "wasmtimer",
@@ -312,7 +312,7 @@ dependencies = [
  "itertools 0.14.0",
  "memmap2",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -329,7 +329,7 @@ dependencies = [
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
 ]
@@ -447,7 +447,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
  "walkdir",
 ]
@@ -459,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
 dependencies = [
  "miette",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -471,7 +471,7 @@ checksum = "dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b"
 dependencies = [
  "miette",
  "semver",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -489,7 +489,7 @@ dependencies = [
  "self-replace",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "url",
 ]
@@ -1160,7 +1160,7 @@ dependencies = [
  "serde_json",
  "spdx",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "uuid",
  "xml-rs",
@@ -2448,7 +2448,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -3490,7 +3490,7 @@ checksum = "60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad"
 dependencies = [
  "hex",
  "percent-encoding",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3529,7 +3529,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3551,7 +3551,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3719,7 +3719,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4093,16 +4093,6 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
-]
-
-[[package]]
-name = "rust-netrc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9"
-dependencies = [
- "shellexpand",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4641,7 +4631,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -5008,31 +4998,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5757,7 +5727,7 @@ dependencies = [
  "tar",
  "tempfile",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5842,7 +5812,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "uv-client",
@@ -5874,14 +5844,13 @@ dependencies = [
  "percent-encoding",
  "reqsign",
  "reqwest",
- "rust-netrc",
  "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
  "tempfile",
  "test-log",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -5889,6 +5858,7 @@ dependencies = [
  "uv-cache-key",
  "uv-fs",
  "uv-keyring",
+ "uv-netrc",
  "uv-once-map",
  "uv-preview",
  "uv-redacted",
@@ -5939,7 +5909,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "url",
@@ -5994,7 +5964,7 @@ dependencies = [
  "spdx",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "uv-distribution-filename",
@@ -6028,7 +5998,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "toml_edit",
  "tracing",
@@ -6061,7 +6031,7 @@ dependencies = [
  "same-file",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uv-cache-info",
  "uv-cache-key",
@@ -6086,7 +6056,7 @@ dependencies = [
  "schemars",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "uv-fs",
@@ -6176,7 +6146,7 @@ dependencies = [
  "serde_json",
  "temp-env",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -6225,7 +6195,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -6318,7 +6288,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "uv-build-backend",
@@ -6360,7 +6330,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "toml",
@@ -6403,7 +6373,7 @@ dependencies = [
  "rkyv",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "uv-cache-key",
  "uv-normalize",
  "uv-pep440",
@@ -6430,7 +6400,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "url",
@@ -6468,7 +6438,7 @@ dependencies = [
  "reqwest",
  "rustc-hash",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6517,7 +6487,7 @@ dependencies = [
  "schemars",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "uv-static",
@@ -6538,7 +6508,7 @@ dependencies = [
  "fs-err",
  "owo-colors",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "uv-auth",
@@ -6558,7 +6528,7 @@ version = "0.0.47"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
  "uv-cache-key",
@@ -6578,7 +6548,7 @@ dependencies = [
  "regex",
  "regex-automata",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "walkdir",
 ]
@@ -6605,7 +6575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uv-distribution-filename",
  "uv-flags",
@@ -6635,7 +6605,7 @@ dependencies = [
  "rustc-hash",
  "same-file",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -6673,7 +6643,7 @@ dependencies = [
  "fastrand",
  "secret-service",
  "security-framework",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "windows",
  "zeroize",
@@ -6707,7 +6677,7 @@ dependencies = [
  "astral_async_zip",
  "fs-err",
  "futures",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6723,7 +6693,7 @@ dependencies = [
  "fs-err",
  "shellexpand",
  "temp-env",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -6784,7 +6754,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "temp-env",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-test",
  "unicode-width 0.2.2",
@@ -6817,7 +6787,7 @@ dependencies = [
  "rustix",
  "target-lexicon",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uv-fs",
  "uv-platform-tags",
@@ -6835,7 +6805,7 @@ dependencies = [
  "rkyv",
  "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "uv-small-str",
 ]
 
@@ -6845,7 +6815,7 @@ version = "0.0.47"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
- "thiserror 2.0.18",
+ "thiserror",
  "uv-preview",
  "uv-warnings",
 ]
@@ -6871,7 +6841,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6911,7 +6881,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "toml_edit",
  "tracing",
  "url",
@@ -6956,7 +6926,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "test-log",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6994,7 +6964,7 @@ dependencies = [
  "ref-cast",
  "schemars",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
 ]
 
@@ -7008,7 +6978,7 @@ dependencies = [
  "fs-err",
  "futures",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "url",
@@ -7049,7 +7019,7 @@ dependencies = [
  "rustc-hash",
  "tempfile",
  "test-case",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "unscanny",
@@ -7093,7 +7063,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "toml",
@@ -7140,7 +7110,7 @@ dependencies = [
  "memchr",
  "regex",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "url",
@@ -7165,7 +7135,7 @@ dependencies = [
  "schemars",
  "serde",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "url",
@@ -7233,7 +7203,7 @@ dependencies = [
 name = "uv-static"
 version = "0.0.47"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
  "uv-macros",
 ]
 
@@ -7275,7 +7245,7 @@ dependencies = [
  "owo-colors",
  "pathdiff",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "toml_edit",
  "tracing",
@@ -7305,7 +7275,7 @@ dependencies = [
  "fs-err",
  "schemars",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
  "uv-distribution-types",
@@ -7329,7 +7299,7 @@ dependencies = [
  "goblin",
  "rcgen",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "uv-fs",
  "which",
  "windows",
@@ -7342,7 +7312,7 @@ dependencies = [
  "anyhow",
  "dashmap",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror",
  "uv-cache",
  "uv-configuration",
  "uv-distribution-filename",
@@ -7362,7 +7332,7 @@ name = "uv-unix"
 version = "0.0.47"
 dependencies = [
  "nix 0.31.2",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -7379,7 +7349,7 @@ dependencies = [
  "owo-colors",
  "pathdiff",
  "self-replace",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "uv-console",
  "uv-fs",
@@ -7428,7 +7398,7 @@ dependencies = [
  "schemars",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "toml",
  "toml_edit",
@@ -8136,7 +8106,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,6 @@ reqwest-retry = { version = "0.9.1", package = "astral-reqwest-retry", features 
 ] }
 rkyv = { version = "0.8.14", features = ["bytecheck"] }
 rmp-serde = { version = "1.3.0" }
-rust-netrc = { version = "0.1.2" }
 rustc-hash = { version = "2.0.0" }
 rustls-native-certs = { version = "0.8.3" }
 rustls-pki-types = { version = "1.14.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ uv-keyring = { version = "0.0.47", path = "crates/uv-keyring" }
 uv-logging = { version = "0.0.47", path = "crates/uv-logging" }
 uv-macros = { version = "0.0.47", path = "crates/uv-macros" }
 uv-metadata = { version = "0.0.47", path = "crates/uv-metadata" }
+uv-netrc = { version = "0.0.47", path = "crates/uv-netrc" }
 uv-normalize = { version = "0.0.47", path = "crates/uv-normalize" }
 uv-once-map = { version = "0.0.47", path = "crates/uv-once-map" }
 uv-options-metadata = { version = "0.0.47", path = "crates/uv-options-metadata" }
@@ -242,6 +243,11 @@ same-file = { version = "1.0.6" }
 schemars = { version = "1.0.0", features = ["url2"] }
 seahash = { version = "4.1.0" }
 secret-service = { version = "5.0.0", features = ["rt-tokio-crypto-rust"] }
+shellexpand = { version = "3.1.0", default-features = false, features = [
+  "base-0",
+  "tilde",
+  "path",
+] }
 security-framework = { version = "3" }
 self-replace = { version = "1.5.0" }
 serde = { version = "1.0.210", features = ["derive", "rc"] }

--- a/crates/README.md
+++ b/crates/README.md
@@ -92,6 +92,10 @@ Functionality for installing Python packages into a virtual environment.
 
 Functionality for detecting and leveraging the current Python interpreter.
 
+## [uv-netrc](./uv-netrc)
+
+A vendored netrc parser for uv.
+
 ## [uv-normalize](./uv-normalize)
 
 Normalize package and extra names as per Python specifications.

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 uv-cache-key = { workspace = true }
 uv-fs = { workspace = true }
 uv-keyring = { workspace = true, features = ["apple-native", "secret-service", "windows-native"] }
+uv-netrc = { workspace = true }
 uv-once-map = { workspace = true }
 uv-preview = { workspace = true }
 uv-redacted = { workspace = true }
@@ -40,7 +41,6 @@ percent-encoding = { workspace = true }
 reqsign = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
-rust-netrc = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -8,7 +8,6 @@ use base64::prelude::BASE64_STANDARD;
 use base64::read::DecoderReader;
 use base64::write::EncoderWriter;
 use http::Uri;
-use netrc::Netrc;
 use reqsign::aws::DefaultSigner as AwsDefaultSigner;
 use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use reqwest::Request;
@@ -16,6 +15,7 @@ use reqwest::header::HeaderValue;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use uv_netrc::Netrc;
 use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
 

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -2,12 +2,12 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::{anyhow, format_err};
 use http::{Extensions, StatusCode};
-use netrc::Netrc;
 use reqwest::{Request, Response};
 use reqwest_middleware::{ClientWithMiddleware, Error, Middleware, Next};
 use tokio::sync::Mutex;
 use tracing::{debug, trace, warn};
 
+use uv_netrc::Netrc;
 use uv_preview::{Preview, PreviewFeature};
 use uv_redacted::DisplaySafeUrl;
 use uv_static::EnvVars;
@@ -40,7 +40,7 @@ impl Default for NetrcMode {
     fn default() -> Self {
         Self::Automatic(LazyLock::new(|| match Netrc::new() {
             Ok(netrc) => Some(netrc),
-            Err(netrc::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            Err(uv_netrc::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
                 debug!("No netrc file found");
                 None
             }

--- a/crates/uv-netrc/Cargo.toml
+++ b/crates/uv-netrc/Cargo.toml
@@ -10,7 +10,7 @@ authors = { workspace = true }
 license = "MIT"
 
 [lib]
-name = "netrc"
+name = "uv_netrc"
 doctest = false
 
 [lints]

--- a/crates/uv-netrc/Cargo.toml
+++ b/crates/uv-netrc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "uv-netrc"
+version = "0.0.47"
+description = "A vendored netrc parser for uv"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = "MIT"
+
+[lib]
+name = "netrc"
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+shellexpand = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+fs-err = { workspace = true }
+temp-env = { workspace = true }

--- a/crates/uv-netrc/LICENSE
+++ b/crates/uv-netrc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Gribouille
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/uv-netrc/README.md
+++ b/crates/uv-netrc/README.md
@@ -1,0 +1,27 @@
+# uv-netrc
+
+This crate vendors the [`rust-netrc`](https://crates.io/crates/rust-netrc) parser for use by uv.
+
+The source was vendored from
+[`gribouille/netrc`](https://github.com/gribouille/netrc/tree/e5f96cc9cc78931b949b48c0758f15da331e9761),
+as published in `rust-netrc` 0.1.2 with checksum
+`7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9`.
+
+The package is named `uv-netrc`, but the library target remains `netrc` to match the upstream API
+surface.
+
+## License
+
+The vendored source is licensed under MIT. See [LICENSE](./LICENSE).
+
+## Patches
+
+The following changes have been applied:
+
+- Renamed the package to `uv-netrc`.
+- Adopted uv workspace metadata and lints.
+- Uses uv's workspace `thiserror` dependency.
+- Uses uv's workspace `fs-err` dependency in tests.
+- Uses uv's workspace `temp-env` test helper for environment-variable tests.
+- Restricted internal lexer visibility to satisfy uv's workspace lints.
+- Applied lint-only style changes for uv's workspace clippy configuration.

--- a/crates/uv-netrc/README.md
+++ b/crates/uv-netrc/README.md
@@ -7,21 +7,8 @@ The source was vendored from
 as published in `rust-netrc` 0.1.2 with checksum
 `7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9`.
 
-The package is named `uv-netrc`, but the library target remains `netrc` to match the upstream API
-surface.
+The package is named `uv-netrc`, and the library target is `uv_netrc`.
 
 ## License
 
 The vendored source is licensed under MIT. See [LICENSE](./LICENSE).
-
-## Patches
-
-The following changes have been applied:
-
-- Renamed the package to `uv-netrc`.
-- Adopted uv workspace metadata and lints.
-- Uses uv's workspace `thiserror` dependency.
-- Uses uv's workspace `fs-err` dependency in tests.
-- Uses uv's workspace `temp-env` test helper for environment-variable tests.
-- Restricted internal lexer visibility to satisfy uv's workspace lints.
-- Applied lint-only style changes for uv's workspace clippy configuration.

--- a/crates/uv-netrc/src/lex.rs
+++ b/crates/uv-netrc/src/lex.rs
@@ -1,0 +1,89 @@
+use std::collections::VecDeque;
+use std::str::Chars;
+
+pub(crate) struct Lex<'a> {
+    pub(crate) lineno: u32,
+    instream: Chars<'a>,
+    pushback: VecDeque<String>,
+}
+
+impl<'a> Lex<'a> {
+    pub(crate) fn new(content: &'a str) -> Self {
+        Lex {
+            lineno: 1,
+            instream: content.chars(),
+            pushback: VecDeque::new(),
+        }
+    }
+
+    fn read_char(&mut self) -> Option<char> {
+        let ch = self.instream.next();
+        if ch == Some('\n') {
+            self.lineno += 1;
+        }
+        ch
+    }
+
+    pub(crate) fn read_line(&mut self) -> String {
+        let mut s = String::new();
+        for ch in &mut self.instream {
+            if ch == '\n' {
+                return s;
+            }
+            s.push(ch);
+        }
+        s
+    }
+
+    pub(crate) fn get_token(&mut self) -> String {
+        let p = self.pushback.pop_front();
+        if let Some(x) = p {
+            return x;
+        }
+        let mut token = String::new();
+
+        while let Some(ch) = self.read_char() {
+            match ch {
+                '\n' | '\t' | '\r' | ' ' => {}
+                '"' => {
+                    while let Some(ch) = self.read_char() {
+                        match ch {
+                            '"' => {
+                                return token;
+                            }
+                            '\\' => {
+                                token.push(self.read_char().unwrap_or(' '));
+                            }
+                            _ => {
+                                token.push(ch);
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    let c = if ch == '\\' {
+                        self.read_char().unwrap_or(' ')
+                    } else {
+                        ch
+                    };
+                    token.push(c);
+                    while let Some(ch) = self.read_char() {
+                        let c = match ch {
+                            '\n' | '\t' | '\r' | ' ' => {
+                                return token;
+                            }
+                            '\\' => self.read_char().unwrap_or(' '),
+                            _ => ch,
+                        };
+                        token.push(c);
+                    }
+                }
+            }
+        }
+        token
+    }
+
+    pub(crate) fn push_token(&mut self, token: &str) {
+        self.pushback.push_back(token.to_owned());
+    }
+}

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -1,0 +1,181 @@
+/*!
+The `netrc` crate provides a parser for the netrc file.
+
+The `reqwest-netrc` crate adds the support of netrc to the `reqwest` crate via the `reqwest-middleware` wrapper.
+
+# Setup
+
+```text
+$ crago add rust-netrc
+```
+
+# Example
+
+```no_run
+use netrc::Netrc;
+
+// ...
+
+let nrc = Netrc::new().unwrap();
+
+// ...
+println!(
+    "login = {}\naccount = {}\npassword = {}",
+    nrc.hosts["my.host"].login,
+    nrc.hosts["my.host"].account,
+    nrc.hosts["my.host"].password,
+);
+```
+
+*/
+
+pub use netrc::{Authenticator, Netrc};
+use std::fs;
+use std::io;
+use std::io::ErrorKind;
+#[cfg(windows)]
+use std::iter::repeat;
+use std::path::{Path, PathBuf};
+use std::result;
+
+mod lex;
+mod netrc;
+
+pub type Result<T> = result::Result<T, Error>;
+
+/// An error that can occur when processing a Netrc file.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Wrap `std::io::Error` when we try to open the netrc file.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Parsing error.
+    #[error("{parser} in the file '{filename}'")]
+    Parsing {
+        parser: netrc::ParsingError,
+        filename: String,
+    },
+}
+
+impl Netrc {
+    /// Create a new `Netrc` object.
+    ///
+    /// Look up the `NETRC` environment variable if it is defined else that the
+    /// default `~/.netrc` file.
+    pub fn new() -> Result<Self> {
+        Self::get_file()
+            .ok_or(Error::Io(io::Error::new(
+                ErrorKind::NotFound,
+                "no netrc file found",
+            )))
+            .and_then(|f| Self::from_file(f.as_path()))
+    }
+
+    /// Create a new `Netrc` object from a file.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Preserve the upstream rust-netrc I/O error surface."
+    )]
+    pub fn from_file(file: &Path) -> Result<Self> {
+        String::from_utf8_lossy(&fs::read(file)?)
+            .parse()
+            .map_err(|e| Error::Parsing {
+                parser: e,
+                filename: file.display().to_string(),
+            })
+    }
+
+    /// Search a netrc file.
+    ///
+    /// Look up the `NETRC` environment variable if it is defined else use the .netrc (or _netrc
+    /// file on windows) in the user's home directory.
+    pub fn get_file() -> Option<PathBuf> {
+        let env_var = std::env::var("NETRC")
+            .map(PathBuf::from)
+            .map(|f| shellexpand::path::tilde(&f).into_owned());
+
+        #[cfg(windows)]
+        let default = std::env::var("USERPROFILE")
+            .into_iter()
+            .flat_map(|home| repeat(home).zip([".netrc", "_netrc"]))
+            .map(|(home, file)| PathBuf::from(home).join(file));
+
+        #[cfg(not(windows))]
+        let default = std::env::var("HOME").map(|home| PathBuf::from(home).join(".netrc"));
+
+        env_var.into_iter().chain(default).find(|f| f.exists())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTENT: &str = "\
+machine cocolog-nifty.com
+login jmarten0
+password cC2&yt7OT
+
+machine wired.com
+login mstanlack1
+password gH4={wx=>VixU
+
+machine joomla.org
+login mbutterley2
+password hY5>yKqU&$vq&0
+";
+
+    fn create_netrc_file() -> PathBuf {
+        let dest = std::env::temp_dir().join("mynetrc");
+        if !dest.exists() {
+            fs_err::write(&dest, CONTENT).unwrap();
+        }
+        dest
+    }
+
+    fn check_nrc(nrc: &Netrc) {
+        assert_eq!(nrc.hosts.len(), 3);
+        assert_eq!(
+            nrc.hosts["cocolog-nifty.com"],
+            Authenticator::new("jmarten0", "", "cC2&yt7OT")
+        );
+        assert_eq!(
+            nrc.hosts["wired.com"],
+            Authenticator::new("mstanlack1", "", "gH4={wx=>VixU")
+        );
+        assert_eq!(
+            nrc.hosts["joomla.org"],
+            Authenticator::new("mbutterley2", "", "hY5>yKqU&$vq&0")
+        );
+    }
+
+    #[test]
+    fn test_new_env() {
+        let fi = create_netrc_file();
+        temp_env::with_var("NETRC", Some(fi.as_os_str()), || {
+            let nrc = Netrc::new().unwrap();
+            check_nrc(&nrc);
+        });
+    }
+
+    #[test]
+    fn test_new_default() {}
+
+    #[test]
+    fn test_from_file_failed() {
+        assert_eq!(
+            Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc"))
+                .unwrap_err()
+                .to_string(),
+            "I/O error: No such file or directory (os error 2)"
+        );
+    }
+
+    #[test]
+    fn test_from_file() {
+        let fi = create_netrc_file();
+        let nrc = Netrc::from_file(fi.as_path()).unwrap();
+        check_nrc(&nrc);
+    }
+}

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -160,9 +160,6 @@ password hY5>yKqU&$vq&0
     }
 
     #[test]
-    fn test_new_default() {}
-
-    #[test]
     fn test_from_file_failed() {
         let err = Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc")).unwrap_err();
         assert!(

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -1,18 +1,16 @@
 /*!
-The `netrc` crate provides a parser for the netrc file.
-
-The `reqwest-netrc` crate adds the support of netrc to the `reqwest` crate via the `reqwest-middleware` wrapper.
+The `uv-netrc` crate provides a parser for the netrc file.
 
 # Setup
 
 ```text
-$ crago add rust-netrc
+$ cargo add uv-netrc
 ```
 
 # Example
 
 ```no_run
-use netrc::Netrc;
+use uv_netrc::Netrc;
 
 // ...
 
@@ -75,7 +73,7 @@ impl Netrc {
     /// Create a new `Netrc` object from a file.
     #[expect(
         clippy::disallowed_methods,
-        reason = "Preserve the upstream rust-netrc I/O error surface."
+        reason = "Preserve the upstream I/O error surface."
     )]
     pub fn from_file(file: &Path) -> Result<Self> {
         String::from_utf8_lossy(&fs::read(file)?)

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -9,7 +9,7 @@ $ cargo add uv-netrc
 
 # Example
 
-```no_run
+```ignore
 use uv_netrc::Netrc;
 
 // ...
@@ -109,11 +109,14 @@ impl Netrc {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NETRC_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     const CONTENT: &str = "\
 machine cocolog-nifty.com
 login jmarten0
-password cC2&yt7OT
+password cC2&yt7ZX
 
 machine wired.com
 login mstanlack1
@@ -125,10 +128,9 @@ password hY5>yKqU&$vq&0
 ";
 
     fn create_netrc_file() -> PathBuf {
-        let dest = std::env::temp_dir().join("mynetrc");
-        if !dest.exists() {
-            fs_err::write(&dest, CONTENT).unwrap();
-        }
+        let id = NETRC_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dest = std::env::temp_dir().join(format!("mynetrc-{}-{id}", std::process::id()));
+        fs_err::write(&dest, CONTENT).unwrap();
         dest
     }
 
@@ -136,7 +138,7 @@ password hY5>yKqU&$vq&0
         assert_eq!(nrc.hosts.len(), 3);
         assert_eq!(
             nrc.hosts["cocolog-nifty.com"],
-            Authenticator::new("jmarten0", "", "cC2&yt7OT")
+            Authenticator::new("jmarten0", "", "cC2&yt7ZX")
         );
         assert_eq!(
             nrc.hosts["wired.com"],

--- a/crates/uv-netrc/src/lib.rs
+++ b/crates/uv-netrc/src/lib.rs
@@ -164,11 +164,10 @@ password hY5>yKqU&$vq&0
 
     #[test]
     fn test_from_file_failed() {
-        assert_eq!(
-            Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc"))
-                .unwrap_err()
-                .to_string(),
-            "I/O error: No such file or directory (os error 2)"
+        let err = Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc")).unwrap_err();
+        assert!(
+            matches!(&err, Error::Io(err) if err.kind() == ErrorKind::NotFound),
+            "expected NotFound I/O error, got {err}",
         );
     }
 

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -1,0 +1,612 @@
+//! This parser and the tests are a translation of the official Python netrc library.
+
+use crate::lex::Lex;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct ParsingError {
+    lineno: u32,
+    message: String,
+}
+
+impl std::fmt::Display for ParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "parsing error: {} (line {})", self.message, self.lineno)
+    }
+}
+
+/// Authenticators for host.
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Authenticator {
+    /// Identify a user on the remote machine.
+    pub login: String,
+
+    /// Supply an additional account password.
+    pub account: String,
+
+    /// Supply a password
+    pub password: String,
+}
+
+impl Authenticator {
+    #[allow(dead_code)]
+    pub fn new(login: &str, account: &str, password: &str) -> Self {
+        Self {
+            login: login.to_owned(),
+            account: account.to_owned(),
+            password: password.to_owned(),
+        }
+    }
+}
+
+/// Represents the netrc file.
+#[derive(Debug, Default)]
+pub struct Netrc {
+    /// Dictionary mapping host names to the authentificators.
+    pub hosts: HashMap<String, Authenticator>,
+
+    /// Dictionary mapping macro names to string lists.
+    pub macros: HashMap<String, Vec<String>>,
+}
+
+impl std::fmt::Display for Netrc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (host, attrs) in &self.hosts {
+            writeln!(f, "machine {host}")?;
+            writeln!(f, "\tlogin {}", attrs.login)?;
+            if !attrs.account.is_empty() {
+                writeln!(f, "\taccount  {}", attrs.account)?;
+            }
+            writeln!(f, "\tpassword  {}", attrs.password)?;
+        }
+        for (macro_, lines) in &self.macros {
+            writeln!(f, "macdef {macro_}")?;
+            for line in lines {
+                writeln!(f, "{line}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for Netrc {
+    type Err = ParsingError;
+
+    fn from_str(s: &str) -> Result<Self, ParsingError> {
+        let mut res = Self::default();
+        let mut lexer = Lex::new(s);
+
+        loop {
+            let saved_lineno = lexer.lineno;
+            let tt = lexer.get_token();
+            if tt.is_empty() {
+                break;
+            }
+            if tt.chars().nth(0) == Some('#') {
+                if lexer.lineno == saved_lineno && tt.len() == 1 {
+                    lexer.read_line();
+                }
+                continue;
+            }
+
+            let entryname = match tt.as_str() {
+                "" => {
+                    break;
+                }
+                "machine" => lexer.get_token(),
+                "default" => String::from("default"),
+                "macdef" => {
+                    let entryname = lexer.get_token();
+                    let mut v = Vec::new();
+                    loop {
+                        let line = lexer.read_line();
+                        if line.trim().is_empty() {
+                            break;
+                        }
+                        v.push(line.trim().to_owned());
+                    }
+                    res.macros.insert(entryname, v);
+                    continue;
+                }
+                _ => {
+                    return Err(ParsingError {
+                        lineno: lexer.lineno,
+                        message: format!("bad toplevel token '{tt}'"),
+                    });
+                }
+            };
+            if entryname.is_empty() {
+                return Err(ParsingError {
+                    lineno: lexer.lineno,
+                    message: format!("missing '{tt}' name"),
+                });
+            }
+
+            let mut auth = Authenticator::default();
+
+            loop {
+                let prev_lineno = lexer.lineno;
+                let tt = lexer.get_token();
+                if tt.starts_with('#') {
+                    if lexer.lineno == prev_lineno {
+                        lexer.read_line();
+                    }
+                    continue;
+                }
+                match tt.as_str() {
+                    "" | "machine" | "default" | "macdef" => {
+                        res.hosts.insert(entryname, auth);
+                        lexer.push_token(&tt);
+                        break;
+                    }
+                    "login" | "user" => {
+                        auth.login = lexer.get_token();
+                    }
+                    "account" => {
+                        auth.account = lexer.get_token();
+                    }
+                    "password" => {
+                        auth.password = lexer.get_token();
+                    }
+                    _ => {
+                        return Err(ParsingError {
+                            lineno: lexer.lineno,
+                            message: format!("bad follower token '{tt}'"),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::needless_raw_string_hashes,
+    reason = "Keep the vendored parser tests close to upstream."
+)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_toplevel_non_ordered_tokens() {
+        let nrc = Netrc::from_str(
+            "\
+            machine host.domain.com password pass1 login log1 account acct1
+            default login log2 password pass2 account acct2
+        ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            nrc.hosts["host.domain.com"],
+            Authenticator::new("log1", "acct1", "pass1")
+        );
+        assert_eq!(
+            nrc.hosts["default"],
+            Authenticator::new("log2", "acct2", "pass2")
+        );
+    }
+
+    #[test]
+    fn test_toplevel_tokens() {
+        let nrc = Netrc::from_str(
+            "\
+            machine host.domain.com login log1 password pass1 account acct1
+            default login log2 password pass2 account acct2
+        ",
+        )
+        .unwrap();
+        assert_eq!(
+            nrc.hosts["host.domain.com"],
+            Authenticator::new("log1", "acct1", "pass1")
+        );
+        assert_eq!(
+            nrc.hosts["default"],
+            Authenticator::new("log2", "acct2", "pass2")
+        );
+    }
+
+    #[test]
+    fn test_macros() {
+        let nrc = Netrc::from_str(
+            "\
+            macdef macro1
+            line1
+            line2
+
+            macdef macro2
+            line3
+            line4
+            ",
+        )
+        .unwrap();
+        assert_eq!(nrc.macros["macro1"], vec!["line1", "line2"]);
+        assert_eq!(nrc.macros["macro2"], vec!["line3", "line4"]);
+    }
+
+    #[test]
+    fn test_optional_tokens_machine() {
+        let data = vec![
+            "machine host.domain.com",
+            "machine host.domain.com login",
+            "machine host.domain.com account",
+            "machine host.domain.com password",
+            "machine host.domain.com login \"\" account",
+            "machine host.domain.com login \"\" password",
+            "machine host.domain.com account \"\" password",
+        ];
+
+        for item in data {
+            let nrc = Netrc::from_str(item).unwrap();
+            assert_eq!(nrc.hosts["host.domain.com"], Authenticator::new("", "", ""));
+        }
+    }
+
+    #[test]
+    fn test_optional_tokens_default() {
+        let data = vec![
+            "default",
+            "default login",
+            "default account",
+            "default password",
+            "default login \"\" account",
+            "default login \"\" password",
+            "default account \"\" password",
+        ];
+
+        for item in data {
+            let nrc = Netrc::from_str(item).unwrap();
+            assert_eq!(nrc.hosts["default"], Authenticator::new("", "", ""));
+        }
+    }
+
+    #[test]
+    fn test_invalid_tokens() {
+        let data = vec![
+            (
+                "invalid host.domain.com",
+                "parsing error: bad toplevel token 'invalid' (line 1)",
+            ),
+            (
+                "machine host.domain.com invalid",
+                "parsing error: bad follower token 'invalid' (line 1)",
+            ),
+            (
+                "machine host.domain.com login log password pass account acct invalid",
+                "parsing error: bad follower token 'invalid' (line 1)",
+            ),
+            (
+                "default host.domain.com invalid",
+                "parsing error: bad follower token 'host.domain.com' (line 1)",
+            ),
+            (
+                "default host.domain.com login log password pass account acct invalid",
+                "parsing error: bad follower token 'host.domain.com' (line 1)",
+            ),
+        ];
+
+        for (item, msg) in data {
+            let nrc = Netrc::from_str(item);
+            assert_eq!(nrc.unwrap_err().to_string(), msg);
+        }
+    }
+
+    fn test_token_x(data: &str, token: &str, value: &str) {
+        let nrc = Netrc::from_str(data).unwrap();
+        match token {
+            "login" => {
+                assert_eq!(
+                    nrc.hosts["host.domain.com"],
+                    Authenticator::new(value, "acct", "pass")
+                );
+            }
+            "account" => {
+                assert_eq!(
+                    nrc.hosts["host.domain.com"],
+                    Authenticator::new("log", value, "pass")
+                );
+            }
+            "password" => {
+                assert_eq!(
+                    nrc.hosts["host.domain.com"],
+                    Authenticator::new("log", "acct", value)
+                );
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn test_token_value_quotes() {
+        test_token_x(
+            "\
+            machine host.domain.com login \"log\" password pass account acct
+            ",
+            "login",
+            "log",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password pass account \"acct\"
+            ",
+            "account",
+            "acct",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password \"pass\" account acct
+            ",
+            "password",
+            "pass",
+        );
+    }
+
+    #[test]
+    fn test_token_value_escape() {
+        test_token_x(
+            r#"machine host.domain.com login \"log password pass account acct"#,
+            "login",
+            "\"log",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login \"\\\"log\" password pass account acct
+            ",
+            "login",
+            "\"log",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password pass account \\\"acct
+            ",
+            "account",
+            "\"acct",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password pass account \"\\\"acct\"
+            ",
+            "account",
+            "\"acct",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password \\\"pass account acct
+            ",
+            "password",
+            "\"pass",
+        );
+        test_token_x(
+            "\
+            machine host.domain.com login log password \"\\\"pass\" account acct
+            ",
+            "password",
+            "\"pass",
+        );
+    }
+
+    #[test]
+    fn test_token_value_whitespace() {
+        test_token_x(
+            r#"machine host.domain.com login "lo g" password pass account acct"#,
+            "login",
+            "lo g",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password "pas s" account acct"#,
+            "password",
+            "pas s",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass account "acc t""#,
+            "account",
+            "acc t",
+        );
+    }
+
+    #[test]
+    fn test_token_value_non_ascii() {
+        test_token_x(
+            r#"machine host.domain.com login ¡¢ password pass account acct"#,
+            "login",
+            "¡¢",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass account ¡¢"#,
+            "account",
+            "¡¢",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password ¡¢ account acct"#,
+            "password",
+            "¡¢",
+        );
+    }
+
+    #[test]
+    fn test_token_value_leading_hash() {
+        test_token_x(
+            r#"machine host.domain.com login #log password pass account acct"#,
+            "login",
+            "#log",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass account #acct"#,
+            "account",
+            "#acct",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password #pass account acct"#,
+            "password",
+            "#pass",
+        );
+    }
+
+    #[test]
+    fn test_token_value_trailing_hash() {
+        test_token_x(
+            r#"machine host.domain.com login log# password pass account acct"#,
+            "login",
+            "log#",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass account acct#"#,
+            "account",
+            "acct#",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass# account acct"#,
+            "password",
+            "pass#",
+        );
+    }
+
+    #[test]
+    fn test_token_value_internal_hash() {
+        test_token_x(
+            r#"machine host.domain.com login lo#g password pass account acct"#,
+            "login",
+            "lo#g",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pass account ac#ct"#,
+            "account",
+            "ac#ct",
+        );
+        test_token_x(
+            r#"machine host.domain.com login log password pa#ss account acct"#,
+            "password",
+            "pa#ss",
+        );
+    }
+
+    fn test_comment(data: &str) {
+        let nrc = Netrc::from_str(data).unwrap();
+        assert_eq!(
+            nrc.hosts["foo.domain.com"],
+            Authenticator::new("bar", "", "pass")
+        );
+        assert_eq!(
+            nrc.hosts["bar.domain.com"],
+            Authenticator::new("foo", "", "pass")
+        );
+    }
+
+    #[test]
+    fn test_comment_before_machine_line() {
+        test_comment(
+            r#"# comment
+            machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+    #[test]
+    fn test_comment_before_machine_line_no_space() {
+        test_comment(
+            r#"#comment
+            machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_before_machine_line_hash_only() {
+        test_comment(
+            r#"#
+            machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_after_machine_line() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            # comment
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            # comment
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_after_machine_line_no_space() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            #comment
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            #comment
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_after_machine_line_hash_only() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            #
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            #
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_at_end_of_machine_line() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass # comment
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_at_end_of_machine_line_no_space() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass #comment
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_at_end_of_machine_line_pass_has_hash() {
+        let nrc = Netrc::from_str(
+            r#"machine foo.domain.com login bar password #pass #comment
+            machine bar.domain.com login foo password pass
+        "#,
+        )
+        .unwrap();
+        assert_eq!(
+            nrc.hosts["foo.domain.com"],
+            Authenticator::new("bar", "", "#pass")
+        );
+        assert_eq!(
+            nrc.hosts["bar.domain.com"],
+            Authenticator::new("foo", "", "pass")
+        );
+    }
+}

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -42,7 +42,7 @@ impl Authenticator {
 /// Represents the netrc file.
 #[derive(Debug, Default)]
 pub struct Netrc {
-    /// Dictionary mapping host names to the authentificators.
+    /// Dictionary mapping host names to the authenticators.
     pub hosts: HashMap<String, Authenticator>,
 
     /// Dictionary mapping macro names to string lists.


### PR DESCRIPTION
## Summary

This is a small crate which nothing else in our tree depends on. By vendoring it, we pull in some fixes that never got released (see @terror's work from https://github.com/astral-sh/uv/issues/16083), and we get to remove `thiserror` v1 from our dependency tree.

Closes https://github.com/astral-sh/uv/issues/16083.
