### PR TITLE
Document marker-platform limit on required-environments

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -657,6 +657,11 @@ pub struct ToolUv {
     /// macOS (and ignoring Linux and Windows). On the other hand, `required-environments = ["sys_platform == 'darwin'"]`
     /// would _require_ that any package without a source distribution include a wheel for macOS in
     /// order to be installable.
+    ///
+    /// Note that uv only maps markers to wheel platform tags for Windows, Linux, and macOS
+    /// targets (the platforms shown in the example below). Markers that name another operating
+    /// system, such as `sys_platform == 'freebsd13'`, are accepted at parse time but do not match
+    /// any wheel platform tag, so they cannot force a wheel to be required.
     #[cfg_attr(
         feature = "schemars",
         schemars(


### PR DESCRIPTION
In #17109, konstin explained that uv currently maps marker expressions to wheel platform tags only for Windows, Linux, and macOS targets, because the mapping in `implied_platform_markers` (`crates/uv-distribution-types/src/prioritized_distribution.rs`) is enumerated by hand. `required-environments` accepts entries like `sys_platform == 'freebsd13'` at parse time, but they cannot match any wheel platform tag, so they silently fail to force a wheel to be required.

In that thread konstin agreed it should be called out in the `required-environments` docstring, and #17382 was filed to track the docs change. I added a short paragraph after the existing `environments` / `required-environments` contrast, naming the mapped platforms and giving the freebsd example as the case that silently has no effect.

Docstring-only. `cargo dev generate-all` picks the new text up cleanly for the generated settings reference, and `uvx prek run --from-ref upstream/main` passes.