### PR TITLE
Use ICF in macOS release builds to reduce binary sizes

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -343,8 +343,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
-          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
+          - target: "i686-unknown-linux-gnu"
+            cc: "gcc -m32"
+            rustflags: ""
+          - target: "x86_64-unknown-linux-gnu"
+            cc: "gcc"
+            # GNU ld.bfd does not support safe ICF. Use the installed mold
+            # linker for identical code folding in release artifacts.
+            rustflags: "-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -395,8 +401,7 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions where the release container opts into mold.
-          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe' || '' }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -443,8 +448,7 @@ jobs:
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions where the release container opts into mold.
-          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe' || '' }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
           # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces macOS binary sizes by up to ~2%.
+          # ICF reduces the macOS x86_64 uv binary size by ~2%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -149,7 +149,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
           # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces macOS binary sizes by up to ~2%.
+          # ICF reduces the macOS x86_64 uv-build binary size by ~0.7%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -186,7 +186,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
           # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces macOS binary sizes by up to ~2%.
+          # ICF reduces the macOS aarch64 uv binary size by ~1.4%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
@@ -228,7 +228,7 @@ jobs:
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
           # Use Rust's bundled Mach-O LLD, which supports ICF.
-          # ICF reduces macOS binary sizes by up to ~2%.
+          # ICF reduces the macOS aarch64 uv-build binary size by ~0.7%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -343,8 +343,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
-          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
+          - target: "i686-unknown-linux-gnu"
+            cc: "gcc -m32"
+            rustflags: ""
+          - target: "x86_64-unknown-linux-gnu"
+            cc: "gcc"
+            # Rust's distributed x86_64 GNU target uses bundled LLD by default.
+            rustflags: "-C link-arg=-Wl,--icf=safe"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -368,7 +373,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e RUSTFLAGS
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -395,6 +400,7 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -435,12 +441,13 @@ jobs:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e RUSTFLAGS
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -112,6 +112,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -145,6 +147,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -179,6 +183,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -218,6 +224,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -360,7 +368,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e RUSTFLAGS
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -387,6 +395,8 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions where the release container opts into mold.
+          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe' || '' }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -427,12 +437,14 @@ jobs:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO
+          docker-options: -e CARGO -e RUSTFLAGS
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
+          # Fold identical functions where the release container opts into mold.
+          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe' || '' }}
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -112,8 +112,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -147,8 +147,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -183,8 +183,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -224,8 +224,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
+          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -395,8 +395,8 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Rust's distributed x86_64 GNU target uses bundled LLD by default.
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
+          # Baseline measurement: Rust's distributed x86_64 GNU target uses bundled LLD by default.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -443,7 +443,7 @@ jobs:
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -343,13 +343,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: "i686-unknown-linux-gnu"
-            cc: "gcc -m32"
-            rustflags: ""
-          - target: "x86_64-unknown-linux-gnu"
-            cc: "gcc"
-            # Rust's distributed x86_64 GNU target uses bundled LLD by default.
-            rustflags: "-C link-arg=-Wl,--icf=safe"
+          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
+          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -373,7 +368,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO -e RUSTFLAGS
+          docker-options: -e CARGO -e CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -400,7 +395,8 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          RUSTFLAGS: ${{ matrix.rustflags }}
+          # Rust's distributed x86_64 GNU target uses bundled LLD by default.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -441,13 +437,13 @@ jobs:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO -e RUSTFLAGS
+          docker-options: -e CARGO -e CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          RUSTFLAGS: ${{ matrix.rustflags }}
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -112,7 +112,7 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -147,7 +147,7 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -183,7 +183,7 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
@@ -224,7 +224,7 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
@@ -368,7 +368,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO -e CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
+          docker-options: -e CARGO
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -395,8 +395,6 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Rust's distributed x86_64 GNU target uses bundled LLD by default.
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -437,13 +435,12 @@ jobs:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO -e CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS
+          docker-options: -e CARGO
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -112,8 +112,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -147,8 +147,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -183,8 +183,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall
@@ -224,8 +224,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Baseline measurement: use Rust's bundled Mach-O LLD without ICF.
-          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld"
+          # Fold identical functions with Rust's bundled Mach-O LLD in optimized artifacts.
+          RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
           pip install ${PACKAGE_NAME}_build --no-index --find-links crates/uv-build/dist --force-reinstall
