### PR TITLE
uv-shell/shlex: quote POSIX paths with any shell-unsafe characters, not just spaces

### DIFF
--- a/crates/uv-shell/src/shlex.rs
+++ b/crates/uv-shell/src/shlex.rs
@@ -6,10 +6,16 @@ pub fn shlex_posix(executable: impl AsRef<Path>) -> String {
     // Convert to a display path.
     let executable = executable.as_ref().portable_display().to_string();
 
-    // Like Python's `shlex.quote`:
+    // Like Python's `shlex.quote`, quote the path if it contains any character that is not
+    // safe to use unquoted in a POSIX shell. The safe set mirrors CPython exactly:
+    // `[a-zA-Z0-9@%+=:,./_-]` — anything outside this set requires quoting.
+    //
     // > Use single quotes, and put single quotes into double quotes
     // > The string $'b is then quoted as '$'"'"'b'
-    if executable.contains(' ') {
+    if executable
+        .chars()
+        .any(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '@' | '%' | '+' | '=' | ':' | ',' | '.' | '/' | '_' | '-'))
+    {
         format!("'{}'", escape_posix_for_single_quotes(&executable))
     } else {
         executable
@@ -46,5 +52,60 @@ pub fn shlex_windows(executable: impl AsRef<Path>, shell: Shell) -> String {
         }
     } else {
         executable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_shlex_posix_no_quoting_needed() {
+        // Purely safe characters: no quoting expected.
+        assert_eq!(shlex_posix(Path::new("/usr/bin/python3")), "/usr/bin/python3");
+        assert_eq!(shlex_posix(Path::new("./venv/bin/activate")), "./venv/bin/activate");
+        assert_eq!(shlex_posix(Path::new("/home/user/.venv/bin/activate")), "/home/user/.venv/bin/activate");
+    }
+
+    #[test]
+    fn test_shlex_posix_space_triggers_quoting() {
+        assert_eq!(
+            shlex_posix(Path::new("/home/user/my project/.venv/bin/activate")),
+            "'/home/user/my project/.venv/bin/activate'"
+        );
+    }
+
+    #[test]
+    fn test_shlex_posix_dollar_triggers_quoting() {
+        // A `$` in the path must be quoted to prevent shell variable expansion.
+        assert_eq!(
+            shlex_posix(Path::new("/home/user/my$project/.venv/bin/activate")),
+            "'/home/user/my$project/.venv/bin/activate'"
+        );
+    }
+
+    #[test]
+    fn test_shlex_posix_parentheses_trigger_quoting() {
+        // Parentheses are common on macOS (e.g., "Applications (Rosetta)").
+        assert_eq!(
+            shlex_posix(Path::new("/Users/user/Applications (Rosetta)/.venv/bin/activate")),
+            "'/Users/user/Applications (Rosetta)/.venv/bin/activate'"
+        );
+    }
+
+    #[test]
+    fn test_shlex_posix_embedded_single_quote() {
+        // A path with an embedded single quote must use the '"'"' idiom.
+        assert_eq!(
+            shlex_posix(Path::new("/home/user/alice's-env/bin/activate")),
+            "'/home/user/alice'\"'\"'s-env/bin/activate'"
+        );
+    }
+
+    #[test]
+    fn test_escape_posix_for_single_quotes() {
+        assert_eq!(escape_posix_for_single_quotes("it's"), "it'\"'\"'s");
+        assert_eq!(escape_posix_for_single_quotes("no quotes here"), "no quotes here");
     }
 }

--- a/crates/uv-shell/src/shlex.rs
+++ b/crates/uv-shell/src/shlex.rs
@@ -12,10 +12,9 @@ pub fn shlex_posix(executable: impl AsRef<Path>) -> String {
     //
     // > Use single quotes, and put single quotes into double quotes
     // > The string $'b is then quoted as '$'"'"'b'
-    if executable
-        .chars()
-        .any(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '@' | '%' | '+' | '=' | ':' | ',' | '.' | '/' | '_' | '-'))
-    {
+    if executable.chars().any(|c| {
+        !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '@' | '%' | '+' | '=' | ':' | ',' | '.' | '/' | '_' | '-')
+    }) {
         format!("'{}'", escape_posix_for_single_quotes(&executable))
     } else {
         executable
@@ -63,9 +62,18 @@ mod tests {
     #[test]
     fn test_shlex_posix_no_quoting_needed() {
         // Purely safe characters: no quoting expected.
-        assert_eq!(shlex_posix(Path::new("/usr/bin/python3")), "/usr/bin/python3");
-        assert_eq!(shlex_posix(Path::new("./venv/bin/activate")), "./venv/bin/activate");
-        assert_eq!(shlex_posix(Path::new("/home/user/.venv/bin/activate")), "/home/user/.venv/bin/activate");
+        assert_eq!(
+            shlex_posix(Path::new("/usr/bin/python3")),
+            "/usr/bin/python3"
+        );
+        assert_eq!(
+            shlex_posix(Path::new("./venv/bin/activate")),
+            "./venv/bin/activate"
+        );
+        assert_eq!(
+            shlex_posix(Path::new("/home/user/.venv/bin/activate")),
+            "/home/user/.venv/bin/activate"
+        );
     }
 
     #[test]
@@ -89,7 +97,9 @@ mod tests {
     fn test_shlex_posix_parentheses_trigger_quoting() {
         // Parentheses are common on macOS (e.g., "Applications (Rosetta)").
         assert_eq!(
-            shlex_posix(Path::new("/Users/user/Applications (Rosetta)/.venv/bin/activate")),
+            shlex_posix(Path::new(
+                "/Users/user/Applications (Rosetta)/.venv/bin/activate"
+            )),
             "'/Users/user/Applications (Rosetta)/.venv/bin/activate'"
         );
     }
@@ -106,6 +116,9 @@ mod tests {
     #[test]
     fn test_escape_posix_for_single_quotes() {
         assert_eq!(escape_posix_for_single_quotes("it's"), "it'\"'\"'s");
-        assert_eq!(escape_posix_for_single_quotes("no quotes here"), "no quotes here");
+        assert_eq!(
+            escape_posix_for_single_quotes("no quotes here"),
+            "no quotes here"
+        );
     }
 }

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -1506,7 +1506,7 @@ fn create_venv_apostrophe() {
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: Testing's
-    Activate with: source Testing's/[BIN]/activate
+    Activate with: source 'Testing'"'"'s/[BIN]/activate'
     "
     );
 


### PR DESCRIPTION
## Summary

`shlex_posix` claimed to behave "like Python's `shlex.quote`" but only
quoted paths containing spaces. Python's `shlex.quote` quotes whenever
*any* shell-unsafe character is present — its safe set is
`[a-zA-Z0-9@%+=:,./_-]`. Anything outside that set (e.g. `$`, `!`,
`(`, `)`, `;`, `&`, `|`) must be quoted to prevent misinterpretation by
the shell.

Concrete failure case: a venv at `/home/user/my$project/.venv` would
produce an unquoted `source` activation suggestion, causing the shell to
expand `$project` as a variable — silently breaking the command.

The fix mirrors CPython exactly: check every character against the safe
set, and if any falls outside it, wrap the entire path in single quotes
(reusing the existing `escape_posix_for_single_quotes` for embedded
single quotes). Paths that are already safe are returned as-is.

## Test Plan

Added unit tests in `crates/uv-shell/src/shlex.rs` covering:
- Safe paths that should not be quoted (`/usr/bin/python3`, relative paths)
- Paths with spaces (existing behavior preserved)
- Paths with `$` (variable expansion risk)
- Paths with parentheses (common on macOS)
- Paths with embedded single quotes (the `'"'"'` idiom)
- `escape_posix_for_single_quotes` directly