### PR TITLE
Fix malformed positional anchors in the CLI reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6224,6 +6224,7 @@ dependencies = [
  "clap",
  "fs-err",
  "futures",
+ "insta",
  "itertools 0.14.0",
  "markdown",
  "owo-colors",

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -63,6 +63,9 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uv-performance-memory-allocator = { path = "../uv-performance-memory-allocator", optional = true }
 walkdir = { workspace = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+
 [lib]
 name = "uv_dev"
 doctest = false

--- a/crates/uv-dev/src/generate_cli_reference.rs
+++ b/crates/uv-dev/src/generate_cli_reference.rs
@@ -204,7 +204,7 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                 let id = format!("{name_key}--{}", arg.get_id());
                 output.push_str(&format!("<dt id=\"{id}\">"));
                 output.push_str(&format!(
-                    "<a href=\"#{id}\"<code>{}</code></a>",
+                    "<a href=\"#{id}\"><code>{}</code></a>",
                     arg.get_id().to_string().to_uppercase(),
                 ));
                 output.push_str("</dt>");
@@ -340,5 +340,28 @@ fn emit_possible_options(opt: &clap::Arg, output: &mut String) {
                 .join("\n"),
         );
         output.push_str(&markdown::to_html(&value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, Command};
+    use insta::assert_snapshot;
+
+    use super::generate_command;
+
+    #[test]
+    fn generates_linked_positional_argument() {
+        let mut command = Command::new("sample").arg(Arg::new("path").index(1));
+        command.build();
+
+        let mut output = String::new();
+        generate_command(&mut output, &command, &mut Vec::new());
+        let argument = output
+            .lines()
+            .find(|line| line.starts_with("<dl class=\"cli-reference\"><dt id=\"sample--path\""))
+            .expect("expected positional argument definition");
+
+        assert_snapshot!(argument, @r##"<dl class="cli-reference"><dt id="sample--path"><a href="#sample--path"><code>PATH</code></a></dt></dl>"##);
     }
 }


### PR DESCRIPTION
Fix the malformed `<a href=...>` tag emitted for positional arguments in `crates/uv-dev/src/generate_cli_reference.rs`, which produced invalid HTML in the generated CLI reference.
