### PR TITLE
fix(requirements): detect uv lockfiles in -r and show actionable error

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -108,6 +108,15 @@ impl RequirementsSource {
                 "The file `{}` appears to be a TOML file, but requirements must be specified in `requirements.txt` format",
                 path.user_display(),
             ));
+        } else if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("lock"))
+        {
+            return Err(anyhow::anyhow!(
+                "The file `{}` appears to be a uv lockfile, not a `requirements.txt` file. \
+                Use `uv export --output-file requirements.txt` to generate a requirements file from the lockfile.",
+                path.user_display(),
+            ));
         }
         Ok(Self::RequirementsTxt(path))
     }
@@ -144,6 +153,15 @@ impl RequirementsSource {
                 "The file `{}` appears to be a TOML file, but constraints must be specified in `requirements.txt` format",
                 path.user_display(),
             ));
+        } else if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("lock"))
+        {
+            return Err(anyhow::anyhow!(
+                "The file `{}` appears to be a uv lockfile, not a `requirements.txt` file. \
+                Use `uv export --output-file requirements.txt` to generate a requirements file from the lockfile.",
+                path.user_display(),
+            ));
         }
         Ok(Self::RequirementsTxt(path))
     }
@@ -178,6 +196,15 @@ impl RequirementsSource {
         {
             return Err(anyhow::anyhow!(
                 "The file `{}` appears to be a TOML file, but overrides must be specified in `requirements.txt` format",
+                path.user_display(),
+            ));
+        } else if path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("lock"))
+        {
+            return Err(anyhow::anyhow!(
+                "The file `{}` appears to be a uv lockfile, not a `requirements.txt` file. \
+                Use `uv export --output-file requirements.txt` to generate a requirements file from the lockfile.",
                 path.user_display(),
             ));
         }


### PR DESCRIPTION
## Summary

Fixes #16192.

When a user passes a `.lock` file to `-r` (e.g. `uv pip install -r action.py.lock`),
uv tries to parse it as a requirements.txt file and emits a confusing pep508 error:

```
error: Couldn't parse requirement in `action.py.lock` at position 0
  Caused by: no such comparison operator "=", must be one of ~= == != <= >= < > ===
version = 1
        ^^^
```

This PR adds a `.lock` extension check to `from_requirements_txt`,
`from_constraints_txt`, and `from_overrides_txt`, matching the existing
pattern for `pyproject.toml`, `setup.cfg`, and `pylock.toml` files.

## New error message

```
error: The file `action.py.lock` appears to be a uv lockfile, not a `requirements.txt` file.
Use `uv export --output-file requirements.txt` to generate a requirements file from the lockfile.
```

## Changes

`crates/uv-requirements/src/sources.rs`:
- Added `.lock` extension detection in three `from_*_txt` functions

## Test plan

- [ ] `uv pip install -r uv.lock` → new clear error message
- [ ] `uv pip install -r requirements.txt` → no regression
- [ ] `uv pip install -r pyproject.toml` → existing TOML error unchanged