### PR TITLE
fix(distribution): validate cached wheel archives against corruption

### DIFF
--- a/crates/uv-distribution/src/archive.rs
+++ b/crates/uv-distribution/src/archive.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use uv_cache::{ARCHIVE_VERSION, ArchiveId, Cache};
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::Hashed;
@@ -27,14 +29,103 @@ impl Archive {
         }
     }
 
-    /// Returns `true` if the archive exists in the cache.
+    /// Returns `true` if the archive exists in the cache and is not corrupted.
     pub(crate) fn exists(&self, cache: &Cache) -> bool {
-        self.version == ARCHIVE_VERSION && cache.archive(&self.id).exists()
+        if self.version != ARCHIVE_VERSION {
+            return false;
+        }
+        let path = cache.archive(&self.id);
+        if !path.is_dir() {
+            return false;
+        }
+        // Validate the archive is not corrupted. A power outage during
+        // `Cache::persist()` can leave the directory intact but with 0-byte
+        // files. Check that the archive contains a non-empty METADATA file in
+        // a `.dist-info` directory.
+        has_non_empty_metadata(&path)
     }
+}
+
+/// Returns `true` if the given path contains a `.dist-info/METADATA` file
+/// with non-zero size.
+///
+/// This validates that an unzipped wheel archive is not corrupted (e.g.,
+/// from a power outage during `Cache::persist()` that leaves 0-byte files).
+fn has_non_empty_metadata(path: &Path) -> bool {
+    let Ok(entries) = fs_err::read_dir(path) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if !name.ends_with(".dist-info") {
+            continue;
+        }
+        let metadata_file = entry.path().join("METADATA");
+        if let Ok(meta) = metadata_file.metadata() {
+            if meta.is_file() && meta.len() > 0 {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 impl Hashed for Archive {
     fn hashes(&self) -> &[HashDigest] {
         self.hashes.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_non_empty_metadata_valid() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dist_info = temp_dir.path().join("foo-1.0.dist-info");
+        fs_err::create_dir(&dist_info).unwrap();
+        fs_err::write(dist_info.join("METADATA"), "Name: foo\nVersion: 1.0\n").unwrap();
+        assert!(has_non_empty_metadata(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_has_non_empty_metadata_empty_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dist_info = temp_dir.path().join("foo-1.0.dist-info");
+        fs_err::create_dir(&dist_info).unwrap();
+        fs_err::write(dist_info.join("METADATA"), "").unwrap();
+        assert!(!has_non_empty_metadata(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_has_non_empty_metadata_missing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        assert!(!has_non_empty_metadata(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_has_non_empty_metadata_no_dist_info() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        fs_err::write(temp_dir.path().join("some_file.txt"), "content").unwrap();
+        assert!(!has_non_empty_metadata(temp_dir.path()));
+    }
+
+    #[test]
+    fn test_has_non_empty_metadata_dist_info_no_metadata() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dist_info = temp_dir.path().join("foo-1.0.dist-info");
+        fs_err::create_dir(&dist_info).unwrap();
+        fs_err::write(dist_info.join("WHEEL"), "Wheel-Version: 1.0\n").unwrap();
+        assert!(!has_non_empty_metadata(temp_dir.path()));
     }
 }


### PR DESCRIPTION
- Does this pull request include a summary of the change? YES
- Does this pull request include a descriptive title? YES
- Does this pull request include references to any relevant issues? YES

## Summary
A power outage or hard crash during `uv tool install` can interrupt wheel extraction into the `archive-v0/` cache. While `Cache::persist()` uses `rename_with_retry` to atomically move the temp directory into place, the individual files inside may not be fully synced to disk.

On retry, `Archive::exists()` only checked `path.is_dir()` — it found the directory intact and tried to install from it. Reading a 0-byte METADATA file then produced the cryptic error:

    error: Failed to install: <wheel>
      Caused by: The wheel is invalid: Metadata field Name not found

This commit adds a lightweight content validation to `Archive::exists()` that verifies the archive contains a non-empty `.dist-info/METADATA` file. When a corrupted archive is detected, `exists()` returns `false`, and callers in `stream_wheel()` and `download_wheel()` fall through to re-download/re-extract the wheel — the existing "heal-by-refetch" pattern already used for HTTP cache corruption.

Fixes: astral-sh/uv#16841

## Test Plan

Added 5 unit tests covering:
- Valid archive with non-empty METADATA -> true
- Empty METADATA file (the exact bug scenario) -> false
- Missing .dist-info entirely -> false
- No .dist-info, just random files -> false
- .dist-info exists but METADATA missing -> false

All 26 uv-distribution tests pass. Clippy clean.