### PR TITLE
Actually use mold for linking in CI

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -268,6 +268,10 @@ jobs:
     name: "msrv"
     runs-on: github-ubuntu-24.04-x86_64-8
     timeout-minutes: 10
+    env:
+      # Rust 1.90+ uses bundled LLD for x86_64 GNU by default; opt out
+      # so `/usr/bin/ld` resolves to the installed mold linker.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -19,6 +19,10 @@ jobs:
     name: "linux libc"
     timeout-minutes: 10
     runs-on: github-ubuntu-24.04-x86_64-8
+    env:
+      # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
+      # so `/usr/bin/ld` resolves to the installed mold linker.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
       # so `/usr/bin/ld` resolves to the installed mold linker.
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -37,6 +37,8 @@ jobs:
 
       - name: "Build"
         run: cargo build --profile no-debug
+      - name: "Check mold linkage"
+        run: ./scripts/check-mold-linked.sh ./target/no-debug/uv ./target/no-debug/uvx
 
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -51,6 +53,8 @@ jobs:
     name: "linux aarch64"
     timeout-minutes: 10
     runs-on: github-ubuntu-24.04-aarch64-4
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -65,6 +69,8 @@ jobs:
 
       - name: "Build"
         run: cargo build --profile no-debug
+      - name: "Check mold linkage"
+        run: ./scripts/check-mold-linked.sh ./target/no-debug/uv ./target/no-debug/uvx
 
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -100,7 +106,10 @@ jobs:
       - name: "Build"
         env:
           CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
+          CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
         run: cargo build --profile no-debug --target armv7-unknown-linux-gnueabihf --bin uv --bin uvx
+      - name: "Check mold linkage"
+        run: ./scripts/check-mold-linked.sh ./target/armv7-unknown-linux-gnueabihf/no-debug/uv ./target/armv7-unknown-linux-gnueabihf/no-debug/uvx
 
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -115,6 +124,8 @@ jobs:
     name: "linux musl"
     timeout-minutes: 10
     runs-on: github-ubuntu-24.04-x86_64-8
+    env:
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -134,6 +145,8 @@ jobs:
 
       - name: "Build"
         run: cargo build --profile no-debug --target x86_64-unknown-linux-musl --bin uv --bin uvx
+      - name: "Check mold linkage"
+        run: ./scripts/check-mold-linked.sh ./target/x86_64-unknown-linux-musl/no-debug/uv ./target/x86_64-unknown-linux-musl/no-debug/uvx
 
       - name: "Upload binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -271,7 +284,7 @@ jobs:
     env:
       # Rust 1.90+ uses bundled LLD for x86_64 GNU by default; opt out
       # so `/usr/bin/ld` resolves to the installed mold linker.
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -293,6 +306,7 @@ jobs:
       - run: cargo +${MSRV} build --profile no-debug
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
+      - run: ./scripts/check-mold-linked.sh ./target/no-debug/uv ./target/no-debug/uvx
       - run: ./target/no-debug/uv --version
 
   build-binary-android-aarch64:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -333,10 +333,10 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: depot-ubuntu-latest-4
     env:
-      # Rust's distributed x86 GNU targets use bundled LLD by default; opt out
+      # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
       # and select installed mold within the manylinux GCC linker search path.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
-      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -332,6 +332,10 @@ jobs:
   linux:
     name: ${{ matrix.target }}
     runs-on: depot-ubuntu-latest-4
+    env:
+      # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
+      # so `/usr/bin/ld` resolves to the installed mold linker.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -458,6 +458,7 @@ jobs:
             fi
             scripts/install-cargo-extensions.sh
         env:
+          CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -433,10 +433,29 @@ jobs:
         with:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
+          # Cross compile i686 from the 64-bit container so the host-native mold binary can run.
+          container: quay.io/pypa/manylinux2014
           manylinux: 2_17
           docker-options: -e CARGO
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
+            # If we're running on rhel centos, install needed packages.
+            if command -v yum &> /dev/null; then
+                yum update -y && yum install -y pkgconfig libatomic
+
+                # Install cross build requirements
+                if [[ "${{ matrix.target }}" == "i686-unknown-linux-gnu" ]]; then
+                  yum install -y glibc-devel.i686 libstdc++-devel.i686 libatomic.i686
+                fi
+
+                # Symlink libatomic so the linker can find it with -latomic.
+                if [[ -f "/usr/lib/libatomic.so.1" && ! -f "/usr/lib/libatomic.so" ]]; then
+                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
+                fi
+            else
+                # If we're running on debian-based system.
+                apt update -y && apt-get install -y pkg-config
+            fi
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -386,6 +386,9 @@ jobs:
                 # If we're running on debian-based system.
                 apt update -y && apt-get install -y pkg-config
             fi
