### PR TITLE
Avoid unwrapping from `OnceMap`

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -705,14 +705,7 @@ impl AuthMiddleware {
         } else {
             (FetchUrl::Realm(Realm::from(&**url)), username)
         };
-        if !self.cache().fetches.register(key.clone()) {
-            let credentials = self
-                .cache()
-                .fetches
-                .wait(&key)
-                .await
-                .expect("The key must exist after register is called");
-
+        if let Some(credentials) = self.cache().fetches.register_or_wait(&key).await {
             if credentials.is_some() {
                 trace!("Using credentials from previous fetch for {}", key.0);
             } else {

--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -133,45 +133,7 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
         }
 
         let id = dist.distribution_id();
-        if in_flight.downloads.register(id.clone()) {
-            let policy = self.hashes.get(&dist);
-
-            let result = self
-                .database
-                .get_or_build_wheel(&dist, self.tags, policy)
-                .boxed_local()
-                .map_err(|err| Error::from_dist(dist.clone(), err, resolution))
-                .await
-                .and_then(|wheel: LocalWheel| {
-                    if wheel.satisfies(policy) {
-                        Ok(wheel)
-                    } else {
-                        let err = uv_distribution::Error::hash_mismatch(
-                            dist.to_string(),
-                            policy.digests(),
-                            wheel.hashes(),
-                        );
-                        Err(Error::from_dist(dist, err, resolution))
-                    }
-                })
-                .map(CachedDist::from);
-            match result {
-                Ok(cached) => {
-                    in_flight.downloads.done(id, Ok(cached.clone()));
-                    Ok(cached)
-                }
-                Err(err) => {
-                    in_flight.downloads.done(id, Err(err.to_string()));
-                    Err(err)
-                }
-            }
-        } else {
-            let result = in_flight
-                .downloads
-                .wait(&id)
-                .await
-                .expect("missing value for registered task");
-
+        if let Some(result) = in_flight.downloads.register_or_wait(&id).await {
             match result.as_ref() {
                 Ok(cached) => {
                     // Validate that the wheel is compatible with the distribution.
@@ -205,6 +167,38 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                     Ok(cached.clone())
                 }
                 Err(err) => Err(Error::Thread(err.to_owned())),
+            }
+        } else {
+            let policy = self.hashes.get(&dist);
+
+            let result = self
+                .database
+                .get_or_build_wheel(&dist, self.tags, policy)
+                .boxed_local()
+                .map_err(|err| Error::from_dist(dist.clone(), err, resolution))
+                .await
+                .and_then(|wheel: LocalWheel| {
+                    if wheel.satisfies(policy) {
+                        Ok(wheel)
+                    } else {
+                        let err = uv_distribution::Error::hash_mismatch(
+                            dist.to_string(),
+                            policy.digests(),
+                            wheel.hashes(),
+                        );
+                        Err(Error::from_dist(dist, err, resolution))
+                    }
+                })
+                .map(CachedDist::from);
+            match result {
+                Ok(cached) => {
+                    in_flight.downloads.done(id, Ok(cached.clone()));
+                    Ok(cached)
+                }
+                Err(err) => {
+                    in_flight.downloads.done(id, Err(err.to_string()));
+                    Err(err)
+                }
             }
         }
     }

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -18,5 +18,5 @@ workspace = true
 
 [dependencies]
 dashmap = { workspace = true }
-tokio = { workspace = true }
 futures = { workspace = true }
+tokio = { workspace = true }

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -1,10 +1,22 @@
 use std::borrow::Borrow;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::Arc;
 
-use dashmap::DashMap;
+use dashmap::{DashMap, Entry};
 use tokio::sync::Notify;
+
+/// The caller tried to wait for a task that was never registered.
+#[derive(Debug)]
+pub struct UnregisteredTask<K>(K);
+
+impl<K: Display> Display for UnregisteredTask<K> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Attempted to wait on an unregistered task: {}", self.0)
+    }
+}
+
+impl<K: Debug + Display> std::error::Error for UnregisteredTask<K> {}
 
 /// Run tasks only once and store the results in a parallel hash map.
 ///
