### PR TITLE
ci: use `uv publish` for astral-test-pypa-gh-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,14 +325,18 @@ jobs:
           ../uv build
 
       - name: "Publish astral-test-pypa-gh-action"
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          # With this GitHub action, we can't do as rigid checks as with our custom Python script, so we publish more
-          # leniently
-          skip-existing: "true"
-          verbose: "true"
-          repository-url: "https://test.pypi.org/legacy/"
-          packages-dir: "astral-test-pypa-gh-action/dist"
+        # Dogfood `uv publish` to publish the test package via TestPyPI's
+        # trusted publishing flow. Replaces `pypa/gh-action-pypi-publish`,
+        # which Renovate could not keep digest-pinned because its tags are
+        # annotated (see astral-sh/uv#15276 for the original investigation).
+        shell: bash -eo pipefail -O failglob {0}
+        run: |
+          ./uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple/astral-test-pypa-gh-action/ \
+            --trusted-publishing automatic \
+            --verbose \
+            astral-test-pypa-gh-action/dist/*
 
       - name: "Request GitLab OIDC tokens for impersonation"
         uses: digital-blueprint/gitlab-pipeline-trigger-action@c59b56e9d2688ab42c1304322ac8831a4ef6f7d2 # v1.4.0


### PR DESCRIPTION
## Summary

Closes #15276.

Per @j178's [suggestion on the prior revision](https://github.com/astral-sh/uv/pull/19526#issuecomment-3838988064), this drops the dependency on `pypa/gh-action-pypi-publish` and uses `uv publish` directly. Two wins:

1. **Dogfoods `uv publish`** end-to-end in CI on every run of the "test uv publish" job.
2. **Moots the original Renovate workaround.** The reason `pypa/gh-action-pypi-publish` couldn't be kept digest-pinned by Renovate is that its tags are annotated (verified: `gh api repos/pypa/gh-action-pypi-publish/git/ref/tags/v1.14.0 -q .object.type` returns `tag`, not `commit`) and Renovate's `github-tags` datasource does not dereference them. With the action gone, no Renovate config exception is required — `.github/renovate.json5` is untouched in this PR.

### What the new step does

The job's `id-token: write` permission was already in place for trusted publishing, and the `uv` binary is downloaded from the build artifacts earlier in the job. The publish step becomes:

```yaml
- name: "Publish astral-test-pypa-gh-action"
  shell: bash -eo pipefail -O failglob {0}
  run: |
    ./uv publish \
      --publish-url https://test.pypi.org/legacy/ \
      --check-url https://test.pypi.org/simple/astral-test-pypa-gh-action/ \
      --trusted-publishing automatic \
      --verbose \
      astral-test-pypa-gh-action/dist/*
```

- `--trusted-publishing automatic` uses GitHub's OIDC token exchange, the same mechanism `pypa/gh-action-pypi-publish` used.
- `--check-url` matches `skip-existing: true` semantically: `crates/uv/src/commands/publish.rs` emits `"File <name> already exists, skipping"` and `continue`s when the file is already on TestPyPI.
- `failglob` makes the step fail loudly (with a clear message) if the prior build step produced no artifacts, rather than passing the literal pattern to `uv publish`.

### Notes for reviewers

- The trusted-publishing environment (`uv-test-publish`) is unchanged.
- I considered keeping the renovate workaround as a defensive measure for any future use of an annotated-tag action, but @j178 is right that removing the dependency is cleaner and the workaround can be re-introduced if and when it's actually needed.
- The "test uv publish" job is gated on `github.repository == 'astral-sh/uv'`, so this won't run on this fork's CI.

## Test plan

- [ ] The `test uv publish` job in CI publishes a new patch version of `astral-test-pypa-gh-action` to TestPyPI successfully on the next run (gated on `publish_code_changed`, which the ci.yml edit triggers).
- [ ] `uv publish` reports `File ... already exists, skipping` correctly if the publish job is re-run on the same SHA.