@@ -395,8 +395,8 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # Baseline measurement: Rust's distributed x86_64 GNU target uses bundled LLD by default.
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
+          # Rust's distributed x86_64 GNU target uses bundled LLD by default.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -443,7 +443,7 @@ jobs:
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-Wl,--icf=safe"
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -343,14 +343,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: "i686-unknown-linux-gnu"
-            cc: "gcc -m32"
-            rustflags: ""
-          - target: "x86_64-unknown-linux-gnu"
-            cc: "gcc"
-            # GNU ld.bfd does not support safe ICF. Use the installed mold
-            # linker for identical code folding in release artifacts.
-            rustflags: "-C link-arg=-B/usr/local/libexec/mold -C link-arg=-Wl,--icf=safe"
+          - { target: "i686-unknown-linux-gnu", cc: "gcc -m32" }
+          - { target: "x86_64-unknown-linux-gnu", cc: "gcc" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -374,7 +368,7 @@ jobs:
           # from 64-bit version of the container, breaking the pattern from other builds.
           container: quay.io/pypa/manylinux2014
           manylinux: 2_17
-          docker-options: -e CARGO -e RUSTFLAGS
+          docker-options: -e CARGO
           args: --release --locked --out dist --features self-update --compatibility pypi
           before-script-linux: |
             # Install the 32-bit cross target on 64-bit (noop if we're already on 64-bit)
@@ -401,7 +395,6 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -442,13 +435,12 @@ jobs:
           maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: 2_17
-          docker-options: -e CARGO -e RUSTFLAGS
+          docker-options: -e CARGO
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
           before-script-linux: |
             scripts/install-cargo-extensions.sh
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          RUSTFLAGS: ${{ matrix.rustflags }}
       - name: "Test wheel uv-build"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -112,7 +112,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
+          # Use Rust's bundled Mach-O LLD, which supports ICF.
+          # ICF reduces macOS binary sizes by up to ~2%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -147,7 +148,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
+          # Use Rust's bundled Mach-O LLD, which supports ICF.
+          # ICF reduces macOS binary sizes by up to ~2%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Upload wheels uv-build"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -183,7 +185,8 @@ jobs:
           args: --release --locked --out dist --features self-update --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
+          # Use Rust's bundled Mach-O LLD, which supports ICF.
+          # ICF reduces macOS binary sizes by up to ~2%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |
@@ -224,7 +227,8 @@ jobs:
           args: --profile minimal-size --locked --out crates/uv-build/dist -m crates/uv-build/Cargo.toml --compatibility pypi
         env:
           CARGO: ${{ github.workspace }}/scripts/cargo.sh
-          # ICF only produced useful size wins on macOS, so use Rust's bundled Mach-O LLD here.
+          # Use Rust's bundled Mach-O LLD, which supports ICF.
+          # ICF reduces macOS binary sizes by up to ~2%.
           RUSTFLAGS: "-C linker=rust-lld -C linker-flavor=ld64.lld -C link-arg=--icf=safe"
       - name: "Test wheel - aarch64"
         run: |


### PR DESCRIPTION
Inspired by https://github.com/denoland/deno/pull/34478

Use `--icf=safe` for optimized macOS release artifacts, via Rust's bundled Mach-O LLD.

Measurements showed useful size wins on macOS; Linux did not show a meaningful artifact-size improvement and are excluded here. See https://github.com/astral-sh/uv/pull/19615#issuecomment-4651558036