+            if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
+                scripts/install-mold.sh
+            fi
             # Install cargo extensions as a static musl binary so it runs in any container.
             scripts/install-cargo-extensions.sh
         env:
@@ -434,6 +437,9 @@ jobs:
           docker-options: -e CARGO
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
+            if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
+                scripts/install-mold.sh
+            fi
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -336,6 +336,7 @@ jobs:
       # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
       # and select installed mold within the manylinux GCC linker search path.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER: gcc
       CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -336,6 +336,7 @@ jobs:
       # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
       # and select installed mold within the manylinux GCC linker search path.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         include:
@@ -386,9 +387,6 @@ jobs:
                 # If we're running on debian-based system.
                 apt update -y && apt-get install -y pkg-config
             fi
-            if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
-                scripts/install-mold.sh
-            fi
             # Install cargo extensions as a static musl binary so it runs in any container.
             scripts/install-cargo-extensions.sh
         env:
@@ -415,6 +413,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -437,9 +436,6 @@ jobs:
           docker-options: -e CARGO
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
-            if [ "${{ matrix.target }}" = "x86_64-unknown-linux-gnu" ]; then
-                scripts/install-mold.sh
-            fi
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
@@ -449,6 +445,8 @@ jobs:
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
           ${MODULE_NAME}-build --help
           python -m ${MODULE_NAME}_build --help
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -459,6 +457,10 @@ jobs:
     name: ${{ matrix.platform.target }}
     runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 30
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         platform:
@@ -535,6 +537,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -578,6 +581,8 @@ jobs:
           env: |
             PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
             MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -589,6 +594,8 @@ jobs:
     name: ${{ matrix.platform.target }}
     timeout-minutes: 30
     runs-on: depot-ubuntu-latest-4
+    env:
+      CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         platform:
@@ -657,6 +664,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -700,6 +708,8 @@ jobs:
           env: |
             PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
             MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -710,6 +720,8 @@ jobs:
   linux-powerpc:
     name: ${{ matrix.platform.target }}
     runs-on: depot-ubuntu-24.04-4
+    env:
+      CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         platform:
@@ -778,6 +790,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -810,6 +823,8 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
       # TODO(charlie): Re-enable testing for PPC wheels.
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -821,6 +836,8 @@ jobs:
     name: ${{ matrix.platform.target }}
     timeout-minutes: 30
     runs-on: depot-ubuntu-latest-4
+    env:
+      CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         platform:
@@ -885,6 +902,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -929,6 +947,8 @@ jobs:
           env: |
             PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
             MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -938,6 +958,9 @@ jobs:
   musllinux:
     name: ${{ matrix.target }}
     runs-on: depot-ubuntu-24.04-4
+    env:
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         target:
@@ -995,6 +1018,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/release/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -1032,6 +1056,8 @@ jobs:
             # TODO(konsti): Enable this test on all platforms, currently `find_uv_bin` is failing to discover uv here.
             # .venv/bin/python -m ${MODULE_NAME}_build --help;
           "
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1042,7 +1068,9 @@ jobs:
     name: ${{ matrix.platform.target }}
     runs-on: depot-ubuntu-24.04-8
     env:
-      CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static"
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         platform:
@@ -1133,6 +1161,7 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/$PROFILE/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/$PROFILE/uvx $ARCHIVE_NAME/uvx
+          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -1196,6 +1225,8 @@ jobs:
           env: |
             PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
             MODULE_NAME: ${{ env.MODULE_NAME }}
+      - name: "Check mold linkage uv-build"
+        run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -334,8 +334,8 @@ jobs:
     runs-on: depot-ubuntu-latest-4
     env:
       # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
-      # so `/usr/bin/ld` resolves to the installed mold linker.
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+      # and select installed mold within the manylinux GCC linker search path.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -333,10 +333,10 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: depot-ubuntu-latest-4
     env:
-      # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
+      # Rust's distributed x86 GNU targets use bundled LLD by default; opt out
       # and select installed mold within the manylinux GCC linker search path.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
