### PR TITLE
Skip and warn on malformed OSV records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5800,6 +5800,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-redacted",
  "uv-small-str",
+ "uv-warnings",
  "wiremock",
 ]
 

--- a/crates/uv-audit/Cargo.toml
+++ b/crates/uv-audit/Cargo.toml
@@ -24,6 +24,7 @@ uv-normalize = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
+uv-warnings = { workspace = true }
 
 clap = { workspace = true, optional = true }
 futures = { workspace = true }

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -8,7 +8,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr as _;
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::types;
 use futures::{StreamExt as _, TryStreamExt as _};
@@ -298,11 +298,14 @@ impl Osv {
         let vuln_details = futures::stream::iter(unique_ids)
             .map(async |id| {
                 let vuln = self.fetch_vuln(&id).await?;
-                Ok::<(String, Vulnerability), Error>((id, vuln))
+                Ok::<Option<(String, Vulnerability)>, Error>(vuln.map(|vuln| (id, vuln)))
             })
             .buffer_unordered(self.concurrency.downloads)
-            .try_collect::<FxHashMap<String, Vulnerability>>()
-            .await?;
+            .try_collect::<Vec<Option<(String, Vulnerability)>>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<FxHashMap<String, Vulnerability>>();
 
         // Build findings from the accumulated (dependency, vuln_id) pairs.
         let findings = dep_vuln_ids
@@ -318,22 +321,30 @@ impl Osv {
     }
 
     /// Fetch a full vulnerability record by ID from OSV.
-    async fn fetch_vuln(&self, id: &str) -> Result<Vulnerability, Error> {
+    ///
+    /// Returns `None` when OSV returns a record that cannot be deserialized.
+    async fn fetch_vuln(&self, id: &str) -> Result<Option<Vulnerability>, Error> {
         let url = self
             .base_url
             .join(&format!("v1/vulns/{id}"))
             .map_err(|e| Error::Url(self.base_url.clone(), e))?;
-        let vuln: Vulnerability = self
+        let response = self
             .client
             .get(url.as_ref())
             .send()
             .await?
             .error_for_status()
-            .map_err(reqwest_middleware::Error::Reqwest)?
-            .json()
-            .await
             .map_err(reqwest_middleware::Error::Reqwest)?;
-        Ok(vuln)
+
+        match response.json::<Vulnerability>().await {
+            Ok(vuln) => Ok(Some(vuln)),
+            Err(err) if err.is_decode() => {
+                warn!("Skipping malformed OSV record {id}");
+                trace!("Failed to deserialize OSV record {id}: {err}");
+                Ok(None)
+            }
+            Err(err) => Err(reqwest_middleware::Error::Reqwest(err).into()),
+        }
     }
 
     /// Convert an OSV-specific [`Vulnerability`] record to a [`types::Finding`].
@@ -449,6 +460,17 @@ mod tests {
                 "46.0.5",
             ),
         ]
+        "#);
+    }
+
+    #[test]
+    fn test_deserialize_empty_event() {
+        let event = serde_json::from_str::<Event>("{}");
+
+        insta::assert_debug_snapshot!(event, @r#"
+        Err(
+            Error("expected value", line: 1, column: 2),
+        )
         "#);
     }
 

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -340,7 +340,7 @@ impl Osv {
         match response.json::<Vulnerability>().await {
             Ok(vuln) => Ok(Some(vuln)),
             Err(err) if err.is_decode() => {
-                warn_user!("Skipping malformed OSV record {id}");
+                warn_user!("Skipping malformed OSV record: {id}");
                 trace!("Failed to deserialize OSV record {id}: {err}");
                 Ok(None)
             }

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -8,7 +8,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr as _;
-use tracing::{trace, warn};
+use tracing::trace;
 
 use crate::types;
 use futures::{StreamExt as _, TryStreamExt as _};
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use uv_configuration::Concurrency;
 use uv_pep440::Version;
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
+use uv_warnings::warn_user;
 
 pub const API_BASE: &str = "https://api.osv.dev/";
 
@@ -339,7 +340,7 @@ impl Osv {
         match response.json::<Vulnerability>().await {
             Ok(vuln) => Ok(Some(vuln)),
             Err(err) if err.is_decode() => {
-                warn!("Skipping malformed OSV record {id}");
+                warn_user!("Skipping malformed OSV record {id}");
                 trace!("Failed to deserialize OSV record {id}: {err}");
                 Ok(None)
             }

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -642,7 +642,7 @@ async fn audit_malformed_vulnerability_record() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    WARN Skipping malformed OSV record VULN-MALFORMED
+    warning: Skipping malformed OSV record VULN-MALFORMED
     Found 1 known vulnerability and no adverse project statuses in 1 package
     ");
 }

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -551,6 +551,102 @@ async fn audit_multiple_vulnerabilities_same_package() {
     ");
 }
 
+/// Audit a project and continue after OSV returns a malformed vulnerability record.
+///
+/// Reproduces bug #19492: <https://github.com/astral-sh/uv/issues/19492>
+#[tokio::test]
+async fn audit_malformed_vulnerability_record() {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "VULN-VALID"}, {"id": "VULN-MALFORMED"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/VULN-VALID"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "VULN-VALID",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A valid vulnerability",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {"fixed": "2.1.0"}
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/VULN-MALFORMED"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "VULN-MALFORMED",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A malformed vulnerability",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"fixed": "2.1.0"},
+                        {},
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - VULN-VALID: A valid vulnerability
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://osv.dev/vulnerability/VULN-VALID
+
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    WARN Skipping malformed OSV record VULN-MALFORMED
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
 /// `--no-dev` excludes dev dependencies from the audit.
 #[tokio::test]
 async fn audit_no_dev() {

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -642,7 +642,7 @@ async fn audit_malformed_vulnerability_record() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    warning: Skipping malformed OSV record VULN-MALFORMED
+    warning: Skipping malformed OSV record: VULN-MALFORMED
     Found 1 known vulnerability and no adverse project statuses in 1 package
     ");
 }


### PR DESCRIPTION
## Summary

We now skip (and warn) if we encounter a malformed OSV record. This is (IMO) more correct that trying to suss out the intent behind a malformed record, since OSV is a strictly-defined format and the only reason we're seeing this at the moment is because OSV appears to be having a regression that their tests didn't catch.

Ref: https://github.com/pypa/advisory-database/issues/284

Fixes #19492.

## Test Plan

Added an integration test.