### PR TITLE
Infer Python version requests from source trees in `uv tool` invocations

### DIFF
--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
     Reqwest(#[from] WrappedReqwestError),
     #[error(transparent)]
     Client(#[from] uv_client::Error),
+    #[error(transparent)]
+    ClientBuild(#[from] uv_client::ClientBuildError),
 
     // Cache writing error
     #[error("Failed to read from the distribution cache")]

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -8,7 +8,7 @@ pub use metadata::{
     SourcedDependencyGroups,
 };
 pub use reporter::Reporter;
-pub use source::prune;
+pub use source::{StaticMetadataDatabase, prune};
 
 mod archive;
 mod distribution_database;

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -25,19 +25,20 @@ use uv_auth::CredentialsCache;
 use uv_cache::{Cache, CacheBucket, CacheEntry, CacheShard, Removal, WheelCache};
 use uv_cache_info::CacheInfo;
 use uv_client::{
-    CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
+    BaseClientBuilder, CacheControl, CachedClientError, Connectivity, DataWithCachePolicy,
+    RegistryClient,
 };
 use uv_configuration::{BuildKind, BuildOutput, NoSources};
 use uv_distribution_filename::{SourceDistExtension, WheelFilename};
 use uv_distribution_types::{
     BuildInfo, BuildVariables, BuildableSource, ConfigSettings, DirectorySourceUrl,
     ExtraBuildRequirement, GitDirectorySourceUrl, GitPathSourceUrl, HashPolicy, Hashed, IndexUrl,
-    PathSourceUrl, SourceDist, SourceUrl,
+    PathSourceUrl, RequirementSource, RequiresPython, SourceDist, SourceUrl,
 };
 use uv_extract::hash::Hasher;
 use uv_fs::{Simplified, rename_with_retry, write_atomic};
-use uv_git::{Fetch, GIT_LFS, GitError};
-use uv_git_types::{GitHubRepository, GitOid};
+use uv_git::{Fetch, GIT_LFS, GitError, GitResolver};
+use uv_git_types::{GitHubRepository, GitOid, GitUrl};
 use uv_metadata::read_archive_metadata;
 use uv_normalize::PackageName;
 use uv_pep440::{Version, release_specifiers_to_ranges};
@@ -56,6 +57,163 @@ use crate::{Reporter, RequiresDist};
 
 mod built_wheel_metadata;
 mod revision;
+
+/// Access distribution metadata without requiring a build interpreter.
+///
+/// This is intended for metadata operations that occur before selecting an interpreter, such as
+/// choosing a tool Python from `requires-python`.
+pub struct StaticMetadataDatabase<'a, 'client> {
+    client_builder: &'a BaseClientBuilder<'client>,
+    git: &'a GitResolver,
+    cache: &'a Cache,
+}
+
+/// A direct source tree materialized on disk for static metadata inspection.
+#[derive(Debug)]
+struct MaterializedSourceTree(Box<Path>);
+
+impl MaterializedSourceTree {
+    /// Return the on-disk path for this source tree.
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl<'a, 'client> StaticMetadataDatabase<'a, 'client> {
+    /// Create a [`StaticMetadataDatabase`] for an invocation.
+    pub fn new(
+        client_builder: &'a BaseClientBuilder<'client>,
+        git: &'a GitResolver,
+        cache: &'a Cache,
+    ) -> Self {
+        Self {
+            client_builder,
+            git,
+            cache,
+        }
+    }
+
+    /// Materialize a direct source tree, if the requirement identifies one.
+    ///
+    /// Directory requirements are already materialized. Git source trees are fetched into the
+    /// Git cache and returned at the requested subdirectory.
+    async fn materialize_source_tree(
+        &self,
+        source: &RequirementSource,
+    ) -> Result<Option<MaterializedSourceTree>, Error> {
+        match source {
+            RequirementSource::Directory { install_path, .. } => Ok(Some(MaterializedSourceTree(
+                install_path.to_path_buf().into_boxed_path(),
+            ))),
+            RequirementSource::GitDirectory {
+                git,
+                subdirectory,
+                url,
+            } => {
+                let client = self.client_builder.build()?;
+                let fetch = fetch_git_source_tree(
+                    self.git,
+                    git,
+                    url.to_url(),
+                    subdirectory.as_deref(),
+                    client.disable_ssl(git.url()),
+                    client.connectivity(),
+                    self.cache,
+                    None,
+                )
+                .await?;
+
+                if let Some(subdirectory) = subdirectory {
+                    let source_tree = fetch.path().join(subdirectory);
+                    Ok(Some(MaterializedSourceTree(source_tree.into_boxed_path())))
+                } else {
+                    Ok(Some(MaterializedSourceTree(
+                        fetch.path().to_path_buf().into_boxed_path(),
+                    )))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Read static [`RequiresPython`] from an already materialized source tree.
+    async fn source_tree_requires_python(
+        &self,
+        source_tree: &MaterializedSourceTree,
+    ) -> Result<Option<RequiresPython>, Error> {
+        let pyproject_toml = match read_pyproject_toml(source_tree.path(), None).await {
+            Ok(pyproject_toml) => pyproject_toml,
+            Err(Error::MissingPyprojectToml) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+        match pyproject_toml.requires_python() {
+            Ok(Some(requires_python)) => {
+                Ok(Some(RequiresPython::from_specifiers(&requires_python)))
+            }
+            Ok(None) | Err(uv_pypi_types::MetadataError::FieldNotFound("project")) => Ok(None),
+            Err(uv_pypi_types::MetadataError::DynamicField("requires-python")) => {
+                debug!("Ignoring dynamic `requires-python` in source tree");
+                Ok(None)
+            }
+            Err(err) => Err(Error::PyprojectToml(err)),
+        }
+    }
+
+    /// Read static [`RequiresPython`] from a direct source-tree requirement.
+    pub async fn requires_python(
+        &self,
+        source: &RequirementSource,
+    ) -> Result<Option<RequiresPython>, Error> {
+        let Some(source_tree) = self.materialize_source_tree(source).await? else {
+            return Ok(None);
+        };
+        self.source_tree_requires_python(&source_tree).await
+    }
+}
+
+/// Fetch and validate a Git source tree.
+async fn fetch_git_source_tree(
+    git_resolver: &GitResolver,
+    git: &GitUrl,
+    url: DisplaySafeUrl,
+    subdirectory: Option<&Path>,
+    disable_ssl: bool,
+    connectivity: Connectivity,
+    cache: &Cache,
+    reporter: Option<Arc<dyn uv_git::Reporter>>,
+) -> Result<Fetch, Error> {
+    let fetch = git_resolver
+        .fetch(
+            git,
+            disable_ssl,
+            connectivity == Connectivity::Offline,
+            cache.bucket(CacheBucket::Git),
+            reporter,
+        )
+        .await?;
+
+    if let Some(subdirectory) = subdirectory
+        && !fetch.path().join(subdirectory).is_dir()
+    {
+        return Err(Error::MissingSubdirectory(url, subdirectory.to_path_buf()));
+    }
+
+    if git.lfs().enabled() && !fetch.lfs_ready() {
+        if GIT_LFS.is_err() {
+            return Err(Error::MissingSourceDistGitLfsArtifacts(
+                url,
+                GitError::GitLfsNotFound,
+            ));
+        }
+        return Err(Error::MissingSourceDistGitLfsArtifacts(
+            url,
+            GitError::GitLfsNotConfigured,
+        ));
+    }
+
+    Ok(fetch)
+}
 
 /// Fetch and build a source distribution from a remote source, or from a local cache.
 pub(crate) struct SourceDistributionBuilder<'a, T: BuildContext> {
@@ -1936,44 +2094,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             return Err(Error::HashesNotSupportedGit(source.to_string()));
         }
 
-        // Fetch the Git repository.
-        let fetch = self
-            .build_context
-            .git()
-            .fetch(
-                resource.git,
-                client.unmanaged.disable_ssl(resource.git.url()),
-                client.unmanaged.connectivity() == Connectivity::Offline,
-                self.build_context.cache().bucket(CacheBucket::Git),
-                self.reporter
-                    .clone()
-                    .map(|reporter| reporter.into_git_reporter()),
-            )
-            .await?;
-
-        // Validate that the subdirectory exists.
-        if let Some(subdirectory) = resource.subdirectory {
-            if !fetch.path().join(subdirectory).is_dir() {
-                return Err(Error::MissingSubdirectory(
-                    resource.url.to_url(),
-                    subdirectory.to_path_buf(),
-                ));
-            }
-        }
-
-        // Validate that LFS artifacts were fully initialized
-        if resource.git.lfs().enabled() && !fetch.lfs_ready() {
-            if GIT_LFS.is_err() {
-                return Err(Error::MissingSourceDistGitLfsArtifacts(
-                    resource.url.to_url(),
-                    GitError::GitLfsNotFound,
-                ));
-            }
-            return Err(Error::MissingSourceDistGitLfsArtifacts(
-                resource.url.to_url(),
-                GitError::GitLfsNotConfigured,
-            ));
-        }
+        let fetch = fetch_git_source_tree(
+            self.build_context.git(),
+            resource.git,
+            resource.url.to_url(),
+            resource.subdirectory,
+            client.unmanaged.disable_ssl(resource.git.url()),
+            client.unmanaged.connectivity(),
+            self.build_context.cache(),
+            self.reporter
+                .clone()
+                .map(|reporter| reporter.into_git_reporter()),
+        )
+        .await?;
 
         let git_sha = fetch.git().precise().expect("Exact commit after checkout");
         let cache_shard = self.build_context.cache().shard(
@@ -2151,44 +2284,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             }
         }
 
-        // Fetch the Git repository.
-        let fetch = self
-            .build_context
-            .git()
-            .fetch(
-                resource.git,
-                client.unmanaged.disable_ssl(resource.git.url()),
-                client.unmanaged.connectivity() == Connectivity::Offline,
-                self.build_context.cache().bucket(CacheBucket::Git),
-                self.reporter
-                    .clone()
-                    .map(|reporter| reporter.into_git_reporter()),
-            )
-            .await?;
-
-        // Validate that the subdirectory exists.
-        if let Some(subdirectory) = resource.subdirectory {
-            if !fetch.path().join(subdirectory).is_dir() {
-                return Err(Error::MissingSubdirectory(
-                    resource.url.to_url(),
-                    subdirectory.to_path_buf(),
-                ));
-            }
-        }
-
-        // Validate that LFS artifacts were fully initialized
-        if resource.git.lfs().enabled() && !fetch.lfs_ready() {
-            if GIT_LFS.is_err() {
-                return Err(Error::MissingSourceDistGitLfsArtifacts(
-                    resource.url.to_url(),
-                    GitError::GitLfsNotFound,
-                ));
-            }
-            return Err(Error::MissingSourceDistGitLfsArtifacts(
-                resource.url.to_url(),
-                GitError::GitLfsNotConfigured,
-            ));
-        }
+        let fetch = fetch_git_source_tree(
+            self.build_context.git(),
+            resource.git,
+            resource.url.to_url(),
+            resource.subdirectory,
+            client.unmanaged.disable_ssl(resource.git.url()),
+            client.unmanaged.connectivity(),
+            self.build_context.cache(),
+            self.reporter
+                .clone()
+                .map(|reporter| reporter.into_git_reporter()),
+        )
+        .await?;
 
         let git_sha = fetch.git().precise().expect("Exact commit after checkout");
         let cache_shard = self.build_context.cache().shard(

--- a/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
+++ b/crates/uv-pypi-types/src/metadata/pyproject_toml.rs
@@ -7,9 +7,9 @@ use serde::de::IntoDeserializer;
 use tracing::instrument;
 
 use uv_normalize::{ExtraName, PackageName};
-use uv_pep440::Version;
+use uv_pep440::{Version, VersionSpecifiers};
 
-use crate::MetadataError;
+use crate::{LenientVersionSpecifiers, MetadataError};
 
 /// A `pyproject.toml` as specified in PEP 517.
 #[derive(Deserialize, Debug, Clone)]
@@ -27,6 +27,33 @@ impl PyProjectToml {
         let pyproject_toml = Self::deserialize(pyproject_toml.into_deserializer())
             .map_err(MetadataError::InvalidPyprojectTomlSchema)?;
         Ok(pyproject_toml)
+    }
+
+    /// Extract static `requires-python` metadata from a PEP 621 project.
+    ///
+    /// Unlike [`crate::ResolutionMetadata::parse_pyproject_toml`], this does not require static
+    /// project version or dependency metadata.
+    pub fn requires_python(&self) -> Result<Option<VersionSpecifiers>, MetadataError> {
+        let project = self
+            .project
+            .as_ref()
+            .ok_or(MetadataError::FieldNotFound("project"))?;
+
+        if project
+            .dynamic
+            .as_ref()
+            .is_some_and(|dynamic| dynamic.iter().any(|field| field == "requires-python"))
+        {
+            return Err(MetadataError::DynamicField("requires-python"));
+        }
+
+        Ok(project
+            .requires_python
+            .as_ref()
+            .map(|requires_python| {
+                LenientVersionSpecifiers::from_str(requires_python).map(VersionSpecifiers::from)
+            })
+            .transpose()?)
     }
 }
 
@@ -91,4 +118,47 @@ pub struct Tool {
 #[serde(rename_all = "kebab-case")]
 pub struct ToolPoetry {
     pub name: Option<PackageName>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PyProjectToml;
+    use crate::MetadataError;
+
+    #[test]
+    fn requires_python_allows_unrelated_dynamic_metadata() {
+        let pyproject_toml = PyProjectToml::from_toml(
+            r#"
+            [project]
+            name = "example"
+            requires-python = ">=3.11,<3.13"
+            dynamic = ["version", "dependencies"]
+            "#,
+            "pyproject.toml",
+        )
+        .unwrap();
+
+        assert_eq!(
+            pyproject_toml.requires_python().unwrap(),
+            Some(">=3.11,<3.13".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn requires_python_rejects_dynamic_field() {
+        let pyproject_toml = PyProjectToml::from_toml(
+            r#"
+            [project]
+            name = "example"
+            dynamic = ["requires-python"]
+            "#,
+            "pyproject.toml",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            pyproject_toml.requires_python(),
+            Err(MetadataError::DynamicField("requires-python"))
+        ));
+    }
 }

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -12,18 +12,24 @@ use thiserror::Error;
 use tracing::{debug, warn};
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
-use uv_distribution_types::{InstalledDist, Name, Requirement};
+use uv_configuration::GitLfsSetting;
+use uv_distribution::StaticMetadataDatabase;
+use uv_distribution_types::{
+    InstalledDist, Name, Requirement, RequiresPython, UnresolvedRequirement,
+};
 use uv_errors::{ErrorWithHints, Hint, Hints};
-use uv_fs::Simplified;
 #[cfg(unix)]
 use uv_fs::replace_symlink;
+use uv_fs::{CWD, Simplified};
+use uv_git::GitResolver;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, Interpreter, PythonDownloads, PythonEnvironment, PythonInstallation,
-    PythonPreference, PythonRequest, PythonVariant, VersionRequest,
+    PythonPreference, PythonRequest, PythonVariant, PythonVersionFile, VersionFileDiscoveryOptions,
+    VersionRequest,
 };
 use uv_settings::{PythonInstallMirrors, ToolOptions};
 use uv_shell::Shell;
@@ -90,7 +96,7 @@ impl Hint for NoExecutablesError {
         hints
     }
 }
-use crate::commands::project::ProjectError;
+use crate::commands::project::{ProjectError, PythonRequestSource};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::printer::Printer;
 
@@ -129,6 +135,122 @@ pub(crate) fn remove_entrypoints(tool: &Tool) {
                 "Failed to remove executable: `{}`: {err}",
                 executable.simplified_display()
             );
+        }
+    }
+}
+
+/// The resolved Python request for a tool invocation.
+#[derive(Debug, Clone)]
+pub(crate) struct ToolPython {
+    /// The source of the Python request.
+    source: PythonRequestSource,
+    /// The selected Python request, computed by considering an explicit request, a global
+    /// version file, and static `requires-python` metadata from the source requirement.
+    pub(crate) python_request: Option<PythonRequest>,
+}
+
+impl ToolPython {
+    /// Determine the [`ToolPython`] request for a tool invocation.
+    pub(crate) async fn from_request(
+        python_request: Option<PythonRequest>,
+        requirement: Option<&UnresolvedRequirement>,
+        no_config: bool,
+        lfs: GitLfsSetting,
+        git_resolver: &GitResolver,
+        client_builder: &BaseClientBuilder<'_>,
+        cache: &Cache,
+    ) -> Result<Self, ProjectError> {
+        let requires_python = if python_request.is_none() {
+            match requirement {
+                Some(requirement) => {
+                    infer_requires_python_from_requirement(
+                        requirement,
+                        lfs,
+                        git_resolver,
+                        client_builder,
+                        cache,
+                    )
+                    .await
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        let (source, python_request) = if let Some(request) = python_request {
+            (PythonRequestSource::UserRequest, Some(request))
+        } else if let Some(file) = PythonVersionFile::discover(
+            &*CWD,
+            &VersionFileDiscoveryOptions::default()
+                .with_no_config(no_config)
+                .with_no_local(true),
+        )
+        .await?
+        .filter(|file| match (file.version(), requires_python.as_ref()) {
+            (Some(request), Some(requires_python)) => {
+                request.intersects_requires_python(requires_python)
+            }
+            _ => true,
+        }) {
+            (
+                PythonRequestSource::DotPythonVersion(file.clone()),
+                file.version().cloned(),
+            )
+        } else {
+            (
+                PythonRequestSource::RequiresPython,
+                requires_python
+                    .as_ref()
+                    .and_then(PythonRequest::from_requires_python),
+            )
+        };
+
+        if let Some(python_request) = python_request.as_ref() {
+            debug!(
+                "Using Python request `{}` from {source}",
+                python_request.to_canonical_string()
+            );
+        }
+
+        Ok(Self {
+            source,
+            python_request,
+        })
+    }
+
+    /// Returns `true` if the selected request was explicitly provided by the user.
+    pub(crate) fn is_explicit(&self) -> bool {
+        matches!(self.source, PythonRequestSource::UserRequest)
+    }
+}
+
+/// Infer [`RequiresPython`] from a direct source requirement by reading its `pyproject.toml`.
+///
+/// Returns `None` when the requirement is not a directory or Git source, its metadata is not
+/// statically available, or the Git source cannot be fetched.
+async fn infer_requires_python_from_requirement(
+    requirement: &UnresolvedRequirement,
+    lfs: GitLfsSetting,
+    git_resolver: &GitResolver,
+    client_builder: &BaseClientBuilder<'_>,
+    cache: &Cache,
+) -> Option<RequiresPython> {
+    let requirement = requirement
+        .clone()
+        .augment_requirement(None, None, None, lfs.into(), None);
+    let source = requirement.source();
+
+    match StaticMetadataDatabase::new(client_builder, git_resolver, cache)
+        .requires_python(source.as_ref())
+        .await
+    {
+        Ok(requires_python) => requires_python,
+        Err(err) => {
+            debug!(
+                "Failed to infer `requires-python` from source requirement (`{requirement}`): {err}"
+            );
+            None
         }
     }
 }

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -16,7 +16,6 @@ use uv_distribution_types::{
     ExtraBuildRequires, IndexCapabilities, NameRequirementSpecification, Requirement,
     RequirementSource, UnresolvedRequirementSpecification,
 };
-use uv_fs::CWD;
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
@@ -24,7 +23,7 @@ use uv_pep508::MarkerTree;
 use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, Interpreter, PythonDownloads, PythonEnvironment, PythonInstallation,
-    PythonPreference, PythonRequest, PythonVersionFile, VersionFileDiscoveryOptions,
+    PythonPreference, PythonRequest,
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
@@ -43,7 +42,7 @@ use crate::commands::project::{
     sync_environment, update_environment,
 };
 use crate::commands::tool::common::{
-    finalize_tool_install, refine_interpreter, remove_entrypoints,
+    ToolPython, finalize_tool_install, refine_interpreter, remove_entrypoints,
 };
 use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::{diagnostics, reporters::PythonDownloadReporter};
@@ -88,24 +87,46 @@ pub(crate) async fn install(
 
     let reporter = PythonDownloadReporter::single(printer);
 
-    let (python_request, explicit_python_request) = if let Some(request) = python.as_deref() {
-        (Some(PythonRequest::parse(request)), true)
-    } else {
-        // Discover a global Python version pin, if no request was made
-        (
-            PythonVersionFile::discover(
-                // TODO(zanieb): We don't use the directory, should we expose another interface?
-                // Should `no_local` be implied by `None` here?
-                &*CWD,
-                &VersionFileDiscoveryOptions::default()
-                    .with_no_config(no_config)
-                    .with_no_local(true),
+    // Initialize any shared state.
+    let state = PlatformState::default();
+
+    // Parse the input requirement.
+    let request = ToolRequest::parse(&package, from.as_deref())?;
+
+    let unresolved_target_requirements = match &request {
+        ToolRequest::Package {
+            target: Target::Unspecified(requirement),
+            ..
+        } => {
+            let source = if editable {
+                RequirementsSource::from_editable(requirement)?
+            } else {
+                RequirementsSource::from_package(requirement)?
+            };
+            Some(
+                RequirementsSpecification::from_source(&source, &client_builder)
+                    .await?
+                    .requirements,
             )
-            .await?
-            .and_then(PythonVersionFile::into_version),
-            false,
-        )
+        }
+        _ => None,
     };
+
+    let tool_python = ToolPython::from_request(
+        python.as_deref().map(PythonRequest::parse),
+        unresolved_target_requirements
+            .as_ref()
+            .and_then(|requirements| requirements.first())
+            .map(|requirement| &requirement.requirement),
+        no_config,
+        lfs,
+        state.git(),
+        &client_builder,
+        &cache,
+    )
+    .await?;
+    let explicit_python_request = tool_python.is_explicit();
+    let python_request = tool_python.python_request;
 
     // Pre-emptively identify a Python interpreter. We need an interpreter to resolve any unnamed
     // requirements, even if we end up using a different interpreter for the tool install itself.
@@ -125,12 +146,6 @@ pub(crate) async fn install(
     .await?
     .into_interpreter();
 
-    // Initialize any shared state.
-    let state = PlatformState::default();
-
-    // Parse the input requirement.
-    let request = ToolRequest::parse(&package, from.as_deref())?;
-
     // If the user passed, e.g., `ruff@latest`, refresh the cache.
     let cache = if request.is_latest() {
         cache.with_refresh(Refresh::All(Timestamp::now()))
@@ -145,14 +160,9 @@ pub(crate) async fn install(
             executable,
             target: Target::Unspecified(from),
         } => {
-            let source = if editable {
-                RequirementsSource::from_editable(from)?
-            } else {
-                RequirementsSource::from_package(from)?
-            };
-            let requirement = RequirementsSpecification::from_source(&source, &client_builder)
-                .await?
-                .requirements;
+            let requirements = unresolved_target_requirements.clone().ok_or_else(|| {
+                anyhow::anyhow!("Expected parsed requirements for unresolved target `{from}`")
+            })?;
 
             // If the user provided an executable name, verify that it matches the `--from` requirement.
             let executable = if let Some(executable) = executable {
@@ -169,7 +179,7 @@ pub(crate) async fn install(
             };
 
             let requirement = resolve_names(
-                requirement,
+                requirements,
                 &interpreter,
                 &settings,
                 &client_builder,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -23,14 +23,11 @@ use uv_distribution_types::{
     IndexCapabilities, IndexUrl, Name, NameRequirementSpecification, Requirement,
     RequirementSource, UnresolvedRequirement, UnresolvedRequirementSpecification,
 };
-use uv_fs::CWD;
 use uv_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_pep440::{VersionSpecifier, VersionSpecifiers};
 use uv_pep508::MarkerTree;
 use uv_preview::Preview;
-use uv_python::PythonVersionFile;
-use uv_python::VersionFileDiscoveryOptions;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonEnvironment, PythonInstallation,
     PythonPreference, PythonRequest,
@@ -56,7 +53,7 @@ use crate::commands::project::{
     EnvironmentSpecification, PlatformState, ProjectError, resolve_names,
 };
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::tool::common::{matching_packages, refine_interpreter};
+use crate::commands::tool::common::{ToolPython, matching_packages, refine_interpreter};
 use crate::commands::tool::{Target, ToolRequest};
 use crate::commands::{diagnostics, project::environment::CachedEnvironment, read_env_files};
 use crate::printer::Printer;
@@ -701,6 +698,17 @@ async fn get_or_create_environment(
 ) -> Result<(ToolRequirement, PythonEnvironment), ProjectError> {
     let reporter = PythonDownloadReporter::single(printer);
 
+    // Initialize any shared state.
+    let state = PlatformState::default();
+
+    let unresolved_target_requirement = match request {
+        ToolRequest::Package {
+            target: Target::Unspecified(requirement),
+            ..
+        } => Some(RequirementsSpecification::parse_package(requirement)?),
+        _ => None,
+    };
+
     // Determine explicit Python version requests
     let explicit_python_request = python.map(PythonRequest::parse);
     let tool_python_request = match request {
@@ -708,7 +716,7 @@ async fn get_or_create_environment(
         ToolRequest::Package { .. } => None,
     };
 
-    // Resolve Python request with version file lookup when no explicit request
+    // Resolve an argument-derived Python request, if any.
     let python_request = match (explicit_python_request, tool_python_request) {
         // e.g., `uvx --python 3.10 python3.12`
         (Some(explicit), Some(tool_request)) if tool_request != PythonRequest::Default => {
@@ -723,17 +731,23 @@ async fn get_or_create_environment(
         // e.g, `uvx --python 3.10 ...`
         (Some(explicit), _) => Some(explicit),
         // e.g., `uvx python` or `uvx <tool>`
-        (None, Some(PythonRequest::Default) | None) => PythonVersionFile::discover(
-            &*CWD,
-            &VersionFileDiscoveryOptions::default()
-                .with_no_config(false)
-                .with_no_local(true),
-        )
-        .await?
-        .and_then(PythonVersionFile::into_version),
+        (None, Some(PythonRequest::Default) | None) => None,
         // e.g., `uvx python3.12`
         (None, Some(tool_request)) => Some(tool_request),
     };
+    let python_request = ToolPython::from_request(
+        python_request,
+        unresolved_target_requirement
+            .as_ref()
+            .map(|requirement| &requirement.requirement),
+        false,
+        lfs,
+        state.git(),
+        client_builder,
+        cache,
+    )
+    .await?
+    .python_request;
 
     // Discover an interpreter.
     let interpreter = PythonInstallation::find_or_download(
@@ -752,9 +766,6 @@ async fn get_or_create_environment(
     .await?
     .into_interpreter();
 
-    // Initialize any shared state.
-    let state = PlatformState::default();
-
     let from = match request {
         ToolRequest::Python {
             executable: request_executable,
@@ -769,7 +780,11 @@ async fn get_or_create_environment(
             let (executable, requirement) = match target {
                 // Ex) `ruff>=0.6.0`
                 Target::Unspecified(requirement) => {
-                    let spec = RequirementsSpecification::parse_package(requirement)?;
+                    let spec = unresolved_target_requirement.clone().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Expected parsed requirement for unresolved target `{requirement}`"
+                        )
+                    })?;
 
                     // Extract the verbatim executable name, if possible.
                     let name = match &spec.requirement {

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1,9 +1,13 @@
 #[cfg(any(feature = "test-git", feature = "test-git-lfs"))]
 use std::collections::BTreeSet;
+#[cfg(feature = "test-git")]
+use std::ffi::OsString;
 use std::process::Command;
 
 use anyhow::Result;
 use assert_cmd::assert::OutputAssertExt;
+#[cfg(feature = "test-git")]
+use assert_fs::fixture::ChildPath;
 use assert_fs::{
     assert::PathAssert,
     fixture::{FileTouch, FileWriteStr, PathChild, PathCreateDir},
@@ -15,6 +19,32 @@ use uv_fs::copy_dir_all;
 use uv_static::EnvVars;
 
 use uv_test::uv_snapshot;
+
+#[cfg(feature = "test-git")]
+fn tool_install_git_path(bin_dir: &ChildPath) -> OsString {
+    let mut paths = BTreeSet::new();
+    paths.insert(bin_dir.to_path_buf());
+    paths.insert(
+        which::which("git")
+            .expect("Failed to find `git` executable.")
+            .parent()
+            .expect("Failed to find `git` executable directory.")
+            .to_path_buf(),
+    );
+
+    // Git Submodule in macOS seems to rely on `sed`.
+    if cfg!(target_os = "macos") {
+        paths.insert(
+            which::which("sed")
+                .expect("Failed to find `sed` executable.")
+                .parent()
+                .expect("Failed to find `sed` executable directory.")
+                .to_path_buf(),
+        );
+    }
+
+    std::env::join_paths(paths).unwrap()
+}
 
 #[test]
 fn tool_install() {
@@ -215,6 +245,168 @@ fn tool_install_relative_exclude_newer_receipt_preserves_span() {
         exclude-newer-span = "P3W"
         "#);
     });
+}
+
+#[test]
+fn tool_install_from_directory_ignores_global_pin_outside_requires_python_range() {
+    let context = uv_test::test_context_with_versions!(&["3.13", "3.12", "3.11"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    let foo_dir = context.temp_dir.child("foo");
+    foo_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.13"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo.main:run"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#
+        })
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("main.py")
+        .write_str(indoc! {r#"
+        import sys
+
+        def run():
+            print(f"{sys.version_info.major}.{sys.version_info.minor}")
+        "#
+        })
+        .unwrap();
+
+    context
+        .python_pin()
+        .arg("3.13")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg(foo_dir.as_os_str())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo)
+    Installed 1 executable: foo
+    ");
+
+    uv_snapshot!(context.filters(), Command::new("foo")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn tool_install_from_directory_uses_global_pin_within_requires_python_range() {
+    let context = uv_test::test_context_with_versions!(&["3.13", "3.12", "3.11"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    let foo_dir = context.temp_dir.child("foo");
+    foo_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.13"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo.main:run"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#
+        })
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("main.py")
+        .write_str(indoc! {r#"
+        import sys
+
+        def run():
+            print(f"{sys.version_info.major}.{sys.version_info.minor}")
+        "#
+        })
+        .unwrap();
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg(foo_dir.as_os_str())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo)
+    Installed 1 executable: foo
+    ");
+
+    uv_snapshot!(context.filters(), Command::new("foo")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11
+
+    ----- stderr -----
+    ");
 }
 
 #[test]
@@ -2932,26 +3124,7 @@ fn tool_install_git() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
-    let mut paths = BTreeSet::new();
-
-    // Avoid removing `git` from PATH
-    let git_path = which::which("git")
-        .expect("Failed to find `git` executable.")
-        .parent()
-        .expect("Failed to find `git` executable directory.")
-        .to_path_buf();
-    paths.insert(bin_dir.to_path_buf());
-    paths.insert(git_path);
-    // Git Submodule in macos seems to rely on `sed`.
-    if cfg!(target_os = "macos") {
-        let sed_path = which::which("sed")
-            .expect("Failed to find `sed` executable.")
-            .parent()
-            .expect("Failed to find `sed` executable directory.")
-            .to_path_buf();
-        paths.insert(sed_path);
-    }
-    let path = std::env::join_paths(paths).unwrap();
+    let path = tool_install_git_path(&bin_dir);
 
     // Unnamed Git Install
     uv_snapshot!(context.filters(), context.tool_install()
@@ -3018,6 +3191,87 @@ fn tool_install_git() {
 
     let executable = bin_dir.child(format!("black{}", std::env::consts::EXE_SUFFIX));
     assert!(executable.exists());
+}
+
+/// Test that installing a tool from Git uses statically available `requires-python` metadata
+/// before selecting a global Python pin.
+#[test]
+#[cfg(feature = "test-git")]
+fn tool_install_git_infers_static_requires_python() {
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.11"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let path = tool_install_git_path(&bin_dir);
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=static")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, path.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + static-requires-python-tool==0.1.0 (from git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=static)
+    Installed 1 executable: static-requires-python-tool
+    ");
+
+    uv_snapshot!(context.filters(), Command::new("static-requires-python-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12
+
+    ----- stderr -----
+    ");
+}
+
+/// Test that installing a tool from Git does not infer dynamic `requires-python` metadata.
+#[test]
+#[cfg(feature = "test-git")]
+fn tool_install_git_does_not_infer_dynamic_requires_python() {
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.11"])
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let path = tool_install_git_path(&bin_dir);
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=dynamic")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, path.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
+          And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
+    ");
 }
 
 /// Test installing a tool with a Git LFS enabled requirement.

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1065,6 +1065,73 @@ fn tool_run_git() {
     ");
 }
 
+/// Test that running a tool from Git uses statically available `requires-python` metadata before
+/// selecting a global Python pin.
+#[test]
+#[cfg(feature = "test-git")]
+fn tool_run_git_infers_static_requires_python() {
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.11"]).with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg("git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=static")
+        .arg("static-requires-python-tool")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + static-requires-python-tool==0.1.0 (from git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=static)
+    ");
+}
+
+/// Test that running a tool from Git does not infer dynamic `requires-python` metadata.
+#[test]
+#[cfg(feature = "test-git")]
+fn tool_run_git_does_not_infer_dynamic_requires_python() {
+    let context = uv_test::test_context_with_versions!(&["3.12", "3.11"]).with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg("git+https://github.com/astral-sh/uv-dynamic-requires-python-test@75a612dc87fc215e999a25a0efc376cbf9831afa#subdirectory=dynamic")
+        .arg("dynamic-requires-python-tool")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving tool dependencies:
+      ╰─▶ Because the current Python version (3.11.[X]) does not satisfy Python>=3.12,<3.13 and dynamic-requires-python-tool==0.1.0 depends on Python>=3.12,<3.13, we can conclude that dynamic-requires-python-tool==0.1.0 cannot be used.
+          And because only dynamic-requires-python-tool==0.1.0 is available and you require dynamic-requires-python-tool, we can conclude that your requirements are unsatisfiable.
+    ");
+}
+
 /// Test running a tool with a Git LFS enabled requirement.
 #[test]
 #[cfg(feature = "test-git-lfs")]
@@ -2619,6 +2686,148 @@ fn tool_run_python_from() {
 
     ----- stderr -----
     Resolved in [TIME]
+    ");
+}
+
+#[test]
+fn tool_run_from_directory_uses_global_pin_when_within_requires_python_range() {
+    let context =
+        uv_test::test_context_with_versions!(&["3.13", "3.12", "3.11"]).with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    let foo_dir = context.temp_dir.child("foo");
+    foo_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.13"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo.main:run"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#
+        })
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("main.py")
+        .write_str(indoc! {r#"
+        import sys
+
+        def run():
+            print(f"{sys.version_info.major}.{sys.version_info.minor}")
+        "#
+        })
+        .unwrap();
+
+    context
+        .python_pin()
+        .arg("3.11")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg(foo_dir.as_os_str())
+        .arg("foo")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo)
+    ");
+}
+
+#[test]
+fn tool_run_from_directory_ignores_global_pin_outside_requires_python_range() {
+    let context =
+        uv_test::test_context_with_versions!(&["3.13", "3.12", "3.11"]).with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    let foo_dir = context.temp_dir.child("foo");
+    foo_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.13"
+        dependencies = []
+
+        [project.scripts]
+        foo = "foo.main:run"
+
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+        "#
+        })
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()
+        .unwrap();
+    foo_dir
+        .child("src")
+        .child("foo")
+        .child("main.py")
+        .write_str(indoc! {r#"
+        import sys
+
+        def run():
+            print(f"{sys.version_info.major}.{sys.version_info.minor}")
+        "#
+        })
+        .unwrap();
+
+    context
+        .python_pin()
+        .arg("3.13")
+        .arg("--global")
+        .assert()
+        .success();
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg(foo_dir.as_os_str())
+        .arg("foo")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo)
     ");
 }
 


### PR DESCRIPTION
Currently, we determine the Python version to use then attempt to resolve the target package. If the Python version is not compatible, we fail.

For source trees, we can peek at the `pyproject.toml` to infer the Python version request from the `requires-python` range instead, which reduces failures and aligns with user expectations. In #19583 (still needs self-review), this is expanded to include inference from distribution metadata, e.g., from wheels on an index.

Closes https://github.com/astral-sh/uv/issues/8206

Related to

- #14110 
- #19079