-      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1071,7 +1071,7 @@ jobs:
     env:
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
       CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUSTFLAGS: "-C link-arg=-B/usr/local/libexec/mold"
-      CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-B/usr/local/libexec/mold"
+      CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static"
     strategy:
       matrix:
         platform:
@@ -1107,7 +1107,7 @@ jobs:
           docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
           before-script-linux: |
-            scripts/install-cargo-extensions.sh
+            UV_NO_INSTALL_MOLD=${{ matrix.platform.arch == 'riscv64' && '1' || '' }} scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
       # TODO(zanieb): Find an alternative for this action; it uses EOL Node 20
@@ -1162,7 +1162,9 @@ jobs:
           mkdir -p $ARCHIVE_NAME
           cp target/$TARGET/$PROFILE/uv $ARCHIVE_NAME/uv
           cp target/$TARGET/$PROFILE/uvx $ARCHIVE_NAME/uvx
-          scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
+          if [[ "${{ matrix.platform.arch }}" != "riscv64" ]]; then
+            scripts/check-mold-linked.sh $ARCHIVE_NAME/uv $ARCHIVE_NAME/uvx
+          fi
           tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
           shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
@@ -1187,7 +1189,7 @@ jobs:
           docker-options: -e CARGO ${{ matrix.platform.maturin_docker_options }}
           rust-toolchain: ${{ matrix.platform.toolchain || null }}
           before-script-linux: |
-            scripts/install-cargo-extensions.sh
+            UV_NO_INSTALL_MOLD=${{ matrix.platform.arch == 'riscv64' && '1' || '' }} scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
       # TODO(zanieb): Find an alternative for this action; it uses EOL Node 20
@@ -1227,6 +1229,7 @@ jobs:
             PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
             MODULE_NAME: ${{ env.MODULE_NAME }}
       - name: "Check mold linkage uv-build"
