### PR TITLE
docs: Clarify that `uv run python` opens an interactive REPL

### DIFF
--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -22,6 +22,21 @@ $ # Running a `bash` script that requires the project to be available
 $ uv run bash scripts/foo.sh
 ```
 
+## Starting an interactive interpreter
+
+Invoking the Python interpreter without further arguments drops you into an interactive REPL,
+scoped to the project's environment:
+
+```console
+$ uv run python
+Python 3.13.0 (...)
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import example
+```
+
+Modules from the project (and its dependencies) are importable from the session, since the
+interpreter is invoked inside the project's virtual environment.
+
 ## Requesting additional dependencies
 
 Additional dependencies or different versions of dependencies can be requested per invocation.

--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -24,8 +24,8 @@ $ uv run bash scripts/foo.sh
 
 ## Starting an interactive interpreter
 
-Invoking the Python interpreter without further arguments drops you into an interactive REPL,
-scoped to the project's environment:
+Invoking the Python interpreter without further arguments drops you into an interactive REPL, scoped
+to the project's environment:
 
 ```console
 $ uv run python

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -230,6 +230,12 @@ print("hello world")
 $ uv run example.py
 ```
 
+Or, to start an interactive Python REPL with the project's dependencies available:
+
+```console
+$ uv run python
+```
+
 Alternatively, you can use `uv sync` to manually update the environment then activate it before
 executing a command:
 


### PR DESCRIPTION
## Summary

Adds a short clarification that invoking the Python interpreter with no further arguments (e.g., `uv run python`) drops the user into an interactive REPL scoped to the project's environment.

Touches two pages:
- `docs/concepts/projects/run.md` — new "Starting an interactive interpreter" section
- `docs/guides/projects.md` — brief one-line example in the existing "Running commands" section

Closes #6548