### PR TITLE
Fix transitive Git archive dependencies in lockfiles

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -533,11 +533,13 @@ impl LoweredRequirement {
             return Ok(Self(Requirement::from(requirement)));
         };
 
-        let ParsedUrl::Directory(directory) = &url.parsed_url else {
-            return Ok(Self(Requirement::from(requirement)));
+        let (install_path, is_archive) = match &url.parsed_url {
+            ParsedUrl::Directory(directory) => (directory.install_path.as_ref(), false),
+            ParsedUrl::Path(path) => (path.install_path.as_ref(), true),
+            _ => return Ok(Self(Requirement::from(requirement))),
         };
 
-        let install_path = git_path(&directory.install_path)?;
+        let install_path = git_path(install_path)?;
         let fetch_root = git_path(git_member.fetch_root)?;
         if !install_path.starts_with(&fetch_root) {
             return Ok(Self(Requirement::from(requirement)));
@@ -548,7 +550,11 @@ impl LoweredRequirement {
             groups: Box::new([]),
             extras: requirement.extras,
             marker: requirement.marker,
-            source: git_source_from_path(&install_path, git_member)?,
+            source: if is_archive {
+                git_archive_source_from_path(&install_path, git_member)?
+            } else {
+                git_directory_source_from_path(&install_path, git_member)?
+            },
             origin: requirement.origin,
         }))
     }
@@ -834,7 +840,7 @@ fn path_source(
     };
     if is_dir {
         if let Some(git_member) = git_member {
-            return git_source_from_path(install_path, git_member);
+            return git_directory_source_from_path(install_path, git_member);
         }
 
         if editable == Some(true) {
@@ -870,7 +876,7 @@ fn path_source(
         }
     } else {
         if let Some(git_member) = git_member {
-            return git_path_source_from_path(install_path, git_member);
+            return git_archive_source_from_path(install_path, git_member);
         }
         if editable == Some(true) {
             return Err(LoweringError::EditableFile(url.to_string()));
@@ -887,7 +893,7 @@ fn path_source(
     }
 }
 
-fn git_source_from_path(
+fn git_directory_source_from_path(
     install_path: impl AsRef<Path>,
     git_member: &GitWorkspaceMember,
 ) -> Result<RequirementSource, LoweringError> {
@@ -913,7 +919,7 @@ fn git_source_from_path(
     })
 }
 
-fn git_path_source_from_path(
+fn git_archive_source_from_path(
     install_path: impl AsRef<Path>,
     git_member: &GitWorkspaceMember,
 ) -> Result<RequirementSource, LoweringError> {

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -11351,6 +11351,144 @@ fn lock_git_poetry_path_dependency() -> Result<()> {
     Ok(())
 }
 
+/// Lock a Git repository with generated metadata that references an archive within the repository.
+///
+/// See: <https://github.com/astral-sh/uv/issues/15417>
+#[test]
+#[cfg(feature = "test-git")]
+fn lock_git_metadata_archive_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    let repository = context.temp_dir.child("repository");
+    repository.child("root").create_dir_all()?;
+    repository.child("root/root.py").touch()?;
+    repository.child("root/archives").create_dir_all()?;
+    fs_err::copy(
+        context
+            .workspace_root
+            .join("test/links/basic_package-0.1.0-py3-none-any.whl"),
+        repository
+            .child("root/archives/basic_package-0.1.0-py3-none-any.whl")
+            .path(),
+    )?;
+    repository.child("root/setup.py").write_str(indoc! {r#"
+        from pathlib import Path
+        from setuptools import setup
+
+        wheel = Path(__file__).parent / "archives" / "basic_package-0.1.0-py3-none-any.whl"
+
+        setup(
+            name="root",
+            version="0.1.0",
+            py_modules=["root"],
+            install_requires=[f"basic-package @ {wheel.as_uri()}"],
+        )
+    "#})?;
+
+    Command::new("git")
+        .arg("init")
+        .arg(repository.path())
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("add")
+        .arg(".")
+        .assert()
+        .success();
+    Command::new("git")
+        .arg("-C")
+        .arg(repository.path())
+        .arg("-c")
+        .arg("user.name=Example")
+        .arg("-c")
+        .arg("user.email=example@example.com")
+        .arg("commit")
+        .arg("-m")
+        .arg("Initial commit")
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .assert()
+        .success();
+
+    let repository_url = Url::from_directory_path(repository.path())
+        .map_err(|()| anyhow!("failed to convert repository path to file URL"))?;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["root"]
+
+        [tool.uv.sources]
+        root = {{ git = "{repository_url}", subdirectory = "root" }}
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--no-cache"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    ");
+
+    let lock = context.read("uv.lock");
+    let mut filters = context.filters();
+    filters.push((r"#[0-9a-f]{40}", "#[COMMIT]"));
+
+    insta::with_settings!(
+        {
+            filters => filters,
+        },
+        {
+            assert_snapshot!(
+                lock, @r#"
+            version = 1
+            revision = 3
+            requires-python = ">=3.13"
+
+            [options]
+            exclude-newer = "2024-03-25T00:00:00Z"
+
+            [[package]]
+            name = "basic-package"
+            version = "0.1.0"
+            source = { git = "file://[TEMP_DIR]/repository/?path=root%2Farchives%2Fbasic_package-0.1.0-py3-none-any.whl#[COMMIT]" }
+            wheels = [
+                { filename = "basic_package-0.1.0-py3-none-any.whl", hash = "sha256:7b6229db79b5800e4e98a351b5628c1c8a944533a2d428aeeaa7275a30d4ea82" },
+            ]
+
+            [[package]]
+            name = "project"
+            version = "0.1.0"
+            source = { virtual = "." }
+            dependencies = [
+                { name = "root" },
+            ]
+
+            [package.metadata]
+            requires-dist = [{ name = "root", git = "file://[TEMP_DIR]/repository/?subdirectory=root" }]
+
+            [[package]]
+            name = "root"
+            version = "0.1.0"
+            source = { git = "file://[TEMP_DIR]/repository/?subdirectory=root#[COMMIT]" }
+            dependencies = [
+                { name = "basic-package" },
+            ]
+            "#
+            );
+        }
+    );
+
+    Ok(())
+}
+
 /// Sync a package with multiple wheels at the same version, differing only in the build tag. We
 /// should choose the wheel with the highest build tag.
 #[test]


### PR DESCRIPTION
## Summary

We now preserve source identity for transitive archive dependencies discovered while lowering metadata from Git-sourced packages. If generated metadata resolves to an archive inside the same Git checkout, we lock it as the corresponding Git source with a `path` instead of serializing the absolute checkout path.

This covers packages like `vsphere-automation-sdk-python`, whose generated metadata references wheels within its Git checkout using absolute `file://` URLs.

Closes https://github.com/astral-sh/uv/issues/15417.
