### PR TITLE
Rebuild explicit local directory tool installs

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -204,6 +204,13 @@ impl Cache {
         Self { refresh, ..self }
     }
 
+    /// Combine the existing [`Refresh`] policy with an additional one.
+    #[must_use]
+    pub fn with_refresh_combined(self, refresh: Refresh) -> Self {
+        let refresh = self.refresh.combine(refresh);
+        Self { refresh, ..self }
+    }
+
     /// Acquire a lock that allows removing entries from the cache.
     pub async fn with_exclusive_lock(self) -> Result<Self, LockedFileError> {
         let Self {

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -204,13 +204,6 @@ impl Cache {
         Self { refresh, ..self }
     }
 
-    /// Combine the existing [`Refresh`] policy with an additional one.
-    #[must_use]
-    pub fn with_refresh_combined(self, refresh: Refresh) -> Self {
-        let refresh = self.refresh.combine(refresh);
-        Self { refresh, ..self }
-    }
-
     /// Acquire a lock that allows removing entries from the cache.
     pub async fn with_exclusive_lock(self) -> Result<Self, LockedFileError> {
         let Self {

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -380,7 +380,10 @@ pub(crate) async fn install(
     // including any requirements provided via `--with`.
     let explicit_local_packages = requirements
         .iter()
-        .filter(|requirement| matches!(requirement.source, RequirementSource::Directory { .. }))
+        .filter(|requirement| {
+            requirement.origin.is_none()
+                && matches!(requirement.source, RequirementSource::Directory { .. })
+        })
         .map(|requirement| requirement.name.clone())
         .collect::<Vec<_>>();
     let (settings, cache) = if explicit_local_packages.is_empty() {

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -76,6 +76,7 @@ pub(crate) async fn install(
     concurrency: Concurrency,
     no_config: bool,
     cache: Cache,
+    refresh: Refresh,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
     preview: Preview,
@@ -132,11 +133,12 @@ pub(crate) async fn install(
     let request = ToolRequest::parse(&package, from.as_deref())?;
 
     // If the user passed, e.g., `ruff@latest`, refresh the cache.
-    let cache = if request.is_latest() {
-        cache.with_refresh(Refresh::All(Timestamp::now()))
+    let refresh = if request.is_latest() {
+        refresh.combine(Refresh::All(Timestamp::now()))
     } else {
-        cache
+        refresh
     };
+    let cache = cache.with_refresh(refresh.clone());
 
     // Resolve the `--from` requirement.
     let requirement = match &request {
@@ -395,7 +397,7 @@ pub(crate) async fn install(
                 reinstall.with_package(package_name)
             })
             .combine(settings.reinstall);
-        let cache = cache.with_refresh_combined(Refresh::from(reinstall.clone()));
+        let cache = cache.with_refresh(refresh.combine(Refresh::from(reinstall.clone())));
         (
             ResolverInstallerSettings {
                 reinstall,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -318,11 +318,6 @@ pub(crate) async fn install(
 
     let package_name = &requirement.name;
 
-    let explicit_local_directory = match &requirement.source {
-        RequirementSource::Directory { install_path, .. } => Some(install_path.clone()),
-        _ => None,
-    };
-
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.
     let settings = if request.is_latest() {
         ResolverInstallerSettings {
@@ -344,22 +339,6 @@ pub(crate) async fn install(
         }
     } else {
         settings
-    };
-
-    let (settings, cache) = if let Some(install_path) = explicit_local_directory {
-        let reinstall = Reinstall::None
-            .with_path(install_path)
-            .combine(settings.reinstall);
-        let cache = cache.with_refresh_combined(Refresh::from(reinstall.clone()));
-        (
-            ResolverInstallerSettings {
-                reinstall,
-                ..settings
-            },
-            cache,
-        )
-    } else {
-        (settings, cache)
     };
 
     // Read the `--with` requirements.
@@ -394,6 +373,33 @@ pub(crate) async fn install(
             .await?,
         );
         requirements
+    };
+
+    // Explicit local directory requirements should always be rebuilt and reinstalled, matching
+    // `uv pip install`. At this point, all unnamed requirements have been resolved to package names,
+    // including any requirements provided via `--with`.
+    let explicit_local_packages = requirements
+        .iter()
+        .filter(|requirement| matches!(requirement.source, RequirementSource::Directory { .. }))
+        .map(|requirement| requirement.name.clone())
+        .collect::<Vec<_>>();
+    let (settings, cache) = if explicit_local_packages.is_empty() {
+        (settings, cache)
+    } else {
+        let reinstall = explicit_local_packages
+            .into_iter()
+            .fold(Reinstall::None, |reinstall, package_name| {
+                reinstall.with_package(package_name)
+            })
+            .combine(settings.reinstall);
+        let cache = cache.with_refresh_combined(Refresh::from(reinstall.clone()));
+        (
+            ResolverInstallerSettings {
+                reinstall,
+                ..settings
+            },
+            cache,
+        )
     };
 
     // Resolve the constraints.

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -318,6 +318,11 @@ pub(crate) async fn install(
 
     let package_name = &requirement.name;
 
+    let explicit_local_directory = match &requirement.source {
+        RequirementSource::Directory { install_path, .. } => Some(install_path.clone()),
+        _ => None,
+    };
+
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.
     let settings = if request.is_latest() {
         ResolverInstallerSettings {
@@ -339,6 +344,22 @@ pub(crate) async fn install(
         }
     } else {
         settings
+    };
+
+    let (settings, cache) = if let Some(install_path) = explicit_local_directory {
+        let reinstall = Reinstall::None
+            .with_path(install_path)
+            .combine(settings.reinstall);
+        let cache = cache.with_refresh_combined(Refresh::from(reinstall.clone()));
+        (
+            ResolverInstallerSettings {
+                reinstall,
+                ..settings
+            },
+            cache,
+        )
+    } else {
+        (settings, cache)
     };
 
     // Read the `--with` requirements.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1514,11 +1514,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .check_refresh_conflict(&args.refresh);
 
             // Initialize the cache.
-            let cache = cache.init().await?.with_refresh(
-                args.refresh
-                    .combine(Refresh::from(args.settings.reinstall.clone()))
-                    .combine(Refresh::from(args.settings.resolver.upgrade.clone())),
-            );
+            let refresh = args
+                .refresh
+                .combine(Refresh::from(args.settings.reinstall.clone()))
+                .combine(Refresh::from(args.settings.resolver.upgrade.clone()));
+            let cache = cache.init().await?.with_refresh(refresh.clone());
 
             let mut entrypoints = Vec::with_capacity(args.with_executables_from.len());
             let mut requirements = Vec::with_capacity(
@@ -1595,6 +1595,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 globals.concurrency,
                 cli.top_level.no_config,
                 cache,
+                refresh,
                 &workspace_cache,
                 printer,
                 globals.preview,

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1994,11 +1994,15 @@ fn tool_install_explicit_local_directory_respects_global_python_change() -> Resu
         .assert()
         .success();
 
-    Command::new("local-tool")
-        .env(EnvVars::PATH, bin_dir.as_os_str())
-        .assert()
-        .success()
-        .stdout("3.12\n");
+    uv_snapshot!(context.filters(), Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12
+
+    ----- stderr -----
+    ");
 
     context
         .python_pin()
@@ -2016,11 +2020,15 @@ fn tool_install_explicit_local_directory_respects_global_python_change() -> Resu
         .assert()
         .success();
 
-    Command::new("local-tool")
-        .env(EnvVars::PATH, bin_dir.as_os_str())
-        .assert()
-        .success()
-        .stdout("3.13\n");
+    uv_snapshot!(context.filters(), Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.13
+
+    ----- stderr -----
+    ");
 
     Ok(())
 }
@@ -2097,11 +2105,15 @@ fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
         .assert()
         .success();
 
-    Command::new("local-tool")
-        .env(EnvVars::PATH, bin_dir.as_os_str())
-        .assert()
-        .success()
-        .stdout("0.1.0\n");
+    uv_snapshot!(context.filters(), Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    0.1.0
+
+    ----- stderr -----
+    ");
 
     helper.child("VERSION").write_str("0.2.0")?;
 
@@ -2116,11 +2128,15 @@ fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
         .assert()
         .success();
 
-    Command::new("local-tool")
-        .env(EnvVars::PATH, bin_dir.as_os_str())
-        .assert()
-        .success()
-        .stdout("0.2.0\n");
+    uv_snapshot!(context.filters(), Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    0.2.0
+
+    ----- stderr -----
+    ");
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!("{}\n", helper.path().display()))?;
@@ -2137,11 +2153,15 @@ fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
         .assert()
         .success();
 
-    Command::new("local-tool")
-        .env(EnvVars::PATH, bin_dir.as_os_str())
-        .assert()
-        .success()
-        .stdout("0.2.0\n");
+    uv_snapshot!(context.filters(), Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    0.2.0
+
+    ----- stderr -----
+    ");
 
     Ok(())
 }

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -2116,6 +2116,27 @@ fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
         .success()
         .stdout("0.2.0\n");
 
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(&format!("{}\n", helper.path().display()))?;
+    helper.child("VERSION").write_str("0.3.0")?;
+
+    context
+        .tool_install()
+        .arg("--with-requirements")
+        .arg(requirements_txt.path())
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout("0.2.0\n");
+
     Ok(())
 }
 

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1801,6 +1801,8 @@ fn tool_install_editable() {
     });
 }
 
+/// An explicit local tool should be rebuilt after its dynamic metadata changes, including when
+/// switching between editable and non-editable installs.
 #[test]
 fn tool_install_editable_rebuilds_explicit_local_directory() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
@@ -1940,6 +1942,8 @@ fn tool_install_editable_rebuilds_explicit_local_directory() -> Result<()> {
     Ok(())
 }
 
+/// Reinstalling an explicit local tool should use a newly selected global Python even when the
+/// tool's source is unchanged.
 #[test]
 fn tool_install_explicit_local_directory_respects_global_python_change() -> Result<()> {
     let context =
@@ -2021,6 +2025,8 @@ fn tool_install_explicit_local_directory_respects_global_python_change() -> Resu
     Ok(())
 }
 
+/// A direct local `--with` requirement should be rebuilt on every invocation, while a local
+/// requirement discovered through `--with-requirements` should retain its normal cache behavior.
 #[test]
 fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1940,6 +1940,185 @@ fn tool_install_editable_rebuilds_explicit_local_directory() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn tool_install_explicit_local_directory_respects_global_python_change() -> Result<()> {
+    let context =
+        uv_test::test_context_with_versions!(&["3.12", "3.13"]).with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+
+        [project]
+        name = "local-tool"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.scripts]
+        local-tool = "local_tool:main"
+        "#
+    })?;
+    project
+        .child("src")
+        .child("local_tool")
+        .child("__init__.py")
+        .write_str(indoc! {r#"
+            import sys
+
+            def main():
+                print(f"{sys.version_info.major}.{sys.version_info.minor}")
+            "#
+        })?;
+
+    context
+        .python_pin()
+        .arg("3.12")
+        .arg("--global")
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout("3.12\n");
+
+    context
+        .python_pin()
+        .arg("3.13")
+        .arg("--global")
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout("3.13\n");
+
+    Ok(())
+}
+
+#[test]
+fn tool_install_rebuilds_explicit_local_with_requirement() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let project = context.temp_dir.child("project");
+    let helper = context.temp_dir.child("helper");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [build-system]
+        requires = ["uv_build>=0.7,<10000"]
+        build-backend = "uv_build"
+
+        [project]
+        name = "local-tool"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.scripts]
+        local-tool = "local_tool:main"
+        "#
+    })?;
+    project
+        .child("src")
+        .child("local_tool")
+        .child("__init__.py")
+        .write_str(indoc! {r#"
+            from importlib.metadata import version
+
+            def main():
+                print(version("local-helper"))
+            "#
+        })?;
+
+    helper.child("pyproject.toml").write_str(indoc! {r#"
+        [build-system]
+        requires = ["setuptools>=61"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        name = "local-helper"
+        dynamic = ["version"]
+        requires-python = ">=3.12"
+        "#
+    })?;
+    helper.child("setup.py").write_str(indoc! {r#"
+        from pathlib import Path
+        from setuptools import setup
+
+        setup(version=(Path(__file__).parent / "VERSION").read_text().strip())
+        "#
+    })?;
+    helper.child("VERSION").write_str("0.1.0")?;
+    helper
+        .child("src")
+        .child("local_helper")
+        .child("__init__.py")
+        .touch()?;
+
+    context
+        .tool_install()
+        .arg("--with")
+        .arg(helper.path())
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout("0.1.0\n");
+
+    helper.child("VERSION").write_str("0.2.0")?;
+
+    context
+        .tool_install()
+        .arg("--with")
+        .arg(helper.path())
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    Command::new("local-tool")
+        .env(EnvVars::PATH, bin_dir.as_os_str())
+        .assert()
+        .success()
+        .stdout("0.2.0\n");
+
+    Ok(())
+}
+
 /// Ensure that we remove any existing entrypoints upon error.
 #[test]
 fn tool_install_remove_on_empty() -> Result<()> {

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1801,6 +1801,145 @@ fn tool_install_editable() {
     });
 }
 
+#[test]
+fn tool_install_editable_rebuilds_explicit_local_directory() -> Result<()> {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+    let project = context.temp_dir.child("dynamic_tool");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [build-system]
+        requires = ["setuptools>=61"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        name = "dynamic-tool-demo"
+        dynamic = ["version", "scripts"]
+        requires-python = ">=3.11"
+        "#
+    })?;
+
+    project.child("setup.py").write_str(indoc! {r#"
+        from pathlib import Path
+        from setuptools import setup
+
+        root = Path(__file__).parent
+        version = (root / "VERSION").read_text().strip()
+        commands = [
+            line.strip()
+            for line in (root / "commands.txt").read_text().splitlines()
+            if line.strip()
+        ]
+
+        setup(
+            version=version,
+            entry_points={
+                "console_scripts": [
+                    f"dynamic-tool-{command}=dynamic_tool.commands.{command}:main"
+                    for command in commands
+                ]
+            },
+        )
+        "#
+    })?;
+
+    project.child("VERSION").write_str("0.1.0")?;
+    project.child("commands.txt").write_str("alpha")?;
+    project
+        .child("src")
+        .child("dynamic_tool")
+        .child("__init__.py")
+        .touch()?;
+    project
+        .child("src")
+        .child("dynamic_tool")
+        .child("commands")
+        .child("__init__.py")
+        .touch()?;
+    project
+        .child("src")
+        .child("dynamic_tool")
+        .child("commands")
+        .child("alpha.py")
+        .write_str(indoc! {r#"
+            def main():
+                print("alpha")
+            "#
+        })?;
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("-e")
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + dynamic-tool-demo==0.1.0 (from file://[TEMP_DIR]/dynamic_tool)
+    Installed 1 executable: dynamic-tool-alpha
+    ");
+
+    project.child("VERSION").write_str("0.2.0")?;
+    project.child("commands.txt").write_str("alpha\nbeta")?;
+    project
+        .child("src")
+        .child("dynamic_tool")
+        .child("commands")
+        .child("beta.py")
+        .write_str(indoc! {r#"
+            def main():
+                print("beta")
+            "#
+        })?;
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - dynamic-tool-demo==0.1.0 (from file://[TEMP_DIR]/dynamic_tool)
+     + dynamic-tool-demo==0.2.0 (from file://[TEMP_DIR]/dynamic_tool)
+    Installed 2 executables: dynamic-tool-alpha, dynamic-tool-beta
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("-e")
+        .arg(project.path())
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .env(EnvVars::PATH, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     ~ dynamic-tool-demo==0.2.0 (from file://[TEMP_DIR]/dynamic_tool)
+    Installed 2 executables: dynamic-tool-alpha, dynamic-tool-beta
+    ");
+
+    Ok(())
+}
+
 /// Ensure that we remove any existing entrypoints upon error.
 #[test]
 fn tool_install_remove_on_empty() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #19541.

This fixes a stale editable install cache issue in `uv tool install`. When a local project uses dynamic metadata for its version or console scripts, reinstalling it with `uv tool install -e .` could reuse an older editable build and restore outdated metadata.

Now, explicit local directory tool installs are refreshed and reinstalled, so the installed tool keeps the updated version and entry points.

## Test Plan

- `cargo test -p uv --test it tool_install_editable_rebuilds_explicit_local_directory`
- `cargo test -p uv --test it tool_install_editable`
- `cargo build --bin uv`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`