### PR TITLE
Add PyEmscripten platform (PEP 783)

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -55,6 +55,7 @@ impl Platform {
             Os::Manylinux { .. } | Os::Musllinux { .. } => "Linux",
             Os::Windows => "Windows",
             Os::Pyodide { .. } => "Pyodide",
+            Os::PyEmscripten { .. } => "Emscripten",
             Os::Macos { .. } => "macOS",
             Os::FreeBsd { .. } => "FreeBSD",
             Os::NetBsd { .. } => "NetBSD",
@@ -83,6 +84,10 @@ pub enum Os {
     },
     Windows,
     Pyodide {
+        major: u16,
+        minor: u16,
+    },
+    PyEmscripten {
         major: u16,
         minor: u16,
     },
@@ -134,6 +139,7 @@ impl fmt::Display for Os {
             Self::Haiku { .. } => write!(f, "haiku"),
             Self::Android { .. } => write!(f, "android"),
             Self::Pyodide { .. } => write!(f, "pyodide"),
+            Self::PyEmscripten { .. } => write!(f, "pyemscripten"),
             Self::Ios { .. } => write!(f, "ios"),
         }
     }

--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -303,4 +303,17 @@ mod tests {
 
         assert_eq!(platform.pretty(), "Linux x86_64");
     }
+
+    #[test]
+    fn platform_pretty_pyemscripten() {
+        let platform = Platform::new(
+            Os::PyEmscripten {
+                major: 2026,
+                minor: 0,
+            },
+            Arch::Wasm32,
+        );
+
+        assert_eq!(platform.pretty(), "Emscripten wasm32");
+    }
 }

