### PR TITLE
Allow retry of `custom-publish-crates` separately from `announce`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,12 +307,10 @@ jobs:
       - host
       - release-gate
       - custom-publish-pypi
-      - custom-publish-crates
-    # use "always() && ..." to allow us to wait for all publish jobs while
-    # still allowing individual publish jobs to skip themselves (for prereleases).
+    # use "always() && ..." to allow publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    # `custom-publish-crates` is intentionally not gated on its result: it's
-    # not critical to the release and isn't idempotent on retry.
+    # `custom-publish-crates` is intentionally not a dependency: it's not
+    # critical to the release and isn't idempotent on retry.
     if: ${{ always() && needs.host.result == 'success' && needs.release-gate.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
     runs-on: "depot-ubuntu-latest-4"
     environment:
@@ -364,9 +362,8 @@ jobs:
     needs:
       - plan
       - announce
-    # Use `always() && ...` so this job is not skipped when an unrelated
-    # upstream job (e.g., `custom-publish-crates`) fails. `announce` itself
-    # tolerates a `custom-publish-crates` failure, so we mirror that here.
+    # Use `always() && ...` so this job gates only on whether `announce`
+    # completed successfully.
     if: ${{ always() && needs.announce.result == 'success' }}
     uses: ./.github/workflows/publish-docs.yml
     with:


### PR DESCRIPTION
This adjusts `announce` to no longer wait for `custom-publish-crates` so we can retry `custom-publish-crates` without re-running `announce`.

This may be temporary — once we can get crates publishing working consistently, we can roll back.