### PR TITLE
distribution-filename: fix source dist parse using normalized name length as stem offset

### DIFF
--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -232,7 +232,7 @@ mod tests {
     /// form must parse correctly. For example, `Foo__Bar` (8 bytes) normalizes to `foo-bar`
     /// (7 bytes) because the double underscore collapses to a single hyphen. The old code used
     /// `package_name.as_ref().len()` (= 7) as a byte offset into the stem `Foo__Bar-1.0`,
-    /// producing `"Foo__Bar-1.0"` split as `"Foo__Ba"` + `"r-1.0"` instead of `"Foo__Bar"` + `"1.0"`.
+    /// producing a wrong prefix and an invalid version string rather than `"1.0"`.
     #[test]
     fn unnormalized_name_different_byte_length() {
         let package_name = PackageName::from_str("foo__bar").unwrap();

--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -232,4 +232,34 @@ mod tests {
             .is_err()
         );
     }
+
+    /// Filenames with un-normalized package names whose byte length differs from the normalized
+    /// form must parse correctly. For example, `Foo__Bar` (8 bytes) normalizes to `foo-bar`
+    /// (7 bytes) because the double underscore collapses to a single hyphen. The old code used
+    /// `package_name.as_ref().len()` (= 7) as a byte offset into the stem `Foo__Bar-1.0`,
+    /// producing `"Foo__Ba"` instead of `"Foo__Bar"` and `"r-1.0"` instead of `"1.0"`.
+    #[test]
+    fn unnormalized_name_different_byte_length() {
+        let package_name = PackageName::from_str("foo__bar").unwrap();
+        // "foo__bar" normalizes to "foo-bar" (7 bytes), but the filename prefix is 8 bytes.
+        let parsed = SourceDistFilename::parse(
+            "foo__bar-1.2.3.tar.gz",
+            SourceDistExtension::from_path("foo__bar-1.2.3.tar.gz").unwrap(),
+            &package_name,
+        )
+        .expect("should parse a filename whose name has more bytes than its normalized form");
+        assert_eq!(parsed.version.to_string(), "1.2.3");
+        assert_eq!(parsed.name, package_name);
+
+        // Uppercase letters also change the byte count when mixed with normalizable separators.
+        // "MyPkg__lib" (10 bytes) normalizes to "mypkg-lib" (9 bytes).
+        let package_name2 = PackageName::from_str("MyPkg__lib").unwrap();
+        let parsed2 = SourceDistFilename::parse(
+            "MyPkg__lib-2.0.zip",
+            SourceDistExtension::from_path("MyPkg__lib-2.0.zip").unwrap(),
+            &package_name2,
+        )
+        .expect("should parse a filename with mixed-case and double-underscore prefix");
+        assert_eq!(parsed2.version.to_string(), "2.0");
+    }
 }

