### PR TITLE
Fix stale git SHA used for branch/default-branch deps on re-resolution

### DIFF
--- a/crates/uv-git-types/src/reference.rs
+++ b/crates/uv-git-types/src/reference.rs
@@ -89,6 +89,24 @@ impl GitReference {
             Self::DefaultBranch => "default branch",
         }
     }
+
+    /// Returns `true` if this reference is pinned to an immutable point in history.
+    ///
+    /// Immutable references are safe to cache across re-resolutions because they will always
+    /// resolve to the same commit. Mutable references (branches, default branch) can move
+    /// and must be re-fetched when re-resolving from a stale or invalidated lockfile.
+    pub fn is_immutable(&self) -> bool {
+        match self {
+            // Tags are conventionally immutable.
+            Self::Tag(_) => true,
+            // A revision that looks like a full or abbreviated commit hash is immutable.
+            Self::BranchOrTagOrCommit(rev) => looks_like_commit_hash(rev),
+            // Branches and the default branch can move.
+            Self::Branch(_) | Self::BranchOrTag(_) | Self::NamedRef(_) | Self::DefaultBranch => {
+                false
+            }
+        }
+    }
 }
 
 impl Display for GitReference {

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -487,10 +487,15 @@ pub(crate) async fn pip_compile(
             LockedRequirements::default()
         };
 
-    // Populate the Git resolver.
+    // Populate the Git resolver with pinned references from the existing lockfile.
+    // Mutable references (branches, default branch) are intentionally excluded: they
+    // can move between resolutions, and pre-seeding them would cause the resolver to
+    // use a stale commit hash even when the lockfile is being regenerated.
     for ResolvedRepositoryReference { reference, sha } in git {
-        debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
-        state.git().insert(reference, sha);
+        if reference.reference.is_immutable() {
+            debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
+            state.git().insert(reference, sha);
+        }
     }
 
     // Combine the `--no-binary` and `--no-build` flags from the requirements files.

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -487,15 +487,13 @@ pub(crate) async fn pip_compile(
             LockedRequirements::default()
         };
 
-    // Populate the Git resolver with pinned references from the existing lockfile.
-    // Mutable references (branches, default branch) are intentionally excluded: they
-    // can move between resolutions, and pre-seeding them would cause the resolver to
-    // use a stale commit hash even when the lockfile is being regenerated.
+    // Populate the Git resolver.
+    // For `pip compile`, the existing output file is treated as an explicit preference
+    // source: re-running without `--upgrade` is expected to preserve pinned SHAs,
+    // including those for branch/default-branch dependencies.
     for ResolvedRepositoryReference { reference, sha } in git {
-        if reference.reference.is_immutable() {
-            debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
-            state.git().insert(reference, sha);
-        }
+        debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
+        state.git().insert(reference, sha);
     }
 
     // Combine the `--no-binary` and `--no-build` flags from the requirements files.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -897,10 +897,15 @@ async fn do_lock(
                 .transpose()?
                 .unwrap_or_default();
 
-            // Populate the Git resolver.
+            // Populate the Git resolver with pinned references from the existing lockfile.
+            // Mutable references (branches, default branch) are intentionally excluded: they
+            // can move between resolutions, and pre-seeding them would cause the resolver to
+            // use a stale commit hash even when the lockfile is being regenerated.
             for ResolvedRepositoryReference { reference, sha } in git {
-                debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
-                state.git().insert(reference, sha);
+                if reference.reference.is_immutable() {
+                    debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
+                    state.git().insert(reference, sha);
+                }
             }
 
             // Determine whether we can reuse the existing package forks.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -2101,10 +2101,15 @@ pub(crate) async fn resolve_environment(
             let LockedRequirements { preferences, git } =
                 read_lock_requirements(lock, install_path, &upgrade)?;
 
-            // Populate the Git resolver.
+            // Populate the Git resolver with pinned references from the existing lockfile.
+            // Mutable references (branches, default branch) are intentionally excluded: they
+            // can move between resolutions, and pre-seeding them would cause the resolver to
+            // use a stale commit hash even when the lockfile is being regenerated.
             for ResolvedRepositoryReference { reference, sha } in git {
-                debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
-                state.git().insert(reference, sha);
+                if reference.reference.is_immutable() {
+                    debug!("Inserting Git reference into resolver: `{reference:?}` at `{sha}`");
+                    state.git().insert(reference, sha);
+                }
             }
 
             preferences


### PR DESCRIPTION
## Summary

When `uv sync` (or `uv lock`) re-resolves because the existing lockfile no longer satisfies requirements, it pre-seeds the `GitResolver` cache with commit SHAs read from the lockfile. For **mutable** references — `Branch`, `BranchOrTag`, `NamedRef`, and `DefaultBranch` — this causes the resolver to treat the old SHA as authoritative and skip fetching the current HEAD from GitHub. The result is that dependency metadata (e.g. `pyproject.toml`) is read at a stale commit, producing incorrect constraint errors.

Reported in #19453: a git dependency pinned to `DefaultBranch` had its upstream `pyproject.toml` updated, but `uv sync` continued using the old commit hash from the lockfile and resolved against stale constraints.

## Root cause

In three places (`lock.rs`, `mod.rs`, `pip/compile.rs`) the resolver is seeded from the lockfile:

```rust
for ResolvedRepositoryReference { reference, sha } in git {
    state.git().insert(reference, sha);  // unconditional
}
```

`GitResolver::github_fast_path` short-circuits when it finds a cache entry, so the SHA from the lock is used without re-fetching, even during a full re-resolution.

## Fix

Add `GitReference::is_immutable()` which returns `true` only for tags and revision strings that look like commit hashes. Mutable references are excluded from pre-seeding so the resolver fetches their current HEAD:

```rust
// crates/uv-git-types/src/reference.rs
pub fn is_immutable(&self) -> bool {
    match self {
        Self::Tag(_) => true,
        Self::BranchOrTagOrCommit(rev) => looks_like_commit_hash(rev),
        Self::Branch(_) | Self::BranchOrTag(_) | Self::NamedRef(_) | Self::DefaultBranch => false,
    }
}
```

The three seeding loops are updated to call `is_immutable()` before inserting.

## Test plan

- [ ] `uv sync` with a `git+https://...` dependency (no `@rev`) where the upstream repo has been updated since the lockfile was written — should now resolve to the current HEAD
- [ ] `uv sync` with a git dependency pinned to a tag or commit SHA — should still use the cached SHA (no regression)
- [ ] `uv lock --upgrade-package <pkg>` still works as before