### PR TITLE
fix: extend uvx typo traps to cover common uv subcommands

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -301,7 +301,6 @@ pub(crate) async fn run(
     let (mut target, mut args) = (target, args);
     if from.is_none()
         && invocation_source == ToolRunCommand::Uvx
-        && target == "run"
         && settings
             .resolver
             .index_locations
@@ -310,25 +309,40 @@ pub(crate) async fn run(
     {
         let term = Term::stderr();
         if term.is_term() {
-            let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
-            let prompt = format!(
-                "`{}` invokes the `{}` package. Did you mean `{}`?",
-                format!("uvx run {rest}").green(),
-                "run".cyan(),
-                format!("uvx {rest}").green()
-            );
-            let confirmation = uv_console::confirm(&prompt, &term, true)?;
-            if confirmation {
-                let Some((next_target, next_args)) = args.split_first() else {
-                    return Err(anyhow::anyhow!("No tool command provided"));
-                };
-                let Some(next_target) = next_target.to_str() else {
+            // List of common uv subcommands that may be confused with package names
+            // See: https://github.com/astral-sh/uv/issues/18482
+            let typo_traps = [
+                ("run", "uv run"),
+                ("add", "uv add"),
+                ("install", "uv tool install"),
+                ("remove", "uv remove"),
+                ("sync", "uv sync"),
+                ("lock", "uv lock"),
+                ("venv", "uv venv"),
+                ("build", "uv build"),
+                ("init", "uv init"),
+                ("clean", "uv clean"),
+                ("pip", "uv pip"),
+                ("python", "uv python"),
+            ];
+
+            if let Some((_, suggested_command)) = typo_traps.iter().find(|(cmd, _)| *cmd == target) {
+                let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
+                let prompt = format!(
+                    "`{}` invokes the `{}` package. Did you mean `{}`?",
+                    format!("uvx {} {}", target, rest).trim().green(),
+                    target.cyan(),
+                    format!("{} {}", suggested_command, rest).trim().green()
+                );
+                let confirmation = uv_console::confirm(&prompt, &term, true)?;
+                if confirmation {
+                    // User wants to use the uv command instead
                     return Err(anyhow::anyhow!(
-                        "Tool command could not be parsed as UTF-8 string. Use `--from` to specify the package name"
+                        "Please use `{}` instead of `uvx {}`",
+                        suggested_command.green(),
+                        target
                     ));
-                };
-                target = next_target;
-                args = next_args;
+                }
             }
         }
     }

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -325,7 +325,9 @@ pub(crate) async fn run(
                 ("python", "uv python"),
             ];
 
-            if let Some((_, suggested_command)) = typo_traps.iter().find(|(cmd, _)| *cmd == target) {
+            if let Some((_, suggested_command)) =
+                typo_traps.iter().find(|(cmd, _)| *cmd == target)
+            {
                 let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
                 let prompt = format!(
                     "`{}` invokes the `{}` package. Did you mean `{}`?",

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -325,9 +325,7 @@ pub(crate) async fn run(
                 ("python", "uv python"),
             ];
 
-            if let Some((_, suggested_command)) =
-                typo_traps.iter().find(|(cmd, _)| *cmd == target)
-            {
+            if let Some((_, suggested_command)) = typo_traps.iter().find(|(cmd, _)| *cmd == target) {
                 let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
                 let prompt = format!(
                     "`{}` invokes the `{}` package. Did you mean `{}`?",

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -298,7 +298,6 @@ pub(crate) async fn run(
 
     // If the user tries to invoke `uvx run ruff`, hint them towards `uvx ruff`, but only if
     // the `run` package is guaranteed to come from PyPI.
-    let (mut target, mut args) = (target, args);
     if from.is_none()
         && invocation_source == ToolRunCommand::Uvx
         && settings
@@ -326,13 +325,15 @@ pub(crate) async fn run(
                 ("python", "uv python"),
             ];
 
-            if let Some((_, suggested_command)) = typo_traps.iter().find(|(cmd, _)| *cmd == target) {
+            if let Some((_, suggested_command)) =
+                typo_traps.iter().find(|(cmd, _)| *cmd == target)
+            {
                 let rest = args.iter().map(|s| s.to_string_lossy()).join(" ");
                 let prompt = format!(
                     "`{}` invokes the `{}` package. Did you mean `{}`?",
-                    format!("uvx {} {}", target, rest).trim().green(),
+                    format!("uvx {target} {rest}").trim().green(),
                     target.cyan(),
-                    format!("{} {}", suggested_command, rest).trim().green()
+                    format!("{suggested_command} {rest}").trim().green()
                 );
                 let confirmation = uv_console::confirm(&prompt, &term, true)?;
                 if confirmation {


### PR DESCRIPTION
## Summary

This PR extends the typo trap protection in `uvx` to cover common `uv` subcommands beyond just `run`.

Closes #18482

## Problem

Previously, only `uvx run` had typo trap protection:
```
% uvx run
? `uvx run ` invokes the `run` package. Did you mean `uvx `? [y/n] › yes
```

But other common uv subcommands like `add`, `install`, `sync`, etc. would attempt to download and run packages with those names:
```
% uvx add
  × No solution found when resolving tool dependencies:
  ╰─▶ Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
```

This attempts to run https://pypi.org/project/add/ , which could potentially be malicious if someone were to squat that name.

## Solution

Extended the typo trap list to include all major uv subcommands:
- `run` → suggests `uv run`
- `add` → suggests `uv add`
- `install` → suggests `uv tool install`
- `remove` → suggests `uv remove`
- `sync` → suggests `uv sync`
- `lock` → suggests `uv lock`
- `venv` → suggests `uv venv`
- `build` → suggests `uv build`
- `init` → suggests `uv init`
- `clean` → suggests `uv clean`
- `pip` → suggests `uv pip`
- `python` → suggests `uv python`

Now when users mistakenly type `uvx add`, they'll see:
```
? `uvx add` invokes the `add` package. Did you mean `uv add`? [y/n] ›
```

If they confirm, they'll get a helpful error message directing them to use the correct command.

## Changes

- Modified `crates/uv/src/commands/tool/run.rs` to use a lookup table for typo traps
- Added 11 additional command pairs to the typo trap list
- Updated behavior to show an error with the suggested command when user confirms they made a typo

## Testing

The existing infrastructure for `uvx run` typo trap is extended to cover all listed commands. Since the confirmation prompt requires a TTY, automated testing would require special setup.

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused on the issue
- [x] Addresses security concern of package name squatting for common typos
- [x] Closes the linked issue