### PR TITLE
feat: add `--env-file-override` flag to `uv run` and `uv tool run`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3641,6 +3641,14 @@ pub struct RunArgs {
     #[arg(long, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_env_file: bool,
 
+    /// Force `.env` file values to override existing environment variables.
+    ///
+    /// By default, environment variables already set in the process take precedence
+    /// over values defined in `.env` files. When this flag is set, `.env` file
+    /// values will override existing environment variables.
+    #[arg(long, env = EnvVars::UV_ENV_FILE_OVERRIDE, value_parser = clap::builder::BoolishValueParser::new())]
+    pub env_file_override: bool,
+
     /// The command to run.
     ///
     /// If the path to a Python script (i.e., ending in `.py`), it will be
@@ -5538,6 +5546,14 @@ pub struct ToolRunArgs {
     /// Avoid reading environment variables from a `.env` file [env: UV_NO_ENV_FILE=]
     #[arg(long, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_env_file: bool,
+
+    /// Force `.env` file values to override existing environment variables.
+    ///
+    /// By default, environment variables already set in the process take precedence
+    /// over values defined in `.env` files. When this flag is set, `.env` file
+    /// values will override existing environment variables.
+    #[arg(long, env = EnvVars::UV_ENV_FILE_OVERRIDE, value_parser = clap::builder::BoolishValueParser::new())]
+    pub env_file_override: bool,
 
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -1254,6 +1254,11 @@ impl EnvVars {
     #[attr_added_in("0.4.30")]
     pub const UV_NO_ENV_FILE: &'static str = "UV_NO_ENV_FILE";
 
+    /// Force `.env` file values to override existing environment variables when executing
+    /// `uv run` or `uv tool run` commands.
+    #[attr_added_in("0.11.17")]
+    pub const UV_ENV_FILE_OVERRIDE: &'static str = "UV_ENV_FILE_OVERRIDE";
+
     /// The URL from which to download uv using the standalone installer and `self update` feature,
     /// in lieu of the default GitHub URL.
     ///

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -115,6 +115,7 @@ pub(crate) async fn run(
     workspace_cache: &WorkspaceCache,
     printer: Printer,
     env_file: EnvFile,
+    env_file_override: bool,
     preview: Preview,
     max_recursion_depth: u32,
     malware_settings: MalwareCheckSettings,
@@ -167,7 +168,12 @@ pub(crate) async fn run(
 
     // Read from the `.env` file, if necessary.
     for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
-        match dotenvy::from_path(env_file_path) {
+        let result = if env_file_override {
+            dotenvy::from_path_override(env_file_path)
+        } else {
+            dotenvy::from_path(env_file_path)
+        };
+        match result {
             Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
                 bail!(
                     "No environment file found at: `{}`",

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -90,6 +90,7 @@ impl Display for ToolRunCommand {
 fn read_env_files(
     env_file: &[PathBuf],
     no_env_file: bool,
+    env_file_override: bool,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let mut environment = Vec::new();
 
@@ -132,7 +133,7 @@ fn read_env_files(
         for item in iter {
             match item {
                 Ok((key, value)) => {
-                    if std::env::var(&key).is_err() {
+                    if env_file_override || std::env::var(&key).is_err() {
                         environment.push((key, value));
                     }
                 }
@@ -218,6 +219,7 @@ pub(crate) async fn run(
     printer: Printer,
     env_file: Vec<PathBuf>,
     no_env_file: bool,
+    env_file_override: bool,
     preview: Preview,
 ) -> anyhow::Result<ExitStatus> {
     /// Whether or not a path looks like a Python script based on the file extension.
@@ -232,7 +234,7 @@ pub(crate) async fn run(
         );
     }
 
-    let env_file_environment = read_env_files(&env_file, no_env_file)?;
+    let env_file_environment = read_env_files(&env_file, no_env_file, env_file_override)?;
 
     let Some(command) = command else {
         // When a command isn't provided, we'll show a brief help including available tools

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1498,6 +1498,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 printer,
                 args.env_file,
                 args.no_env_file,
+                args.env_file_override,
                 globals.preview,
             ))
             .await
@@ -2215,6 +2216,7 @@ async fn run_project(
                 workspace_cache,
                 printer,
                 args.env_file,
+                args.env_file_override,
                 globals.preview,
                 args.max_recursion_depth,
                 args.malware_settings,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -602,6 +602,7 @@ pub(crate) struct RunSettings {
     pub(crate) refresh: Refresh,
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) env_file: EnvFile,
+    pub(crate) env_file_override: bool,
     pub(crate) max_recursion_depth: u32,
     pub(crate) malware_settings: MalwareCheckSettings,
 }
@@ -660,6 +661,7 @@ impl RunSettings {
             show_resolution,
             env_file,
             no_env_file,
+            env_file_override,
             max_recursion_depth,
         } = args;
 
@@ -759,6 +761,7 @@ impl RunSettings {
                 &environment,
             ),
             env_file: EnvFile::from_args(env_file, no_env_file),
+            env_file_override,
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
@@ -790,6 +793,7 @@ pub(crate) struct ToolRunSettings {
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) env_file: Vec<PathBuf>,
     pub(crate) no_env_file: bool,
+    pub(crate) env_file_override: bool,
 }
 
 impl ToolRunSettings {
@@ -812,6 +816,7 @@ impl ToolRunSettings {
             isolated,
             env_file,
             no_env_file,
+            env_file_override,
             show_resolution,
             installer,
             build,
@@ -917,6 +922,7 @@ impl ToolRunSettings {
                 .combine(filesystem_install_mirrors),
             env_file,
             no_env_file,
+            env_file_override,
         }
     }
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -5180,6 +5180,116 @@ fn run_with_not_existing_env_file() -> Result<()> {
 }
 
 #[test]
+fn run_with_env_file_override() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("test.py").write_str(indoc! { "
+        import os
+        print(os.environ.get('MY_VAR'))
+       "
+    })?;
+
+    context.temp_dir.child(".env").write_str(indoc! { "
+        MY_VAR=from_file
+       "
+    })?;
+
+    // Without --env-file-override, the process env wins.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--env-file").arg(".env")
+        .arg("test.py")
+        .env("MY_VAR", "from_process"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_process
+
+    ----- stderr -----
+    ");
+
+    // With --env-file-override, the .env file wins.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--env-file").arg(".env")
+        .arg("--env-file-override")
+        .arg("test.py")
+        .env("MY_VAR", "from_process"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_file
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn run_with_env_file_override_via_env_var() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("test.py").write_str(indoc! { "
+        import os
+        print(os.environ.get('MY_VAR'))
+       "
+    })?;
+
+    context.temp_dir.child(".env").write_str(indoc! { "
+        MY_VAR=from_file
+       "
+    })?;
+
+    // UV_ENV_FILE_OVERRIDE=true activates the override behavior.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--env-file").arg(".env")
+        .arg("test.py")
+        .env("MY_VAR", "from_process")
+        .env(EnvVars::UV_ENV_FILE_OVERRIDE, "true"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_file
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn run_with_env_file_override_no_env_file_wins() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context.temp_dir.child("test.py").write_str(indoc! { "
+        import os
+        print(os.environ.get('MY_VAR'))
+       "
+    })?;
+
+    context.temp_dir.child(".env").write_str(indoc! { "
+        MY_VAR=from_file
+       "
+    })?;
+
+    // --no-env-file should still disable loading, even with --env-file-override.
+    uv_snapshot!(context.filters(), context.run()
+        .arg("--env-file").arg(".env")
+        .arg("--env-file-override")
+        .arg("--no-env-file")
+        .arg("test.py")
+        .env("MY_VAR", "from_process"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_process
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn run_with_extra_conflict() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2771,6 +2771,93 @@ fn run_with_env_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn run_with_env_file_override() -> anyhow::Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Create a project with a custom script.
+    let foo_dir = context.temp_dir.child("foo");
+    let foo_pyproject_toml = foo_dir.child("pyproject.toml");
+
+    foo_pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [project.scripts]
+        script = "foo.main:run"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#
+    })?;
+
+    let foo_project_src = foo_dir.child("src");
+    let foo_module = foo_project_src.child("foo");
+    foo_module.child("__init__.py").touch()?;
+    let foo_main_py = foo_module.child("main.py");
+    foo_main_py.write_str(indoc! { r#"
+        def run():
+            import os
+            print(os.environ.get('MY_VAR'))
+
+        __name__ == "__main__" and run()
+       "#
+    })?;
+
+    context.temp_dir.child(".env").write_str(indoc! { "
+        MY_VAR=from_file
+       "
+    })?;
+
+    // Without --env-file-override, process env wins.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--env-file").arg(".env")
+        .arg("--from")
+        .arg("./foo")
+        .arg("script")
+        .env("MY_VAR", "from_process")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_process
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + foo==1.0.0 (from file://[TEMP_DIR]/foo)
+    ");
+
+    // With --env-file-override, .env file wins.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--env-file").arg(".env")
+        .arg("--env-file-override")
+        .arg("--from")
+        .arg("./foo")
+        .arg("script")
+        .env("MY_VAR", "from_process")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    from_file
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn tool_run_from_at() {
     let context = uv_test::test_context!("3.12")
         .with_exclude_newer("2025-01-18T00:00:00Z")

--- a/docs/concepts/configuration-files.md
+++ b/docs/concepts/configuration-files.md
@@ -102,7 +102,19 @@ argument), set the `UV_NO_ENV_FILE` environment variable to `1`, or pass the`--n
 `uv run`.
 
 If the same variable is defined in the environment and in a `.env` file, the value from the
-environment will take precedence.
+environment will take precedence. To reverse this behavior and have `.env` file values override
+existing environment variables, pass the `--env-file-override` flag or set
+`UV_ENV_FILE_OVERRIDE=true`:
+
+```console
+$ export MY_VAR="from_env"
+$ echo "MY_VAR='from_file'" > .env
+$ uv run --env-file .env --env-file-override -- python -c 'import os; print(os.getenv("MY_VAR"))'
+from_file
+```
+
+This is useful when a parent process sets environment variables at startup, but the `.env` file
+contains more up-to-date values that should take precedence.
 
 ## Configuring the pip interface
 


### PR DESCRIPTION
## Summary

Adds a new `--env-file-override` flag (and corresponding `UV_ENV_FILE_OVERRIDE` environment
variable) to `uv run` and `uv tool run` that forces `.env` file values to override existing
process environment variables.

By default, `dotenvy::from_path()` skips variables that already exist in the process environment.
This is the correct behavior for most cases, but becomes problematic when a wrapper or launcher
pre-loads environment variables at startup that may become stale (e.g., port reassignment,
credential rotation) while the `.env` file is updated during the session.

The new flag switches from `dotenvy::from_path()` to `dotenvy::from_path_override()`, reversing
the precedence so `.env` file values win.

Closes #9465

## Test Plan

- Added integration tests in `crates/uv/tests/it/run.rs`:
  - `run_with_env_file_override` — verifies process env wins without the flag, `.env` wins with it
  - `run_with_env_file_override_via_env_var` — verifies `UV_ENV_FILE_OVERRIDE=true` activates override
  - `run_with_env_file_override_no_env_file_wins` — verifies `--no-env-file` still disables loading even with `--env-file-override`
- Added integration test in `crates/uv/tests/it/tool_run.rs`:
  - `run_with_env_file_override` — verifies the same flag/behavior for `uv tool run`
- All 4 tests pass locally
- `cargo clippy -p uv --tests -- -D warnings` — zero warnings
- `cargo fmt --check` — no diffs
- Updated docs in `docs/concepts/configuration-files.md`