### PR TITLE
Don't use `--update` with apt in CI

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture armhf
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
-          sudo apt install -y libc6:armhf libgcc-s1:armhf
+          sudo apt install -y --update libc6:armhf libgcc-s1:armhf
 
       - name: "Prepare binary"
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture armhf
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
-          sudo apt install -y --update libc6:armhf libgcc-s1:armhf
+          sudo apt install -y libc6:armhf libgcc-s1:armhf
 
       - name: "Prepare binary"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: "Install secret service"
         run: |
           echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries > /dev/null
-          sudo apt install -y --update gnome-keyring
+          sudo apt install -y gnome-keyring
 
       - name: "Start gnome-keyring"
         # run gnome-keyring with 'foobar' as password for the login keyring
@@ -63,7 +63,7 @@ jobs:
 
       - name: "Create btrfs filesystem"
         run: |
-          sudo apt install -y --update btrfs-progs
+          sudo apt install -y btrfs-progs
           truncate -s 1G /tmp/btrfs.img
           mkfs.btrfs /tmp/btrfs.img
           sudo mkdir /btrfs


### PR DESCRIPTION
## Summary

`apt install --update ...` is roughly equivalent to running `apt update && apt install ...` on newer apt versions. I think this is almost never what we want, at least in CI: 

1. It's slow, since updating forces apt to refresh all index listings (including third party listings that happen to be enabled on the runner, like the Google Chrome listing).
2. It's a source of unreliability/flakes, since listings frequently either 404 or are not updated atomically, meaning apt fails with consistency errors. Example: https://github.com/astral-sh/uv/actions/runs/26763578883/job/78883783836?pr=18927

Note: I haven't changed this in any Dockerfiles, since I don't think `--update` is as much of a reliability risk there.

NB: There's one place where I think we want it, i.e. when we do `dpkg --add-architecture` since `dpkg` won't update the lists for us.

## Test Plan

NFC. CI only.