### PR TITLE
fix: prevent activate.fish from changing cwd on relocatable venvs

### DIFF
--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -488,7 +488,7 @@ pub(crate) fn create(
             }
             (true, "activate.bat") => r"%~dp0..".to_string(),
             (true, "activate.fish") => {
-                r#"'"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"'"#.to_string()
+                r#"'"$(dirname -- "$(dirname -- "$(realpath -- "$(status -f)")")")"'"#.to_string()
             }
             (true, "activate.nu") => r"(path self | path dirname | path dirname)".to_string(),
             (false, "activate.nu") => {


### PR DESCRIPTION
Fixes #19631

## Problem
Sourcing  from a relocatable virtual environment changes the shell's current working directory to the venv's  directory on fish.

**Root cause:** The relocatable  computes  using:


Fish evaluates command substitutions in the same process — there is no subshell — so the  leaks into the interactive session and the cwd stays in .

## Fix
Replace the  + /d/project/python/auto pattern with , matching the approach used by the bash activator:

**Before:**


**After:**


 resolves symlinks without changing the current directory, avoiding the fish subshell issue entirely. This is a fish builtin since fish 3.0.