@@ -25,7 +37,7 @@ impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher + Clone> Debug for OnceMap<K
     }
 }
 
-impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
+impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// Register that you want to start a job.
     ///
     /// If this method returns `true`, you need to start a job and call [`OnceMap::done`] eventually
@@ -34,30 +46,47 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     pub fn register(&self, key: K) -> bool {
         let entry = self.items.entry(key);
         match entry {
-            dashmap::mapref::entry::Entry::Occupied(_) => false,
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
                 entry.insert(Value::Waiting(Arc::new(Notify::new())));
                 true
             }
         }
     }
 
-    /// Submit the result of a job you registered.
-    pub fn done(&self, key: K, value: V) {
-        if let Some(Value::Waiting(notify)) = self.items.insert(key, Value::Filled(value)) {
-            notify.notify_waiters();
-        }
-    }
-
-    /// Wait for the result of a job that is running.
+    /// Register that you want to start a job, unless it was already started, then wait for its
+    /// result.
     ///
-    /// Will hang if [`OnceMap::done`] isn't called for this key.
-    pub async fn wait(&self, key: &K) -> Option<V> {
+    /// Use this method for once-only operations.
+    ///
+    /// Returns `None` if the job needs to be started, otherwise returns the result of the job.
+    ///
+    ///  # Example
+    ///
+    /// ```rust,no-build
+    /// if let Some(response) = cache.register_or_wait(&id).await {
+    ///     response
+    /// } else {
+    ///     let response = fetch(&id).await;
+    ///     cache.done(id, response.clone());
+    ///     response
+    /// }
+    /// ```
+    pub async fn register_or_wait(&self, key: &K) -> Option<V> {
         let notify = {
-            let entry = self.items.get(key)?;
-            match entry.value() {
-                Value::Filled(value) => return Some(value.clone()),
-                Value::Waiting(notify) => notify.clone(),
+            let entry = self.items.entry(key.clone());
+            match entry {
+                Entry::Occupied(value) => match value.get() {
+                    Value::Filled(value) => return Some(value.clone()),
+                    Value::Waiting(notify) => notify.clone(),
+                },
+                Entry::Vacant(entry) => {
+                    // We insert the notify even if the caller is `wait`. Calling `wait` without
+                    // a previous `register` is a fatal error, so the state of the map doesn't
+                    // matter.
+                    entry.insert(Value::Waiting(Arc::new(Notify::new())));
+                    return None;
+                }
             }
         };
 
@@ -79,11 +108,30 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         }
     }
 
+    /// Submit the result of a job you registered.
+    pub fn done(&self, key: K, value: V) {
+        if let Some(Value::Waiting(notify)) = self.items.insert(key, Value::Filled(value)) {
+            notify.notify_waiters();
+        }
+    }
+
+    /// Wait for the result of a job that is running.
+    ///
+    /// Will hang if [`OnceMap::done`] isn't called for this key, or if `UnregisteredTask` is a
+    /// non-fatal error and [`OnceMap::done`] isn't called for this key.
+    pub async fn wait(&self, key: &K) -> Result<V, UnregisteredTask<K>> {
+        self.register_or_wait(key)
+            .await
+            .ok_or_else(|| UnregisteredTask(key.clone()))
+    }
+
     /// Wait for the result of a job that is running, in a blocking context.
     ///
-    /// Will hang if [`OnceMap::done`] isn't called for this key.
-    pub fn wait_blocking(&self, key: &K) -> Option<V> {
-        futures::executor::block_on(self.wait(key))
+    /// Will hang if [`OnceMap::done`] isn't called for this key, or if `UnregisteredTask` is a
+    /// non-fatal error and [`OnceMap::done`] isn't called for this key.
+    pub fn wait_blocking(&self, key: &K) -> Result<V, UnregisteredTask<K>> {
+        futures::executor::block_on(self.register_or_wait(key))
+            .ok_or_else(|| UnregisteredTask(key.clone()))
     }
 
     /// Return the result of a previous job, if any.

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -150,7 +150,12 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
         // Fetch the metadata for the distribution.
         let metadata = {
             let id = dist.distribution_id();
-            if self.index.distributions().register(id.clone()) {
+            if let Some(response) = self.index.distributions().register_or_wait(&id).await {
+                let MetadataResponse::Found(archive) = &*response else {
+                    panic!("Failed to find metadata for: {requirement}");
+                };
+                archive.metadata.clone()
+            } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = self
                     .database
@@ -166,17 +171,6 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
                     .done(id, Arc::new(MetadataResponse::Found(archive)));
 
                 metadata
-            } else {
-                let response = self
-                    .index
-                    .distributions()
-                    .wait(&id)
-                    .await
-                    .expect("missing value for registered task");
-                let MetadataResponse::Found(archive) = &*response else {
-                    panic!("Failed to find metadata for: {requirement}");
-                };
-                archive.metadata.clone()
             }
         };
 

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -220,7 +220,12 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
         // Fetch the metadata for the distribution.
         let metadata = {
             let id = source.distribution_id();
-            if self.index.distributions().register(id.clone()) {
+            if let Some(response) = self.index.distributions().register_or_wait(&id).await {
+                let MetadataResponse::Found(archive) = &*response else {
+                    panic!("Failed to find metadata for: {}", path.user_display());
+                };
+                archive.metadata.clone()
+            } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
                 let archive = self.database.build_wheel_metadata(&source, hashes).await?;
@@ -233,17 +238,6 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
                     .done(id, Arc::new(MetadataResponse::Found(archive)));
 
                 metadata
-            } else {
-                let response = self
-                    .index
-                    .distributions()
-                    .wait(&id)
-                    .await
-                    .expect("missing value for registered task");
-                let MetadataResponse::Found(archive) = &*response else {
-                    panic!("Failed to find metadata for: {}", path.user_display());
-                };
-                archive.metadata.clone()
             }
         };
 

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -111,13 +111,13 @@ impl BatchPrefetcher {
                 .index
                 .explicit()
                 .wait_blocking(&(name.clone(), index.url().clone()))
-                .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?
+                .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?
         } else {
             self.prefetch_runner
                 .index
                 .implicit()
                 .wait_blocking(name)
-                .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?
+                .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?
         };
 
         let phase = BatchPrefetchStrategy::Compatible {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1154,7 +1154,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             .index
             .distributions()
             .wait_blocking(&distribution_id)
-            .ok_or_else(|| ResolveError::UnregisteredTask(dist.to_string()))?;
+            .map_err(|_| ResolveError::UnregisteredTask(dist.to_string()))?;
 
         // If we failed to fetch the metadata for a URL, we can't proceed.
         let metadata = match &*response {
@@ -1270,12 +1270,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             self.index
                 .explicit()
                 .wait_blocking(&(name.clone(), index.clone()))
-                .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?
+                .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?
         } else {
             self.index
                 .implicit()
                 .wait_blocking(name)
-                .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?
+                .map_err(|_| ResolveError::UnregisteredTask(name.to_string()))?
         };
         visited.insert(name.clone());
 
@@ -1847,7 +1847,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     .index
                     .distributions()
                     .wait_blocking(distribution_id)
-                    .ok_or_else(|| ResolveError::UnregisteredTask(format!("{name}=={version}")))?;
+                    .map_err(|_| ResolveError::UnregisteredTask(format!("{name}=={version}")))?;
 
                 let metadata = match &*response {
                     MetadataResponse::Found(archive) => &archive.metadata,
@@ -2514,7 +2514,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     .implicit()
                     .wait(&package_name)
                     .await
-                    .ok_or_else(|| ResolveError::UnregisteredTask(package_name.to_string()))?;
+                    .map_err(|_| ResolveError::UnregisteredTask(package_name.to_string()))?;
 
                 let version_map = match *versions_response {
                     VersionsResponse::Found(ref version_map) => version_map,


### PR DESCRIPTION
By merging `register` and `wait`, we can avoid unwrapping when using the `OnceMap`.

I didn't change the existing error handling.