### PR TITLE
Use resolution hints for standard library diagnostics

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -18,6 +18,7 @@ use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerEnvironment, MarkerExpression, MarkerTree, MarkerValueVersion};
 use uv_platform_tags::{AbiTag, IncompatibleTag, LanguageTag, PlatformTag, Tags};
+use uv_static::is_known_standard_library_package;
 
 use crate::candidate_selector::CandidateSelector;
 use crate::error::{ErrorTree, PrefixMatch};
@@ -565,6 +566,8 @@ impl PubGrubReportFormatter<'_> {
         match derivation_tree {
             DerivationTree::External(External::Custom(package, set, reason)) => {
                 if let Some(name) = package.name_no_root() {
+                    Self::standard_library_hint(name, current_environment, output_hints);
+
                     // Check for no versions due to pre-release options.
                     if !fork_urls.contains_key(name) {
                         self.prerelease_hint(name, set, selector, env, options, output_hints);
@@ -623,6 +626,8 @@ impl PubGrubReportFormatter<'_> {
             }
             DerivationTree::External(External::NoVersions(package, set)) => {
                 if let Some(name) = package.name_no_root() {
+                    Self::standard_library_hint(name, current_environment, output_hints);
+
                     // Check for no versions due to pre-release options.
                     if !fork_urls.contains_key(name) {
                         self.prerelease_hint(name, set, selector, env, options, output_hints);
@@ -1130,6 +1135,25 @@ impl PubGrubReportFormatter<'_> {
         }
     }
 
+    fn standard_library_hint(
+        name: &PackageName,
+        current_environment: &MarkerEnvironment,
+        hints: &mut IndexSet<PubGrubHint>,
+    ) {
+        if let Some(minor) = current_environment
+            .python_version()
+            .version
+            .release()
+            .get(1)
+            .and_then(|minor| u8::try_from(*minor).ok())
+            && is_known_standard_library_package(minor, name.as_ref())
+        {
+            hints.insert(PubGrubHint::StandardLibrary {
+                package: name.clone(),
+            });
+        }
+    }
+
     fn prerelease_hint(
         &self,
         name: &PackageName,
@@ -1265,6 +1289,8 @@ pub enum PubGrubHint {
     NoIndex,
     /// A package was not found in the registry, but network access was disabled.
     Offline,
+    /// A package is provided by the Python standard library.
+    StandardLibrary { package: PackageName },
     /// Metadata for a package could not be parsed.
     InvalidPackageMetadata {
         package: PackageName,
@@ -1436,6 +1462,9 @@ enum PubGrubHintCore {
     },
     NoIndex,
     Offline,
+    StandardLibrary {
+        package: PackageName,
+    },
     InvalidPackageMetadata {
         package: PackageName,
     },
@@ -1517,6 +1546,7 @@ impl From<PubGrubHint> for PubGrubHintCore {
             }
             PubGrubHint::NoIndex => Self::NoIndex,
             PubGrubHint::Offline => Self::Offline,
+            PubGrubHint::StandardLibrary { package } => Self::StandardLibrary { package },
             PubGrubHint::InvalidPackageMetadata { package, .. } => {
                 Self::InvalidPackageMetadata { package }
             }
@@ -1640,6 +1670,13 @@ impl std::fmt::Display for PubGrubHint {
                 write!(
                     f,
                     "Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.",
+                )
+            }
+            Self::StandardLibrary { package } => {
+                write!(
+                    f,
+                    "The module `{}` is included in the Python standard library and usually should not be added as a dependency",
+                    package.cyan(),
                 )
             }
             Self::InvalidPackageMetadata { package, reason } => {

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -41,8 +41,8 @@ static SUGGESTIONS: LazyLock<FxHashMap<PackageName, PackageName>> = LazyLock::ne
 /// installation.
 #[derive(Debug, Default)]
 pub(crate) struct OperationDiagnostic {
-    /// Caller-provided hints to render after the error output.
-    hints: Vec<String>,
+    /// A caller-provided hint to render after the error output.
+    hint: Option<String>,
     /// Whether system certificates are being used.
     pub(crate) system_certs: bool,
     /// The context to display to the user upon resolution failure.
@@ -59,11 +59,13 @@ impl OperationDiagnostic {
         }
     }
 
-    /// Add a hint to display to the user upon resolution failure.
+    /// Set the hint to display to the user upon resolution failure.
     #[must_use]
-    pub(crate) fn with_hint(mut self, hint: String) -> Self {
-        self.hints.push(hint);
-        self
+    pub(crate) fn with_hint(self, hint: String) -> Self {
+        Self {
+            hint: Some(hint),
+            ..self
+        }
     }
 
     /// Set the context to display to the user upon resolution failure.
@@ -138,10 +140,12 @@ impl OperationDiagnostic {
             err => Some(err),
         };
 
-        // Render the caller-provided hints after the error output.
+        // Render the caller-provided hint after the error output.
         if result.is_none() {
-            let hints: Hints<'_> = self.hints.into_iter().collect();
-            anstream::eprint!("{hints}");
+            if let Some(hint) = &self.hint {
+                let hints = Hints::from(hint.as_str());
+                anstream::eprint!("{hints}");
+            }
         }
 
         result

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -36,7 +36,6 @@ use uv_requirements::{NamedRequirementsResolver, RequirementsSource, Requirement
 use uv_resolver::FlatIndex;
 use uv_scripts::{Pep723Metadata, Pep723Script};
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
-use uv_static::is_known_standard_library_package;
 use uv_types::{BuildIsolation, HashStrategy, SourceTreeEditablePolicy};
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::{
@@ -737,7 +736,6 @@ pub(crate) async fn add(
     // Use separate state for locking and syncing.
     let lock_state = state.fork();
     let sync_state = state;
-    let python_minor = target.interpreter().python_minor();
 
     match Box::pin(lock_and_sync(
         target,
@@ -777,57 +775,13 @@ pub(crate) async fn add(
                 let _ = snapshot.revert();
             }
             match err {
-                ProjectError::Operation(err) => {
-                    let standard_library_hint = standard_library_hint(&err, &edits, python_minor);
-                    let diagnostic = diagnostics::OperationDiagnostic::with_system_certs(
-                        client_builder.system_certs(),
-                    );
-                    let diagnostic = if let Some(hint) = standard_library_hint {
-                        diagnostic.with_hint(hint)
-                    } else {
-                        diagnostic
-                    };
-                    diagnostic
-                        .with_hint(format!("If you want to add the package regardless of the failed resolution, provide the `{}` flag to skip locking and syncing", "--frozen".green()))
-                        .report(err)
-                        .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
-                }
+                ProjectError::Operation(err) => diagnostics::OperationDiagnostic::with_system_certs(client_builder.system_certs()).with_hint(format!("If you want to add the package regardless of the failed resolution, provide the `{}` flag to skip locking and syncing", "--frozen".green()))
+                    .report(err)
+                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into())),
                 err => Err(err.into()),
             }
         }
     }
-}
-
-fn standard_library_hint(
-    operation_error: &crate::commands::pip::operations::Error,
-    edits: &[DependencyEdit],
-    python_minor: u8,
-) -> Option<String> {
-    let crate::commands::pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(
-        no_solution_error,
-    )) = operation_error
-    else {
-        return None;
-    };
-
-    edits.iter().find_map(|edit| {
-        if edit
-            .source
-            .as_ref()
-            .is_none_or(|source| matches!(source, Source::Registry { .. }))
-            && is_known_standard_library_package(python_minor, edit.requirement.name.as_ref())
-            && no_solution_error
-                .packages()
-                .any(|package| package == &edit.requirement.name)
-        {
-            Some(format!(
-                "The module `{}` is included in the Python standard library and usually should not be added as a dependency",
-                edit.requirement.name
-            ))
-        } else {
-            None
-        }
-    })
 }
 
 fn edits(

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -11278,6 +11278,35 @@ async fn lock_redact_url_sources() -> Result<()> {
     Ok(())
 }
 
+/// Suggest avoiding dependencies for modules in the Python standard library.
+#[test]
+fn lock_standard_library_error() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["pickle"]
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.lock(), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because pickle was not found in the package registry and your project depends on pickle, we can conclude that your project's requirements are unsatisfiable.
+
+    hint: The module `pickle` is included in the Python standard library and usually should not be added as a dependency
+    ");
+
+    Ok(())
+}
+
 /// Pass credentials for a named index via environment variables.
 #[tokio::test]
 async fn lock_env_credentials() -> Result<()> {


### PR DESCRIPTION
## Summary

- generate standard-library suggestions through the resolver's structured hint machinery
- remove the `uv add`-specific multiple-caller-hint plumbing
- retain proof-derived scoping so unrelated resolution failures do not suggest a standard-library module
- add `uv lock` coverage for the resolver-owned hint

## Test plan

- `cargo test --package uv --test it -- standard_library`
- `cargo fmt --all --check`
- `cargo clippy --package uv --test it --all-features --locked -- -D warnings`
- `git diff --check`

Stacked on #19572.
