### PR TITLE
fix(audit): skip and warn on malformed OSV records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5800,6 +5800,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-redacted",
  "uv-small-str",
+ "uv-warnings",
  "wiremock",
 ]
 

--- a/crates/uv-audit/Cargo.toml
+++ b/crates/uv-audit/Cargo.toml
@@ -24,6 +24,7 @@ uv-normalize = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-redacted = { workspace = true }
 uv-small-str = { workspace = true }
+uv-warnings = { workspace = true }
 
 clap = { workspace = true, optional = true }
 futures = { workspace = true }

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use uv_configuration::Concurrency;
 use uv_pep440::Version;
 use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
+use uv_warnings::warn_user;
 
 pub const API_BASE: &str = "https://api.osv.dev/";
 
@@ -298,11 +299,14 @@ impl Osv {
         let vuln_details = futures::stream::iter(unique_ids)
             .map(async |id| {
                 let vuln = self.fetch_vuln(&id).await?;
-                Ok::<(String, Vulnerability), Error>((id, vuln))
+                Ok::<Option<(String, Vulnerability)>, Error>(vuln.map(|vuln| (id, vuln)))
             })
             .buffer_unordered(self.concurrency.downloads)
-            .try_collect::<FxHashMap<String, Vulnerability>>()
-            .await?;
+            .try_collect::<Vec<Option<(String, Vulnerability)>>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<FxHashMap<String, Vulnerability>>();
 
         // Build findings from the accumulated (dependency, vuln_id) pairs.
         let findings = dep_vuln_ids
@@ -318,22 +322,30 @@ impl Osv {
     }
 
     /// Fetch a full vulnerability record by ID from OSV.
-    async fn fetch_vuln(&self, id: &str) -> Result<Vulnerability, Error> {
+    ///
+    /// Returns `None` when OSV returns a record that cannot be deserialized.
+    async fn fetch_vuln(&self, id: &str) -> Result<Option<Vulnerability>, Error> {
         let url = self
             .base_url
             .join(&format!("v1/vulns/{id}"))
             .map_err(|e| Error::Url(self.base_url.clone(), e))?;
-        let vuln: Vulnerability = self
+        let response = self
             .client
             .get(url.as_ref())
             .send()
             .await?
             .error_for_status()
-            .map_err(reqwest_middleware::Error::Reqwest)?
-            .json()
-            .await
             .map_err(reqwest_middleware::Error::Reqwest)?;
-        Ok(vuln)
+
+        match response.json::<Vulnerability>().await {
+            Ok(vuln) => Ok(Some(vuln)),
+            Err(err) if err.is_decode() => {
+                warn_user!("Skipping malformed OSV record: {id}");
+                trace!("Failed to deserialize OSV record {id}: {err}");
+                Ok(None)
+            }
+            Err(err) => Err(reqwest_middleware::Error::Reqwest(err).into()),
+        }
     }
 
     /// Convert an OSV-specific [`Vulnerability`] record to a [`types::Finding`].
@@ -434,6 +446,17 @@ mod tests {
 
     use super::Event;
     use super::Osv;
+
+    #[test]
+    fn test_deserialize_empty_event() {
+        let event = serde_json::from_str::<Event>("{}");
+
+        insta::assert_debug_snapshot!(event, @r#"
+        Err(
+            Error("expected value", line: 1, column: 2),
+        )
+        "#);
+    }
 
     #[test]
     fn test_deserialize_events() {

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -551,6 +551,102 @@ async fn audit_multiple_vulnerabilities_same_package() {
     ");
 }
 
+/// Audit a project and continue after OSV returns a malformed vulnerability record.
+///
+/// Reproduces bug #19492: <https://github.com/astral-sh/uv/issues/19492>
+#[tokio::test]
+async fn audit_malformed_vulnerability_record() {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "VULN-VALID"}, {"id": "VULN-MALFORMED"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/VULN-VALID"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "VULN-VALID",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A valid vulnerability",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {"fixed": "2.1.0"}
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/VULN-MALFORMED"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "VULN-MALFORMED",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A malformed vulnerability",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"fixed": "2.1.0"},
+                        {},
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - VULN-VALID: A valid vulnerability
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://osv.dev/vulnerability/VULN-VALID
+
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    warning: Skipping malformed OSV record: VULN-MALFORMED
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
 /// `--no-dev` excludes dev dependencies from the audit.
 #[tokio::test]
 async fn audit_no_dev() {


### PR DESCRIPTION
## Summary

`uv audit` was crashing with `error decoding response body` / `expected value at line 1 column N` when the OSV batch query returned an advisory whose `affected.ranges.events` array contained an empty `{}` object. The `Event` enum uses serde's externally-tagged representation and requires exactly one named field (`introduced`, `fixed`, `last_affected`, or `limit`); an empty object satisfies none of those.

The specific trigger is `PYSEC-2025-183` (pyjwt) and `PYSEC-2026-89`, both of which have a malformed empty event in their OSV records. A bug report against the upstream advisory database has been filed at pypa/advisory-database#284.

This fix makes `fetch_vuln` return `Option<Vulnerability>`. When `.json()` deserialization fails with a decode error, it emits a `warn_user!` naming the advisory ID and returns `None`; the caller flattens out the `None`s before building the findings map. Network and HTTP errors still propagate as before.

Fixes #19492.

## Test plan

- Added `test_deserialize_empty_event` unit test in `uv-audit` documenting the exact serde failure mode.
- Added `audit_malformed_vulnerability_record` integration test using a mock OSV server that returns one valid and one malformed record, verifying the command completes, reports the valid finding, and emits the skip warning.
- Ran `cargo test -p uv-audit` (all 6 unit tests pass) and `cargo test -p uv --test it audit_malformed_vulnerability_record` (passes).
- Manually verified with `uv audit` against a lockfile containing `pyjwt==2.12.1`: previously crashed, now completes with `warning: Skipping malformed OSV record: PYSEC-2025-183`.

## AI Disclaimer

Written with Claude Sonnet 4.6