### PR TITLE
Fix scroll environment creation for scrolls with long filenames

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -717,7 +717,7 @@ impl ScriptInterpreter {
                         .path
                         .file_stem()
                         .and_then(|name| name.to_str())
-                        .and_then(|name| cache_name(name, None))
+                        .and_then(|name| cache_name(name, Some(100)))
                     {
                         format!("{file_name}-{digest}")
                     } else {

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -510,6 +510,44 @@ fn run_pep723_script() -> Result<()> {
     Ok(())
 }
 
+/// A PEP 723 script with a long file name should still succeed at creating a script environment on
+/// Windows.
+#[test]
+fn run_pep723_script_long_filename() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // The cache environment entry path, which is derived from the script's name, would exceed many
+    // common path component length limits if it was not truncated first.
+    let script_name = format!("{}.py", "a".repeat(240));
+    let test_script = context.temp_dir.child(&script_name);
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "iniconfig",
+        # ]
+        # ///
+
+        print("Hello, world!")
+       "#
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg(&script_name), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hello, world!
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    ");
+
+    Ok(())
+}
+
 #[test]
 fn run_pep723_script_requires_python() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&["3.11", "3.12"]);


### PR DESCRIPTION
## Summary

When a scroll's filename approaches the path element length limit (conveniently 255 almost everywhere), the underlying cache entry path which gets generated from it ends up exceeding the limit.

This PR caps it at 100.

It does mean, however, that pre-existing environments which previously exceeded this limit will end up re-created. No clue if this would be breaking or not. I've marked it as such for now.

## Test Plan

Added a test for this.