### PR TITLE
Use async tar crate in `uv-build-backend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4866,17 +4866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddb6b06d20fba9ed21fca3d696ee1b6e870bca0bcf9fa2971f6ae2436de576a"
 
 [[package]]
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5681,6 +5670,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "astral-tokio-tar",
  "astral-version-ranges",
  "astral_async_zip",
  "axoupdater",
@@ -5724,7 +5714,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tar",
  "tempfile",
  "textwrap",
  "thiserror",
@@ -5943,6 +5932,7 @@ dependencies = [
 name = "uv-build-backend"
 version = "0.0.47"
 dependencies = [
+ "astral-tokio-tar",
  "astral-version-ranges",
  "astral_async_zip",
  "base64",
@@ -5962,9 +5952,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "spdx",
- "tar",
  "tempfile",
  "thiserror",
+ "tokio",
  "toml",
  "tracing",
  "uv-distribution-filename",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,6 @@ sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
 spdx = { version = "0.13.0" }
 syn = { version = "2.0.77" }
-tar = { version = "0.4.43" }
 target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.14.0" }
 textwrap = { version = "0.16.1" }

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -27,6 +27,7 @@ uv-pypi-types = { workspace = true }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
 
+astral-tokio-tar = { workspace = true }
 async_zip = { workspace = true }
 base64 = { workspace = true }
 csv = { workspace = true }
@@ -42,9 +43,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 spdx = { workspace = true }
-tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 version-ranges = { workspace = true }

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -442,7 +442,7 @@ mod tests {
     use async_zip::base::read::mem::ZipFileReader;
     use flate2::bufread::GzDecoder;
     use fs_err::File;
-    use futures_lite::future::block_on;
+    use futures_lite::{StreamExt, future::block_on};
     use indoc::indoc;
     use insta::assert_snapshot;
     use itertools::Itertools;
@@ -450,10 +450,13 @@ mod tests {
     use sha2::Digest;
     use std::io::BufReader;
     use std::iter;
+    use std::pin::Pin;
     use tempfile::TempDir;
     use uv_distribution_filename::{SourceDistFilename, WheelFilename};
     use uv_fs::{copy_dir_all, relative_to};
     use uv_preview::PreviewFeature;
+
+    use crate::source_dist::SyncReader;
 
     const MOCK_UV_VERSION: &str = "1.0.0+test";
 
@@ -515,9 +518,7 @@ mod tests {
 
         // Unpack the source distribution and build a wheel from it.
         let sdist_tree = TempDir::new()?;
-        let sdist_reader = BufReader::new(File::open(&source_dist_path)?);
-        let mut source_dist = tar::Archive::new(GzDecoder::new(sdist_reader));
-        source_dist.unpack(sdist_tree.path())?;
+        unpack_sdist(&source_dist_path, sdist_tree.path())?;
         let sdist_top_level_directory = sdist_tree.path().join(format!(
             "{}-{}",
             source_dist_filename.name.as_dist_info_name(),
@@ -565,22 +566,38 @@ mod tests {
 
     fn sdist_contents(source_dist_path: &Path) -> Vec<String> {
         let sdist_reader = BufReader::new(File::open(source_dist_path).unwrap());
-        let mut source_dist = tar::Archive::new(GzDecoder::new(sdist_reader));
-        let mut source_dist_contents: Vec<_> = source_dist
-            .entries()
-            .unwrap()
-            .map(|entry| {
-                entry
-                    .unwrap()
-                    .path()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .replace('\\', "/")
-            })
-            .collect();
+        let mut source_dist =
+            tokio_tar::Archive::new(SyncReader::new(GzDecoder::new(sdist_reader)));
+        let mut source_dist_contents = block_on(async {
+            let mut entries = source_dist.entries().unwrap();
+            let mut entries = Pin::new(&mut entries);
+            let mut contents = Vec::new();
+            while let Some(entry) = entries.next().await {
+                contents.push(
+                    entry
+                        .unwrap()
+                        .path()
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .replace('\\', "/"),
+                );
+            }
+            contents
+        });
         source_dist_contents.sort();
         source_dist_contents
+    }
+
+    fn unpack_sdist(source_dist_path: &Path, target: &Path) -> Result<(), Error> {
+        let sdist_reader = BufReader::new(File::open(source_dist_path)?);
+        let mut source_dist =
+            tokio_tar::Archive::new(SyncReader::new(GzDecoder::new(sdist_reader)));
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(source_dist.unpack(target))?;
+        Ok(())
     }
 
     fn wheel_contents(direct_output_dir: &Path) -> Vec<String> {
@@ -881,9 +898,7 @@ mod tests {
         build_source_dist(src.path(), output_dir.path(), "0.5.15", false).unwrap();
         let sdist_tree = TempDir::new().unwrap();
         let source_dist_path = output_dir.path().join("pep_pep639_license-1.0.0.tar.gz");
-        let sdist_reader = BufReader::new(File::open(&source_dist_path).unwrap());
-        let mut source_dist = tar::Archive::new(GzDecoder::new(sdist_reader));
-        source_dist.unpack(sdist_tree.path()).unwrap();
+        unpack_sdist(&source_dist_path, sdist_tree.path()).unwrap();
         {
             let _preview = uv_preview::test::with_features(&[]);
             build_wheel(

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -7,11 +7,15 @@ use crate::{
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use fs_err::File;
+use futures_lite::future::block_on;
 use globset::{Glob, GlobSet};
 use std::io;
-use std::io::{BufReader, Cursor, Write};
+use std::io::{BufReader, Cursor, Read, Write};
 use std::path::{Component, Path, PathBuf};
-use tar::{EntryType, Header};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_tar::{EntryType, Header};
 use tracing::{debug, trace};
 use uv_distribution_filename::{SourceDistExtension, SourceDistFilename};
 use uv_fs::{Simplified, normalize_path};
@@ -288,21 +292,78 @@ fn write_source_dist(
     Ok(filename)
 }
 
-struct TarGzWriter<W: Write> {
-    path: PathBuf,
-    tar: tar::Builder<GzEncoder<W>>,
+pub(crate) struct SyncReader<R> {
+    reader: R,
 }
 
-impl<W: Write> TarGzWriter<W> {
+impl<R> SyncReader<R> {
+    pub(crate) fn new(reader: R) -> Self {
+        Self { reader }
+    }
+}
+
+impl<R: Read + Unpin> AsyncRead for SyncReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let read = self.reader.read(buffer.initialize_unfilled())?;
+        buffer.advance(read);
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct SyncWriter<W> {
+    writer: W,
+}
+
+impl<W> SyncWriter<W> {
+    fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+impl<W: Write + Unpin> AsyncWrite for SyncWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(self.writer.write(buffer))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // `tokio::io::copy` flushes after each copied entry. Forwarding those flushes to the gzip
+        // encoder changes the deflate stream, even though the tar payload is identical. The
+        // encoder is finalized by `GzEncoder::finish` when the archive is closed.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_flush(context)
+    }
+}
+
+struct TarGzWriter<W: Write + Unpin + Send> {
+    path: PathBuf,
+    tar: tokio_tar::Builder<SyncWriter<GzEncoder<W>>>,
+}
+
+impl<W: Write + Unpin + Send> TarGzWriter<W> {
     fn new(writer: W, path: impl Into<PathBuf>) -> Self {
         let path = path.into();
         let enc = GzEncoder::new(writer, Compression::default());
-        let tar = tar::Builder::new(enc);
+        let tar = tokio_tar::Builder::new_non_terminated(SyncWriter::new(enc));
         Self { path, tar }
     }
 }
 
-impl<W: Write> DirectoryWriter for TarGzWriter<W> {
+impl<W: Write + Unpin + Send> DirectoryWriter for TarGzWriter<W> {
     fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error> {
         let mut header = Header::new_gnu();
         // Work around bug in Python's std tar module
@@ -313,9 +374,11 @@ impl<W: Write> DirectoryWriter for TarGzWriter<W> {
         // Reasonable default to avoid 0o000 permissions, the user's umask will be applied on
         // unpacking.
         header.set_mode(0o644);
-        self.tar
-            .append_data(&mut header, path, Cursor::new(bytes))
-            .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
+        block_on(
+            self.tar
+                .append_data(&mut header, path, SyncReader::new(Cursor::new(bytes))),
+        )
+        .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
         Ok(())
     }
 
@@ -346,9 +409,11 @@ impl<W: Write> DirectoryWriter for TarGzWriter<W> {
         }
         header.set_size(metadata.len());
         let reader = BufReader::new(File::open(file)?);
-        self.tar
-            .append_data(&mut header, path, reader)
-            .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
+        block_on(
+            self.tar
+                .append_data(&mut header, path, SyncReader::new(reader)),
+        )
+        .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
         Ok(())
     }
 
@@ -358,16 +423,22 @@ impl<W: Write> DirectoryWriter for TarGzWriter<W> {
         header.set_mode(0o755);
         header.set_entry_type(EntryType::Directory);
         header.set_size(0);
-        self.tar
-            .append_data(&mut header, directory, io::empty())
-            .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
+        block_on(
+            self.tar
+                .append_data(&mut header, directory, SyncReader::new(io::empty())),
+        )
+        .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
         Ok(())
     }
 
-    fn close(mut self, _dist_info_dir: &str) -> Result<(), Error> {
-        self.tar
+    fn close(self, _dist_info_dir: &str) -> Result<(), Error> {
+        let path = self.path;
+        let writer =
+            block_on(self.tar.into_inner()).map_err(|err| Error::TarWrite(path.clone(), err))?;
+        writer
+            .into_inner()
             .finish()
-            .map_err(|err| Error::TarWrite(self.path.clone(), err))?;
+            .map_err(|err| Error::TarWrite(path, err))?;
         Ok(())
     }
 }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -146,7 +146,7 @@ predicates = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"], default-features = false }
 sha2 = { workspace = true }
-tar = { workspace = true }
+astral-tokio-tar = { workspace = true }
 tempfile = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -3,12 +3,14 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileTouch, FileWriteBin, FileWriteStr, PathChild, PathCreateDir};
 use flate2::bufread::GzDecoder;
 use fs_err::File;
+use futures::io::AllowStdIo;
 use indoc::{formatdoc, indoc};
 use insta::{assert_json_snapshot, assert_snapshot};
 use std::io::BufReader;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
+use tokio_util::compat::FuturesAsyncReadCompatExt;
 use uv_static::EnvVars;
 use uv_test::{uv_snapshot, venv_bin_path};
 
@@ -19,6 +21,17 @@ const BUILT_BY_UV_TEST_SCRIPT: &str = indoc! {r#"
     print(greet())
     print(f"Area of a circle with r=2: {area(2)}")
 "#};
+
+fn unpack_tar_gz(source_dist_path: &Path, target: &Path) -> Result<()> {
+    let sdist_reader = BufReader::new(File::open(source_dist_path)?);
+    let mut source_dist =
+        tokio_tar::Archive::new(AllowStdIo::new(GzDecoder::new(sdist_reader)).compat());
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(source_dist.unpack(target))?;
+    Ok(())
+}
 
 /// Test that build backend works if we invoke it directly.
 ///
@@ -102,10 +115,10 @@ fn built_by_uv_direct() -> Result<()> {
 
     let sdist_tree = TempDir::new()?;
 
-    let sdist_reader = BufReader::new(File::open(
-        sdist_dir.path().join("built_by_uv-0.1.0.tar.gz"),
-    )?);
-    tar::Archive::new(GzDecoder::new(sdist_reader)).unpack(sdist_tree.path())?;
+    unpack_tar_gz(
+        &sdist_dir.path().join("built_by_uv-0.1.0.tar.gz"),
+        sdist_tree.path(),
+    )?;
 
     drop(sdist_dir);
 

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -8,8 +8,11 @@ use anyhow::Result;
 use assert_fs::prelude::*;
 use flate2::write::GzEncoder;
 use fs_err::File;
+use futures::executor::block_on;
+use futures::io::AllowStdIo;
 use http::StatusCode;
 use indoc::indoc;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use url::Url;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -20,6 +23,27 @@ use uv_static::EnvVars;
 use uv_test::{
     DEFAULT_PYTHON_VERSION, TestContext, download_to_disk, packse_index_url, uv_snapshot,
 };
+
+fn write_tar_gz(file: File, entries: &[(&str, &str)]) -> Result<()> {
+    let enc = GzEncoder::new(file, flate2::Compression::default());
+    let mut tar = tokio_tar::Builder::new_non_terminated(AllowStdIo::new(enc).compat_write());
+
+    for (path, contents) in entries {
+        let mut header = tokio_tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        block_on(tar.append_data(
+            &mut header,
+            path,
+            AllowStdIo::new(Cursor::new(contents)).compat(),
+        ))?;
+    }
+
+    let writer = block_on(tar.into_inner())?;
+    writer.into_inner().into_inner().finish()?;
+    Ok(())
+}
 
 #[test]
 fn compile_requirements_in() -> Result<()> {
@@ -15444,20 +15468,13 @@ fn dynamic_version_source_dist() -> Result<()> {
     // Flush the file after we're done.
     {
         let file = File::create(source_dist.path())?;
-        let enc = GzEncoder::new(file, flate2::Compression::default());
-        let mut tar = tar::Builder::new(enc);
-
-        for (path, contents) in [
-            ("foo-1.2.3/pyproject.toml", pyproject_toml),
-            ("foo-1.2.3/setup.py", setup_py),
-        ] {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(contents.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            tar.append_data(&mut header, path, Cursor::new(contents))?;
-        }
-        tar.finish()?;
+        write_tar_gz(
+            file,
+            &[
+                ("foo-1.2.3/pyproject.toml", pyproject_toml),
+                ("foo-1.2.3/setup.py", setup_py),
+            ],
+        )?;
     }
 
     let requirements_in = context.temp_dir.child("requirements.in");

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -11,9 +11,11 @@ use flate2::write::GzEncoder;
 use fs_err as fs;
 use fs_err::File;
 use futures::executor::block_on;
+use futures::io::AllowStdIo;
 use indoc::{formatdoc, indoc};
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use url::Url;
 use walkdir::WalkDir;
 use wiremock::{
@@ -29,6 +31,27 @@ use uv_test::{
     DEFAULT_PYTHON_VERSION, TestContext, apply_filters, build_vendor_links_url, download_to_disk,
     get_bin, packse_index_url, uv_snapshot, venv_bin_path,
 };
+
+fn write_tar_gz(file: File, entries: &[(&str, &str)]) -> Result<()> {
+    let enc = GzEncoder::new(file, flate2::Compression::default());
+    let mut tar = tokio_tar::Builder::new_non_terminated(AllowStdIo::new(enc).compat_write());
+
+    for (path, contents) in entries {
+        let mut header = tokio_tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        block_on(tar.append_data(
+            &mut header,
+            path,
+            AllowStdIo::new(Cursor::new(contents)).compat(),
+        ))?;
+    }
+
+    let writer = block_on(tar.into_inner())?;
+    writer.into_inner().into_inner().finish()?;
+    Ok(())
+}
 
 #[test]
 fn missing_requirements_txt() {
@@ -10071,20 +10094,13 @@ fn test_dynamic_version_sdist_wrong_version() -> Result<()> {
     // Flush the file after we're done.
     {
         let file = File::create(source_dist.path())?;
-        let enc = GzEncoder::new(file, flate2::Compression::default());
-        let mut tar = tar::Builder::new(enc);
-
-        for (path, contents) in [
-            ("foo-1.2.3/pyproject.toml", pyproject_toml),
-            ("foo-1.2.3/setup.py", setup_py),
-        ] {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(contents.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            tar.append_data(&mut header, path, Cursor::new(contents))?;
-        }
-        tar.finish()?;
+        write_tar_gz(
+            file,
+            &[
+                ("foo-1.2.3/pyproject.toml", pyproject_toml),
+                ("foo-1.2.3/setup.py", setup_py),
+            ],
+        )?;
     }
 
     uv_snapshot!(context.filters(), context


### PR DESCRIPTION
## Summary

The motivation and approach here is identical to #19365, but for tar. This doesn't have a meaningful effect on build size (since we _only_ use `tar` in `uv-build` and `astral-tokio-tar` in `uv`), but it does mean we aren't exposed to CVEs in `tar`.
