### PR TITLE
netrc/lex: fix `lineno` not incremented in `read_line`

### DIFF
--- a/crates/uv-netrc/src/lex.rs
+++ b/crates/uv-netrc/src/lex.rs
@@ -26,7 +26,7 @@ impl<'a> Lex<'a> {
 
     pub(crate) fn read_line(&mut self) -> String {
         let mut s = String::new();
-        for ch in &mut self.instream {
+        while let Some(ch) = self.read_char() {
             if ch == '\n' {
                 return s;
             }

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -610,11 +610,9 @@ mod tests {
         );
     }
 
-    #[test]
+   #[test]
     fn test_lineno_after_macdef() {
-        let nrc = Netrc::from_str(
-            "macdef mymacro\nline1\nline2\n\nbad_token foo",
-        );
+        let nrc = Netrc::from_str("macdef mymacro\nline1\nline2\n\nbad_token foo");
         let err = nrc.unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -624,9 +622,7 @@ mod tests {
 
     #[test]
     fn test_lineno_after_comment() {
-        let nrc = Netrc::from_str(
-            "# comment\n# comment\nbad_token foo",
-        );
+        let nrc = Netrc::from_str("# comment\n# comment\nbad_token foo");
         let err = nrc.unwrap_err();
         assert_eq!(
             err.to_string(),

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -610,7 +610,8 @@ mod tests {
         );
     }
 
-   #[test]
+
+    #[test]
     fn test_lineno_after_macdef() {
         let nrc = Netrc::from_str("macdef mymacro\nline1\nline2\n\nbad_token foo");
         let err = nrc.unwrap_err();

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -610,7 +610,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_lineno_after_macdef() {
         let nrc = Netrc::from_str("macdef mymacro\nline1\nline2\n\nbad_token foo");
@@ -620,7 +619,6 @@ mod tests {
             "parsing error: bad toplevel token 'bad_token' (line 5)"
         );
     }
-
     #[test]
     fn test_lineno_after_comment() {
         let nrc = Netrc::from_str("# comment\n# comment\nbad_token foo");

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -609,4 +609,28 @@ mod tests {
             Authenticator::new("foo", "", "pass")
         );
     }
+
+    #[test]
+    fn test_lineno_after_macdef() {
+        let nrc = Netrc::from_str(
+            "macdef mymacro\nline1\nline2\n\nbad_token foo",
+        );
+        let err = nrc.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "parsing error: bad toplevel token 'bad_token' (line 5)"
+        );
+    }
+
+    #[test]
+    fn test_lineno_after_comment() {
+        let nrc = Netrc::from_str(
+            "# comment\n# comment\nbad_token foo",
+        );
+        let err = nrc.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "parsing error: bad toplevel token 'bad_token' (line 3)"
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

`Lex::read_line` iterates directly over `self.instream` instead of going
through `self.read_char`, which is the only place that increments
`self.lineno`. As a result, every newline consumed by `read_line` is
invisible to the line counter, causing parse errors reported after any
`macdef` block or bare-`#` comment to show an incorrect (too-low) line
number.

The fix is a one-line change: replace the `for ch in &mut self.instream`
loop with `while let Some(ch) = self.read_char()`. The parsed output is
identical; only the line-number bookkeeping is corrected.

The three call sites affected are:
- Discarding a bare `#` comment line in the top-level token loop
- Reading each line of a `macdef` macro body
- Discarding a bare `#` comment line in the follower-token loop

## Test Plan

Existing tests in `crates/uv-netrc/src/netrc.rs` continue to pass. The
bug manifests only in error-message line numbers, so no behavioural test
was previously catching it. A targeted regression test can be added if
the maintainers prefer — happy to include one on request.