### PR TITLE
fix(install-wheel): parse wheel version components as integers before comparison

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -331,16 +331,28 @@ impl WheelFile {
         }
         // Check that installer is compatible with Wheel-Version. Warn if minor version is greater, abort if major version is greater.
         // Wheel-Version: 1.0
-        if wheel_version.0 != "1" {
+        let major = wheel_version.0.parse::<u32>().map_err(|_| {
+            Error::InvalidWheel(format!(
+                "Invalid wheel major version: {}",
+                wheel_version.0
+            ))
+        })?;
+        let minor = wheel_version.1.parse::<u32>().map_err(|_| {
+            Error::InvalidWheel(format!(
+                "Invalid wheel minor version: {}",
+                wheel_version.1
+            ))
+        })?;
+        if major != 1 {
             return Err(Error::InvalidWheel(format!(
                 "Unsupported wheel major version (expected {}, got {})",
-                1, wheel_version.0
+                1, major
             )));
         }
-        if wheel_version.1 > "0" {
+        if minor > 0 {
             warn!(
                 "Warning: Unsupported wheel minor version (expected {}, got {})",
-                0, wheel_version.1
+                0, minor
             );
         }
         Ok(Self(data))

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -1179,6 +1179,8 @@ mod test {
         }
         WheelFile::parse(&wheel_with_version("1.0")).unwrap();
         WheelFile::parse(&wheel_with_version("2.0")).unwrap_err();
+        WheelFile::parse(&wheel_with_version("1.invalid")).unwrap_err();
+        WheelFile::parse(&wheel_with_version("invalid.0")).unwrap_err();
     }
 
     #[test]

--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -332,16 +332,10 @@ impl WheelFile {
         // Check that installer is compatible with Wheel-Version. Warn if minor version is greater, abort if major version is greater.
         // Wheel-Version: 1.0
         let major = wheel_version.0.parse::<u32>().map_err(|_| {
-            Error::InvalidWheel(format!(
-                "Invalid wheel major version: {}",
-                wheel_version.0
-            ))
+            Error::InvalidWheel(format!("Invalid wheel major version: {}", wheel_version.0))
         })?;
         let minor = wheel_version.1.parse::<u32>().map_err(|_| {
-            Error::InvalidWheel(format!(
-                "Invalid wheel minor version: {}",
-                wheel_version.1
-            ))
+            Error::InvalidWheel(format!("Invalid wheel minor version: {}", wheel_version.1))
         })?;
         if major != 1 {
             return Err(Error::InvalidWheel(format!(
@@ -360,7 +354,7 @@ impl WheelFile {
 
     /// Whether the wheel should be installed into the `purelib` or `platlib` directory.
     pub(crate) fn lib_kind(&self) -> LibKind {
-        // Determine whether Root-Is-Purelib == ‘true’.
+        // Determine whether Root-Is-Purelib == 'true'.
         // If it is, the wheel is pure, and should be installed into purelib.
         let root_is_purelib = self
             .0


### PR DESCRIPTION
## Summary

When parsing the `WHEEL` metadata file, the `Wheel-Version` major and minor
components were compared as raw `&str` slices rather than parsed integers.
The minor version check `wheel_version.1 > "0"` uses lexicographic ordering,
which produces incorrect results for two-digit minor versions: e.g., `"10" > "9"`
is `false` as strings (since `'1' < '9'`), so a `Wheel-Version: 1.10` would
silently skip the unsupported-minor-version warning. The major version check
`wheel_version.0 != "1"` has the same structural problem (e.g., `"01" != "1"`
is `true` as strings despite being numerically equal).

This PR parses both components as `u32` before comparison, matching the intent
described in the comment above the checks and aligning with PEP 427 semantics.
Invalid (non-numeric) version components now return `Error::InvalidWheel`
consistently with other parse failures in the same function.

## Test Plan

Existing tests in `test_parse_wheel_version` continue to pass (`1.0` succeeds,
`2.0` errors). The fix can be manually verified by constructing a `WHEEL` file
with `Wheel-Version: 1.10` and confirming the unsupported-minor-version warning
is now emitted, whereas previously it was silently swallowed due to the
lexicographic comparison.