### PR TITLE
Fix performance regression in unzip of local wheels

### DIFF
--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -13,13 +13,16 @@ use tracing::warn;
 use uv_configuration::initialize_rayon_once;
 use uv_warnings::warn_user_once;
 
+const DEFAULT_BUF_SIZE: usize = 128 * 1024;
+const JOBS_PER_THREAD: usize = 4;
+
 /// Unzip a `.zip` archive into the target directory.
 ///
 /// Returns the list of unpacked files and their sizes.
 pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>, Error> {
     let (reader, filename) = reader.into_parts();
 
-    // Parse the central directory once, then clone the archive reader per Rayon worker so
+    // Parse the central directory once, then clone the archive reader per Rayon job so
     // extraction stays parallel for already-downloaded wheels.
     let archive = block_on(ZipFileReader::new(AllowStdIo::new(
         CloneableSeekableReader::new(reader),
@@ -28,10 +31,18 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
     let skip_validation = insecure_no_validate();
     // Initialize the threadpool with the user settings.
     initialize_rayon_once();
-    (0..archive.file().entries().len())
+    let entry_count = archive.file().entries().len();
+    let min_entries_per_job = entry_count
+        .div_ceil(rayon::current_num_threads().saturating_mul(JOBS_PER_THREAD))
+        .max(1);
+    (0..entry_count)
         .into_par_iter()
-        .map(|file_number| {
-            let mut archive = archive.clone();
+        // Cloning the async ZIP reader clones the entire central directory, so reuse one
+        // reader and copy buffer per Rayon job instead of allocating both for every entry.
+        .with_min_len(min_entries_per_job)
+        .map_init(
+            || (archive.clone(), vec![0; DEFAULT_BUF_SIZE]),
+            |(archive, buffer), file_number| {
             let entry = archive.file().entries()[file_number].clone();
             let file_name = match entry.filename().as_str() {
                 Ok(file_name) => file_name,
@@ -95,12 +106,8 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
                 let mut file = archive.reader_with_entry(file_number).await?;
                 let mut writer = AllowStdIo::new(writer);
                 let mut copied = 0;
-                let mut buffer = vec![0; 128 * 1024];
                 loop {
-                    let read = file
-                        .read(&mut buffer)
-                        .await
-                        .map_err(Error::io_or_compression)?;
+                    let read = file.read(buffer).await.map_err(Error::io_or_compression)?;
                     if read == 0 {
                         break;
                     }
@@ -151,7 +158,8 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>,
             }
 
             Ok(Some((enclosed_name, size)))
-        })
+            },
+        )
         // Filter out directories and skipped dangerous paths, we only want to collect the files.
         .filter_map(Result::transpose)
         .collect::<Result<_, Error>>()


### PR DESCRIPTION
Closes #19635 

I reproduced the issue over increasing target sizes

| File count | Directory count | `0.11.14` | `0.11.15` | Regression |
|---:|---:|---:|---:|---:|
| `1,000` | `250` | `0.045s` | `0.048s` | `1.1x` |
| `3,000` | `750` | `0.117s` | `0.147s` | `1.3x` |
| `10,000` | `2,500` | `0.379s` | `0.844s` | `2.2x` |
| `30,000` | `7,500` | `1.16s` | `11.42s` | `9.8x` |
| `100,000` | `25,000` | `3.59s` | `213.5s` | `59.5x` |

The issue appears to not be build, e.g., `uv build --wheel` was no affected, but unpacking the wheel into the cache.

The root cause is that cloning the zip reader is really expensive in `rs-async-zip`, unlike the sync `zip` crate.

Here are the results for 100k files, including after this fix.

| Binary | Prepare | Install | Total | User CPU | Sys CPU |
|---|---:|---:|---:|---:|---:|
| `0.11.14` | `3.71s` | `28.59s` | `38.41s` | `3.17s` | `42.04s` |
| `0.11.15` | `3m34s` | `30.84s` | `251.03s` | `1755.53s` | `1367.60s` |
| branch | `3.07s` | `27.03s` | `35.09s` | `3.57s` | `39.95s` |