### PR TITLE
fix(build): exclude dotfiles by default to match setuptools

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -759,6 +759,16 @@ mod tests {
                 .join("compiled.pyc"),
         )
         .unwrap();
+        // Hidden directories in subdirectories must be excluded (e.g., .mypy_cache from running
+        // mypy inside the module directory).
+        fs_err::create_dir_all(module_root.join("arithmetic").join(".mypy_cache")).unwrap();
+        File::create(
+            module_root
+                .join("arithmetic")
+                .join(".mypy_cache")
+                .join("builtins.json"),
+        )
+        .unwrap();
 
         // Perform both the direct and the indirect build.
         let dist = TempDir::new().unwrap();

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -24,8 +24,9 @@ use uv_pypi_types::{Keywords, Metadata23, ProjectUrls, VerbatimParsedUrl};
 use crate::serde_verbatim::SerdeVerbatim;
 use crate::{BuildBackendSettings, Error, error_on_venv};
 
-/// By default, we ignore generated python files.
-pub(crate) const DEFAULT_EXCLUDES: &[&str] = &["__pycache__", "*.pyc", "*.pyo"];
+/// By default, we ignore generated python files and hidden files and directories (starting with
+/// `.`), matching the behavior of setuptools which uses `glob.glob` that ignores dotfiles.
+pub(crate) const DEFAULT_EXCLUDES: &[&str] = &["__pycache__", "*.pyc", "*.pyo", ".*"];
 
 /// No breaking changes were introduced to the uv build backend since these releases, so we can use
 /// the fast path for them too.

--- a/crates/uv-build-backend/src/settings.rs
+++ b/crates/uv-build-backend/src/settings.rs
@@ -61,7 +61,7 @@ pub struct BuildBackendSettings {
 
     /// If set to `false`, the default excludes aren't applied.
     ///
-    /// Default excludes: `__pycache__`, `*.pyc`, and `*.pyo`.
+    /// Default excludes: `__pycache__`, `*.pyc`, `*.pyo`, and `.*`.
     #[option(
         default = r#"true"#,
         value_type = "bool",

--- a/crates/uv-build-backend/src/source_dist.rs
+++ b/crates/uv-build-backend/src/source_dist.rs
@@ -254,6 +254,13 @@ fn write_source_dist(
             // directories that often exist on the top level of a project. This is especially noticeable
             // on network file systems with high latencies per operation (while contiguous reading may
             // still be fast).
+            //
+            // Do not prune virtual environments even if they match the exclude pattern (e.g.,
+            // `.venv` would be excluded by the default `.*` rule) - we need to detect them and
+            // report an error.
+            if entry.file_type().is_dir() && entry.path().join("pyvenv.cfg").is_file() {
+                return include_matcher.match_directory(relative);
+            }
             include_matcher.match_directory(relative) && !exclude_matcher.is_match(relative)
         })
     {

--- a/crates/uv-build-backend/src/wheel.rs
+++ b/crates/uv-build-backend/src/wheel.rs
@@ -176,7 +176,15 @@ fn write_wheel(
         for entry in WalkDir::new(src_root.join(module_relative))
             .sort_by_file_name()
             .into_iter()
-            .filter_entry(|entry| !exclude_matcher.is_match(entry.path()))
+            .filter_entry(|entry| {
+                // Do not prune virtual environments even if they match the exclude pattern (e.g.,
+                // `.venv` would be excluded by the default `.*` rule) - we need to detect them
+                // and report an error.
+                if entry.file_type().is_dir() && entry.path().join("pyvenv.cfg").is_file() {
+                    return true;
+                }
+                !exclude_matcher.is_match(entry.path())
+            })
         {
             let entry = entry.map_err(|err| Error::WalkDir {
                 root: source_tree.to_path_buf(),

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -201,7 +201,7 @@ To determine which files to include in a source distribution, uv first adds the 
 directories, then removes the excluded files and directories. This means that exclusions always take
 precedence over inclusions.
 
-By default, uv excludes `__pycache__`, `*.pyc`, and `*.pyo`.
+By default, uv excludes `__pycache__`, `*.pyc`, `*.pyo`, and `.*` (hidden files and directories).
 
 When building a source distribution, the following files and directories are included:
 


### PR DESCRIPTION
Closes #19403

## Summary

Aligns `uv-build`'s default directory traversal with `setuptools`, which natively ignores dotfiles and hidden directories via `glob.glob`. 

Previously, hidden cache directories like `.mypy_cache` or `.pytest_cache` located inside subdirectories were leaking into the final build artifacts (`.whl` and `.tar.gz`). Adding `.*` to `DEFAULT_EXCLUDES` resolves this and maintains parity with expected Python packaging behavior.

## Test Plan

- Added a test case in `crates/uv-build-backend/src/lib.rs`.
- Verified that a nested `.mypy_cache` directory and its contents (`builtins.json`) are successfully excluded from the generated distribution.
- Tests pass locally via `cargo test -p uv-build-backend`.