### PR TITLE
uv audit: specialize malformed OSV error

### DIFF
--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -30,6 +30,13 @@ pub enum Error {
     /// An error when constructing the URL for an API request.
     #[error("Invalid API URL: {0}")]
     Url(DisplaySafeUrl, #[source] DisplaySafeUrlError),
+    /// An error when OSV returns an invalid vulnerability record.
+    #[error("OSV returned a malformed vulnerability record for `{id}`")]
+    MalformedVulnerabilityRecord {
+        id: String,
+        #[source]
+        err: reqwest_middleware::Error,
+    },
 }
 
 /// Package specification for OSV queries.
@@ -332,7 +339,10 @@ impl Osv {
             .map_err(reqwest_middleware::Error::Reqwest)?
             .json()
             .await
-            .map_err(reqwest_middleware::Error::Reqwest)?;
+            .map_err(|err| Error::MalformedVulnerabilityRecord {
+                id: id.to_string(),
+                err: reqwest_middleware::Error::Reqwest(err),
+            })?;
         Ok(vuln)
     }
 

--- a/crates/uv-audit/src/service/osv.rs
+++ b/crates/uv-audit/src/service/osv.rs
@@ -32,7 +32,7 @@ pub enum Error {
     Url(DisplaySafeUrl, #[source] DisplaySafeUrlError),
     /// An error when OSV returns an invalid vulnerability record.
     #[error("OSV returned a malformed vulnerability record for `{id}`")]
-    MalformedVulnerabilityRecord {
+    MalformedRecord {
         id: String,
         #[source]
         err: reqwest_middleware::Error,
@@ -339,7 +339,7 @@ impl Osv {
             .map_err(reqwest_middleware::Error::Reqwest)?
             .json()
             .await
-            .map_err(|err| Error::MalformedVulnerabilityRecord {
+            .map_err(|err| Error::MalformedRecord {
                 id: id.to_string(),
                 err: reqwest_middleware::Error::Reqwest(err),
             })?;

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -273,6 +273,60 @@ async fn audit_vulnerability_found() {
     ");
 }
 
+/// Audit a project when OSV returns a malformed vulnerability record.
+#[tokio::test]
+async fn audit_malformed_vulnerability_record() {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2023-0001"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2023-0001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2023-0001"
+        })))
+        .mount(&server)
+        .await;
+
+    uv_snapshot!(context.filters(), context
+        .audit()
+        .arg("--preview-features")
+        .arg("audit")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    error: OSV returned a malformed vulnerability record for `PYSEC-2023-0001`
+      Caused by: error decoding response body
+      Caused by: missing field `modified` at line 1 column 24
+    ");
+}
+
 /// Audit a project with no dependencies.
 #[tokio::test]
 async fn audit_no_dependencies() {

--- a/crates/uv/tests/it/audit.rs
+++ b/crates/uv/tests/it/audit.rs
@@ -304,7 +304,23 @@ async fn audit_malformed_vulnerability_record() {
     Mock::given(method("GET"))
         .and(path("/v1/vulns/PYSEC-2023-0001"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "id": "PYSEC-2023-0001"
+            "id": "PYSEC-2023-0001",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A test vulnerability in iniconfig",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {}
+                    ]
+                }]
+            }],
+            "references": [{
+                "type": "ADVISORY",
+                "url": "https://example.com/advisory/PYSEC-2023-0001"
+            }]
+
         })))
         .mount(&server)
         .await;
@@ -323,7 +339,7 @@ async fn audit_malformed_vulnerability_record() {
     Resolved 2 packages in [TIME]
     error: OSV returned a malformed vulnerability record for `PYSEC-2023-0001`
       Caused by: error decoding response body
-      Caused by: missing field `modified` at line 1 column 24
+      Caused by: expected value at line 1 column 56
     ");
 }
 


### PR DESCRIPTION
## Summary

See https://github.com/astral-sh/uv/issues/19492. This doesn't fix the error (it's on OSV's side), but this makes the error more intelligible to users.

## Test Plan

Added an integration test.