### PR TITLE
Avoid including `schemars` in the production build

### DIFF
--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -26,10 +26,10 @@ uv-normalize = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
-uv-python = { workspace = true, features = ["clap", "schemars"]}
+uv-python = { workspace = true, features = ["clap"] }
 uv-redacted = { workspace = true }
 uv-resolver = { workspace = true, features = ["clap"] }
-uv-settings = { workspace = true, features = ["schemars"] }
+uv-settings = { workspace = true }
 uv-static = { workspace = true }
 uv-torch = { workspace = true, features = ["clap"] }
 uv-version = { workspace = true }

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -23,7 +23,7 @@ uv-distribution-types = { workspace = true }
 uv-git = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
-uv-pep508 = { workspace = true, features = ["schemars"] }
+uv-pep508 = { workspace = true }
 uv-platform-tags = { workspace = true }
 uv-redacted = { workspace = true }
 uv-static = { workspace = true }
@@ -50,3 +50,11 @@ serde_json = { workspace = true }
 
 [features]
 default = []
+schemars = [
+  "dep:schemars",
+  "uv-auth/schemars",
+  "uv-distribution-types/schemars",
+  "uv-normalize/schemars",
+  "uv-pep508/schemars",
+  "uv-redacted/schemars",
+]

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
-uv-auth = { workspace = true, features = ["schemars"] }
+uv-auth = { workspace = true }
 uv-cache-info = { workspace = true }
 uv-cache-key = { workspace = true }
 uv-distribution-filename = { workspace = true }
@@ -55,4 +55,4 @@ version-ranges = { workspace = true }
 toml = { workspace = true }
 
 [features]
-schemars = ["dep:schemars", "uv-redacted/schemars"]
+schemars = ["dep:schemars", "uv-auth/schemars", "uv-redacted/schemars"]

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -17,28 +17,28 @@ test = false
 workspace = true
 
 [dependencies]
-uv-cache-info = { workspace = true, features = ["schemars"] }
+uv-cache-info = { workspace = true }
 uv-client = { workspace = true }
-uv-configuration = { workspace = true, features = ["schemars", "clap"] }
+uv-configuration = { workspace = true, features = ["clap"] }
 uv-dirs = { workspace = true }
-uv-distribution-types = { workspace = true, features = ["schemars"] }
+uv-distribution-types = { workspace = true }
 uv-flags = { workspace = true }
 uv-fs = { workspace = true }
-uv-install-wheel = { workspace = true, features = ["schemars", "clap"] }
+uv-install-wheel = { workspace = true, features = ["clap"] }
 uv-macros = { workspace = true }
-uv-normalize = { workspace = true, features = ["schemars"] }
+uv-normalize = { workspace = true }
 uv-options-metadata = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }
-uv-python = { workspace = true, features = ["schemars", "clap"] }
+uv-python = { workspace = true, features = ["clap"] }
 uv-redacted = { workspace = true }
-uv-resolver = { workspace = true, features = ["schemars", "clap"] }
+uv-resolver = { workspace = true, features = ["clap"] }
 uv-static = { workspace = true }
-uv-torch = { workspace = true, features = ["schemars", "clap"] }
+uv-torch = { workspace = true, features = ["clap"] }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
-uv-workspace = { workspace = true, features = ["schemars", "clap"] }
+uv-workspace = { workspace = true, features = ["clap"] }
 
 clap = { workspace = true }
 fs-err = { workspace = true }
@@ -54,4 +54,16 @@ url = { workspace = true }
 ignored = ["uv-options-metadata", "clap"]
 
 [features]
+schemars = [
+  "dep:schemars",
+  "uv-cache-info/schemars",
+  "uv-configuration/schemars",
+  "uv-distribution-types/schemars",
+  "uv-install-wheel/schemars",
+  "uv-normalize/schemars",
+  "uv-python/schemars",
+  "uv-resolver/schemars",
+  "uv-torch/schemars",
+  "uv-workspace/schemars",
+]
 tracing-durations-export = []

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -16,11 +16,11 @@ doctest = false
 workspace = true
 
 [dependencies]
-uv-build-backend = { workspace = true, features = ["schemars"] }
+uv-build-backend = { workspace = true }
 uv-cache-key = { workspace = true }
 uv-configuration = { workspace = true }
 uv-distribution-types = { workspace = true }
-uv-fs = { workspace = true, features = ["tokio", "schemars"] }
+uv-fs = { workspace = true, features = ["tokio"] }
 uv-git-types = { workspace = true }
 uv-macros = { workspace = true }
 uv-normalize = { workspace = true }
@@ -55,4 +55,12 @@ regex = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-schemars = ["dep:schemars", "uv-pypi-types/schemars", "uv-redacted/schemars"]
+schemars = [
+  "dep:schemars",
+  "uv-build-backend/schemars",
+  "uv-fs/schemars",
+  "uv-normalize/schemars",
+  "uv-pep508/schemars",
+  "uv-pypi-types/schemars",
+  "uv-redacted/schemars",
+]

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -48,13 +48,13 @@ uv-platform-tags = { workspace = true }
 uv-preview = { workspace = true }
 uv-publish = { workspace = true }
 uv-pypi-types = { workspace = true }
-uv-python = { workspace = true, features = ["schemars"] }
+uv-python = { workspace = true }
 uv-redacted = { workspace = true }
 uv-requirements = { workspace = true }
 uv-requirements-txt = { workspace = true }
 uv-resolver = { workspace = true }
 uv-scripts = { workspace = true }
-uv-settings = { workspace = true, features = ["schemars"] }
+uv-settings = { workspace = true }
 uv-shell = { workspace = true }
 uv-static = { workspace = true }
 uv-test = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

Only needed a development time, and cuts 100K off the binary.