+        if: matrix.platform.arch != 'riscv64'
         run: scripts/check-mold-linked.sh crates/uv-build/dist/*.whl
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
             [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
-            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" ]] && release_build_changed=1
+            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" || "$file" == "scripts/install-cargo-extensions.sh" || "$file" == "scripts/install-mold.sh" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1
             [[ "$file" =~ ^crates/uv-publish/ || "$file" =~ ^scripts/publish/ || "$file" == "crates/uv/src/commands/publish.rs" ]] && publish_code_changed=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
             [[ "$file" == ".github/workflows/build-release-binaries.yml" || "$file" == ".github/workflows/release.yml" ]] && release_workflow_changed=1
-            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" || "$file" == "scripts/install-cargo-extensions.sh" || "$file" == "scripts/install-mold.sh" ]] && release_build_changed=1
+            [[ "$file" == "scripts/check_uv_wheel_contents.py" || "$file" == "scripts/patch-dist-manifest-checksums.py" || "$file" == "scripts/repair-sdist-cargo-lock.py" || "$file" == "scripts/check-mold-linked.sh" || "$file" == "scripts/install-cargo-extensions.sh" || "$file" == "scripts/install-mold.sh" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "uv.schema.json" ]] && schema_changed=1
             [[ "$file" =~ ^crates/uv-publish/ || "$file" =~ ^scripts/publish/ || "$file" == "crates/uv/src/commands/publish.rs" ]] && publish_code_changed=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
       # so `/usr/bin/ld` resolves to the installed mold linker.
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld -C link-arg=-B/usr/local/libexec/mold"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
     timeout-minutes: 10
     runs-on: depot-ubuntu-24.04-16
     name: "cargo test on linux"
+    env:
+      # Rust's distributed x86_64 GNU target uses bundled LLD by default; opt out
+      # so `/usr/bin/ld` resolves to the installed mold linker.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C linker-features=-lld"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/scripts/check-mold-linked.sh
+++ b/scripts/check-mold-linked.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+## Verify that release executables were linked with mold.
+
+set -eu
+
+for artifact in "$@"; do
+    case "$artifact" in
+        *.whl)
+            if ! unzip -p "$artifact" '*.data/scripts/uv-build' | grep -aFq 'mold '; then
+                echo "Expected $artifact to contain an executable linked with mold" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            if ! grep -aFq 'mold ' "$artifact"; then
+                echo "Expected $artifact to be linked with mold" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -13,6 +13,14 @@
 
 set -eu
 
+if [ "$(uname -s 2>/dev/null)" = "Linux" ]; then
+    # mold does not publish 32-bit x86 Linux binaries.
+    case "$(uname -m 2>/dev/null)" in
+        i?86) ;;
+        *) scripts/install-mold.sh ;;
+    esac
+fi
+
 CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
     --locked \
     --version 0.7.4"

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -17,14 +17,6 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
     --locked \
     --version 0.7.4"
 
-if [ "$(uname -s 2>/dev/null)" = "Linux" ]; then
-    # mold does not publish 32-bit x86 Linux binaries.
-    case "$(uname -m 2>/dev/null)" in
-        i?86) ;;
-        *) scripts/install-mold.sh ;;
-    esac
-fi
-
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in
 # musl-based environments (Alpine, etc.).
 #

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -17,6 +17,10 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
     --locked \
     --version 0.7.4"
 
+if [ "$(uname -s 2>/dev/null)" = "Linux" ]; then
+    scripts/install-mold.sh
+fi
+
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in
 # musl-based environments (Alpine, etc.).
 #

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -18,7 +18,11 @@ CARGO_AUDITABLE_INSTALL="cargo install cargo-auditable \
     --version 0.7.4"
 
 if [ "$(uname -s 2>/dev/null)" = "Linux" ]; then
-    scripts/install-mold.sh
+    # mold does not publish 32-bit x86 Linux binaries.
+    case "$(uname -m 2>/dev/null)" in
+        i?86) ;;
+        *) scripts/install-mold.sh ;;
+    esac
 fi
 
 # In Linux containers running on x86_64, build a static musl binary so the installed tool works in

--- a/scripts/install-cargo-extensions.sh
+++ b/scripts/install-cargo-extensions.sh
@@ -13,7 +13,7 @@
 
 set -eu
 
-if [ "$(uname -s 2>/dev/null)" = "Linux" ]; then
+if [ "$(uname -s 2>/dev/null)" = "Linux" ] && [ "${UV_NO_INSTALL_MOLD:-}" != "1" ]; then
     # mold does not publish 32-bit x86 Linux binaries.
     case "$(uname -m 2>/dev/null)" in
         i?86) ;;

--- a/scripts/install-mold.sh
+++ b/scripts/install-mold.sh
@@ -19,13 +19,10 @@ fi
 
 echo "Installing mold ${MOLD_VERSION} (${arch})..."
 
-wget -O- \
-    --timeout=10 \
-    --tries=5 \
-    --waitretry=3 \
-    --retry-connrefused \
-    --retry-on-http-error=429,500,502,503,504 \
-    --progress=dot:mega \
+curl --fail --location \
+    --connect-timeout 10 \
+    --retry 5 \
+    --retry-delay 3 \
     "$url" \
     | $SUDO tar -C /usr/local --strip-components=1 --no-overwrite-dir -xzf -
 


### PR DESCRIPTION
Rust 1.90 switched `x86_64-unknown-linux-gnu` to bundled LLD by default, so merely installing mold no longer selects it. This PR opts out of bundled LLD for x86_64 Linux CI and explicitly routes the mold-enabled Linux release builds through mold. It also checks the linked artifacts for mold's `.comment` marker so installing mold without using it fails CI.

`riscv64gc-unknown-linux-musl` remains intentionally excluded: mold cannot link its self-contained CRT object. The `i686-unknown-linux-gnu` `uv-build` wheel is cross-compiled from the 64-bit manylinux container so the host-native mold binary can run.

## Observed release timings

These are GitHub Actions job elapsed times, not isolated linker benchmarks. The table compares averages from three retained pre-routing reference runs ([1](https://github.com/astral-sh/uv/actions/runs/26662071685/attempts/2), [2](https://github.com/astral-sh/uv/actions/runs/26686860912/attempts/2), [3](https://github.com/astral-sh/uv/actions/runs/26689595822)) with three current-head runs ([1](https://github.com/astral-sh/uv/actions/runs/26780905627/attempts/1), [2](https://github.com/astral-sh/uv/actions/runs/26780905627/attempts/2), [3](https://github.com/astral-sh/uv/actions/runs/26780905627/attempts/3)), filtered to Linux release jobs where explicit routing changed the emitted artifact to use mold. The repaired runs also install mold in cross containers and verify the emitted artifacts, so treat these as observed CI costs rather than linker-only measurements.

`x86_64-unknown-linux-gnu` is excluded because its retained before artifacts were already linked with mold. `riscv64gc-unknown-linux-musl` is excluded because mold cannot link its self-contained CRT object.

| Target | Before avg (`n=3`) | Before range | With mold avg (`n=3`) | With mold range | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `aarch64-unknown-linux-gnu` | `11:00` | `10:59-11:02` | `12:56` | `11:13-14:02` | `+17.57%` |
| `aarch64-unknown-linux-musl` | `11:39` | `11:36-11:43` | `13:25` | `11:35-14:29` | `+15.17%` |
| `arm-unknown-linux-musleabihf` | `10:19` | `10:14-10:26` | `12:24` | `12:18-12:29` | `+20.25%` |
| `armv7-unknown-linux-gnueabihf` | `10:29` | `10:22-10:40` | `13:11` | `12:39-14:03` | `+25.74%` |
| `armv7-unknown-linux-musleabihf` | `9:56` | `9:52-10:01` | `11:46` | `9:57-13:13` | `+18.40%` |
| `i686-unknown-linux-musl` | `10:43` | `10:35-10:58` | `11:40` | `10:44-13:17` | `+8.92%` |
| `powerpc64le-unknown-linux-gnu` | `11:26` | `11:17-11:35` | `12:36` | `11:16-13:28` | `+10.15%` |
| `riscv64gc-unknown-linux-gnu` | `12:15` | `12:04-12:21` | `13:46` | `12:19-15:13` | `+12.43%` |
| `s390x-unknown-linux-gnu` | `12:31` | `12:09-12:57` | `14:02` | `12:28-14:53` | `+12.02%` |
| `x86_64-unknown-linux-musl` | `11:01` | `10:28-11:40` | `11:30` | `10:40-12:44` | `+4.39%` |
| **Comparable total** | **`1:51:20`** | **`1:49:47-1:52:25`** | **`2:07:16`** | **`1:59:17-2:17:48`** | **`+14.32%`** |

The `i686-unknown-linux-gnu` wheel needed a later cross-compilation fix, so it is reported separately:

| Target | Before avg (`n=3`) | Before range | Current head with mold avg (`n=3`) | Current head range | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `i686-unknown-linux-gnu` | `11:04` | `10:57-11:09` | `13:08` | `12:37-13:49` | `+18.72%` |

## Observed non-release timings

These are also GitHub Actions job elapsed times, not isolated linker benchmarks. The reference averages use eight nearby successful `main` pushes with warm caches. A ninth reference run is excluded from the averages because every development build reported `No cache found`.

The current-head averages use full-match cache restores from repeated current-head runs. Cold-cache and fallback-cache samples are excluded. Every row has at least three admitted samples; rows with additional full-match restores retain them. Repeated current-head reruns can reuse exact artifacts more thoroughly than nearby `main` commits, so treat the deltas as workload observations rather than isolated mold costs.

| Job | Warm reference avg (`n=8`) | Warm reference range | Warm current-head avg (`n>=3`) | Warm current-head range | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `test / cargo test on linux` | `4:39` | `3:40-6:08` | `4:12` | `3:36-5:01` | `-9.7%` |
| `build-dev-binaries / linux libc` | `1:14` | `1:05-1:32` | `1:15` | `1:11-1:19` | `+2.0%` |
| `build-dev-binaries / linux aarch64` | `1:21` | `1:10-1:31` | `1:07` | `1:03-1:12` | `-16.8%` |
| `build-dev-binaries / linux armv7 gnueabihf` | `2:12` | `1:53-2:31` | `2:01` | `1:22-2:27` | `-8.7%` |
| `build-dev-binaries / linux musl` | `1:50` | `1:26-2:13` | `1:28` | `1:11-1:41` | `-19.9%` |
| `build-dev-binaries / msrv` | `1:20` | `1:17-1:25` | `1:20` | `1:17-1:23` | `-0.6%` |

## Artifact size

Across the 12 mold-enabled Linux release archives, the retained same-base comparison is `280,497,102 -> 281,759,338` bytes: `+1,262,236` bytes (`+0.4500%`). This full coverage aggregate includes `x86_64-unknown-linux-gnu`, whose retained before artifact was already linked with mold, and excludes the intentional no-mold `riscv64gc-unknown-linux-musl` lane.
