### PR TITLE
Preserve files claimed by another package's RECORD on uninstall

### DIFF
--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -36,6 +36,14 @@ pub fn uninstall_wheel(
         read_record(&mut record_file)?
     };
 
+    // Build the set of paths that are also claimed by some other installed package's
+    // `RECORD`. Some package pairs (e.g. `opencv-python` and `opencv-contrib-python`,
+    // which both ship a top-level `cv2/` package) overlap on disk. When the user
+    // removes one of them, we must NOT delete files that the remaining package
+    // also claims, otherwise `import cv2` (or the equivalent) breaks until the
+    // user re-installs from scratch. See issue #19412.
+    let shared_paths = collect_shared_paths(site_packages, dist_info);
+
     let mut file_count = 0usize;
     let mut dir_count = 0usize;
 
@@ -48,6 +56,16 @@ pub fn uninstall_wheel(
         let path = site_packages.join(&entry.path);
 
         if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
+            continue;
+        }
+
+        // Skip files that another installed package's `RECORD` also claims; the
+        // remaining package still needs them. See issue #19412.
+        if shared_paths.contains(&path) {
+            trace!(
+                "Skipping shared file (also owned by another installed package): {}",
+                path.display()
+            );
             continue;
         }
 
@@ -238,6 +256,51 @@ fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
 
 fn is_safe_top_level_entry(entry: &str) -> bool {
     !entry.is_empty() && entry != "." && entry != ".." && !entry.contains(['/', '\\'])
+}
+
+/// Collect the set of paths under `site_packages` that are listed in some OTHER
+/// installed package's `RECORD`, excluding the one we are about to uninstall
+/// (`dist_info_being_removed`).
+///
+/// This walks every `*.dist-info` directory in `site_packages` other than the
+/// one being removed and reads each `RECORD`. Any `RECORD` we cannot read (e.g.
+/// missing, malformed, or a path we cannot resolve) is silently skipped, since
+/// the existing uninstall logic already tolerates missing-on-disk entries via
+/// `ErrorKind::NotFound` and the worst case from skipping a malformed `RECORD`
+/// here is reverting to the pre-fix behavior for those specific files. This is
+/// strictly an additive safety check.
+///
+/// Returns an empty set if `site_packages` cannot be read at all.
+fn collect_shared_paths(site_packages: &Path, dist_info_being_removed: &Path) -> HashSet<PathBuf> {
+    let mut shared = HashSet::new();
+    let Ok(entries) = fs_err::read_dir(site_packages) else {
+        return shared;
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        if entry_path == dist_info_being_removed {
+            continue;
+        }
+        // Only consider sibling `.dist-info` directories.
+        if !entry_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".dist-info"))
+        {
+            continue;
+        }
+        let other_record_path = entry_path.join("RECORD");
+        let Ok(mut other_record_file) = fs_err::File::open(&other_record_path) else {
+            continue;
+        };
+        let Ok(other_record) = read_record(&mut other_record_file) else {
+            continue;
+        };
+        for other_entry in other_record {
+            shared.insert(site_packages.join(&other_entry.path));
+        }
+    }
+    shared
 }
 
 /// Uninstall the egg represented by the `.egg-info` directory.
@@ -456,6 +519,8 @@ fn normalize_path(path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use assert_fs::prelude::*;
 
     use uv_pypi_types::Scheme;
@@ -652,5 +717,102 @@ mod tests {
             "uninstall must not remove site-packages itself"
         );
         assert!(sibling_init.exists(), "sibling package must not be removed");
+    }
+
+    /// Build a layout whose install scheme points at `site_packages`.
+    fn layout_for(venv: &Path, site_packages: &Path) -> Layout {
+        Layout {
+            sys_executable: venv.join("bin/python"),
+            python_version: (3, 12),
+            os_name: "posix".to_string(),
+            scheme: Scheme {
+                purelib: site_packages.to_path_buf(),
+                platlib: site_packages.to_path_buf(),
+                scripts: venv.join("bin"),
+                data: venv.to_path_buf(),
+                include: venv.join("include/python3.12"),
+            },
+        }
+    }
+
+    /// Two installed wheels sharing a file (the `opencv-python` / `opencv-contrib-python`
+    /// pattern reported in #19412): uninstalling one must not delete the shared file.
+    #[test]
+    fn shared_files_are_preserved_when_one_overlapping_wheel_is_uninstalled() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        site_packages.create_dir_all().unwrap();
+
+        let shared = site_packages.child("cv2/__init__.py");
+        shared.touch().unwrap();
+        let pkg_a_only = site_packages.child("pkg_a_only.py");
+        pkg_a_only.touch().unwrap();
+        let pkg_b_only = site_packages.child("pkg_b_only.py");
+        pkg_b_only.touch().unwrap();
+
+        let dist_a = site_packages.child("pkg_a-1.0.dist-info");
+        dist_a.create_dir_all().unwrap();
+        dist_a
+            .child("RECORD")
+            .write_str(
+                "cv2/__init__.py,,\n\
+                 pkg_a_only.py,,\n\
+                 pkg_a-1.0.dist-info/RECORD,,\n",
+            )
+            .unwrap();
+
+        let dist_b = site_packages.child("pkg_b-1.0.dist-info");
+        dist_b.create_dir_all().unwrap();
+        dist_b
+            .child("RECORD")
+            .write_str(
+                "cv2/__init__.py,,\n\
+                 pkg_b_only.py,,\n\
+                 pkg_b-1.0.dist-info/RECORD,,\n",
+            )
+            .unwrap();
+
+        uninstall_wheel(
+            dist_a.path(),
+            "pkg_a 1.0",
+            &layout_for(venv.path(), site_packages.path()),
+        )
+        .unwrap();
+
+        assert!(!pkg_a_only.exists());
+        assert!(pkg_b_only.exists());
+        assert!(
+            shared.exists(),
+            "shared cv2/__init__.py was deleted when uninstalling pkg_a, but pkg_b still needs it"
+        );
+    }
+
+    /// A wheel with no overlapping dist-info should still have its files removed normally.
+    #[test]
+    fn unique_files_are_removed_when_no_overlap_exists() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        site_packages.create_dir_all().unwrap();
+
+        let solo = site_packages.child("solo/__init__.py");
+        solo.touch().unwrap();
+
+        let dist = site_packages.child("solo-1.0.dist-info");
+        dist.create_dir_all().unwrap();
+        dist.child("RECORD")
+            .write_str(
+                "solo/__init__.py,,\n\
+                 solo-1.0.dist-info/RECORD,,\n",
+            )
+            .unwrap();
+
+        uninstall_wheel(
+            dist.path(),
+            "solo 1.0",
+            &layout_for(venv.path(), site_packages.path()),
+        )
+        .unwrap();
+
+        assert!(!solo.exists());
     }
 }


