### PR TITLE
Apply workspace-member `[tool.uv.sources]` credentials under `uv sync --frozen`

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3657,15 +3657,6 @@ impl Package {
             is_local: self.id.source.is_local(),
         }
     }
-
-    /// If this package represents a workspace member, return its path relative
-    /// to the workspace install root.
-    pub fn as_workspace_member(&self) -> Option<&Path> {
-        match &self.id.source {
-            Source::Editable(path) | Source::Virtual(path) => Some(path),
-            _ => None,
-        }
-    }
 }
 
 /// Attempts to construct a `VerbatimUrl` from the given normalized `Path`.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3657,6 +3657,15 @@ impl Package {
             is_local: self.id.source.is_local(),
         }
     }
+
+    /// If this package represents a workspace member, return its path relative
+    /// to the workspace install root.
+    pub fn as_workspace_member(&self) -> Option<&Path> {
+        match &self.id.source {
+            Source::Editable(path) | Source::Virtual(path) => Some(path),
+            _ => None,
+        }
+    }
 }
 
 /// Attempts to construct a `VerbatimUrl` from the given normalized `Path`.

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -92,6 +92,8 @@ pub enum MemberDiscovery {
     /// Discover all workspace members.
     #[default]
     All,
+    /// Discover workspace members that are present, but ignore missing members.
+    Existing,
     /// Don't discover any workspace members.
     None,
     /// Discover workspace members, but ignore the given paths.
@@ -1005,7 +1007,7 @@ impl Workspace {
 
                 // If the directory is explicitly ignored, skip it.
                 let skip = match &options.members {
-                    MemberDiscovery::All => false,
+                    MemberDiscovery::All | MemberDiscovery::Existing => false,
                     MemberDiscovery::None => true,
                     MemberDiscovery::Ignore(ignore) => ignore.contains(member_root.as_path()),
                 };
@@ -1036,7 +1038,21 @@ impl Workspace {
                 let contents = match fs_err::tokio::read_to_string(&pyproject_path).await {
                     Ok(contents) => contents,
                     Err(err) => {
-                        if !fs_err::metadata(&member_root)?.is_dir() {
+                        let metadata = match fs_err::metadata(&member_root) {
+                            Ok(metadata) => metadata,
+                            Err(err)
+                                if matches!(options.members, MemberDiscovery::Existing)
+                                    && err.kind() == std::io::ErrorKind::NotFound =>
+                            {
+                                debug!(
+                                    "Ignoring missing workspace member: `{}`",
+                                    member_root.simplified_display()
+                                );
+                                continue;
+                            }
+                            Err(err) => return Err(err.into()),
+                        };
+                        if !metadata.is_dir() {
                             warn!(
                                 "Ignoring non-directory workspace member: `{}`",
                                 member_root.simplified_display()
@@ -1064,6 +1080,14 @@ impl Workspace {
                             if has_only_gitignored_files(&member_root) {
                                 debug!(
                                     "Ignoring workspace member with only gitignored files: `{}`",
+                                    member_root.simplified_display()
+                                );
+                                continue;
+                            }
+
+                            if matches!(options.members, MemberDiscovery::Existing) {
+                                debug!(
+                                    "Ignoring missing workspace member: `{}`",
                                     member_root.simplified_display()
                                 );
                                 continue;

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
-use tracing::warn;
+use tracing::{debug, warn};
 use uv_cache::Cache;
 use uv_cli::SyncFormat;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -31,7 +31,7 @@ use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user;
-use uv_workspace::pyproject::Source;
+use uv_workspace::pyproject::{PyProjectToml, Source, Sources, ToolUvSources};
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::editable::apply_editable_mode;
@@ -784,7 +784,7 @@ pub(super) async fn do_sync(
     let extra_build_requires = extra_build_requires.match_runtime(&resolution)?;
 
     // Populate credentials from the target.
-    store_credentials_from_target(target, &client_builder);
+    store_credentials_from_target(target, &client_builder).await;
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder, cache.clone())
@@ -905,7 +905,20 @@ fn apply_no_virtual_project(resolution: Resolution) -> Resolution {
 ///
 /// These credentials can come from any of `tool.uv.sources`, `tool.uv.dev-dependencies`,
 /// `project.dependencies`, and `project.optional-dependencies`.
-fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &BaseClientBuilder) {
+async fn store_credentials_from_target(
+    target: InstallTarget<'_>,
+    client_builder: &BaseClientBuilder<'_>,
+) {
+    let dispatch = |source: &Source| match source {
+        Source::Git { git, .. } => {
+            uv_git::store_credentials_from_url(git);
+        }
+        Source::Url { url, .. } => {
+            client_builder.store_credentials_from_url(url);
+        }
+        _ => {}
+    };
+
     // Iterate over any indexes in the target.
     for index in target.indexes() {
         if let Some(credentials) = index.credentials() {
@@ -918,15 +931,7 @@ fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &Bas
 
     // Iterate over any sources in the target.
     for source in target.sources() {
-        match source {
-            Source::Git { git, .. } => {
-                uv_git::store_credentials_from_url(git);
-            }
-            Source::Url { url, .. } => {
-                client_builder.store_credentials_from_url(url);
-            }
-            _ => {}
-        }
+        dispatch(source);
     }
 
     // Iterate over any dependencies defined in the target.
@@ -942,6 +947,59 @@ fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &Bas
                 client_builder.store_credentials_from_url(url);
             }
             _ => {}
+        }
+    }
+
+    // Under `--frozen` (and similar), workspace members aren't loaded into
+    // `workspace.packages()`, so their `[tool.uv.sources]` entries are
+    // invisible to the iteration above. Re-discover them via the lockfile.
+    let (workspace, lock) = match target {
+        InstallTarget::Project {
+            workspace, lock, ..
+        }
+        | InstallTarget::Projects {
+            workspace, lock, ..
+        }
+        | InstallTarget::Workspace { workspace, lock }
+        | InstallTarget::NonProjectWorkspace { workspace, lock } => (workspace, lock),
+        InstallTarget::Script { .. } => return,
+    };
+    let loaded = workspace.packages();
+    let install_path = workspace.install_path();
+    for package in lock.packages() {
+        let Some(relative) = package.as_workspace_member() else {
+            continue;
+        };
+        if loaded.contains_key(package.name()) {
+            continue;
+        }
+        let pyproject_path = install_path.join(relative).join("pyproject.toml");
+        let pyproject = match fs_err::tokio::read_to_string(&pyproject_path)
+            .await
+            .map_err(|err| err.to_string())
+            .and_then(|contents| {
+                PyProjectToml::from_string(contents, &pyproject_path).map_err(|err| err.to_string())
+            }) {
+            Ok(pyproject) => pyproject,
+            Err(err) => {
+                debug!(
+                    "Skipping credential discovery for `{}`: {err}",
+                    pyproject_path.display()
+                );
+                continue;
+            }
+        };
+        let Some(sources) = pyproject
+            .tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.sources.as_ref())
+            .map(ToolUvSources::inner)
+        else {
+            continue;
+        };
+        for source in sources.values().flat_map(Sources::iter) {
+            dispatch(source);
         }
     }
 }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -31,7 +31,7 @@ use uv_scripts::Pep723Script;
 use uv_settings::PythonInstallMirrors;
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user;
-use uv_workspace::pyproject::{PyProjectToml, Source, Sources, ToolUvSources};
+use uv_workspace::pyproject::Source;
 use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::editable::apply_editable_mode;
@@ -101,7 +101,7 @@ pub(crate) async fn sync(
             VirtualProject::discover(
                 project_dir,
                 &DiscoveryOptions {
-                    members: MemberDiscovery::None,
+                    members: MemberDiscovery::Existing,
                     ..DiscoveryOptions::default()
                 },
                 workspace_cache,
@@ -784,7 +784,7 @@ pub(super) async fn do_sync(
     let extra_build_requires = extra_build_requires.match_runtime(&resolution)?;
 
     // Populate credentials from the target.
-    store_credentials_from_target(target, &client_builder).await;
+    store_credentials_from_target(target, &client_builder);
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder, cache.clone())
@@ -905,20 +905,7 @@ fn apply_no_virtual_project(resolution: Resolution) -> Resolution {
 ///
 /// These credentials can come from any of `tool.uv.sources`, `tool.uv.dev-dependencies`,
 /// `project.dependencies`, and `project.optional-dependencies`.
-async fn store_credentials_from_target(
-    target: InstallTarget<'_>,
-    client_builder: &BaseClientBuilder<'_>,
-) {
-    let dispatch = |source: &Source| match source {
-        Source::Git { git, .. } => {
-            uv_git::store_credentials_from_url(git);
-        }
-        Source::Url { url, .. } => {
-            client_builder.store_credentials_from_url(url);
-        }
-        _ => {}
-    };
-
+fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &BaseClientBuilder) {
     // Iterate over any indexes in the target.
     for index in target.indexes() {
         if let Some(credentials) = index.credentials() {
@@ -931,7 +918,15 @@ async fn store_credentials_from_target(
 
     // Iterate over any sources in the target.
     for source in target.sources() {
-        dispatch(source);
+        match source {
+            Source::Git { git, .. } => {
+                uv_git::store_credentials_from_url(git);
+            }
+            Source::Url { url, .. } => {
+                client_builder.store_credentials_from_url(url);
+            }
+            _ => {}
+        }
     }
 
     // Iterate over any dependencies defined in the target.
@@ -947,50 +942,6 @@ async fn store_credentials_from_target(
                 client_builder.store_credentials_from_url(url);
             }
             _ => {}
-        }
-    }
-
-    // Under `--frozen` (and similar), workspace members aren't loaded into
-    // `workspace.packages()`, so their `[tool.uv.sources]` entries are
-    // invisible to the iteration above. Re-discover them via the lockfile.
-    let (workspace, lock) = match target {
-        InstallTarget::Project {
-            workspace, lock, ..
-        }
-        | InstallTarget::Projects {
-            workspace, lock, ..
-        }
-        | InstallTarget::Workspace { workspace, lock }
-        | InstallTarget::NonProjectWorkspace { workspace, lock } => (workspace, lock),
-        InstallTarget::Script { .. } => return,
-    };
-    let loaded = workspace.packages();
-    let install_path = workspace.install_path();
-    for package in lock.packages() {
-        let Some(relative) = package.as_workspace_member() else {
-            continue;
-        };
-        if loaded.contains_key(package.name()) {
-            continue;
-        }
-        let pyproject_path = install_path.join(relative).join("pyproject.toml");
-        let Ok(contents) = fs_err::tokio::read_to_string(&pyproject_path).await else {
-            continue;
-        };
-        let Ok(pyproject) = PyProjectToml::from_string(contents, &pyproject_path) else {
-            continue;
-        };
-        let Some(sources) = pyproject
-            .tool
-            .as_ref()
-            .and_then(|tool| tool.uv.as_ref())
-            .and_then(|uv| uv.sources.as_ref())
-            .map(ToolUvSources::inner)
-        else {
-            continue;
-        };
-        for source in sources.values().flat_map(Sources::iter) {
-            dispatch(source);
         }
     }
 }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
-use tracing::{debug, warn};
+use tracing::warn;
 use uv_cache::Cache;
 use uv_cli::SyncFormat;
 use uv_client::{BaseClientBuilder, FlatIndexClient, RegistryClientBuilder};
@@ -974,20 +974,11 @@ async fn store_credentials_from_target(
             continue;
         }
         let pyproject_path = install_path.join(relative).join("pyproject.toml");
-        let pyproject = match fs_err::tokio::read_to_string(&pyproject_path)
-            .await
-            .map_err(|err| err.to_string())
-            .and_then(|contents| {
-                PyProjectToml::from_string(contents, &pyproject_path).map_err(|err| err.to_string())
-            }) {
-            Ok(pyproject) => pyproject,
-            Err(err) => {
-                debug!(
-                    "Skipping credential discovery for `{}`: {err}",
-                    pyproject_path.display()
-                );
-                continue;
-            }
+        let Ok(contents) = fs_err::tokio::read_to_string(&pyproject_path).await else {
+            continue;
+        };
+        let Ok(pyproject) = PyProjectToml::from_string(contents, &pyproject_path) else {
+            continue;
         };
         let Some(sources) = pyproject
             .tool

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -16477,3 +16477,70 @@ fn sync_reinstalls_on_version_change() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for #19419: `uv sync --frozen` must honor credentials
+/// declared in a workspace member's `[tool.uv.sources]`. Under `--frozen`,
+/// project discovery skips members, so credentials have to be re-collected
+/// from each member's `pyproject.toml` on disk.
+#[test]
+#[cfg(feature = "test-git")]
+fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
+    use uv_test::{READ_ONLY_GITHUB_TOKEN, decode_token};
+
+    let context = uv_test::test_context!("3.12").with_filtered_link_mode_warning();
+    let token = decode_token(READ_ONLY_GITHUB_TOKEN);
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc::indoc! {r#"
+        [project]
+        name = "root"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["uv-private-pypackage"]
+
+        [tool.uv.workspace]
+        members = ["nested"]
+    "#})?;
+
+    let nested = context.temp_dir.child("nested");
+    nested.create_dir_all()?;
+    nested.child("pyproject.toml").write_str(&formatdoc! {
+        r#"
+        [project]
+        name = "nested"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["uv-private-pypackage"]
+
+        [tool.uv.sources]
+        uv-private-pypackage = {{ git = "https://{token}@github.com/astral-test/uv-private-pypackage" }}
+        "#,
+        token = token,
+    })?;
+
+    // `uv lock` reads the member's `[tool.uv.sources]` and resolves successfully.
+    uv_snapshot!(&context.filters(), context.lock(), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    // `uv sync --frozen` must propagate credentials from the member's
+    // `[tool.uv.sources]` to `GIT_STORE`, even though member discovery is
+    // disabled. Use `--reinstall --no-cache` so the git fetch actually runs.
+    uv_snapshot!(&context.filters(), context.sync().arg("--frozen").arg("--reinstall").arg("--no-cache"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-private-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-private-pypackage@d780faf0ac91257d4d5a4f0c5a0e4509608c0071)
+    ");
+
+    Ok(())
+}

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -16479,9 +16479,7 @@ fn sync_reinstalls_on_version_change() -> Result<()> {
 }
 
 /// Regression test for #19419: `uv sync --frozen` must honor credentials
-/// declared in a workspace member's `[tool.uv.sources]`. Under `--frozen`,
-/// project discovery skips members, so credentials have to be re-collected
-/// from each member's `pyproject.toml` on disk.
+/// declared in a workspace member's `[tool.uv.sources]`.
 #[test]
 #[cfg(feature = "test-git")]
 fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
@@ -16529,8 +16527,8 @@ fn sync_frozen_workspace_member_git_credentials() -> Result<()> {
     ");
 
     // `uv sync --frozen` must propagate credentials from the member's
-    // `[tool.uv.sources]` to `GIT_STORE`, even though member discovery is
-    // disabled. Use `--reinstall --no-cache` so the git fetch actually runs.
+    // `[tool.uv.sources]` to `GIT_STORE`. Use `--reinstall --no-cache` so the
+    // git fetch actually runs.
     uv_snapshot!(&context.filters(), context.sync().arg("--frozen").arg("--reinstall").arg("--no-cache"), @r"
     success: true
     exit_code: 0


### PR DESCRIPTION
When running `uv sync --frozen`, project discovery uses `MemberDiscovery::None`, so workspace members aren't loaded into `workspace.packages()` and their `[tool.uv.sources]` entries are invisible to `store_credentials_from_target`. For private Git dependencies this fails with e.g. `fatal: could not read Username for 'https://github.com': terminal prompts disabled`.

Walk `lock.packages()` for workspace-member entries (`Source::Editable` or `Source::Virtual`) not already loaded, read each `pyproject.toml` off disk, and feed `[tool.uv.sources]` `Git` or `Url` entries into the existing credential stores.

Closes #19419.