--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -47,31 +47,28 @@ impl SourceDistFilename {
 
         let stem = &filename[..(filename.len() - (extension.name().len() + 1))];
 
-        if stem.len() <= package_name.as_ref().len() + "-".len() {
-            return Err(SourceDistFilenameError {
+        // Find the separator position by scanning for `-` occurrences in the stem and checking
+        // which prefix normalizes to the expected package name. This correctly handles filenames
+        // where the original (un-normalized) package name has a different byte length than the
+        // normalized form — e.g., `Foo__Bar-1.0.tar.gz` where `Foo__Bar` (8 bytes) normalizes
+        // to `foo-bar` (7 bytes). Using the normalized length as an index into the stem would
+        // yield the wrong split point.
+        let sep_pos = memchr::memchr_iter(b'-', stem.as_bytes())
+            .find(|&pos| {
+                PackageName::from_str(&stem[..pos])
+                    .ok()
+                    .as_ref()
+                    == Some(package_name)
+            })
+            .ok_or_else(|| SourceDistFilenameError {
                 filename: filename.to_string(),
                 kind: SourceDistFilenameErrorKind::Filename(package_name.clone()),
-            });
-        }
-        let actual_package_name = PackageName::from_str(&stem[..package_name.as_ref().len()])
-            .map_err(|err| SourceDistFilenameError {
-                filename: filename.to_string(),
-                kind: SourceDistFilenameErrorKind::PackageName(err),
             })?;
-        if actual_package_name != *package_name {
-            return Err(SourceDistFilenameError {
-                filename: filename.to_string(),
-                kind: SourceDistFilenameErrorKind::Filename(package_name.clone()),
-            });
-        }
 
-        // We checked the length above
         let version =
-            Version::from_str(&stem[package_name.as_ref().len() + "-".len()..]).map_err(|err| {
-                SourceDistFilenameError {
-                    filename: filename.to_string(),
-                    kind: SourceDistFilenameErrorKind::Version(err),
-                }
+            Version::from_str(&stem[sep_pos + 1..]).map_err(|err| SourceDistFilenameError {
+                filename: filename.to_string(),
+                kind: SourceDistFilenameErrorKind::Version(err),
             })?;
 
         Ok(Self {

--- a/crates/uv-distribution-filename/src/source_dist.rs
+++ b/crates/uv-distribution-filename/src/source_dist.rs
@@ -54,12 +54,7 @@ impl SourceDistFilename {
         // to `foo-bar` (7 bytes). Using the normalized length as an index into the stem would
         // yield the wrong split point.
         let sep_pos = memchr::memchr_iter(b'-', stem.as_bytes())
-            .find(|&pos| {
-                PackageName::from_str(&stem[..pos])
-                    .ok()
-                    .as_ref()
-                    == Some(package_name)
-            })
+            .find(|&pos| PackageName::from_str(&stem[..pos]).ok().as_ref() == Some(package_name))
             .ok_or_else(|| SourceDistFilenameError {
                 filename: filename.to_string(),
                 kind: SourceDistFilenameErrorKind::Filename(package_name.clone()),
@@ -237,7 +232,7 @@ mod tests {
     /// form must parse correctly. For example, `Foo__Bar` (8 bytes) normalizes to `foo-bar`
     /// (7 bytes) because the double underscore collapses to a single hyphen. The old code used
     /// `package_name.as_ref().len()` (= 7) as a byte offset into the stem `Foo__Bar-1.0`,
-    /// producing `"Foo__Ba"` instead of `"Foo__Bar"` and `"r-1.0"` instead of `"1.0"`.
+    /// producing `"Foo__Bar-1.0"` split as `"Foo__Ba"` + `"r-1.0"` instead of `"Foo__Bar"` + `"1.0"`.
     #[test]
     fn unnormalized_name_different_byte_length() {
         let package_name = PackageName::from_str("foo__bar").unwrap();


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

`SourceDistFilename::parse` accepted a `&PackageName`, which is always
stored in normalized form (lowercase, runs of `-`/`_`/`.` collapsed to
a single `-`). It used `package_name.as_ref().len()` — the normalized
name's byte length — as a literal byte offset into the raw filename
stem to split the package name from the version string.

This is incorrect when normalization changes the byte length. For
example, `Foo__Bar` (8 bytes) normalizes to `foo-bar` (7 bytes) because
the double underscore collapses to a single hyphen. The old code would
slice `stem[..7]` on `foo__bar-1.2.3`, producing `"foo__ba"` instead of
`"foo__bar"`, causing a spurious parse error on a perfectly valid
filename.

The fix scans for `-` byte positions in the stem using
`memchr::memchr_iter` (already a dependency of this crate) and finds
the first position where the prefix normalizes to the expected package
name. This correctly handles all cases where the original name has a
different byte length than its normalized form.

## Test Plan

Added a new unit test `unnormalized_name_different_byte_length` that
exercises two cases where normalization changes the byte count:

- `foo__bar-1.2.3.tar.gz` — double underscore collapses (`foo__bar`
  is 8 bytes, normalizes to `foo-bar` at 7 bytes)
- `MyPkg__lib-2.0.zip` — mixed case plus double underscore
  (`MyPkg__lib` is 10 bytes, normalizes to `mypkg-lib` at 9 bytes)

Both previously returned a parse error; both now parse successfully
with the correct version extracted.