### PR DESCRIPTION
## Summary

When two installed wheels overlap on disk, uninstalling one currently deletes the shared files even though the remaining package's `RECORD` still claims them. The canonical example is `opencv-python` and `opencv-contrib-python`, which both ship a top-level `cv2/__init__.py`; the same pattern shows up for `types-boto3-full` vs `types-boto3-ecr`, and for any other pair of distributions that share files. After the uninstall the surviving package's metadata is intact but `import` fails, and a subsequent `uv sync` does not notice anything is wrong because each installed dist-info is still present.

This is the "(2)" path Charlie sketched in #15238:

> It would be nice if we could either (1) detect incomplete installs or (2) avoid removing those files when they're referenced in another `RECORD`.

`uninstall_wheel` now builds a one-shot `HashSet<PathBuf>` of paths claimed by all OTHER sibling `*.dist-info/RECORD` files in the same `site-packages` before the deletion loop runs, and skips any path in that set during deletion. Sibling RECORDs that are missing or malformed are silently skipped; the worst case for those specific files is reverting to the pre-fix behavior.

This is a deliberate divergence from pip, which exhibits the same bug ([Charlie's repro on #15238](https://github.com/astral-sh/uv/issues/15238#issuecomment-3169570974)). Reinstalling does not fix it under pip because the package appears to be installed, so the shared file stays gone until the venv is recreated.

Closes #19412.
Addresses option (2) from #15238 and #16468.

## Reproduction

Before this change, on `astral-sh/uv@main`:

```
$ uv init repro && cd repro
$ uv add opencv-python opencv-contrib-python
$ uv run python -c "import cv2; print(cv2.__version__)"
4.13.0

$ uv remove opencv-python
$ uv sync
$ uv run python -c "import cv2; print(cv2.__version__)"
AttributeError: module 'cv2' has no attribute '__version__'
```

After this change the second `uv run` succeeds with `4.13.0`, because `cv2/__init__.py` is preserved on the uninstall (it is still listed in `opencv_contrib_python-*.dist-info/RECORD`).

## Cost

The new check runs once per uninstalled wheel and is bounded by the number of *other* installed packages, not by the file count of the wheel being removed.

For a venv with `N` sibling `.dist-info` directories each listing `M` files, the cost is `O(N)` `open()` + `read()` calls plus `O(N*M)` hash inserts. On a typical venv (tens to a few hundred packages, tens to a few hundred files each) this is dominated by the syscalls the deletion loop itself does. The hot path (the per-entry `remove_file` loop) gets one extra `HashSet::contains` per entry, which is `O(1)`.

## Implementation notes

- The skip happens after the existing `is_path_in_scheme` check and before any `remove_file` / `remove_dir_all` call, so a shared path is logged via `trace!` and otherwise treated identically to a missing-on-disk entry (no `file_count` increment, no `visited` set entry).
- Only `*.dist-info` siblings are scanned. Egg-info directories are skipped intentionally; the legacy egg layout has its own uninstall path that does not interact with wheel RECORDs.
- The `collect_shared_paths` helper builds absolute paths via `site_packages.join(&entry.path)`, matching the lookup key built the same way in the deletion loop.

## What this does NOT fix

This is the defensive half of the problem. It prevents new breakage from the overlapping-wheel pattern, but it does not repair venvs that are already in a broken state from a previous uninstall (or from any other cause that leaves a `RECORD`-on-disk mismatch: manual `rm`, interrupted install, etc.). That is option (1) from Charlie's #15238 comment, and is a separate, more involved change in `RequirementSatisfaction::check` and `SitePackages::diagnostics`. I am happy to take that on as a follow-up if there is interest.

## Test plan

- [x] New regression test `shared_files_are_preserved_when_one_overlapping_wheel_is_uninstalled` in `crates/uv-install-wheel/src/uninstall.rs` mirrors the opencv pattern with two synthetic packages sharing `cv2/__init__.py`; the test asserts the shared file survives the uninstall while each package's unique file is removed.
- [x] New regression test `unique_files_are_removed_when_no_overlap_exists` confirms the no-overlap path is unaffected (a single package with no sibling RECORDs has its files deleted normally).
- [x] `cargo test -p uv-install-wheel --lib`: 22 passed (20 pre-existing + 2 new), 0 failures.
- [x] `cargo clippy -p uv-install-wheel --all-features --tests`: 0 warnings.
- [x] `cargo fmt --check -p uv-install-wheel`: clean.
- [x] End-to-end repro at the top of this PR passes after the change.
