### PR TITLE
Allow passing `--runs` to hyperfine in the benchmarking harness

### DIFF
--- a/scripts/benchmark/src/benchmark/resolver.py
+++ b/scripts/benchmark/src/benchmark/resolver.py
@@ -1289,7 +1289,6 @@ def main():
         "--min-runs",
         type=int,
         help="The minimum number of runs to perform.",
-        default=10,
     )
     parser.add_argument(
         "--runs",
@@ -1382,8 +1381,11 @@ def main():
     json = args.json
     python = args.python
     warmup = args.warmup
-    min_runs = args.min_runs
     runs = args.runs
+    min_runs = args.min_runs
+    # --min-runs and --runs conflict
+    if runs is None and min_runs is None:
+        min_runs = 10
 
     requirements_file = os.path.abspath(args.file)
     if not os.path.exists(requirements_file):

--- a/scripts/benchmark/src/benchmark/tools.py
+++ b/scripts/benchmark/src/benchmark/tools.py
@@ -243,7 +243,6 @@ def main():
         "--min-runs",
         type=int,
         help="The minimum number of runs to perform.",
-        default=10,
     )
     parser.add_argument(
         "--runs",
@@ -291,8 +290,11 @@ def main():
     verbose = args.verbose
     json = args.json
     warmup = args.warmup
-    min_runs = args.min_runs
     runs = args.runs
+    min_runs = args.min_runs
+    # --min-runs and --runs conflict
+    if runs is None and min_runs is None:
+        min_runs = 10
 
     # Determine the tools to benchmark, based on the user-provided arguments.
     suites = []


### PR DESCRIPTION
## Summary

hyperfine complains if both `--min-runs` and `--runs` are passed so `--min-runs` should be conditionally default.

## Test Plan

Manual testing.