### PR TITLE
docs: remove '7 days' as possible value for 'exclude-newer'

### DIFF
--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -742,12 +742,12 @@ Likewise, an individual index can override the global cutoff:
 
 ```pyproject.toml
 [tool.uv]
-exclude-newer = "2006-12-02T02:07:43Z"
+exclude-newer = "2012-12-02T02:07:43Z"
 
 [[tool.uv.index]]
 name = "internal"
 url = "https://internal.example.com/simple"
-exclude-newer = "7 days"
+exclude-newer = "2006-12-02T02:07:43Z"
 ```
 
 Or disable it entirely for that index:


### PR DESCRIPTION
It seems like uv only accepts an RFC 3339 / ISO date (e.g. "2026-04-23") for that field - relative time strings are not supported, but the docs suggest you can put strings like '7 days'.

See also: https://github.com/NousResearch/hermes-agent/issues/17908