### PR TITLE
Add `replace_symlink_lenient`

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -248,6 +248,50 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
     }
 }
 
+/// Like [`replace_symlink`], but on windows also handles the case where `dst` is a file or
+/// empty directory rather than a junction.
+#[cfg(unix)]
+pub fn replace_symlink_lenient(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+) -> std::io::Result<()> {
+    replace_symlink(src, dst)
+}
+
+/// Like [`replace_symlink`], but on windows also handles the case where `dst` is a file or
+/// empty directory rather than a junction.
+#[cfg(windows)]
+pub fn replace_symlink_lenient(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+) -> std::io::Result<()> {
+    use windows::Win32::Foundation::{ERROR_NOT_A_REPARSE_POINT, WIN32_ERROR};
+
+    // Try to remove an existing junction.
+    match junction::delete(dst.as_ref()) {
+        Ok(()) => fs_err::remove_dir(dst.as_ref())?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        // `junction::delete` will produce this error when the path exists but is not a junction.
+        Err(err)
+            if err
+                .raw_os_error()
+                .map(|err| WIN32_ERROR(err.cast_unsigned()))
+                == Some(ERROR_NOT_A_REPARSE_POINT) =>
+        {
+            match fs_err::remove_dir(dst.as_ref()) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => {
+                    fs_err::remove_file(dst.as_ref())?;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Err(err) => return Err(err),
+    }
+
+    create_junction(src.as_ref(), dst.as_ref())
+}
+
 /// Create a directory link at `dst` pointing to `src`.
 ///
 /// On Windows, this normally creates an NTFS junction, falling back to a Windows

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -338,16 +338,86 @@ pub fn remove_symlink(path: impl AsRef<Path>) -> std::io::Result<()> {
 mod tests {
     use super::*;
 
+    fn create_directory_link_target(tempdir: &tempfile::TempDir) -> std::io::Result<PathBuf> {
+        let target = tempdir.path().join("target");
+        fs_err::create_dir(&target)?;
+        Ok(target)
+    }
+
     #[test]
     fn read_link_reads_created_directory_link() -> std::io::Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let target = tempdir.path().join("target");
-        fs_err::create_dir(&target)?;
+        let target = create_directory_link_target(&tempdir)?;
         let link = tempdir.path().join("link");
 
         create_symlink(&target, &link)?;
 
         assert_eq!(read_link(&link)?, dunce::simplified(&target));
+        Ok(())
+    }
+
+    #[test]
+    fn replace_symlink_lenient_replaces_existing_file() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let target = create_directory_link_target(&tempdir)?;
+        let link = tempdir.path().join("link");
+        fs_err::write(&link, "contents")?;
+
+        replace_symlink_lenient(&target, &link)?;
+
+        assert_eq!(read_link(&link)?, dunce::simplified(&target));
+        Ok(())
+    }
+
+    #[test]
+    fn replace_symlink_lenient_replaces_existing_empty_directory() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let target = create_directory_link_target(&tempdir)?;
+        let link = tempdir.path().join("link");
+        fs_err::create_dir(&link)?;
+
+        replace_symlink_lenient(&target, &link)?;
+
+        assert_eq!(read_link(&link)?, dunce::simplified(&target));
+        Ok(())
+    }
+
+    #[test]
+    fn replace_symlink_lenient_preserves_non_empty_directory() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let target = create_directory_link_target(&tempdir)?;
+        let link = tempdir.path().join("link");
+        fs_err::create_dir(&link)?;
+        let child = link.join("child.txt");
+        fs_err::write(&child, "contents")?;
+
+        let err = match replace_symlink_lenient(&target, &link) {
+            Ok(()) => {
+                return Err(std::io::Error::other(
+                    "expected non-empty destination directory to be preserved",
+                ));
+            }
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::DirectoryNotEmpty);
+        assert_eq!(fs_err::read_to_string(&child)?, "contents");
+        Ok(())
+    }
+
+    #[test]
+    fn replace_symlink_lenient_replaces_existing_junction() -> std::io::Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let old_target = tempdir.path().join("old-target");
+        fs_err::create_dir(&old_target)?;
+        let new_target = tempdir.path().join("new-target");
+        fs_err::create_dir(&new_target)?;
+        let link = tempdir.path().join("link");
+        create_symlink(&old_target, &link)?;
+
+        replace_symlink_lenient(&new_target, &link)?;
+
+        assert_eq!(read_link(&link)?, dunce::simplified(&new_target));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This function is intended for centralised venvs. Pulling it out here to slim down that PR.

It might be helpful elsewhere though, haven't investigated yet.

## Test Plan

Added new windows unit tests (the \*nix path is just a forward to "replace_symlink").