### PR TITLE
Add tests for Azure signing: x-ms-version preservation and blob storage URL matching

### DIFF
--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -806,6 +806,40 @@ mod tests {
         );
     }
 
+    /// A caller that already set `x-ms-version` should have it preserved, not overwritten.
+    ///
+    /// The signing path uses `entry().or_insert()` so that users who need a specific API
+    /// version (e.g., for preview features) can supply it themselves.
+    #[tokio::test]
+    async fn authenticated_request_with_azure_signer_preserves_caller_ms_version() {
+        let custom_version = "2020-08-04";
+        let signer = reqsign::azure::default_signer().with_credential_provider(
+            reqsign::azure::StaticCredentialProvider::new_bearer_token("token"),
+        );
+        let authentication = Authentication::from(signer);
+
+        let mut request = Request::new(
+            reqwest::Method::GET,
+            Url::parse("https://account.blob.core.windows.net/container/blob.whl").unwrap(),
+        );
+        request.headers_mut().insert(
+            HeaderName::from_static("x-ms-version"),
+            HeaderValue::from_static(custom_version),
+        );
+        let request = authentication.authenticate(request).await.unwrap();
+
+        assert_eq!(
+            request
+                .headers()
+                .get("x-ms-version")
+                .expect("x-ms-version header should be set")
+                .to_str()
+                .unwrap(),
+            custom_version,
+            "A caller-supplied x-ms-version should not be overwritten by the signer"
+        );
+    }
+
     #[tokio::test]
     async fn authenticated_request_with_aws_signer_missing_credentials() {
         let signer = reqsign::aws::default_signer("s3", "us-east-1")

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -264,4 +264,38 @@ mod tests {
             );
         }
     }
+
+    /// Verify the canonical Azure Blob Storage URL pattern:
+    /// endpoint = `https://myaccount.blob.core.windows.net`, requests go to
+    /// `https://myaccount.blob.core.windows.net/<container>/<blob>`.
+    /// This is the primary real-world shape of `UV_AZURE_ENDPOINT_URL`.
+    #[test]
+    fn test_endpoint_url_matches_azure_blob_storage_pattern() {
+        let endpoint_url =
+            Url::parse("https://myaccount.blob.core.windows.net").unwrap();
+
+        // Container and blob paths under the same account should match.
+        for url in [
+            "https://myaccount.blob.core.windows.net/mycontainer/package.whl",
+            "https://myaccount.blob.core.windows.net/mycontainer/subdir/package.whl",
+            "https://myaccount.blob.core.windows.net/othercontainer/other.whl",
+        ] {
+            assert!(
+                is_endpoint_url(&Url::parse(url).unwrap(), &endpoint_url),
+                "Should match Azure blob URL under the configured account endpoint: {url}"
+            );
+        }
+
+        // A different account on the same domain should not match.
+        assert!(
+            !is_endpoint_url(
+                &Url::parse(
+                    "https://otheraccount.blob.core.windows.net/mycontainer/package.whl"
+                )
+                .unwrap(),
+                &endpoint_url
+            ),
+            "Should not match a different Azure storage account"
+        );
+    }
 }

--- a/crates/uv-auth/src/providers.rs
+++ b/crates/uv-auth/src/providers.rs
@@ -271,8 +271,7 @@ mod tests {
     /// This is the primary real-world shape of `UV_AZURE_ENDPOINT_URL`.
     #[test]
     fn test_endpoint_url_matches_azure_blob_storage_pattern() {
-        let endpoint_url =
-            Url::parse("https://myaccount.blob.core.windows.net").unwrap();
+        let endpoint_url = Url::parse("https://myaccount.blob.core.windows.net").unwrap();
 
         // Container and blob paths under the same account should match.
         for url in [
@@ -289,10 +288,8 @@ mod tests {
         // A different account on the same domain should not match.
         assert!(
             !is_endpoint_url(
-                &Url::parse(
-                    "https://otheraccount.blob.core.windows.net/mycontainer/package.whl"
-                )
-                .unwrap(),
+                &Url::parse("https://otheraccount.blob.core.windows.net/mycontainer/package.whl")
+                    .unwrap(),
                 &endpoint_url
             ),
             "Should not match a different Azure storage account"


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Adds two tests to cover behavior introduced in #19421 (Azure request signing support) that was left untested:

1. **`x-ms-version` preservation** (`credentials.rs`): The Azure signer uses `entry().or_insert()` rather than `insert()` when setting the `x-ms-version` header, meaning a caller-supplied value is intentionally preserved. This test verifies that contract — a request carrying a custom `x-ms-version` (e.g., `"2020-08-04"`) exits `Authentication::authenticate` with its original value intact, not silently replaced by `AZURE_STORAGE_VERSION`.

2. **Azure Blob Storage URL pattern** (`providers.rs`): Verifies that `is_endpoint_url` correctly matches the canonical real-world shape of `UV_AZURE_ENDPOINT_URL` — an account-level endpoint like `https://myaccount.blob.core.windows.net` matching container/blob sub-paths under it, while correctly rejecting a different storage account on the same domain.

## Test Plan

Both changes are test-only. Verified locally with:

```
cargo test -p uv-auth
```