### PR TITLE
Reject unsafe entry points in `uv-build`

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -12,7 +12,7 @@ use uv_warnings::warn_user_once;
 use version_ranges::Ranges;
 use walkdir::WalkDir;
 
-use uv_fs::{Simplified, normalize_path_under};
+use uv_fs::Simplified;
 use uv_globfilter::{GlobDirFilter, PortableGlobParser};
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
@@ -59,8 +59,10 @@ pub enum ValidationError {
         "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: {0}"
     )]
     InvalidGroup(String),
-    #[error("Script entry point names must not escape the scripts directory: `{0}`")]
-    UnsafeScriptName(String),
+    #[error(
+        "Script entry point name `{0}` must consist only of letters, numbers, dots, underscores and dashes"
+    )]
+    InvalidScriptName(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]
     ReservedScripts,
     #[error("Use `project.gui-scripts` instead of `project.entry-points.gui_scripts`")]
@@ -732,16 +734,18 @@ impl PyProjectToml {
 
         let _ = writeln!(writer, "[{group}]");
         for (name, object_reference) in entries {
+            let compliant_name = name.chars().all(|character| {
+                character.is_alphanumeric() || matches!(character, '.' | '-' | '_')
+            });
+            let dot_only_name = name.chars().all(|character| character == '.');
+
             if matches!(group, "console_scripts" | "gui_scripts")
-                && normalize_path_under(Path::new("scripts").join(name), "scripts").is_none()
+                && (name.is_empty() || dot_only_name || !compliant_name)
             {
-                return Err(ValidationError::UnsafeScriptName(name.clone()));
+                return Err(ValidationError::InvalidScriptName(name.clone()));
             }
 
-            if !name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
-            {
+            if !compliant_name {
                 warn!(
                     "Entrypoint names should consist of letters, numbers, dots, underscores and \
                     dashes; non-compliant name: {name}"

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -60,7 +60,7 @@ pub enum ValidationError {
     )]
     InvalidGroup(String),
     #[error(
-        "Script entry point name `{0}` must consist only of letters, numbers, dots, underscores and dashes"
+        "Script entry point name `{0}` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes"
     )]
     InvalidScriptName(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -12,7 +12,7 @@ use uv_warnings::warn_user_once;
 use version_ranges::Ranges;
 use walkdir::WalkDir;
 
-use uv_fs::Simplified;
+use uv_fs::{Simplified, normalize_path_under};
 use uv_globfilter::{GlobDirFilter, PortableGlobParser};
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
@@ -59,6 +59,8 @@ pub enum ValidationError {
         "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: {0}"
     )]
     InvalidGroup(String),
+    #[error("Script entry point names must not escape the scripts directory: `{0}`")]
+    UnsafeScriptName(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]
     ReservedScripts,
     #[error("Use `project.gui-scripts` instead of `project.entry-points.gui_scripts`")]
@@ -730,6 +732,12 @@ impl PyProjectToml {
 
         let _ = writeln!(writer, "[{group}]");
         for (name, object_reference) in entries {
+            if matches!(group, "console_scripts" | "gui_scripts")
+                && normalize_path_under(Path::new("scripts").join(name), "scripts").is_none()
+            {
+                return Err(ValidationError::UnsafeScriptName(name.clone()));
+            }
+
             if !name
                 .chars()
                 .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2065,6 +2065,50 @@ fn build_fast_path() -> Result<()> {
     Ok(())
 }
 
+/// Reject script entry point names that the installer would write outside the scripts directory.
+#[test]
+fn build_unsafe_script_entry_point_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "../script" = "project:main"
+
+        [build-system]
+        requires = ["uv_build>=0.5.15,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (uv build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point names must not escape the scripts directory: `../script`
+    ");
+
+    Ok(())
+}
+
 /// Test the `--list` option.
 #[test]
 fn build_list_files() -> Result<()> {

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2103,7 +2103,7 @@ fn build_unsafe_script_entry_point_name() -> Result<()> {
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
       ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `../script` must consist only of letters, numbers, dots, underscores and dashes
+      ╰─▶ Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2147,7 +2147,7 @@ fn build_dot_script_entry_point_name() -> Result<()> {
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
       ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `.` must consist only of letters, numbers, dots, underscores and dashes
+      ╰─▶ Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())
@@ -2191,7 +2191,7 @@ fn build_nested_script_entry_point_name() -> Result<()> {
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
       ├─▶ Invalid project metadata
-      ╰─▶ Script entry point name `nested/script` must consist only of letters, numbers, dots, underscores and dashes
+      ╰─▶ Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())

--- a/crates/uv/tests/it/build.rs
+++ b/crates/uv/tests/it/build.rs
@@ -2065,7 +2065,7 @@ fn build_fast_path() -> Result<()> {
     Ok(())
 }
 
-/// Reject script entry point names that the installer would write outside the scripts directory.
+/// Reject path-shaped script entry point names before writing wheel metadata.
 #[test]
 fn build_unsafe_script_entry_point_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -2103,7 +2103,95 @@ fn build_unsafe_script_entry_point_name() -> Result<()> {
     Building wheel (uv build backend)...
       × Failed to build `[TEMP_DIR]/`
       ├─▶ Invalid project metadata
-      ╰─▶ Script entry point names must not escape the scripts directory: `../script`
+      ╰─▶ Script entry point name `../script` must consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject dot-only script entry point names that do not resolve below the scripts directory.
+#[test]
+fn build_dot_script_entry_point_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "." = "project:main"
+
+        [build-system]
+        requires = ["uv_build>=0.5.15,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (uv build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `.` must consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject script entry point names that PyPI rejects in uploaded wheels.
+#[test]
+fn build_nested_script_entry_point_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "nested/script" = "project:main"
+
+        [build-system]
+        requires = ["uv_build>=0.5.15,<10000"]
+        build-backend = "uv_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    uv_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (uv build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `nested/script` must consist only of letters, numbers, dots, underscores and dashes
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary
In `uv-build`, reject building wheels that contain unsafe console entrypoints. This complements the existing warnings (which still highlight things like reserved names, etc), and aligns the build backend with the behavior in the installer (https://github.com/astral-sh/uv/pull/19464).

## Testing
- Added/updated integration tests covering the unsafe metadata rejection behavior.
- Existing CI validation should exercise the updated build-path checks.