### PR TITLE
Validate Git LFS artifacts for Git archives

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -14,6 +14,7 @@ use crate::{FlatIndexError, html};
 use uv_cache::Error as CacheError;
 use uv_distribution_filename::{WheelFilename, WheelFilenameError};
 use uv_distribution_types::IndexUrl;
+use uv_git::GitError;
 use uv_normalize::PackageName;
 use uv_redacted::DisplaySafeUrl;
 
@@ -384,6 +385,9 @@ pub enum ErrorKind {
 
     #[error(transparent)]
     Git(#[from] uv_git::GitResolverError),
+
+    #[error("The wheel `{0}` is missing Git LFS artifacts.")]
+    MissingGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
 
     #[error("Expected a file URL, but received: {0}")]
     NonFileUrl(DisplaySafeUrl),

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -387,7 +387,7 @@ pub enum ErrorKind {
     Git(#[from] uv_git::GitResolverError),
 
     #[error("The wheel `{0}` is missing Git LFS artifacts.")]
-    MissingGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
+    MissingWheelGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
 
     #[error("Expected a file URL, but received: {0}")]
     NonFileUrl(DisplaySafeUrl),

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -24,7 +24,7 @@ use uv_distribution_types::{
     BuiltDist, File, IndexCapabilities, IndexFormat, IndexLocations, IndexMetadataRef,
     IndexStatusCodeDecision, IndexStatusCodeStrategy, IndexUrl, IndexUrls, Name,
 };
-use uv_git::{GitResolver, Reporter};
+use uv_git::{GIT_LFS, GitError, GitResolver, Reporter};
 use uv_metadata::{read_metadata_async_seek, read_metadata_async_stream};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
@@ -1001,6 +1001,21 @@ impl RegistryClient {
                     )
                     .await
                     .map_err(ErrorKind::Git)?;
+
+                if wheel.git.lfs().enabled() && !fetch.lfs_ready() {
+                    if GIT_LFS.is_err() {
+                        return Err(ErrorKind::MissingGitLfsArtifacts(
+                            wheel.url.to_url(),
+                            GitError::GitLfsNotFound,
+                        )
+                        .into());
+                    }
+                    return Err(ErrorKind::MissingGitLfsArtifacts(
+                        wheel.url.to_url(),
+                        GitError::GitLfsNotConfigured,
+                    )
+                    .into());
+                }
 
                 // Read the metadata.
                 let file = fs_err::tokio::File::open(fetch.path().join(&wheel.install_path))

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1004,13 +1004,13 @@ impl RegistryClient {
 
                 if wheel.git.lfs().enabled() && !fetch.lfs_ready() {
                     if GIT_LFS.is_err() {
-                        return Err(ErrorKind::MissingGitLfsArtifacts(
+                        return Err(ErrorKind::MissingWheelGitLfsArtifacts(
                             wheel.url.to_url(),
                             GitError::GitLfsNotFound,
                         )
                         .into());
                     }
-                    return Err(ErrorKind::MissingGitLfsArtifacts(
+                    return Err(ErrorKind::MissingWheelGitLfsArtifacts(
                         wheel.url.to_url(),
                         GitError::GitLfsNotConfigured,
                     )

--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -382,10 +382,11 @@ impl Display for Requirement {
                 if let Some(reference) = git.reference().as_url_rev() {
                     write!(f, "@{reference}")?;
                 }
-                writeln!(f, "#path={}", install_path.display())?;
+                write!(f, "#path={}", install_path.display())?;
                 if git.lfs().enabled() {
-                    writeln!(f, "&lfs=true")?;
+                    write!(f, "&lfs=true")?;
                 }
+                writeln!(f)?;
             }
             RequirementSource::Path { url, .. } => {
                 write!(f, " @ {url}")?;
@@ -882,10 +883,11 @@ impl Display for RequirementSource {
                 if let Some(reference) = git.reference().as_url_rev() {
                     write!(f, "@{reference}")?;
                 }
-                writeln!(f, "#path={}", install_path.display())?;
+                write!(f, "#path={}", install_path.display())?;
                 if git.lfs().enabled() {
-                    writeln!(f, "&lfs=true")?;
+                    write!(f, "&lfs=true")?;
                 }
+                writeln!(f)?;
             }
             Self::Path { url, .. } => {
                 write!(f, "{url}")?;
@@ -1301,7 +1303,20 @@ mod tests {
 
         assert_eq!(
             source.to_string(),
-            " git+https://github.com/astral-sh/archive-in-git-test#path=archives/iniconfig-2.0.0-py3-none-any.whl\n&lfs=true\n"
+            " git+https://github.com/astral-sh/archive-in-git-test#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true\n"
+        );
+
+        let requirement = Requirement {
+            name: "iniconfig".parse().unwrap(),
+            extras: Box::new([]),
+            groups: Box::new([]),
+            marker: MarkerTree::TRUE,
+            source,
+            origin: None,
+        };
+        assert_eq!(
+            requirement.to_string(),
+            "iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true\n"
         );
     }
 }

--- a/crates/uv-distribution-types/src/requirement.rs
+++ b/crates/uv-distribution-types/src/requirement.rs
@@ -883,6 +883,9 @@ impl Display for RequirementSource {
                     write!(f, "@{reference}")?;
                 }
                 writeln!(f, "#path={}", install_path.display())?;
+                if git.lfs().enabled() {
+                    writeln!(f, "&lfs=true")?;
+                }
             }
             Self::Path { url, .. } => {
                 write!(f, "{url}")?;
@@ -1287,5 +1290,18 @@ mod tests {
         let raw = toml::to_string(&requirement).unwrap();
         let deserialized: Requirement = toml::from_str(&raw).unwrap();
         assert_eq!(requirement, deserialized);
+    }
+
+    #[test]
+    fn display_git_path_lfs() {
+        let source: RequirementSource = toml::from_str(
+            r#"git = "https://github.com/astral-sh/archive-in-git-test?lfs=true&path=archives%2Finiconfig-2.0.0-py3-none-any.whl""#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            source.to_string(),
+            " git+https://github.com/astral-sh/archive-in-git-test#path=archives/iniconfig-2.0.0-py3-none-any.whl\n&lfs=true\n"
+        );
     }
 }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -376,12 +376,12 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
                 if wheel.git.lfs().enabled() && !fetch.lfs_ready() {
                     if GIT_LFS.is_err() {
-                        return Err(Error::MissingGitLfsArtifacts(
+                        return Err(Error::MissingWheelGitLfsArtifacts(
                             wheel.url.to_url(),
                             GitError::GitLfsNotFound,
                         ));
                     }
-                    return Err(Error::MissingGitLfsArtifacts(
+                    return Err(Error::MissingWheelGitLfsArtifacts(
                         wheel.url.to_url(),
                         GitError::GitLfsNotConfigured,
                     ));

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -24,6 +24,7 @@ use uv_distribution_types::{
 };
 use uv_extract::hash::Hasher;
 use uv_fs::write_atomic;
+use uv_git::{GIT_LFS, GitError};
 use uv_install_wheel::validate_and_heal_record;
 use uv_platform_tags::Tags;
 use uv_pypi_types::{HashDigest, HashDigests, PyProjectToml};
@@ -372,6 +373,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         self.reporter.clone().map(<dyn Reporter>::into_git_reporter),
                     )
                     .await?;
+
+                if wheel.git.lfs().enabled() && !fetch.lfs_ready() {
+                    if GIT_LFS.is_err() {
+                        return Err(Error::MissingGitLfsArtifacts(
+                            wheel.url.to_url(),
+                            GitError::GitLfsNotFound,
+                        ));
+                    }
+                    return Err(Error::MissingGitLfsArtifacts(
+                        wheel.url.to_url(),
+                        GitError::GitLfsNotConfigured,
+                    ));
+                }
 
                 let git_sha = fetch.git().precise().expect("Exact commit after checkout");
                 let cache_entry = self.build_context.cache().entry(

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -132,6 +132,8 @@ pub enum Error {
     MissingSubdirectory(DisplaySafeUrl, PathBuf),
     #[error("The source distribution `{0}` is missing Git LFS artifacts.")]
     MissingGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
+    #[error("The wheel `{0}` is missing Git LFS artifacts.")]
+    MissingWheelGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
     #[error("Failed to extract static metadata from `PKG-INFO`")]
     PkgInfo(#[source] uv_pypi_types::MetadataError),
     #[error("The source distribution is missing a `pyproject.toml` file")]

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -131,7 +131,7 @@ pub enum Error {
     #[error("The source distribution `{}` has no subdirectory `{}`", _0, _1.display())]
     MissingSubdirectory(DisplaySafeUrl, PathBuf),
     #[error("The source distribution `{0}` is missing Git LFS artifacts.")]
-    MissingGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
+    MissingSourceDistGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
     #[error("The wheel `{0}` is missing Git LFS artifacts.")]
     MissingWheelGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
     #[error("Failed to extract static metadata from `PKG-INFO`")]

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1610,12 +1610,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Validate that LFS artifacts were fully initialized.
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
             if GIT_LFS.is_err() {
-                return Err(Error::MissingGitLfsArtifacts(
+                return Err(Error::MissingSourceDistGitLfsArtifacts(
                     resource.url.to_url(),
                     GitError::GitLfsNotFound,
                 ));
             }
-            return Err(Error::MissingGitLfsArtifacts(
+            return Err(Error::MissingSourceDistGitLfsArtifacts(
                 resource.url.to_url(),
                 GitError::GitLfsNotConfigured,
             ));
@@ -1964,12 +1964,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Validate that LFS artifacts were fully initialized
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
             if GIT_LFS.is_err() {
-                return Err(Error::MissingGitLfsArtifacts(
+                return Err(Error::MissingSourceDistGitLfsArtifacts(
                     resource.url.to_url(),
                     GitError::GitLfsNotFound,
                 ));
             }
-            return Err(Error::MissingGitLfsArtifacts(
+            return Err(Error::MissingSourceDistGitLfsArtifacts(
                 resource.url.to_url(),
                 GitError::GitLfsNotConfigured,
             ));
@@ -2179,12 +2179,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         // Validate that LFS artifacts were fully initialized
         if resource.git.lfs().enabled() && !fetch.lfs_ready() {
             if GIT_LFS.is_err() {
-                return Err(Error::MissingGitLfsArtifacts(
+                return Err(Error::MissingSourceDistGitLfsArtifacts(
                     resource.url.to_url(),
                     GitError::GitLfsNotFound,
                 ));
             }
-            return Err(Error::MissingGitLfsArtifacts(
+            return Err(Error::MissingSourceDistGitLfsArtifacts(
                 resource.url.to_url(),
                 GitError::GitLfsNotConfigured,
             ));

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1607,6 +1607,20 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
         hashes: HashPolicy<'_>,
     ) -> Result<RevisionHashes, Error> {
+        // Validate that LFS artifacts were fully initialized.
+        if resource.git.lfs().enabled() && !fetch.lfs_ready() {
+            if GIT_LFS.is_err() {
+                return Err(Error::MissingGitLfsArtifacts(
+                    resource.url.to_url(),
+                    GitError::GitLfsNotFound,
+                ));
+            }
+            return Err(Error::MissingGitLfsArtifacts(
+                resource.url.to_url(),
+                GitError::GitLfsNotConfigured,
+            ));
+        }
+
         // Verify that the archive exists.
         let install_path = fetch.path().join(&resource.path);
         if !install_path.is_file() {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -1064,6 +1064,46 @@ fn lock_sdist_git_archive() -> Result<()> {
     Ok(())
 }
 
+/// Reject a Git source archive when Git LFS was requested but could not be initialized.
+#[test]
+#[cfg(feature = "test-git")]
+fn lock_sdist_git_archive_missing_lfs() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = { git = "https://github.com/astral-sh/archive-in-git-test", path = "archives/iniconfig-2.0.0.tar.gz", lfs = true }
+        "#,
+    )?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .lock()
+            .env(EnvVars::UV_INTERNAL__TEST_LFS_DISABLED, "1"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to download and build `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0.tar.gz`
+      ├─▶ The source distribution `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0.tar.gz` is missing Git LFS artifacts.
+      ╰─▶ Git LFS extension not found. Ensure that Git LFS is installed and available.
+    "###
+    );
+
+    Ok(())
+}
+
 /// Lock a Git requirement that points to a pre-built wheel within a repository.
 #[test]
 #[cfg(feature = "test-git")]
@@ -1181,6 +1221,46 @@ fn lock_wheel_git_archive() -> Result<()> {
      + iniconfig==2.0.0 (from git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl)
      + project==0.1.0 (from file://[TEMP_DIR]/)
     "###);
+
+    Ok(())
+}
+
+/// Reject a Git wheel archive when Git LFS was requested but could not be initialized.
+#[test]
+#[cfg(feature = "test-git")]
+fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = { git = "https://github.com/astral-sh/archive-in-git-test", path = "archives/iniconfig-2.0.0-py3-none-any.whl", lfs = true }
+        "#,
+    )?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .lock()
+            .env(EnvVars::UV_INTERNAL__TEST_LFS_DISABLED, "1"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl`
+      ├─▶ The source distribution `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl` is missing Git LFS artifacts.
+      ╰─▶ Git LFS extension not found. Ensure that Git LFS is installed and available.
+    "###
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -1257,7 +1257,7 @@ fn lock_wheel_git_archive_missing_lfs() -> Result<()> {
 
     ----- stderr -----
       × Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl`
-      ├─▶ The source distribution `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl` is missing Git LFS artifacts.
+      ├─▶ The wheel `git+https://github.com/astral-sh/archive-in-git-test#lfs=true&path=archives/iniconfig-2.0.0-py3-none-any.whl` is missing Git LFS artifacts.
       ╰─▶ Git LFS extension not found. Ensure that Git LFS is installed and available.
     "###
     );

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -11089,7 +11089,7 @@ fn sync_git_path_archive_missing_lfs() -> Result<()> {
 
     ----- stderr -----
       × Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true`
-      ├─▶ The source distribution `git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true` is missing Git LFS artifacts.
+      ├─▶ The wheel `git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true` is missing Git LFS artifacts.
       ╰─▶ Git LFS extension not found. Ensure that Git LFS is installed and available.
 
     hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -11025,6 +11025,80 @@ fn sync_git_path_archive() -> Result<()> {
     Ok(())
 }
 
+/// Reject a locked Git wheel archive when Git LFS was requested but could not be initialized.
+#[test]
+#[cfg(feature = "test-git")]
+fn sync_git_path_archive_missing_lfs() -> Result<()> {
+    let context = uv_test::test_context!("3.13");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["iniconfig"]
+
+        [tool.uv.sources]
+        iniconfig = { git = "https://github.com/astral-sh/archive-in-git-test", path = "archives/iniconfig-2.0.0-py3-none-any.whl", lfs = true }
+        "#,
+    )?;
+
+    let lock = context.temp_dir.child("uv.lock");
+    lock.write_str(
+        r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.13"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "foo"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", git = "https://github.com/astral-sh/archive-in-git-test?path=archives%2Finiconfig-2.0.0-py3-none-any.whl&lfs=true" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { git = "https://github.com/astral-sh/archive-in-git-test?path=archives%2Finiconfig-2.0.0-py3-none-any.whl&lfs=true#bb7ce6abf9f90544767701de5b7b0c7802dc642b" }
+        wheels = [
+            { filename = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .sync()
+            .arg("--frozen")
+            .env(EnvVars::UV_INTERNAL__TEST_LFS_DISABLED, "1"),
+        @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × Failed to download `iniconfig @ git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true`
+      ├─▶ The source distribution `git+https://github.com/astral-sh/archive-in-git-test@bb7ce6abf9f90544767701de5b7b0c7802dc642b#path=archives/iniconfig-2.0.0-py3-none-any.whl&lfs=true` is missing Git LFS artifacts.
+      ╰─▶ Git LFS extension not found. Ensure that Git LFS is installed and available.
+
+    hint: `iniconfig` (v2.0.0) was included because `foo` (v0.1.0) depends on `iniconfig`
+    "###
+    );
+
+    Ok(())
+}
+
 /// The project itself is marked as an editable dependency, but under the wrong name. The project
 /// is a package.
 #[test]


### PR DESCRIPTION
## Summary

We now validate Git LFS initialization before reading archives stored within Git repositories, and preserve `lfs = true` when rendering Git archive requirements.

While adding Git archive dependencies in #10072, we added new wheel and source archive paths that bypassed the existing Git-directory LFS check. As a result, when an archive was stored via Git LFS and LFS could not be initialized, we could attempt to consume the pointer file as the archive. The same representation also omitted the LFS fragment from user-facing Git archive requirement output.

This extends the existing LFS failure behavior to Git archive metadata and installation paths, and adds snapshot coverage for locking and frozen sync. The affected integration tests, workspace Clippy, and `prek` pass with the fix.
