### PR TITLE
Added support for NO_PROGRESS environment flag

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -100,7 +100,7 @@ The documentation is divided into:
 1. All CLI output must be interpretable and understandable _without_ the use of color and other
    styling. (For example: even if a command is rendered in green, wrap it in backticks.)
 1. `NO_COLOR` must be respected when using any colors or styling.
-1. `UV_NO_PROGRESS` must be respected when using progress-styling like bars or spinners.
+1. `NO_PROGRESS` and `UV_NO_PROGRESS` must be respected when using progress-styling like bars or spinners.
 1. In general, use:
    - Green for success.
    - Red for error.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -345,7 +345,7 @@ pub struct GlobalArgs {
     #[arg(global = true, long, hide = true)]
     pub show_settings: bool,
 
-    /// Hide all progress outputs [env: UV_NO_PROGRESS=]
+    /// Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
     ///
     /// For example, spinners or progress bars.
     #[arg(global = true, long, value_parser = clap::builder::BoolishValueParser::new())]

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -711,6 +711,17 @@ impl EnvFlag {
             env_var,
         })
     }
+
+    /// Create a new [`EnvFlag`] by parsing a given environment variable and fallback.
+    pub fn coalesce(env_var: &'static str, fallback: &'static str) -> Result<Self, Error> {
+        let left = parse_boolish_environment_variable(env_var)?.unwrap_or(false);
+        let right = parse_boolish_environment_variable(fallback)?.unwrap_or(false);
+
+        Ok(Self {
+            value: Some(left || right),
+            env_var,
+        })
+    }
 }
 
 /// Options loaded from environment variables.
@@ -848,7 +859,7 @@ impl EnvironmentOptions {
             system_certs: EnvFlag::new(EnvVars::UV_SYSTEM_CERTS)?,
             preview: EnvFlag::new(EnvVars::UV_PREVIEW)?,
             isolated: EnvFlag::new(EnvVars::UV_ISOLATED)?,
-            no_progress: EnvFlag::new(EnvVars::UV_NO_PROGRESS)?,
+            no_progress: EnvFlag::coalesce(EnvVars::NO_PROGRESS, EnvVars::UV_NO_PROGRESS)?,
             no_installer_metadata: EnvFlag::new(EnvVars::UV_NO_INSTALLER_METADATA)?,
             dev: EnvFlag::new(EnvVars::UV_DEV)?,
             no_dev: EnvFlag::new(EnvVars::UV_NO_DEV)?,

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -872,6 +872,13 @@ impl EnvVars {
     #[attr_added_in("0.2.7")]
     pub const NO_COLOR: &'static str = "NO_COLOR";
 
+    /// Equivalent to the `--no-progress` command-line argument. Disables all progress output. For
+    /// example, spinners and progress bars.
+    ///
+    /// See [no-progress.org](https://no-progress.org).
+    #[attr_added_in("0.11.17")]
+    pub const NO_PROGRESS: &'static str = "NO_PROGRESS";
+
     /// Forces colored output regardless of terminal support.
     ///
     /// See [force-color.org](https://force-color.org).

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -67,7 +67,7 @@ fn help() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -150,7 +150,7 @@ fn help_flag() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -233,7 +233,7 @@ fn help_short_flag() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -296,7 +296,7 @@ fn help_flag_workspace() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -474,7 +474,7 @@ fn help_subcommand() {
 
               For example, spinners or progress bars.
 
-              [env: UV_NO_PROGRESS=]
+              [env: NO_PROGRESS=,UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
@@ -758,7 +758,7 @@ fn help_subsubcommand() {
 
               For example, spinners or progress bars.
 
-              [env: UV_NO_PROGRESS=]
+              [env: NO_PROGRESS=,UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
@@ -856,7 +856,7 @@ fn help_flag_subcommand() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -940,7 +940,7 @@ fn help_flag_subsubcommand() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -1111,7 +1111,7 @@ fn help_with_global_option() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>
@@ -1236,7 +1236,7 @@ fn help_with_no_pager() {
           --allow-insecure-host <ALLOW_INSECURE_HOST>
               Allow insecure connections to a host [env: UV_INSECURE_HOST=]
           --no-progress
-              Hide all progress outputs [env: UV_NO_PROGRESS=]
+              Hide all progress outputs [env: NO_PROGRESS=,UV_NO_PROGRESS=]
           --directory <DIRECTORY>
               Change to the given directory prior to running the command [env: UV_WORKING_DIR=]
           --project <PROJECT>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR proposes adding support for the [`NO_PROGRESS`](https://no-progress.org/) environment variable. For more information regarding why this PR was submitted, see the feature request: [19411](https://github.com/astral-sh/uv/issues/19411)

## Test Plan

It was tested similar to the original `UV_NO_PROGRESS` environment variable as it is interchangeable.
