### PR TITLE
Update Rust toolchain to 1.96 and MSRV to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 homepage = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"
 authors = ["uv"]

--- a/crates/uv-build/rust-toolchain.toml
+++ b/crates/uv-build/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"

--- a/crates/uv-trampoline/rust-toolchain.toml
+++ b/crates/uv-trampoline/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-11-02"
+channel = "nightly-2025-12-12"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"


### PR DESCRIPTION
## Summary

Update the MSRV to 1.94.0, the pinned Rust toolchain to 1.96.0, and the trampoline nightly toolchain to remain compatible with the new MSRV.
