### PR TITLE
Document uv.lock merge-conflict resolution

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -192,6 +192,26 @@ project defines an upper bound for a package then an upgrade will not go beyond 
 These flags can also be provided to `uv sync` or `uv run` to update the lockfile _and_ the
 environment.
 
+## Resolving lockfile merge conflicts
+
+When the same lockfile is updated on two branches, merging or rebasing one into the other will
+typically produce a conflict in `uv.lock`. Because the lockfile is a resolved output rather than a
+hand-edited source file, the recommended workflow is to discard the conflicted lockfile and re-run
+the resolver rather than attempt a textual merge.
+
+After encountering a conflict during a merge of the parent branch, take the parent's lockfile and
+re-lock on top of the merged dependency state:
+
+```console
+$ git checkout <parent> -- uv.lock
+$ uv lock
+```
+
+This produces a single coherent resolution against the post-merge `pyproject.toml`, instead of an
+ad-hoc mix of pins from each side. If the resulting lockfile changes more than expected, the usual
+[upgrade flags](#upgrading-locked-package-versions) can be used to constrain or expand what gets
+relocked.
+
 ## Exporting the lockfile
 
 If you need to integrate uv with other tools or workflows, you can export `uv.lock` to different


### PR DESCRIPTION
In #5633, zanieb gave the recommended recipe for resolving a `uv.lock` merge conflict: instead of trying to merge two resolved lockfiles textually, restore the parent's `uv.lock` and re-lock on top of the merged dependency state. The recipe was in the issue thread but had never made it into the docs, and there were no open PRs against the issue.

I added a "Resolving lockfile merge conflicts" section to `docs/concepts/projects/sync.md`, slotted between "Upgrading locked package versions" and "Exporting the lockfile" so the lockfile-management sections stay grouped. The body follows zanieb's recipe step for step (`git checkout <parent> -- uv.lock` followed by `uv lock`), notes briefly why the textual merge isn't the right approach for a resolved-output file, and points back to the upgrade flags for cases where the relock changes more than expected.

Docs-only. `uvx prek run --from-ref upstream/main` passes.