### PR TITLE
Refuse uv venv --clear on a path that is not a virtual environment

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -125,6 +125,8 @@ pub(crate) fn create(
                 OnExisting::Allow => {
                     debug!("Allowing existing {name} due to `--allow-existing`");
                 }
+                // Refuse to remove a non-virtual environment, even if `--clear` is provided.
+                OnExisting::Remove(_) if !is_virtualenv => return err,
                 OnExisting::Remove(reason) => {
                     debug!("Removing existing {name} ({reason})");
                     // Before removing the virtual environment, we need to canonicalize the path

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -1046,9 +1046,11 @@ fn non_empty_dir_exists() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.12"]);
 
     // Create a non-empty directory at `.venv`. Creating a virtualenv at the same path should fail,
-    // unless `--clear` is specified.
+    // even when `--clear` is specified, because the directory is not a virtual environment and
+    // `--clear` should not wipe arbitrary contents.
     context.venv.create_dir_all()?;
-    context.venv.child("file").touch()?;
+    let file = context.venv.child("file");
+    file.touch()?;
 
     uv_snapshot!(context.filters(), context.venv()
         .arg(context.venv.as_os_str())
@@ -1072,16 +1074,21 @@ fn non_empty_dir_exists() -> Result<()> {
         .arg("--clear")
         .arg("--python")
         .arg("3.12"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv
-    Activate with: source .venv/[BIN]/activate
-    "
-    );
+    error: Failed to create virtual environment
+      Caused by: A directory already exists at: .venv
+
+    hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing directory
+    ");
+
+    // The existing file should still be present; `--clear` must not wipe a non-virtual environment.
+    file.assert(predicates::path::is_file());
 
     Ok(())
 }


### PR DESCRIPTION
Closes #19395. The OnExisting::Remove branch in uv-virtualenv removes whatever sits at the target path without first checking that it actually looks like a virtual environment, so a stray 'uv venv . --clear' wipes the project directory instead of a venv. The OnExisting::Prompt branch already guards against this with is_virtualenv_base; this PR runs the same check for Remove and returns the existing Exists error when the directory exists and is not a venv.

This re-applies the behaviour zanieb mentioned forgetting to follow up on in #19395, the same guard that was introduced in #15538 and then reverted at 193ac6e to avoid a breaking change at the time. The breaking label is on the issue, so I went with the simple refusal rather than a flag-gated opt-in; happy to switch to --force-clear or similar if that fits better.

I updated the existing non_empty_dir_exists test, which previously asserted that 'uv venv --clear' on a non-empty plain directory succeeded; it now asserts that the command fails and the existing file is still there.