### PR TITLE
Move `cache_name` to uv-cache-key

### DIFF
--- a/crates/uv-cache-key/src/digest.rs
+++ b/crates/uv-cache-key/src/digest.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 
 use seahash::SeaHasher;
@@ -33,4 +34,60 @@ pub fn hash_digest<H: Hash>(hashable: &H) -> String {
 /// Convert a u64 to a hex string.
 fn to_hex(num: u64) -> String {
     hex::encode(num.to_le_bytes())
+}
+
+/// Normalize a name for use in a cache entry.
+///
+/// Replaces non-alphanumeric characters with dashes, and lowercases the name.
+pub fn cache_name(name: &str) -> Option<Cow<'_, str>> {
+    if name
+        .bytes()
+        .all(|char| matches!(char, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return if name.is_empty() {
+            None
+        } else {
+            Some(Cow::Borrowed(name))
+        };
+    }
+    let mut normalized = String::with_capacity(name.len());
+    let mut dash = false;
+    for char in name.bytes() {
+        match char {
+            b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
+                dash = false;
+                normalized.push(char.to_ascii_lowercase() as char);
+            }
+            _ => {
+                if !dash {
+                    normalized.push('-');
+                    dash = true;
+                }
+            }
+        }
+    }
+    if normalized.ends_with('-') {
+        normalized.pop();
+    }
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(Cow::Owned(normalized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_name() {
+        assert_eq!(cache_name("foo"), Some("foo".into()));
+        assert_eq!(cache_name("foo-bar"), Some("foo-bar".into()));
+        assert_eq!(cache_name("foo_bar"), Some("foo-bar".into()));
+        assert_eq!(cache_name("foo-bar_baz"), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("foo-bar_baz_"), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("foo-_bar_baz"), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("_+-_"), None);
+    }
 }

--- a/crates/uv-cache-key/src/digest.rs
+++ b/crates/uv-cache-key/src/digest.rs
@@ -39,7 +39,12 @@ fn to_hex(num: u64) -> String {
 /// Normalize a name for use in a cache entry.
 ///
 /// Replaces non-alphanumeric characters with dashes, and lowercases the name.
-pub fn cache_name(name: &str) -> Option<Cow<'_, str>> {
+///
+/// If `max_len` is provided, the output is truncated to at most that many bytes
+/// (trailing dashes from truncation are stripped).
+pub fn cache_name(name: &str, max_len: Option<usize>) -> Option<Cow<'_, str>> {
+    let limit = max_len.unwrap_or(usize::MAX);
+
     if name
         .bytes()
         .all(|char| matches!(char, b'0'..=b'9' | b'a'..=b'f'))
@@ -47,12 +52,12 @@ pub fn cache_name(name: &str) -> Option<Cow<'_, str>> {
         return if name.is_empty() {
             None
         } else {
-            Some(Cow::Borrowed(name))
+            Some(Cow::Borrowed(name.get(..limit).unwrap_or(name)))
         };
     }
-    let mut normalized = String::with_capacity(name.len());
+    let mut normalized = String::with_capacity(name.len().min(limit));
     let mut dash = false;
-    for char in name.bytes() {
+    for char in name.bytes().take(limit) {
         match char {
             b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
                 dash = false;
@@ -82,12 +87,30 @@ mod tests {
 
     #[test]
     fn test_cache_name() {
-        assert_eq!(cache_name("foo"), Some("foo".into()));
-        assert_eq!(cache_name("foo-bar"), Some("foo-bar".into()));
-        assert_eq!(cache_name("foo_bar"), Some("foo-bar".into()));
-        assert_eq!(cache_name("foo-bar_baz"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("foo-bar_baz_"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("foo-_bar_baz"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("_+-_"), None);
+        assert_eq!(cache_name("foo", None), Some("foo".into()));
+        assert_eq!(cache_name("foo-bar", None), Some("foo-bar".into()));
+        assert_eq!(cache_name("foo_bar", None), Some("foo-bar".into()));
+        assert_eq!(cache_name("foo-bar_baz", None), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("foo-bar_baz_", None), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("foo-_bar_baz", None), Some("foo-bar-baz".into()));
+        assert_eq!(cache_name("_+-_", None), None);
+    }
+
+    #[test]
+    fn test_cache_name_max_len() {
+        let long = "a".repeat(300);
+        assert_eq!(
+            cache_name(&long, Some(100)).as_deref().map(str::len),
+            Some(100)
+        );
+
+        let long_hex = "abcdef".repeat(50);
+        assert_eq!(
+            cache_name(&long_hex, Some(100)).as_deref().map(str::len),
+            Some(100)
+        );
+
+        assert_eq!(cache_name("aaaa_bbbb", Some(5)), Some("aaaa".into()));
+        assert_eq!(cache_name(&long, None).as_deref().map(str::len), Some(300));
     }
 }

--- a/crates/uv-cache-key/src/lib.rs
+++ b/crates/uv-cache-key/src/lib.rs
@@ -1,6 +1,6 @@
 pub use cache_key::{CacheKey, CacheKeyHasher};
 pub use canonical_url::{CanonicalUrl, RepositoryUrl};
-pub use digest::{cache_digest, hash_digest};
+pub use digest::{cache_digest, cache_name, hash_digest};
 
 mod cache_key;
 mod canonical_url;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -663,7 +663,7 @@ impl ScriptInterpreter {
                         .path
                         .file_stem()
                         .and_then(|name| name.to_str())
-                        .and_then(cache_name)
+                        .and_then(|name| cache_name(name, None))
                     {
                         format!("{file_name}-{digest}")
                     } else {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
@@ -9,7 +8,7 @@ use owo_colors::OwoColorize;
 use tracing::{debug, trace, warn};
 use uv_auth::CredentialsCache;
 use uv_cache::{Cache, CacheBucket};
-use uv_cache_key::cache_digest;
+use uv_cache_key::{cache_digest, cache_name};
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
@@ -2960,43 +2959,6 @@ fn warn_on_requirements_txt_setting(spec: &RequirementsSpecification, settings: 
     }
 }
 
-/// Normalize a filename for use in a cache entry.
-///
-/// Replaces non-alphanumeric characters with dashes, and lowercases the filename.
-fn cache_name(name: &str) -> Option<Cow<'_, str>> {
-    if name.bytes().all(|c| matches!(c, b'0'..=b'9' | b'a'..=b'f')) {
-        return if name.is_empty() {
-            None
-        } else {
-            Some(Cow::Borrowed(name))
-        };
-    }
-    let mut normalized = String::with_capacity(name.len());
-    let mut dash = false;
-    for char in name.bytes() {
-        match char {
-            b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
-                dash = false;
-                normalized.push(char.to_ascii_lowercase() as char);
-            }
-            _ => {
-                if !dash {
-                    normalized.push('-');
-                    dash = true;
-                }
-            }
-        }
-    }
-    if normalized.ends_with('-') {
-        normalized.pop();
-    }
-    if normalized.is_empty() {
-        None
-    } else {
-        Some(Cow::Owned(normalized))
-    }
-}
-
 fn format_requires_python_sources(conflicts: &RequiresPythonSources) -> String {
     conflicts
         .iter()
@@ -3039,20 +3001,4 @@ fn format_optional_requires_python_sources(
     }
     // Otherwise don't elaborate
     String::new()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_cache_name() {
-        assert_eq!(cache_name("foo"), Some("foo".into()));
-        assert_eq!(cache_name("foo-bar"), Some("foo-bar".into()));
-        assert_eq!(cache_name("foo_bar"), Some("foo-bar".into()));
-        assert_eq!(cache_name("foo-bar_baz"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("foo-bar_baz_"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("foo-_bar_baz"), Some("foo-bar-baz".into()));
-        assert_eq!(cache_name("_+-_"), None);
-    }
 }


### PR DESCRIPTION
## Summary

A small refactor which aims to slim down the centralised envs PR. I also think it makes more sense for this to be in the uv-cache-key crate.

Also add an optional parameter for length limits (currently unused, specifically for centralised envs).

## Test Plan

Existing tests + new tests.