### PR TITLE
Test `create_junction` changes from #19402

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,11 @@ jobs:
       - name: "Create NTFS test directory (low hardlink limit)"
         run: New-Item -Path "C:\uv" -ItemType Directory -Force
 
+      - name: "Create SMB test share (alternative filesystem)"
+        run: |
+          New-Item -Path "C:\uv-smb" -ItemType Directory -Force
+          New-SmbShare -Name "uv-alt-fs" -Path "C:\uv-smb" -FullAccess "Everyone"
+
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8 # v2.77.5
         with:
@@ -259,6 +264,7 @@ jobs:
           # See https://github.com/astral-sh/uv/issues/6940
           UV_LINK_MODE: copy
           RUST_BACKTRACE: 1
+          UV_INTERNAL__TEST_ALT_FS: "\\\\localhost\\uv-alt-fs"
           UV_INTERNAL__TEST_LOWLINKS_FS: "C:\\uv"
           # Write pending snapshots to a separate directory for artifact upload
           INSTA_UPDATE: new

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,6 +265,7 @@ jobs:
           UV_LINK_MODE: copy
           RUST_BACKTRACE: 1
           UV_INTERNAL__TEST_ALT_FS: "\\\\localhost\\uv-alt-fs"
+          UV_INTERNAL__TEST_SMB_FS: "\\\\localhost\\uv-alt-fs"
           UV_INTERNAL__TEST_LOWLINKS_FS: "C:\\uv"
           # Write pending snapshots to a separate directory for artifact upload
           INSTA_UPDATE: new

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -304,21 +304,20 @@ mod tests {
     }
 
     #[test]
-    fn create_junction_failure_removes_directory() -> std::io::Result<()> {
+    fn create_junction_from_smb_failure_removes_directory() -> std::io::Result<()> {
         #[expect(clippy::print_stderr)]
-        let Some(alt_fs) = std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_ALT_FS).ok() else {
-            eprintln!("Skipping: UV_INTERNAL__TEST_ALT_FS not set");
+        let Some(smb_fs) = std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_SMB_FS).ok() else {
+            eprintln!("Skipping: UV_INTERNAL__TEST_SMB_FS not set");
             return Ok(());
         };
-        fs_err::create_dir_all(&alt_fs)?;
-        let alt_tempdir = tempfile::tempdir_in(alt_fs)?;
+        fs_err::create_dir_all(&smb_fs)?;
+        let alt_tempdir = tempfile::tempdir_in(smb_fs)?;
         let tempdir = tempfile::tempdir()?;
         let link = tempdir.path().join("link");
         let target = alt_tempdir.path().join("target");
         fs_err::create_dir(&target)?;
 
         let err = create_junction(&target, &link).unwrap_err();
-        // This relies on ALT_FS pointing at a SMB share
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidFilename);
         assert!(!link.exists());
         Ok(())

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -302,6 +302,27 @@ mod tests {
         assert_eq!(read_link(&link)?, dunce::simplified(&target));
         Ok(())
     }
+
+    #[test]
+    fn create_junction_failure_removes_directory() -> std::io::Result<()> {
+        #[expect(clippy::print_stderr)]
+        let Some(alt_fs) = std::env::var(uv_static::EnvVars::UV_INTERNAL__TEST_ALT_FS).ok() else {
+            eprintln!("Skipping: UV_INTERNAL__TEST_ALT_FS not set");
+            return Ok(());
+        };
+        fs_err::create_dir_all(&alt_fs)?;
+        let alt_tempdir = tempfile::tempdir_in(alt_fs)?;
+        let tempdir = tempfile::tempdir()?;
+        let link = tempdir.path().join("link");
+        let target = alt_tempdir.path().join("target");
+        fs_err::create_dir(&target)?;
+
+        let err = create_junction(&target, &link).unwrap_err();
+        // This relies on ALT_FS pointing at a SMB share
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidFilename);
+        assert!(!link.exists());
+        Ok(())
+    }
 }
 
 /// Create a symlink at `dst` pointing to `src` on Unix or copy `src` to `dst` on Windows

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -634,6 +634,13 @@ impl EnvVars {
     #[attr_added_in("0.10.5")]
     pub const UV_INTERNAL__TEST_ALT_FS: &'static str = "UV_INTERNAL__TEST_ALT_FS";
 
+    /// Network path to a directory on an SMB filesystem for testing.
+    ///
+    /// When populated, uv will run additional tests that cover SMB-specific filesystem behavior.
+    #[attr_hidden]
+    #[attr_added_in("next release")]
+    pub const UV_INTERNAL__TEST_SMB_FS: &'static str = "UV_INTERNAL__TEST_SMB_FS";
+
     /// Path to a directory on a filesystem with a low hardlink limit (e.g., minix with ~250).
     ///
     /// When populated, uv will run additional tests that exercise EMLINK recovery.


### PR DESCRIPTION
## Summary

Expose `C:/uv-smb` as a SMB share.

Set it for `ALT_FS` to expand existing coverage for windows.

Add and set it for `SMB_FS` to test `create_junction`.

Follow up to #19402.