### PR TITLE
Support inline comments in package args

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -228,8 +228,7 @@ impl RequirementsSource {
             }
         }
 
-        let requirement = RequirementsTxtRequirement::parse(name, &*CWD, false)
-            .with_context(|| format!("Failed to parse: `{name}`"))?;
+        let requirement = parse_command_line_requirement(name, false)?;
 
         Ok(Self::Package(requirement))
     }
@@ -278,24 +277,21 @@ impl RequirementsSource {
             }
         }
 
-        let requirement = RequirementsTxtRequirement::parse(name, &*CWD, false)
-            .with_context(|| format!("Failed to parse: `{name}`"))?;
+        let requirement = parse_command_line_requirement(name, false)?;
 
         Ok(Self::Package(requirement))
     }
 
     /// Parse an editable [`RequirementsSource`] (e.g., `uv pip install -e .`).
     pub fn from_editable(name: &str) -> Result<Self> {
-        let requirement = RequirementsTxtRequirement::parse(name, &*CWD, true)
-            .with_context(|| format!("Failed to parse: `{name}`"))?;
+        let requirement = parse_command_line_requirement(name, true)?;
 
         Ok(Self::Editable(requirement))
     }
 
     /// Parse a package [`RequirementsSource`] (e.g., `uv pip install ruff`).
     pub fn from_package(name: &str) -> Result<Self> {
-        let requirement = RequirementsTxtRequirement::parse(name, &*CWD, false)
-            .with_context(|| format!("Failed to parse: `{name}`"))?;
+        let requirement = parse_command_line_requirement(name, false)?;
 
         Ok(Self::Package(requirement))
     }
@@ -307,6 +303,37 @@ impl RequirementsSource {
             Self::PylockToml(_) | Self::PyprojectToml(_) | Self::SetupPy(_) | Self::SetupCfg(_)
         )
     }
