### PR TITLE
Replace dashmap with papaya

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,20 +1186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6754,8 +6740,8 @@ dependencies = [
 name = "uv-once-map"
 version = "0.0.54"
 dependencies = [
- "dashmap",
  "futures",
+ "papaya",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6740,8 +6754,8 @@ dependencies = [
 name = "uv-once-map"
 version = "0.0.54"
 dependencies = [
+ "dashmap",
  "futures",
- "papaya",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,20 +1186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3066,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,6 +4390,16 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6526,9 +6532,9 @@ dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
  "cargo-util",
- "dashmap",
  "fs-err",
  "owo-colors",
+ "papaya",
  "reqwest",
  "thiserror",
  "tokio",
@@ -6734,8 +6740,8 @@ dependencies = [
 name = "uv-once-map"
 version = "0.0.54"
 dependencies = [
- "dashmap",
  "futures",
+ "papaya",
  "tokio",
 ]
 
@@ -7072,7 +7078,6 @@ dependencies = [
  "astral-pubgrub",
  "clap",
  "cyclonedx-bom",
- "dashmap",
  "either",
  "fs-err",
  "futures",
@@ -7082,6 +7087,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "owo-colors",
+ "papaya",
  "percent-encoding",
  "petgraph",
  "rkyv",
@@ -7365,7 +7371,7 @@ name = "uv-types"
 version = "0.0.54"
 dependencies = [
  "anyhow",
- "dashmap",
+ "papaya",
  "rustc-hash",
  "thiserror",
  "uv-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ console = { version = "0.16.0", default-features = false, features = ["std"] }
 csv = { version = "1.3.0" }
 ctrlc = { version = "3.4.5" }
 cyclonedx-bom = { version = "0.8.1" }
-dashmap = { version = "6.1.0" }
 data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }
@@ -183,6 +182,7 @@ miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 nix = { version = "0.31.2", features = ["resource", "signal"] }
 open = { version = "5.3.2" }
 owo-colors = { version = "4.1.0" }
+papaya = { version = "0.2.4" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 percent-encoding = { version = "2.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ console = { version = "0.16.0", default-features = false, features = ["std"] }
 csv = { version = "1.3.0" }
 ctrlc = { version = "3.4.5" }
 cyclonedx-bom = { version = "0.8.1" }
-dashmap = { version = "6.1.0" }
 data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ console = { version = "0.16.0", default-features = false, features = ["std"] }
 csv = { version = "1.3.0" }
 ctrlc = { version = "3.4.5" }
 cyclonedx-bom = { version = "0.8.1" }
+dashmap = { version = "6.1.0" }
 data-encoding = { version = "2.6.0" }
 diskus = { version = "0.9.0", default-features = false }
 dotenvy = { version = "0.15.7" }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -3025,7 +3025,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             };
 
             if let Some(builder) = self.build_context.build_arena().remove(&build_key) {
-                debug!("Creating build environment for: {source}");
+                debug!("Reusing existing build environment for: {source}");
                 let wheel = builder.wheel(temp_dir.path()).await.map_err(Error::Build)?;
 
                 // Store the build context.
@@ -3033,7 +3033,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
                 wheel
             } else {
-                debug!("Reusing existing build environment for: {source}");
+                debug!("Creating build environment for: {source}");
 
                 let builder = self
                     .build_context

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -27,7 +27,7 @@ uv-warnings = { workspace = true }
 
 anyhow = { workspace = true }
 cargo-util = { workspace = true }
-dashmap = { workspace = true }
+papaya = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 owo-colors = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use fs_err::tokio as fs;
-use papaya::HashMap;
+use papaya::{HashMap, ResizeMode};
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::debug;
 
@@ -59,8 +59,16 @@ impl GitHttpSettings {
 }
 
 /// A resolver for Git repositories.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct GitResolver(Arc<HashMap<RepositoryReference, GitOid>>);
+
+impl Default for GitResolver {
+    fn default() -> Self {
+        Self(Arc::new(
+            HashMap::builder().resize_mode(ResizeMode::Blocking).build(),
+        ))
+    }
+}
 
 impl GitResolver {
     /// Inserts a new [`GitOid`] for the given [`RepositoryReference`].

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -3,9 +3,8 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use dashmap::DashMap;
-use dashmap::mapref::one::Ref;
 use fs_err::tokio as fs;
+use papaya::HashMap;
 use reqwest_middleware::ClientWithMiddleware;
 use tracing::debug;
 
@@ -61,17 +60,17 @@ impl GitHttpSettings {
 
 /// A resolver for Git repositories.
 #[derive(Default, Clone)]
-pub struct GitResolver(Arc<DashMap<RepositoryReference, GitOid>>);
+pub struct GitResolver(Arc<HashMap<RepositoryReference, GitOid>>);
 
 impl GitResolver {
     /// Inserts a new [`GitOid`] for the given [`RepositoryReference`].
     pub fn insert(&self, reference: RepositoryReference, sha: GitOid) {
-        self.0.insert(reference, sha);
+        self.0.pin().insert(reference, sha);
     }
 
     /// Returns the [`GitOid`] for the given [`RepositoryReference`], if it exists.
-    fn get(&self, reference: &RepositoryReference) -> Option<Ref<'_, RepositoryReference, GitOid>> {
-        self.0.get(reference)
+    fn get(&self, reference: &RepositoryReference) -> Option<GitOid> {
+        self.0.pin().get(reference).copied()
     }
 
     /// Return the [`GitOid`] for the given [`GitUrl`], if it is already known.
@@ -84,7 +83,7 @@ impl GitResolver {
         // If we know the precise commit already, return it.
         let reference = RepositoryReference::from(url);
         if let Some(precise) = self.get(&reference) {
-            return Some(*precise);
+            return Some(precise);
         }
 
         None
@@ -181,7 +180,7 @@ impl GitResolver {
         // single process are consistent.
         let url = {
             if let Some(precise) = self.get(&reference) {
-                Cow::Owned(url.clone().with_precise(*precise))
+                Cow::Owned(url.clone().with_precise(precise))
             } else {
                 Cow::Borrowed(url)
             }
@@ -241,7 +240,7 @@ impl GitResolver {
     pub fn precise(&self, url: GitUrl) -> Option<GitUrl> {
         let reference = RepositoryReference::from(&url);
         let precise = self.get(&reference)?;
-        Some(url.with_precise(*precise))
+        Some(url.with_precise(precise))
     }
 
     /// Returns `true` if the two Git URLs refer to the same precise commit.
@@ -263,11 +262,11 @@ impl GitResolver {
         }
 
         // Otherwise, the URLs must resolve to the same precise commit.
-        let Some(a_precise) = a.precise().or_else(|| self.get(&a_ref).map(|sha| *sha)) else {
+        let Some(a_precise) = a.precise().or_else(|| self.get(&a_ref)) else {
             return false;
         };
 
-        let Some(b_precise) = b.precise().or_else(|| self.get(&b_ref).map(|sha| *sha)) else {
+        let Some(b_precise) = b.precise().or_else(|| self.get(&b_ref)) else {
             return false;
         };
 

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -17,6 +17,6 @@ test = false
 workspace = true
 
 [dependencies]
-dashmap = { workspace = true }
+papaya = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -17,6 +17,6 @@ test = false
 workspace = true
 
 [dependencies]
-papaya = { workspace = true }
+dashmap = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-once-map/Cargo.toml
+++ b/crates/uv-once-map/Cargo.toml
@@ -17,6 +17,6 @@ test = false
 workspace = true
 
 [dependencies]
-dashmap = { workspace = true }
 futures = { workspace = true }
+papaya = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::Arc;
 
-use dashmap::{DashMap, Entry};
+use papaya::HashMap;
 use tokio::sync::Notify;
 
 /// The caller tried to wait for a task that was never registered.
@@ -28,7 +28,7 @@ impl<K: Debug + Display> std::error::Error for UnregisteredTask<K> {}
 /// Note that this always clones the value out of the underlying map. Because
 /// of this, it's common to wrap the `V` in an `Arc<V>` to make cloning cheap.
 pub struct OnceMap<K, V, S = RandomState> {
-    items: DashMap<K, Value<V>, S>,
+    items: HashMap<K, Value<V>, S>,
 }
 
 impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher + Clone> Debug for OnceMap<K, V, S> {
@@ -44,14 +44,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// or other tasks will hang. If it returns `false`, this job is already in progress and you
     /// can [`OnceMap::wait`] for the result.
     pub fn register(&self, key: K) -> bool {
-        let entry = self.items.entry(key);
-        match entry {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(entry) => {
-                entry.insert(Value::Waiting(Arc::new(Notify::new())));
-                true
-            }
-        }
+        self.items
+            .pin()
+            .try_insert(key, Value::Waiting(Arc::new(Notify::new())))
+            .is_ok()
     }
 
     /// Register that you want to start a job, unless it was already started, then wait for its
@@ -74,19 +70,13 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// ```
     pub async fn register_or_wait(&self, key: &K) -> Option<V> {
         let notify = {
-            let entry = self.items.entry(key.clone());
-            match entry {
-                Entry::Occupied(value) => match value.get() {
+            let items = self.items.pin();
+            match items.try_insert(key.clone(), Value::Waiting(Arc::new(Notify::new()))) {
+                Ok(_) => return None,
+                Err(entry) => match entry.current {
                     Value::Filled(value) => return Some(value.clone()),
                     Value::Waiting(notify) => notify.clone(),
                 },
-                Entry::Vacant(entry) => {
-                    // We insert the notify even if the caller is `wait`. Calling `wait` without
-                    // a previous `register` is a fatal error, so the state of the map doesn't
-                    // matter.
-                    entry.insert(Value::Waiting(Arc::new(Notify::new())));
-                    return None;
-                }
             }
         };
 
@@ -94,23 +84,18 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         let notification = notify.notified();
 
         // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
-        if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
-            return Some(value.clone());
+        if let Some(value) = self.get(key) {
+            return Some(value);
         }
 
         // Wait until the value is inserted.
         notification.await;
-
-        let entry = self.items.get(key).expect("map is append-only");
-        match entry.value() {
-            Value::Filled(value) => Some(value.clone()),
-            Value::Waiting(_) => unreachable!("notify was called"),
-        }
+        self.get(key)
     }
 
     /// Submit the result of a job you registered.
     pub fn done(&self, key: K, value: V) {
-        if let Some(Value::Waiting(notify)) = self.items.insert(key, Value::Filled(value)) {
+        if let Some(Value::Waiting(notify)) = self.items.pin().insert(key, Value::Filled(value)) {
             notify.notify_waiters();
         }
     }
@@ -139,8 +124,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        let entry = self.items.get(key)?;
-        match entry.value() {
+        match self.items.pin().get(key)? {
             Value::Filled(value) => Some(value.clone()),
             Value::Waiting(_) => None,
         }
@@ -151,10 +135,9 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        let entry = self.items.remove(key)?;
-        match entry {
-            (_, Value::Filled(value)) => Some(value),
-            (_, Value::Waiting(_)) => None,
+        match self.items.pin().remove(key)? {
+            Value::Filled(value) => Some(value.clone()),
+            Value::Waiting(_) => None,
         }
     }
 }
@@ -162,7 +145,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
 impl<K: Eq + Hash + Clone, V, H: Default + BuildHasher + Clone> Default for OnceMap<K, V, H> {
     fn default() -> Self {
         Self {
-            items: DashMap::with_hasher(H::default()),
+            items: HashMap::with_hasher(H::default()),
         }
     }
 }

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use papaya::{HashMap, ResizeMode};
 use tokio::sync::Notify;
@@ -74,7 +74,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
             match items.try_insert(key.clone(), Value::Waiting(Arc::new(Notify::new()))) {
                 Ok(_) => return None,
                 Err(value) => match value.current {
-                    Value::Filled(value) => return Some(value.clone()),
+                    Value::Filled(_) => return value.current.get(),
                     Value::Waiting(notify) => notify.clone(),
                 },
             }
@@ -84,23 +84,24 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         let notification = notify.notified();
 
         // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
-        if let Value::Filled(value) = self.items.pin().get(key).expect("map is append-only") {
-            return Some(value.clone());
+        if let Some(value) = self.items.pin().get(key).expect("map is append-only").get() {
+            return Some(value);
         }
 
         // Wait until the value is inserted.
         notification.await;
 
         let items = self.items.pin();
-        match items.get(key).expect("map is append-only") {
-            Value::Filled(value) => Some(value.clone()),
+        let value = items.get(key).expect("map is append-only");
+        match value {
+            Value::Filled(_) => value.get(),
             Value::Waiting(_) => unreachable!("notify was called"),
         }
     }
 
     /// Submit the result of a job you registered.
     pub fn done(&self, key: K, value: V) {
-        if let Some(Value::Waiting(notify)) = self.items.pin().insert(key, Value::Filled(value)) {
+        if let Some(Value::Waiting(notify)) = self.items.pin().insert(key, Value::filled(value)) {
             notify.notify_waiters();
         }
     }
@@ -130,10 +131,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         K: Borrow<Q>,
     {
         let items = self.items.pin();
-        match items.get(key)? {
-            Value::Filled(value) => Some(value.clone()),
-            Value::Waiting(_) => None,
-        }
+        items.get(key)?.get()
     }
 
     /// Remove the result of a previous job, if any.
@@ -142,10 +140,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         K: Borrow<Q>,
     {
         let items = self.items.pin();
-        match items.remove(key)? {
-            Value::Filled(value) => Some(value.clone()),
-            Value::Waiting(_) => None,
-        }
+        items.remove(key)?.take()
     }
 }
 
@@ -169,7 +164,7 @@ where
         Self {
             items: iter
                 .into_iter()
-                .map(|(k, v)| (k, Value::Filled(v)))
+                .map(|(k, v)| (k, Value::filled(v)))
                 .collect(),
         }
     }
@@ -178,5 +173,34 @@ where
 #[derive(Debug)]
 enum Value<V> {
     Waiting(Arc<Notify>),
-    Filled(V),
+    Filled(Mutex<Option<V>>),
+}
+
+impl<V> Value<V> {
+    fn filled(value: V) -> Self {
+        Self::Filled(Mutex::new(Some(value)))
+    }
+
+    fn lock(value: &Mutex<Option<V>>) -> MutexGuard<'_, Option<V>> {
+        match value.lock() {
+            Ok(value) => value,
+            Err(err) => err.into_inner(),
+        }
+    }
+
+    fn take(&self) -> Option<V> {
+        match self {
+            Self::Filled(value) => Self::lock(value).take(),
+            Self::Waiting(_) => None,
+        }
+    }
+}
+
+impl<V: Clone> Value<V> {
+    fn get(&self) -> Option<V> {
+        match self {
+            Self::Filled(value) => Self::lock(value).clone(),
+            Self::Waiting(_) => None,
+        }
+    }
 }

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use papaya::{HashMap, ResizeMode};
 use tokio::sync::Notify;
@@ -71,10 +71,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     pub async fn register_or_wait(&self, key: &K) -> Option<V> {
         let notify = {
             let items = self.items.pin();
-            match items.try_insert(key.clone(), Value::Waiting(Arc::new(Notify::new()))) {
+            match items.try_insert_with(key.clone(), || Value::Waiting(Arc::new(Notify::new()))) {
                 Ok(_) => return None,
-                Err(value) => match value.current {
-                    Value::Filled(_) => return value.current.get(),
+                Err(value) => match value {
+                    Value::Filled(_) => return value.get(),
                     Value::Waiting(notify) => notify.clone(),
                 },
             }
@@ -183,7 +183,7 @@ impl<V> Value<V> {
     }
 
     fn lock(value: &Mutex<Option<V>>) -> MutexGuard<'_, Option<V>> {
-        value.lock().unwrap_or_else(|err| err.into_inner())
+        value.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     fn take(&self) -> Option<V> {

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::Arc;
 
-use dashmap::{DashMap, Entry};
+use papaya::{HashMap, ResizeMode};
 use tokio::sync::Notify;
 
 /// The caller tried to wait for a task that was never registered.
@@ -28,7 +28,7 @@ impl<K: Debug + Display> std::error::Error for UnregisteredTask<K> {}
 /// Note that this always clones the value out of the underlying map. Because
 /// of this, it's common to wrap the `V` in an `Arc<V>` to make cloning cheap.
 pub struct OnceMap<K, V, S = RandomState> {
-    items: DashMap<K, Value<V>, S>,
+    items: HashMap<K, Value<V>, S>,
 }
 
 impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher + Clone> Debug for OnceMap<K, V, S> {
@@ -44,14 +44,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// or other tasks will hang. If it returns `false`, this job is already in progress and you
     /// can [`OnceMap::wait`] for the result.
     pub fn register(&self, key: K) -> bool {
-        let entry = self.items.entry(key);
-        match entry {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(entry) => {
-                entry.insert(Value::Waiting(Arc::new(Notify::new())));
-                true
-            }
-        }
+        self.items
+            .pin()
+            .try_insert(key, Value::Waiting(Arc::new(Notify::new())))
+            .is_ok()
     }
 
     /// Register that you want to start a job, unless it was already started, then wait for its
@@ -74,19 +70,13 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// ```
     pub async fn register_or_wait(&self, key: &K) -> Option<V> {
         let notify = {
-            let entry = self.items.entry(key.clone());
-            match entry {
-                Entry::Occupied(value) => match value.get() {
+            let items = self.items.pin();
+            match items.try_insert(key.clone(), Value::Waiting(Arc::new(Notify::new()))) {
+                Ok(_) => return None,
+                Err(value) => match value.current {
                     Value::Filled(value) => return Some(value.clone()),
                     Value::Waiting(notify) => notify.clone(),
                 },
-                Entry::Vacant(entry) => {
-                    // We insert the notify even if the caller is `wait`. Calling `wait` without
-                    // a previous `register` is a fatal error, so the state of the map doesn't
-                    // matter.
-                    entry.insert(Value::Waiting(Arc::new(Notify::new())));
-                    return None;
-                }
             }
         };
 
@@ -94,15 +84,15 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         let notification = notify.notified();
 
         // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
-        if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
+        if let Value::Filled(value) = self.items.pin().get(key).expect("map is append-only") {
             return Some(value.clone());
         }
 
         // Wait until the value is inserted.
         notification.await;
 
-        let entry = self.items.get(key).expect("map is append-only");
-        match entry.value() {
+        let items = self.items.pin();
+        match items.get(key).expect("map is append-only") {
             Value::Filled(value) => Some(value.clone()),
             Value::Waiting(_) => unreachable!("notify was called"),
         }
@@ -110,7 +100,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
 
     /// Submit the result of a job you registered.
     pub fn done(&self, key: K, value: V) {
-        if let Some(Value::Waiting(notify)) = self.items.insert(key, Value::Filled(value)) {
+        if let Some(Value::Waiting(notify)) = self.items.pin().insert(key, Value::Filled(value)) {
             notify.notify_waiters();
         }
     }
@@ -139,8 +129,8 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        let entry = self.items.get(key)?;
-        match entry.value() {
+        let items = self.items.pin();
+        match items.get(key)? {
             Value::Filled(value) => Some(value.clone()),
             Value::Waiting(_) => None,
         }
@@ -151,10 +141,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        let entry = self.items.remove(key)?;
-        match entry {
-            (_, Value::Filled(value)) => Some(value),
-            (_, Value::Waiting(_)) => None,
+        let items = self.items.pin();
+        match items.remove(key)? {
+            Value::Filled(value) => Some(value.clone()),
+            Value::Waiting(_) => None,
         }
     }
 }
@@ -162,7 +152,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
 impl<K: Eq + Hash + Clone, V, H: Default + BuildHasher + Clone> Default for OnceMap<K, V, H> {
     fn default() -> Self {
         Self {
-            items: DashMap::with_hasher(H::default()),
+            items: HashMap::builder()
+                .hasher(H::default())
+                .resize_mode(ResizeMode::Blocking)
+                .build(),
         }
     }
 }

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -173,6 +173,7 @@ where
 #[derive(Debug)]
 enum Value<V> {
     Waiting(Arc<Notify>),
+    /// The mutex is a workaround to papaya always returning borrowed instead of owned values.
     Filled(Mutex<Option<V>>),
 }
 
@@ -182,10 +183,7 @@ impl<V> Value<V> {
     }
 
     fn lock(value: &Mutex<Option<V>>) -> MutexGuard<'_, Option<V>> {
-        match value.lock() {
-            Ok(value) => value,
-            Err(err) => err.into_inner(),
-        }
+        value.lock().unwrap_or_else(|err| err.into_inner())
     }
 
     fn take(&self) -> Option<V> {

--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::{BuildHasher, Hash, RandomState};
 use std::sync::Arc;
 
-use papaya::HashMap;
+use dashmap::{DashMap, Entry};
 use tokio::sync::Notify;
 
 /// The caller tried to wait for a task that was never registered.
@@ -28,7 +28,7 @@ impl<K: Debug + Display> std::error::Error for UnregisteredTask<K> {}
 /// Note that this always clones the value out of the underlying map. Because
 /// of this, it's common to wrap the `V` in an `Arc<V>` to make cloning cheap.
 pub struct OnceMap<K, V, S = RandomState> {
-    items: HashMap<K, Value<V>, S>,
+    items: DashMap<K, Value<V>, S>,
 }
 
 impl<K: Eq + Hash + Debug, V: Debug, S: BuildHasher + Clone> Debug for OnceMap<K, V, S> {
@@ -44,10 +44,14 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// or other tasks will hang. If it returns `false`, this job is already in progress and you
     /// can [`OnceMap::wait`] for the result.
     pub fn register(&self, key: K) -> bool {
-        self.items
-            .pin()
-            .try_insert(key, Value::Waiting(Arc::new(Notify::new())))
-            .is_ok()
+        let entry = self.items.entry(key);
+        match entry {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
+                entry.insert(Value::Waiting(Arc::new(Notify::new())));
+                true
+            }
+        }
     }
 
     /// Register that you want to start a job, unless it was already started, then wait for its
@@ -70,13 +74,19 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     /// ```
     pub async fn register_or_wait(&self, key: &K) -> Option<V> {
         let notify = {
-            let items = self.items.pin();
-            match items.try_insert(key.clone(), Value::Waiting(Arc::new(Notify::new()))) {
-                Ok(_) => return None,
-                Err(entry) => match entry.current {
+            let entry = self.items.entry(key.clone());
+            match entry {
+                Entry::Occupied(value) => match value.get() {
                     Value::Filled(value) => return Some(value.clone()),
                     Value::Waiting(notify) => notify.clone(),
                 },
+                Entry::Vacant(entry) => {
+                    // We insert the notify even if the caller is `wait`. Calling `wait` without
+                    // a previous `register` is a fatal error, so the state of the map doesn't
+                    // matter.
+                    entry.insert(Value::Waiting(Arc::new(Notify::new())));
+                    return None;
+                }
             }
         };
 
@@ -84,18 +94,23 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         let notification = notify.notified();
 
         // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
-        if let Some(value) = self.get(key) {
-            return Some(value);
+        if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
+            return Some(value.clone());
         }
 
         // Wait until the value is inserted.
         notification.await;
-        self.get(key)
+
+        let entry = self.items.get(key).expect("map is append-only");
+        match entry.value() {
+            Value::Filled(value) => Some(value.clone()),
+            Value::Waiting(_) => unreachable!("notify was called"),
+        }
     }
 
     /// Submit the result of a job you registered.
     pub fn done(&self, key: K, value: V) {
-        if let Some(Value::Waiting(notify)) = self.items.pin().insert(key, Value::Filled(value)) {
+        if let Some(Value::Waiting(notify)) = self.items.insert(key, Value::Filled(value)) {
             notify.notify_waiters();
         }
     }
@@ -124,7 +139,8 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        match self.items.pin().get(key)? {
+        let entry = self.items.get(key)?;
+        match entry.value() {
             Value::Filled(value) => Some(value.clone()),
             Value::Waiting(_) => None,
         }
@@ -135,9 +151,10 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
     where
         K: Borrow<Q>,
     {
-        match self.items.pin().remove(key)? {
-            Value::Filled(value) => Some(value.clone()),
-            Value::Waiting(_) => None,
+        let entry = self.items.remove(key)?;
+        match entry {
+            (_, Value::Filled(value)) => Some(value),
+            (_, Value::Waiting(_)) => None,
         }
     }
 }
@@ -145,7 +162,7 @@ impl<K: Eq + Hash + Clone, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
 impl<K: Eq + Hash + Clone, V, H: Default + BuildHasher + Clone> Default for OnceMap<K, V, H> {
     fn default() -> Self {
         Self {
-            items: HashMap::with_hasher(H::default()),
+            items: DashMap::with_hasher(H::default()),
         }
     }
 }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -50,7 +50,7 @@ uv-workspace = { workspace = true }
 arcstr = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 cyclonedx-bom = { workspace = true }
-dashmap = { workspace = true }
+papaya = { workspace = true }
 either = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2721,7 +2721,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             if let PubGrubPackageInner::Package { name, .. } = &**package
                 && let Some(versions) = incomplete_packages_cache.get(name)
             {
-                for (version, reason) in versions.pin().iter() {
+                for (version, reason) in &versions.pin() {
                     incomplete_packages
                         .entry(name.clone())
                         .or_insert_with(BTreeMap::default)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -129,10 +129,11 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     selector: CandidateSelector,
     index: InMemoryIndex,
     installed_packages: InstalledPackages,
+    // Papaya's maps are large on Windows, so box them to keep resolver futures small.
     /// Incompatibilities for packages that are entirely unavailable.
-    unavailable_packages: HashMap<PackageName, UnavailablePackage>,
+    unavailable_packages: Box<HashMap<PackageName, UnavailablePackage>>,
     /// Incompatibilities for packages that are unavailable at specific versions.
-    incomplete_packages: HashMap<PackageName, HashMap<Version, MetadataUnavailable>>,
+    incomplete_packages: Box<HashMap<PackageName, HashMap<Version, MetadataUnavailable>>>,
     /// The options that were used to configure this resolver.
     options: Options,
     /// The reporter to use for this resolver.
@@ -251,8 +252,8 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             python_requirement: python_requirement.clone(),
             conflicts,
             installed_packages,
-            unavailable_packages: HashMap::default(),
-            incomplete_packages: HashMap::default(),
+            unavailable_packages: Box::default(),
+            incomplete_packages: Box::default(),
             options,
             reporter: None,
         };
@@ -1868,7 +1869,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         }
                         let incomplete_packages = self.incomplete_packages.pin();
                         let versions =
-                            incomplete_packages.get_or_insert_with(name.clone(), HashMap::default);
+                            incomplete_packages.get_or_insert(name.clone(), HashMap::new());
                         versions.pin().insert(version.clone(), reason.clone());
                         return Ok(Dependencies::Unavailable(unavailable_version));
                     }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -12,7 +12,7 @@ use std::{iter, slice, thread};
 use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
-use papaya::HashMap;
+use papaya::{HashMap, ResizeMode};
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -1868,8 +1868,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             warn!("{name} {message}");
                         }
                         let incomplete_packages = self.incomplete_packages.pin();
-                        let versions =
-                            incomplete_packages.get_or_insert(name.clone(), HashMap::new());
+                        let versions = incomplete_packages.get_or_insert(
+                            name.clone(),
+                            HashMap::builder().resize_mode(ResizeMode::Blocking).build(),
+                        );
                         versions.pin().insert(version.clone(), reason.clone());
                         return Ok(Dependencies::Unavailable(unavailable_version));
                     }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -9,10 +9,10 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::{iter, slice, thread};
 
-use dashmap::DashMap;
 use either::Either;
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
+use papaya::HashMap;
 use pubgrub::{Id, IncompId, Incompatibility, Kind, Range, Ranges, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -130,9 +130,9 @@ struct ResolverState<InstalledPackages: InstalledPackagesProvider> {
     index: InMemoryIndex,
     installed_packages: InstalledPackages,
     /// Incompatibilities for packages that are entirely unavailable.
-    unavailable_packages: DashMap<PackageName, UnavailablePackage>,
+    unavailable_packages: HashMap<PackageName, UnavailablePackage>,
     /// Incompatibilities for packages that are unavailable at specific versions.
-    incomplete_packages: DashMap<PackageName, DashMap<Version, MetadataUnavailable>>,
+    incomplete_packages: HashMap<PackageName, HashMap<Version, MetadataUnavailable>>,
     /// The options that were used to configure this resolver.
     options: Options,
     /// The reporter to use for this resolver.
@@ -251,8 +251,8 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             python_requirement: python_requirement.clone(),
             conflicts,
             installed_packages,
-            unavailable_packages: DashMap::default(),
-            incomplete_packages: DashMap::default(),
+            unavailable_packages: HashMap::default(),
+            incomplete_packages: HashMap::default(),
             options,
             reporter: None,
         };
@@ -538,13 +538,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                         if let PubGrubPackageInner::Package { name, .. } = &**next_package {
                             // Check if the decision was due to the package being unavailable
-                            if let Some(entry) = self.unavailable_packages.get(name) {
+                            if let Some(reason) = self.unavailable_packages.pin().get(name) {
                                 state
                                     .pubgrub
                                     .add_incompatibility(Incompatibility::custom_term(
                                         next_id,
                                         term_intersection.clone(),
-                                        UnavailableReason::Package(entry.clone()),
+                                        UnavailableReason::Package(reason.clone()),
                                     ));
                                 continue;
                             }
@@ -1161,6 +1161,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             MetadataResponse::Found(archive) => &archive.metadata,
             MetadataResponse::Unavailable(reason) => {
                 self.unavailable_packages
+                    .pin()
                     .insert(name.clone(), reason.into());
                 return Ok(None);
             }
@@ -1284,16 +1285,19 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             VersionsResponse::Found(ref version_maps) => version_maps.as_slice(),
             VersionsResponse::NoIndex => {
                 self.unavailable_packages
+                    .pin()
                     .insert(name.clone(), UnavailablePackage::NoIndex);
                 &[]
             }
             VersionsResponse::Offline => {
                 self.unavailable_packages
+                    .pin()
                     .insert(name.clone(), UnavailablePackage::Offline);
                 &[]
             }
             VersionsResponse::NotFound => {
                 self.unavailable_packages
+                    .pin()
                     .insert(name.clone(), UnavailablePackage::NotFound);
                 &[]
             }
@@ -1834,7 +1838,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                 // If the package does not exist in the registry or locally, we cannot fetch its dependencies
                 if self.dependency_mode.is_transitive()
-                    && self.unavailable_packages.get(name).is_some()
+                    && self.unavailable_packages.pin().contains_key(name)
                     && self.installed_packages.get_packages(name).is_empty()
                 {
                     debug_assert!(
@@ -1862,10 +1866,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         } else {
                             warn!("{name} {message}");
                         }
-                        self.incomplete_packages
-                            .entry(name.clone())
-                            .or_default()
-                            .insert(version.clone(), reason.clone());
+                        let incomplete_packages = self.incomplete_packages.pin();
+                        let versions =
+                            incomplete_packages.get_or_insert_with(name.clone(), HashMap::default);
+                        versions.pin().insert(version.clone(), reason.clone());
                         return Ok(Dependencies::Unavailable(unavailable_version));
                     }
                     MetadataResponse::Error(dist, err) => {
@@ -2523,18 +2527,21 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     // Short-circuit if we did not find any versions for the package
                     VersionsResponse::NoIndex => {
                         self.unavailable_packages
+                            .pin()
                             .insert(package_name.clone(), UnavailablePackage::NoIndex);
 
                         return Ok(None);
                     }
                     VersionsResponse::Offline => {
                         self.unavailable_packages
+                            .pin()
                             .insert(package_name.clone(), UnavailablePackage::Offline);
 
                         return Ok(None);
                     }
                     VersionsResponse::NotFound => {
                         self.unavailable_packages
+                            .pin()
                             .insert(package_name.clone(), UnavailablePackage::NotFound);
 
                         return Ok(None);
@@ -2702,23 +2709,23 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         let mut unavailable_packages = FxHashMap::default();
         for package in derivation_tree_packages(&err) {
             if let PubGrubPackageInner::Package { name, .. } = &**package {
-                if let Some(reason) = self.unavailable_packages.get(name) {
+                if let Some(reason) = self.unavailable_packages.pin().get(name) {
                     unavailable_packages.insert(name.clone(), reason.clone());
                 }
             }
         }
 
         let mut incomplete_packages = FxHashMap::default();
+        let incomplete_packages_cache = self.incomplete_packages.pin();
         for package in derivation_tree_packages(&err) {
-            if let PubGrubPackageInner::Package { name, .. } = &**package {
-                if let Some(versions) = self.incomplete_packages.get(name) {
-                    for entry in versions.iter() {
-                        let (version, reason) = entry.pair();
-                        incomplete_packages
-                            .entry(name.clone())
-                            .or_insert_with(BTreeMap::default)
-                            .insert(version.clone(), reason.clone());
-                    }
+            if let PubGrubPackageInner::Package { name, .. } = &**package
+                && let Some(versions) = incomplete_packages_cache.get(name)
+            {
+                for (version, reason) in versions.pin().iter() {
+                    incomplete_packages
+                        .entry(name.clone())
+                        .or_insert_with(BTreeMap::default)
+                        .insert(version.clone(), reason.clone());
                 }
             }
         }

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -31,7 +31,7 @@ uv-redacted = { workspace = true }
 uv-workspace = { workspace = true }
 
 anyhow = { workspace = true }
-dashmap = { workspace = true }
+papaya = { workspace = true }
 rustc-hash = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/uv-types/src/builds.rs
+++ b/crates/uv-types/src/builds.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use dashmap::DashMap;
+use papaya::HashMap;
 
 use uv_configuration::{BuildKind, NoSources};
 use uv_normalize::PackageName;
@@ -57,11 +57,11 @@ pub struct BuildKey {
 
 /// An arena of in-process builds.
 #[derive(Debug)]
-pub struct BuildArena<T>(Arc<DashMap<BuildKey, T>>);
+pub struct BuildArena<T>(Arc<HashMap<BuildKey, Arc<T>>>);
 
 impl<T> Default for BuildArena<T> {
     fn default() -> Self {
-        Self(Arc::new(DashMap::new()))
+        Self(Arc::new(HashMap::new()))
     }
 }
 
@@ -73,12 +73,12 @@ impl<T> Clone for BuildArena<T> {
 
 impl<T> BuildArena<T> {
     /// Insert a build entry into the arena.
-    pub fn insert(&self, key: BuildKey, value: T) {
-        self.0.insert(key, value);
+    pub fn insert(&self, key: BuildKey, value: impl Into<Arc<T>>) {
+        self.0.pin().insert(key, value.into());
     }
 
     /// Remove a build entry from the arena.
-    pub fn remove(&self, key: &BuildKey) -> Option<T> {
-        self.0.remove(key).map(|entry| entry.1)
+    pub fn remove(&self, key: &BuildKey) -> Option<Arc<T>> {
+        self.0.pin().remove(key).cloned()
     }
 }

--- a/crates/uv-types/src/builds.rs
+++ b/crates/uv-types/src/builds.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use papaya::HashMap;
+use papaya::{HashMap, ResizeMode};
 
 use uv_configuration::{BuildKind, NoSources};
 use uv_normalize::PackageName;
@@ -61,7 +61,9 @@ pub struct BuildArena<T>(Arc<HashMap<BuildKey, Arc<T>>>);
 
 impl<T> Default for BuildArena<T> {
     fn default() -> Self {
-        Self(Arc::new(HashMap::new()))
+        Self(Arc::new(
+            HashMap::builder().resize_mode(ResizeMode::Blocking).build(),
+        ))
     }
 }
 


### PR DESCRIPTION
`DashMap` has a lot of deadlock conditions. Our cases aren't about performance, but about concurrent access, and deadlocks are a bad experience for users (aka CI getting stuck for 6h until the hard job limit kills it).