--- a/crates/uv-platform-tags/src/platform_tag.rs
+++ b/crates/uv-platform-tags/src/platform_tag.rs
@@ -112,6 +112,8 @@ pub enum PlatformTag {
     Solaris { release_arch: ReleaseArch },
     /// Ex) `pyodide_2024_0_wasm32`
     Pyodide { major: u16, minor: u16 },
+    /// Ex) `pyemscripten_2026_0_wasm32`
+    PyEmscripten { major: u16, minor: u16 },
     /// Ex) `ios_13_0_arm64_iphoneos` / `ios_13_0_arm64_iphonesimulator`
     Ios {
         major: u16,
@@ -148,6 +150,7 @@ impl PlatformTag {
             Self::Illumos { .. } => Some("Illumos"),
             Self::Solaris { .. } => Some("Solaris"),
             Self::Pyodide { .. } => Some("Pyodide"),
+            Self::PyEmscripten { .. } => Some("Emscripten"),
             Self::Ios { .. } => Some("iOS"),
         }
     }
@@ -465,6 +468,9 @@ impl std::fmt::Display for PlatformTag {
             Self::Illumos { release_arch } => write!(f, "illumos_{release_arch}"),
             Self::Solaris { release_arch } => write!(f, "solaris_{release_arch}_64bit"),
             Self::Pyodide { major, minor } => write!(f, "pyodide_{major}_{minor}_wasm32"),
+            Self::PyEmscripten { major, minor } => {
+                write!(f, "pyemscripten_{major}_{minor}_wasm32")
+            }
             Self::Ios {
                 major,
                 minor,
@@ -859,6 +865,35 @@ impl FromStr for PlatformTag {
                 }
             })?;
             return Ok(Self::Pyodide { major, minor });
+        }
+
+        if let Some(rest) = s.strip_prefix("pyemscripten_") {
+            let mid =
+                rest.strip_suffix("_wasm32")
+                    .ok_or_else(|| ParsePlatformTagError::InvalidArch {
+                        platform: "pyemscripten",
+                        tag: s.to_string(),
+                    })?;
+            let underscore = memchr::memchr(b'_', mid.as_bytes()).ok_or_else(|| {
+                ParsePlatformTagError::InvalidFormat {
+                    platform: "pyemscripten",
+                    tag: s.to_string(),
+                }
+            })?;
+            let major: u16 = mid[..underscore].parse().map_err(|_| {
+                ParsePlatformTagError::InvalidMajorVersion {
+                    platform: "pyemscripten",
+                    tag: s.to_string(),
+                }
+            })?;
+
+            let minor: u16 = mid[underscore + 1..].parse().map_err(|_| {
+                ParsePlatformTagError::InvalidMinorVersion {
+                    platform: "pyemscripten",
+                    tag: s.to_string(),
+                }
+            })?;
+            return Ok(Self::PyEmscripten { major, minor });
         }
 
         if let Some(rest) = s.strip_prefix("ios_") {
@@ -1270,6 +1305,27 @@ mod tests {
             Err(ParsePlatformTagError::InvalidArch {
                 platform: "pyodide",
                 tag: "pyodide_2024_0_wasm64".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn pyemscripten_platform() {
+        let tag = PlatformTag::PyEmscripten {
+            major: 2026,
+            minor: 0,
+        };
+        assert_eq!(
+            PlatformTag::from_str("pyemscripten_2026_0_wasm32").as_ref(),
+            Ok(&tag)
+        );
+        assert_eq!(tag.to_string(), "pyemscripten_2026_0_wasm32");
+
+        assert_eq!(
+            PlatformTag::from_str("pyemscripten_2026_0_wasm64"),
+            Err(ParsePlatformTagError::InvalidArch {
+                platform: "pyemscripten",
+                tag: "pyemscripten_2026_0_wasm64".to_string()
             })
         );
     }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -787,10 +787,28 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             platform_tags
         }
         (Os::Pyodide { major, minor }, Arch::Wasm32) => {
-            vec![PlatformTag::Pyodide {
-                major: *major,
-                minor: *minor,
-            }]
+            vec![
+                PlatformTag::PyEmscripten {
+                    major: *major,
+                    minor: *minor,
+                },
+                PlatformTag::Pyodide {
+                    major: *major,
+                    minor: *minor,
+                },
+            ]
+        }
+        (Os::PyEmscripten { major, minor }, Arch::Wasm32) => {
+            vec![
+                PlatformTag::PyEmscripten {
+                    major: *major,
+                    minor: *minor,
+                },
+                PlatformTag::Pyodide {
+                    major: *major,
+                    minor: *minor,
+                },
+            ]
         }
         (
             Os::Ios {

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -1640,6 +1640,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_platform_tags_pyodide() {
+        let tags = compatible_tags(&Platform::new(
+            Os::Pyodide {
+                major: 2025,
+                minor: 0,
+            },
+            Arch::Wasm32,
+        ))
+        .unwrap();
+        let tags = tags.iter().map(ToString::to_string).collect::<Vec<_>>();
+        assert_debug_snapshot!(
+            tags,
+            @r#"
+        [
+            "pyemscripten_2025_0_wasm32",
+            "pyodide_2025_0_wasm32",
+        ]
+        "#
+        );
+    }
+
+    #[test]
+    fn test_platform_tags_pyemscripten() {
+        let tags = compatible_tags(&Platform::new(
+            Os::PyEmscripten {
+                major: 2026,
+                minor: 0,
+            },
+            Arch::Wasm32,
+        ))
+        .unwrap();
+        let tags = tags.iter().map(ToString::to_string).collect::<Vec<_>>();
+        assert_debug_snapshot!(
+            tags,
+            @r#"
+        [
+            "pyemscripten_2026_0_wasm32",
+            "pyodide_2026_0_wasm32",
+        ]
+        "#
+        );
+    }
+
     /// Ensure the tags returned do not include the `manylinux` tags
     /// when `manylinux_incompatible` is set to `false`.
     #[test]

--- a/crates/uv-platform/src/libc.rs
+++ b/crates/uv-platform/src/libc.rs
@@ -143,7 +143,9 @@ impl From<&uv_platform_tags::Os> for Libc {
         match value {
             uv_platform_tags::Os::Manylinux { .. } => Self::Some(target_lexicon::Environment::Gnu),
             uv_platform_tags::Os::Musllinux { .. } => Self::Some(target_lexicon::Environment::Musl),
-            uv_platform_tags::Os::Pyodide { .. } => Self::Some(target_lexicon::Environment::Musl),
+            uv_platform_tags::Os::Pyodide { .. } | uv_platform_tags::Os::PyEmscripten { .. } => {
+                Self::Some(target_lexicon::Environment::Musl)
+            }
             _ => Self::None,
         }
     }

--- a/crates/uv-platform/src/os.rs
+++ b/crates/uv-platform/src/os.rs
@@ -101,7 +101,7 @@ impl From<&uv_platform_tags::Os> for Os {
                 Self::new(target_lexicon::OperatingSystem::Openbsd)
             }
             uv_platform_tags::Os::Windows => Self::new(target_lexicon::OperatingSystem::Windows),
-            uv_platform_tags::Os::Pyodide { .. } => {
+            uv_platform_tags::Os::Pyodide { .. } | uv_platform_tags::Os::PyEmscripten { .. } => {
                 Self::new(target_lexicon::OperatingSystem::Emscripten)
             }
             uv_platform_tags::Os::Ios { .. } => {

--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -535,8 +535,26 @@ def get_operating_system_and_architecture():
         }
         [_version, architecture, _platform] = version_arch.split("-")
     elif operating_system == "emscripten":
+        pyemscripten_platform_version = sysconfig.get_config_var(
+            "PYEMSCRIPTEN_PLATFORM_VERSION"
+        )
+        # fallback to PYODIDE_ABI_VERSION for backward compatibility
         pyodide_abi_version = sysconfig.get_config_var("PYODIDE_ABI_VERSION")
-        if not pyodide_abi_version:
+        if pyemscripten_platform_version:
+            version = pyemscripten_platform_version.split("_")
+            operating_system = {
+                "name": "pyemscripten",
+                "major": int(version[0]),
+                "minor": int(version[1]),
+            }
+        elif pyodide_abi_version:
+            version = pyodide_abi_version.split("_")
+            operating_system = {
+                "name": "pyodide",
+                "major": int(version[0]),
+                "minor": int(version[1]),
+            }
+        else:
             print(
                 json.dumps(
                     {
@@ -546,12 +564,6 @@ def get_operating_system_and_architecture():
                 )
             )
             sys.exit(0)
-        version = pyodide_abi_version.split("_")
-        operating_system = {
-            "name": "pyodide",
-            "major": int(version[0]),
-            "minor": int(version[1]),
-        }
     elif operating_system == "android":
         # Python 3.13+ supports Android. We map the Android ABIs to our standard architectures.
         #

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -941,7 +941,7 @@ pub enum InterpreterInfoError {
         python_major: usize,
         python_minor: usize,
     },
-    #[error("Only Pyodide is support for Emscripten Python")]
+    #[error("Only Pyodide is supported for Emscripten Python")]
     EmscriptenNotPyodide,
 }
 

--- a/crates/uv-torch/src/backend.rs
+++ b/crates/uv-torch/src/backend.rs
@@ -469,6 +469,7 @@ impl TorchStrategy {
                     | Os::Haiku { .. }
                     | Os::Android { .. }
                     | Os::Pyodide { .. }
+                    | Os::PyEmscripten { .. }
                     | Os::Ios { .. } => Either::Right(Either::Left(std::iter::once(
                         TorchBackend::Cpu.index_url(*source),
                     ))),
@@ -501,6 +502,7 @@ impl TorchStrategy {
                 | Os::Haiku { .. }
                 | Os::Android { .. }
                 | Os::Pyodide { .. }
+                | Os::PyEmscripten { .. }
                 | Os::Ios { .. } => Either::Right(Either::Left(std::iter::once(
                     TorchBackend::Cpu.index_url(*source),
                 ))),
@@ -519,6 +521,7 @@ impl TorchStrategy {
                 | Os::Haiku { .. }
                 | Os::Android { .. }
                 | Os::Pyodide { .. }
+                | Os::PyEmscripten { .. }
                 | Os::Ios { .. } => Either::Right(Either::Left(std::iter::once(
                     TorchBackend::Cpu.index_url(*source),
                 ))),

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -325,8 +325,11 @@ pub(crate) fn create(
                 replace_link_to_executable(targetwt.as_path(), &executable_target)
                     .map_err(Error::Python)?;
             }
-        } else if matches!(interpreter.platform().os(), Os::Pyodide { .. }) {
-            // For Pyodide, link only `python.exe`.
+        } else if matches!(
+            interpreter.platform().os(),
+            Os::Pyodide { .. } | Os::PyEmscripten { .. }
+        ) {
+            // For PyEmscripten, link only `python.exe`.
             // This should not be copied as `python.exe` is a wrapper that launches Pyodide.
             let target = scripts.join(WindowsExecutable::Python.exe(interpreter));
             replace_link_to_executable(target.as_path(), &executable_target)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This adds PyEmscripten platform, which is standardized in [PEP 783](https://peps.python.org/pep-0783/). This basically replaces the Pyodide platform. I kept the Pyodide platform for backward compatibility.

## Test Plan

`cargo test`