+}
+
+fn parse_command_line_requirement(
+    name: &str,
+    editable: bool,
+) -> Result<RequirementsTxtRequirement> {
+    match RequirementsTxtRequirement::parse(name, &*CWD, editable) {
+        Ok(requirement) => Ok(requirement),
+        Err(err) => match strip_inline_comment(name) {
+            Some(stripped) => RequirementsTxtRequirement::parse(stripped, &*CWD, editable)
+                .with_context(|| format!("Failed to parse: `{name}`")),
+            None => Err(err).with_context(|| format!("Failed to parse: `{name}`")),
+        },
+    }
+}
+
+fn strip_inline_comment(name: &str) -> Option<&str> {
+    for (index, character) in name.char_indices() {
+        if character == '#'
+            && name[..index]
+                .chars()
+                .next_back()
+                .is_some_and(|character| matches!(character, ' ' | '\t'))
+        {
+            return Some(
+                name[..index].trim_end_matches(|character| matches!(character, ' ' | '\t')),
+            );
+        }
+    }
+
+    None
 }
 
 impl std::fmt::Display for RequirementsSource {

--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -327,9 +327,7 @@ fn strip_inline_comment(name: &str) -> Option<&str> {
                 .next_back()
                 .is_some_and(|character| matches!(character, ' ' | '\t'))
         {
-            return Some(
-                name[..index].trim_end_matches(|character| matches!(character, ' ' | '\t')),
-            );
+            return Some(name[..index].trim_end_matches([' ', '\t']));
         }
     }
 

--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -4,8 +4,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use console::Term;
 
-use uv_fs::{CWD, Simplified};
+use uv_fs::Simplified;
 use uv_requirements_txt::RequirementsTxtRequirement;
+
+use crate::specification::parse_command_line_requirement;
 
 #[derive(Debug, Clone)]
 pub enum RequirementsSource {
@@ -303,35 +305,6 @@ impl RequirementsSource {
             Self::PylockToml(_) | Self::PyprojectToml(_) | Self::SetupPy(_) | Self::SetupCfg(_)
         )
     }
-}
-
-fn parse_command_line_requirement(
-    name: &str,
-    editable: bool,
-) -> Result<RequirementsTxtRequirement> {
-    match RequirementsTxtRequirement::parse(name, &*CWD, editable) {
-        Ok(requirement) => Ok(requirement),
-        Err(err) => match strip_inline_comment(name) {
-            Some(stripped) => RequirementsTxtRequirement::parse(stripped, &*CWD, editable)
-                .with_context(|| format!("Failed to parse: `{name}`")),
-            None => Err(err).with_context(|| format!("Failed to parse: `{name}`")),
-        },
-    }
-}
-
-fn strip_inline_comment(name: &str) -> Option<&str> {
-    for (index, character) in name.char_indices() {
-        if character == '#'
-            && name[..index]
-                .chars()
-                .next_back()
-                .is_some_and(|character| matches!(character, ' ' | '\t'))
-        {
-            return Some(name[..index].trim_end_matches([' ', '\t']));
-        }
-    }
-
-    None
 }
 
 impl std::fmt::Display for RequirementsSource {

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -666,8 +666,7 @@ impl RequirementsSpecification {
 
     /// Parse an individual package requirement.
     pub fn parse_package(name: &str) -> Result<UnresolvedRequirementSpecification> {
-        let requirement = RequirementsTxtRequirement::parse(name, &*CWD, false)
-            .with_context(|| format!("Failed to parse: `{name}`"))?;
+        let requirement = parse_command_line_requirement(name, false)?;
         Ok(UnresolvedRequirementSpecification::from(requirement))
     }
 
@@ -709,6 +708,35 @@ impl RequirementsSpecification {
     pub fn is_empty(&self) -> bool {
         self.requirements.is_empty() && self.source_trees.is_empty() && self.overrides.is_empty()
     }
+}
+
+pub(crate) fn parse_command_line_requirement(
+    name: &str,
+    editable: bool,
+) -> Result<RequirementsTxtRequirement> {
+    match RequirementsTxtRequirement::parse(name, &*CWD, editable) {
+        Ok(requirement) => Ok(requirement),
+        Err(err) => match strip_inline_comment(name) {
+            Some(stripped) => RequirementsTxtRequirement::parse(stripped, &*CWD, editable)
+                .with_context(|| format!("Failed to parse: `{name}`")),
+            None => Err(err).with_context(|| format!("Failed to parse: `{name}`")),
+        },
+    }
+}
+
+fn strip_inline_comment(name: &str) -> Option<&str> {
+    for (index, character) in name.char_indices() {
+        if character == '#'
+            && name[..index]
+                .chars()
+                .next_back()
+                .is_some_and(|character| matches!(character, ' ' | '\t'))
+        {
+            return Some(name[..index].trim_end_matches([' ', '\t']));
+        }
+    }
+
+    None
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -631,6 +631,44 @@ fn install_package() {
     context.assert_command("import flask").success();
 }
 
+/// Install a package with a requirements-style inline comment from the command line.
+#[test]
+fn install_package_with_inline_comment() {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.pip_install()
+        .arg("iniconfig # optional dependency")
+        .arg("--strict"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    "
+    );
+
+    context.assert_command("import iniconfig").success();
+
+    uv_snapshot!(context.pip_install()
+        .arg("iniconfig#comment")
+        .arg("--strict"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse: `iniconfig#comment`
+      Caused by: Expected one of `@`, `(`, `<`, `=`, `>`, `~`, `!`, `;`, found `#`
+    iniconfig#comment
+             ^
+    "
+    );
+}
+
 /// Install a package from a `requirements.txt` into a virtual environment.
 #[test]
 fn install_requirements_txt() -> Result<()> {

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -162,6 +162,49 @@ fn tool_run_at_version() {
 }
 
 #[test]
+fn tool_run_package_with_inline_comment() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("pytest # optional tool")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pytest 8.1.1
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + iniconfig==2.0.0
+     + packaging==24.0
+     + pluggy==1.4.0
+     + pytest==8.1.1
+    ");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("pytest#comment")
+        .arg("--version")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to parse: `pytest#comment`
+      Caused by: Expected one of `@`, `(`, `<`, `=`, `>`, `~`, `!`, `;`, found `#`
+    pytest#comment
+          ^
+    ");
+}
+
+#[test]
 fn tool_run_no_binary_package_env_var() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");


### PR DESCRIPTION
## Summary

- Retry command-line package argument parsing after stripping a requirements-style inline comment when the original parse fails.
- Keep `name#comment` invalid by only stripping comments introduced by whitespace before `#`.
- Add a `uv pip install` regression test that covers both accepted inline comments and the no-whitespace guard.

## Root cause

The requirements file parser already treats whitespace followed by `#` as an inline comment, but positional package arguments were passed directly to `RequirementsTxtRequirement::parse` without that requirements-line handling. That caused callers that pass a requirements line directly, such as `uv pip install "pandas # optional"`, to fail before resolution.

Closes #19621.

## Validation

- `cargo fmt --check`
- `cargo test -p uv-requirements`
- `cargo test -p uv --test it pip_install::install_package_with_inline_comment -- --exact`