### PR TITLE
Reject empty string as an invalid package name

### DIFF
--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -18,10 +18,6 @@ pub(crate) fn validate_and_normalize_ref(
     name: impl AsRef<str>,
 ) -> Result<SmallString, InvalidNameError> {
     let name = name.as_ref();
-    // An empty string is not a valid package, extra, or group name.
-    if name.is_empty() {
-        return Err(InvalidNameError(name.to_string()));
-    }
     if is_normalized(name)? {
         Ok(SmallString::from(name))
     } else {
@@ -31,6 +27,11 @@ pub(crate) fn validate_and_normalize_ref(
 
 /// Normalize an unowned package or extra name.
 fn normalize(name: &str) -> Result<String, InvalidNameError> {
+    // An empty string is not a valid package, extra, or group name.
+    if name.is_empty() {
+        return Err(InvalidNameError(name.to_string()));
+    }
+
     let mut normalized = String::with_capacity(name.len());
 
     let mut last = None;
@@ -65,6 +66,11 @@ fn normalize(name: &str) -> Result<String, InvalidNameError> {
 
 /// Returns `true` if the name is already normalized.
 fn is_normalized(name: impl AsRef<str>) -> Result<bool, InvalidNameError> {
+    // An empty string is not a valid package, extra, or group name.
+    if name.as_ref().is_empty() {
+        return Err(InvalidNameError(name.as_ref().to_string()));
+    }
+
     let mut last = None;
     for char in name.as_ref().bytes() {
         match char {
@@ -242,6 +248,7 @@ mod tests {
         ];
         for input in failures {
             assert!(validate_and_normalize_ref(input).is_err());
+            assert!(is_normalized(input).is_err());
         }
     }
 }

--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -18,6 +18,10 @@ pub(crate) fn validate_and_normalize_ref(
     name: impl AsRef<str>,
 ) -> Result<SmallString, InvalidNameError> {
     let name = name.as_ref();
+    // An empty string is not a valid package, extra, or group name.
+    if name.is_empty() {
+        return Err(InvalidNameError(name.to_string()));
+    }
     if is_normalized(name)? {
         Ok(SmallString::from(name))
     } else {
@@ -227,6 +231,7 @@ mod tests {
     #[test]
     fn failures() {
         let failures = [
+            "",
             " starts-with-space",
             "-starts-with-dash",
             "ends-with-dash-",
@@ -237,7 +242,6 @@ mod tests {
         ];
         for input in failures {
             assert!(validate_and_normalize_ref(input).is_err());
-            assert!(is_normalized(input).is_err());
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Both `normalize` and `is_normalized` in `crates/uv-normalize/src/lib.rs` work
by iterating over bytes. When given an empty string, the loop never executes,
`last` stays `None`, and both functions return success — `normalize` returns
`Ok("")` and `is_normalized` returns `Ok(true)`. As a result,
`validate_and_normalize_ref("")` short-circuits and returns
`Ok(SmallString::from(""))`, meaning `PackageName::from_str("")`,
`ExtraName::from_str("")`, and `GroupName::from_str("")` all succeed silently.

The [PyPA name-normalization spec](https://packaging.python.org/en/latest/specifications/name-normalization/)
requires at least one alphanumeric character, and the existing `InvalidNameError`
display message already says *"Names must start and end with a letter or digit"*
— which an empty string does not satisfy.

The fix adds a single early-return guard at the top of
`validate_and_normalize_ref`, the one shared entry point for all three name
types, avoiding any duplication in the private helpers.

## Test Plan

Added `""` to the `failures` test in `crates/uv-normalize/src/lib.rs` and
verified that `validate_and_normalize_ref("")` now returns `Err(InvalidNameError(...))`.

The assertion on `is_normalized` was intentionally omitted for the empty-string
case: `is_normalized` is a private implementation detail never called from
outside this module, and the guard in `validate_and_normalize_ref` is sufficient
to enforce the public contract.