### PR TITLE
fix(audit): skip empty branch in malformed OSV range events

### DIFF
--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -14,7 +14,7 @@ use crate::types;
 use futures::{StreamExt as _, TryStreamExt as _};
 use jiff::Timestamp;
 use reqwest_middleware::ClientWithMiddleware;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use uv_configuration::Concurrency;
 use uv_pep440::Version;
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
@@ -66,6 +66,51 @@ enum Event {
     Limit(#[allow(dead_code)] String),
 }
 
+/// Raw event object from OSV, used to tolerate malformed entries (e.g. `{}`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+struct EventRaw {
+    introduced: Option<String>,
+    fixed: Option<String>,
+    last_affected: Option<String>,
+    limit: Option<String>,
+}
+
+impl EventRaw {
+    fn into_event(self) -> Option<Event> {
+        if let Some(version) = self.introduced {
+            return Some(Event::Introduced(version));
+        }
+        if let Some(version) = self.fixed {
+            return Some(Event::Fixed(version));
+        }
+        if let Some(version) = self.last_affected {
+            return Some(Event::LastAffected(version));
+        }
+        if let Some(version) = self.limit {
+            return Some(Event::Limit(version));
+        }
+        None
+    }
+}
+
+/// Deserialize OSV range events, skipping empty or unrecognized entries.
+fn deserialize_events<'de, D>(deserializer: D) -> Result<Vec<Event>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Vec::<EventRaw>::deserialize(deserializer)?;
+    let mut events = Vec::with_capacity(raw.len());
+    for entry in raw {
+        if let Some(event) = entry.into_event() {
+            events.push(event);
+        } else {
+            trace!("Skipping empty or unrecognized OSV range event");
+        }
+    }
+    Ok(events)
+}
+
 /// The type of a version range in an OSV vulnerability record.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -91,6 +136,7 @@ enum RangeType {
 struct Range {
     #[serde(rename = "type")]
     range_type: RangeType,
+    #[serde(deserialize_with = "deserialize_events")]
     events: Vec<Event>,
 }
 
@@ -434,13 +480,17 @@ mod tests {
 
     use super::Event;
     use super::Osv;
+    use super::Range;
 
     #[test]
     fn test_deserialize_events() {
-        let json = r#"[{ "introduced": "0" }, { "fixed": "46.0.5" }]"#;
-        let events: Vec<Event> = serde_json::from_str(json).expect("Failed to deserialize events");
+        let range: Range = serde_json::from_value(json!({
+            "type": "ECOSYSTEM",
+            "events": [{ "introduced": "0" }, { "fixed": "46.0.5" }],
+        }))
+        .expect("deserialize range");
 
-        insta::assert_debug_snapshot!(events, @r#"
+        insta::assert_debug_snapshot!(range.events, @r#"
         [
             Introduced(
                 "0",
@@ -450,6 +500,49 @@ mod tests {
             ),
         ]
         "#);
+    }
+
+    #[test]
+    fn test_deserialize_events_skips_empty_object() {
+        let range: Range = serde_json::from_value(json!({
+            "type": "ECOSYSTEM",
+            "events": [{ "introduced": "0" }, {}],
+        }))
+        .expect("deserialize range");
+
+        insta::assert_debug_snapshot!(range.events, @r#"
+        [
+            Introduced(
+                "0",
+            ),
+        ]
+        "#);
+    }
+
+    #[test]
+    fn test_deserialize_vulnerability_with_empty_range_event() {
+        let vuln: super::Vulnerability = serde_json::from_value(json!({
+            "id": "PYSEC-2026-89",
+            "modified": "2026-05-20T08:00:29.202212087Z",
+            "published": "2026-03-05T15:16:11.243Z",
+            "summary": "Example vulnerability",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        { "introduced": "0" },
+                        {}
+                    ]
+                }]
+            }]
+        }))
+        .expect("deserialize vulnerability");
+
+        assert_eq!(vuln.id, "PYSEC-2026-89");
+        let ranges = vuln.affected.unwrap();
+        let events = &ranges[0].ranges.as_ref().unwrap()[0].events;
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Event::Introduced(_)));
     }
 
     #[test]

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -273,6 +273,80 @@ async fn audit_vulnerability_found() {
     ");
 }
 
+/// Ensure audit tolerates OSV vulnerability records with empty range events (`{}`).
+#[tokio::test]
+async fn audit_empty_osv_range_event() {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2026-89"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2026-89"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2026-89",
+            "modified": "2026-05-20T08:00:29.202212087Z",
+            "summary": "Malformed range event in OSV record",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {}
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - PYSEC-2026-89: Malformed range event in OSV record
+
+      No fix versions available
+
+      Advisory information: https://osv.dev/vulnerability/PYSEC-2026-89
+
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
 /// Audit a project with no dependencies.
 #[tokio::test]
 async fn audit_no_dependencies() {


### PR DESCRIPTION
Fixes astral-sh/uv#19492