### PR TITLE
uv-netrc: fix multi-word no-space comment lines causing parse errors

### DIFF
--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -83,7 +83,7 @@ impl std::str::FromStr for Netrc {
                 break;
             }
             if tt.chars().nth(0) == Some('#') {
-                if lexer.lineno == saved_lineno && tt.len() == 1 {
+                if lexer.lineno == saved_lineno {
                     lexer.read_line();
                 }
                 continue;

--- a/crates/uv-netrc/src/netrc.rs
+++ b/crates/uv-netrc/src/netrc.rs
@@ -527,6 +527,32 @@ mod tests {
     }
 
     #[test]
+    fn test_comment_before_machine_line_multiword_no_space() {
+        test_comment(
+            r#"#comment word2 word3
+            machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_comment_after_machine_line_multiword_no_space() {
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            #comment word2 word3
+            machine bar.domain.com login foo password pass
+            "#,
+        );
+        test_comment(
+            r#"machine foo.domain.com login bar password pass
+            machine bar.domain.com login foo password pass
+            #comment word2 word3
+            "#,
+        );
+    }
+
+    #[test]
     fn test_comment_after_machine_line() {
         test_comment(
             r#"machine foo.domain.com login bar password pass


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `uv-netrc` parser failed to correctly skip comment lines of the form
`#word1 word2 word3` (a `#` immediately followed by text, then additional
space-separated words on the same line).

`get_token()` reads non-whitespace characters as a single token, so
`#word1 word2` yields the token `"#word1"` and leaves `word2` unconsumed
on the same line. The outer parsing loop guarded the `read_line()` call
(which discards the remainder of the line) with `tt.len() == 1`, meaning
it only cleaned up after a bare `#` token. For any longer `#…` token the
remaining words were returned as the next tokens, causing a spurious
`bad toplevel token` parse error and silently denying credentials to
anyone whose `.netrc` file contains comments like: