### PR TITLE
Ban graalpy and pypy as script/gui entry point names

### DIFF
--- a/crates/uv-install-wheel/src/wheel.rs
+++ b/crates/uv-install-wheel/src/wheel.rs
@@ -160,7 +160,9 @@ fn get_script_executable(python_executable: &Path, is_gui: bool) -> PathBuf {
     }
 }
 
-const RESERVED_SCRIPT_NAMES_ERROR: &[&str; 3] = &["python", "pythonw", "python3"];
+const RESERVED_SCRIPT_NAMES_ERROR: &[&str; 7] = &[
+    "python", "pythonw", "python3", "graalpy", "pypy", "pypy2", "pypy3",
+];
 const RESERVED_VERSIONED_SCRIPT_NAME_PREFIX_ERROR: &str = "python3.";
 const RESERVED_FREE_THREADED_SCRIPT_NAME_PREFIXES_ERROR: &[&str; 2] = &["python3.", "pythonw3."];
 const RESERVED_SCRIPT_NAMES_WARN: &[&str; 2] = &["activate", "activate_this.py"];
@@ -195,7 +197,7 @@ impl<'script> ValidatedScript<'script> {
             );
         }
 
-        // Reserve CPython launcher basenames emitted by `uv venv` across supported platforms.
+        // Reserve launcher basenames emitted by `uv venv` across supported platforms.
         // Apply the Windows launcher normalization before checking so wheel validity is portable.
         // FIXME: What are the in-reality rules here for name normalization?
         let normalized_name = name.strip_suffix(".py").unwrap_or(name.as_str());

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -13507,6 +13507,90 @@ fn reject_windows_rewritten_free_threaded_python_wheel_entrypoint_name() -> Resu
 }
 
 #[test]
+fn reject_graalpy_wheel_entrypoint_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "graalpy")?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `graalpy`, got: `graalpy`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_pypy_wheel_entrypoint_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy")?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pypy`, got: `pypy`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_pypy_major_wheel_entrypoint_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy3")?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pypy3`, got: `pypy3`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_windows_rewritten_pypy_wheel_entrypoint_name() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy.py")?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pypy`, got: `pypy.py`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn warn_normalized_activation_wheel_entrypoint_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let repacked_wheel =

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -13507,48 +13507,6 @@ fn reject_windows_rewritten_free_threaded_python_wheel_entrypoint_name() -> Resu
 }
 
 #[test]
-fn reject_graalpy_wheel_entrypoint_name() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "graalpy")?;
-
-    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      Caused by: Scripts must not use the reserved name `graalpy`, got: `graalpy`
-    "
-    );
-
-    Ok(())
-}
-
-#[test]
-fn reject_pypy_wheel_entrypoint_name() -> Result<()> {
-    let context = uv_test::test_context!("3.12");
-    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy")?;
-
-    uv_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
-    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
-      Caused by: Scripts must not use the reserved name `pypy`, got: `pypy`
-    "
-    );
-
-    Ok(())
-}
-
-#[test]
 fn reject_pypy_major_wheel_entrypoint_name() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy3")?;


### PR DESCRIPTION
This is a followup to #19535, and it extends the reserved script names to include graalpy and the forms of pypy that `uv venv` supports.
