### PR TITLE
Skip Unix-specific installation steps when cross-installing Windows Python distributions

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1370,19 +1370,22 @@ impl ManagedPythonDownload {
                 )?;
             }
 
-            // If the distribution is missing a `python` -> `pythonX.Y` symlink, add it.
+            // If the distribution is missing a `python` -> `pythonX.Y` symlink and the target is
+            // not windows, add it.
             //
             // Pyodide releases never contain this link by default.
             //
             // PEP 394 permits it, and python-build-standalone releases after `20240726` include it,
             // but releases prior to that date do not.
-            match fs_err::os::unix::fs::symlink(
-                format!("python{}.{}", self.key.major, self.key.minor),
-                extracted.join("bin").join("python"),
-            ) {
-                Ok(()) => {}
-                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
-                Err(err) => return Err(err.into()),
+            if !self.os().is_windows() {
+                match fs_err::os::unix::fs::symlink(
+                    format!("python{}.{}", self.key.major, self.key.minor),
+                    extracted.join("bin").join("python"),
+                ) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(err) => return Err(err.into()),
+                }
             }
         }
 

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -1370,8 +1370,9 @@ impl ManagedPythonDownload {
                 )?;
             }
 
-            // If the distribution is missing a `python` -> `pythonX.Y` symlink and the target is
-            // not windows, add it.
+            // If the distribution is missing a `python` -> `pythonX.Y` symlink, add it.
+            //
+            // We skip for Windows distributions, allowing cross-installs from Unix.
             //
             // Pyodide releases never contain this link by default.
             //

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -604,7 +604,7 @@ impl ManagedPythonInstallation {
                 // sysconfig directly
                 return Ok(());
             }
-            if self.implementation() == ImplementationName::CPython {
+            if !self.key.os().is_windows() && self.implementation() == ImplementationName::CPython {
                 sysconfig::update_sysconfig(
                     self.path(),
                     self.key.major,

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -598,13 +598,13 @@ impl ManagedPythonInstallation {
 
     /// Ensure that the `sysconfig` data is patched to match the installation path.
     pub fn ensure_sysconfig_patched(&self) -> Result<(), Error> {
-        if cfg!(unix) {
+        if cfg!(unix) && !self.key.os().is_windows() {
             if self.key.os().is_emscripten() {
                 // Emscripten's stdlib is a zip file so we can't update the
                 // sysconfig directly
                 return Ok(());
             }
-            if !self.key.os().is_windows() && self.implementation() == ImplementationName::CPython {
+            if self.implementation() == ImplementationName::CPython {
                 sysconfig::update_sysconfig(
                     self.path(),
                     self.key.major,


### PR DESCRIPTION
## Summary

Previously installing a windows python on linux failed, because the windows python install does not have a `python` binary and it does not use a `_sysconfigdata_*` file.

## Test Plan

Manually tested by running `uv python install  cpython-3.12.3-windows-x86_64-none`