### PR TITLE
Continue tool uninstall after dangling receipts

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -137,11 +137,12 @@ async fn do_uninstall(
                 // If the tool is not installed properly, attempt to remove the environment anyway.
                 match installed_tools.remove_environment(&name) {
                     Ok(()) => {
+                        dangling = true;
                         writeln!(
                             printer.stderr(),
                             "Removed dangling environment for `{name}`"
                         )?;
-                        return Ok(());
+                        continue;
                     }
                     Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
                         if err.kind() == std::io::ErrorKind::NotFound =>

--- a/crates/uv/tests/it/tool_uninstall.rs
+++ b/crates/uv/tests/it/tool_uninstall.rs
@@ -161,6 +161,56 @@ fn tool_uninstall_missing_receipt() {
 }
 
 #[test]
+fn tool_uninstall_multiple_names_with_missing_receipt() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    context
+        .tool_install()
+        .arg("ruff==0.3.4")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    fs_err::remove_file(tool_dir.join("black").join("uv-receipt.toml")).unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black").arg("ruff")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed dangling environment for `black`
+    Uninstalled 1 executable: ruff
+    ");
+
+    // After uninstalling both tools, neither should be listed.
+    uv_snapshot!(context.filters(), context.tool_list()
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    No tools installed
+    ");
+}
+
+#[test]
 fn tool_uninstall_all_missing_receipt() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");


### PR DESCRIPTION
## Summary

Fixes #19219.

When uninstalling explicitly named tools, a missing receipt currently falls back to removing the dangling environment and then returns immediately. That skips any later tool names in the same command. This changes that path to match the multi-tool flow by recording that a dangling environment was removed and continuing to the next requested tool.

## Test Plan

- cargo fmt --check
- cargo test -p uv --test it tool_uninstall_multiple_names_with_missing_receipt
- cargo test -p uv --test it tool_uninstall_missing_receipt