### PR TITLE
fix(#16963): Add a hint when requires-python contains a free-threaded selector

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2101,3 +2101,198 @@ impl OptionsMetadata for BuildBackendSettingsSchema {
         BuildBackendSettings::metadata()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use uv_errors::Hint;
+
+    use super::{PyprojectTomlError, PyProjectToml, extract_free_threaded_selector};
+
+    // --- extract_free_threaded_selector ---
+
+    #[test]
+    fn test_extract_free_threaded_selector_single_ge() {
+        // Basic `>=3.13t` — the most common real-world case.
+        let raw = r#"
+[project]
+requires-python = ">=3.13t"
+"#;
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.13t".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_eq() {
+        // Exact pin: `==3.14t`.
+        let raw = r#"
+[project]
+requires-python = "==3.14t"
+"#;
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.14t".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_compatible() {
+        // Compatible release: `~=3.13t`.
+        let raw = r#"
+[project]
+requires-python = "~=3.13t"
+"#;
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.13t".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_multi_specifier_second() {
+        // `t` suffix is in the second specifier of a comma-separated pair.
+        let raw = r#"
+[project]
+requires-python = ">=3.12, <3.14t"
+"#;
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.14t".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_single_quoted() {
+        // Single-quoted TOML value.
+        let raw = r#"
+[project]
+requires-python = '>=3.13t'
+"#;
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.13t".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_normal_version_no_match() {
+        // Normal PEP 440 specifier — must return None.
+        let raw = r#"
+[project]
+requires-python = ">=3.13"
+"#;
+        assert_eq!(extract_free_threaded_selector(raw), None);
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_no_requires_python() {
+        // No `requires-python` key at all.
+        let raw = r#"
+[project]
+name = "foo"
+"#;
+        assert_eq!(extract_free_threaded_selector(raw), None);
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_trailing_t_not_digit_before() {
+        // `t` suffix where the character before `t` is not a digit — must not match.
+        // e.g. a hypothetical `>=3.13.post1t` where last-before-t is not a digit.
+        let raw = r#"
+[project]
+requires-python = ">=3.13.post1t"
+"#;
+        // "post1t" — last char before 't' is '1' which IS a digit, so this DOES match.
+        // Adjust to a case where it genuinely shouldn't: letter before t.
+        let raw2 = r#"
+[project]
+requires-python = ">=3.13at"
+"#;
+        // "at" — char before 't' is 'a', not a digit → no match.
+        assert_eq!(extract_free_threaded_selector(raw2), None);
+        // "post1t" → last digit before 't' is '1' → matches (expected behaviour).
+        assert_eq!(
+            extract_free_threaded_selector(raw),
+            Some("3.13.post1t".to_string())
+        );
+    }
+
+    // --- PyprojectTomlError::FreeThreadedSelector hint ---
+
+    #[test]
+    fn test_hint_free_threaded_selector() {
+        let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
+        let hints = err.hints();
+        let hint_text = hints.iter().next().expect("expected at least one hint");
+        assert!(
+            hint_text.contains("uv python pin 3.13t"),
+            "hint should suggest `uv python pin 3.13t`, got: {hint_text}"
+        );
+        assert!(
+            hint_text.contains("requires-python"),
+            "hint should mention `requires-python`, got: {hint_text}"
+        );
+    }
+
+    #[test]
+    fn test_hint_other_errors_are_empty() {
+        // Non-FreeThreadedSelector variants must not emit hints.
+        let err = PyprojectTomlError::MissingName;
+        assert!(err.hints().iter().next().is_none());
+    }
+
+    // --- PyProjectToml::from_string integration ---
+
+    #[test]
+    fn test_from_string_free_threaded_selector_returns_dedicated_error() {
+        let raw = r#"
+[project]
+name = "myapp"
+version = "0.1.0"
+requires-python = ">=3.13t"
+"#;
+        let err = PyProjectToml::from_string(raw.to_string(), Path::new("pyproject.toml"))
+            .expect_err("should fail to parse");
+        assert!(
+            matches!(err, PyprojectTomlError::FreeThreadedSelector(ref v) if v == "3.13t"),
+            "expected FreeThreadedSelector(\"3.13t\"), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_from_string_valid_requires_python_parses_ok() {
+        let raw = r#"
+[project]
+name = "myapp"
+version = "0.1.0"
+requires-python = ">=3.13"
+"#;
+        assert!(
+            PyProjectToml::from_string(raw.to_string(), Path::new("pyproject.toml")).is_ok(),
+            "valid requires-python should parse without error"
+        );
+    }
+
+    #[test]
+    fn test_from_string_free_threaded_eq_pin() {
+        let raw = r#"
+[project]
+name = "myapp"
+version = "0.1.0"
+requires-python = "==3.13t"
+"#;
+        let err = PyProjectToml::from_string(raw.to_string(), Path::new("pyproject.toml"))
+            .expect_err("should fail to parse");
+        assert!(
+            matches!(err, PyprojectTomlError::FreeThreadedSelector(ref v) if v == "3.13t"),
+            "expected FreeThreadedSelector(\"3.13t\"), got: {err:?}"
+        );
+        // Also verify the hint points to the right pin command.
+        let hints = err.hints();
+        let hint_text = hints.iter().next().expect("expected a hint");
+        assert!(hint_text.contains("uv python pin 3.13t"));
+    }
+}

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2291,7 +2291,8 @@ requires-python = ">=3.13.post1t"
     #[test]
     fn test_hint_free_threaded_selector() {
         let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
-        let hint_text = err.hints()
+        let hint_text = err
+            .hints()
             .into_iter()
             .next()
             .expect("expected at least one hint");

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2291,11 +2291,7 @@ requires-python = ">=3.13.post1t"
     #[test]
     fn test_hint_free_threaded_selector() {
         let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
-        let hint_text = err
-            .hints()
-            .into_iter()
-            .next()
-            .expect("expected at least one hint");
+        let hint_text = err.hints().into_iter().next().expect("expected at least one hint");
         assert!(
             hint_text.contains("uv python pin 3.13t"),
             "hint should suggest `uv python pin 3.13t`, got: {hint_text}"
@@ -2385,11 +2381,7 @@ requires-python = "==3.13t"
             "expected FreeThreadedSelector(\"3.13t\"), got: {err:?}"
         );
         // Also verify the hint points to the right pin command.
-        let hint_text = err
-            .hints()
-            .into_iter()
-            .next()
-            .expect("expected a hint");
+        let hint_text = err.hints().into_iter().next().expect("expected a hint");
         assert!(hint_text.contains("uv python pin 3.13t"));
     }
 }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2291,7 +2291,10 @@ requires-python = ">=3.13.post1t"
     #[test]
     fn test_hint_free_threaded_selector() {
         let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
-        let hint_text = err.hints().into_iter().next().expect("expected at least one hint");
+        let hint_text = err.hints()
+            .into_iter()
+            .next()
+            .expect("expected at least one hint");
         assert!(
             hint_text.contains("uv python pin 3.13t"),
             "hint should suggest `uv python pin 3.13t`, got: {hint_text}"

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -53,6 +53,46 @@ pub enum PyprojectTomlError {
         "`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list"
     )]
     MissingVersion,
+    /// Occurs when `requires-python` contains a free-threaded selector like `>=3.14t`.
+    #[error(
+        "`requires-python` does not support free-threaded Python selectors (e.g. `{0}`); \
+         version specifiers must be valid PEP 440 versions"
+    )]
+    FreeThreadedSelector(String),
+}
+
+/// Check whether the raw `pyproject.toml` string contains a `requires-python` value with a
+/// free-threaded selector suffix (e.g. `>=3.14t`). Returns the offending specifier string
+/// (e.g. `"3.14t"`) if one is found.
+///
+/// This is used to provide an actionable error message when TOML deserialization fails because
+/// the PEP 440 version parser rejects the `t` suffix.
+fn extract_free_threaded_selector(raw: &str) -> Option<String> {
+    // Find `requires-python` in the raw TOML text.
+    let after_key = raw.split("requires-python").nth(1)?;
+    // Find the opening quote of the value (`=  "..."` or `= '...'`).
+    let after_eq = after_key.splitn(2, '=').nth(1)?;
+    let trimmed = after_eq.trim_start();
+    let quote_char = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'')?;
+    let value_start = 1; // skip the opening quote
+    let value_end = trimmed[value_start..].find(quote_char)? + value_start;
+    let value = &trimmed[value_start..value_end];
+
+    // Scan each comma-separated specifier for a free-threaded suffix: ends with \d+t.
+    for spec in value.split(',') {
+        let spec = spec.trim();
+        // Strip leading operator characters to get to the version part.
+        let version_part = spec.trim_start_matches(|c: char| !c.is_ascii_digit());
+        if version_part.ends_with('t')
+            && version_part[..version_part.len() - 1]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_ascii_digit())
+        {
+            return Some(version_part.to_string());
+        }
+    }
+    None
 }
 
 /// Helper function to deserialize a map while ensuring all keys are unique.
@@ -137,7 +177,16 @@ impl PyProjectToml {
             .map(ToolUvSources::try_from)
             .transpose()?;
 
-        let mut pyproject: Self = toml::from_str(&raw).map_err(PyprojectTomlError::Toml)?;
+        let mut pyproject: Self = toml::from_str(&raw).map_err(|err| {
+            // If the TOML error is caused by a free-threaded selector in `requires-python`
+            // (e.g. `>=3.14t`), return a dedicated, actionable error variant instead of the
+            // generic TOML parse error, which would otherwise be cryptic.
+            if let Some(version) = extract_free_threaded_selector(&raw) {
+                PyprojectTomlError::FreeThreadedSelector(version)
+            } else {
+                PyprojectTomlError::Toml(err)
+            }
+        })?;
         if let Some(sources) = sources {
             let tool_uv = pyproject
                 .tool
@@ -1692,6 +1741,18 @@ impl uv_errors::Hint for SourceError {
             Self::OverlappingMarkers(_, rhs, replacement) => {
                 uv_errors::Hints::from(format!("replace `{rhs}` with `{replacement}`"))
             }
+            _ => uv_errors::Hints::none(),
+        }
+    }
+}
+
+impl uv_errors::Hint for PyprojectTomlError {
+    fn hints(&self) -> uv_errors::Hints<'_> {
+        match self {
+            Self::FreeThreadedSelector(version) => uv_errors::Hints::from(format!(
+                "`requires-python` cannot include a free-threaded selector; \
+                 to pin a free-threaded interpreter, use `uv python pin {version}` instead"
+            )),
             _ => uv_errors::Hints::none(),
         }
     }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -71,7 +71,7 @@ fn extract_free_threaded_selector(raw: &str) -> Option<String> {
     // Find `requires-python` in the raw TOML text.
     let after_key = raw.split("requires-python").nth(1)?;
     // Find the opening quote of the value (`=  "..."` or `= '...'`).
-    let after_eq = after_key.splitn(2, '=').nth(1)?;
+    let after_eq = after_key.split_once('=')?.1;
     let trimmed = after_eq.trim_start();
     let quote_char = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'')?;
     let value_start = 1; // skip the opening quote

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -62,35 +62,70 @@ pub enum PyprojectTomlError {
 }
 
 /// Check whether the raw `pyproject.toml` string contains a `requires-python` value with a
-/// free-threaded selector suffix (e.g. `>=3.14t`). Returns the offending specifier string
-/// (e.g. `"3.14t"`) if one is found.
+/// free-threaded selector suffix (e.g. `>=3.13t`). Returns the offending specifier string
+/// (e.g. `"3.13t"`) if one is found.
 ///
 /// This is used to provide an actionable error message when TOML deserialization fails because
 /// the PEP 440 version parser rejects the `t` suffix.
+///
+/// The scan is line-based and restricted to the `[project]` table section so that occurrences
+/// of `requires-python` in comments, string values, or other tables are not matched.
 fn extract_free_threaded_selector(raw: &str) -> Option<String> {
-    // Find `requires-python` in the raw TOML text.
-    let after_key = raw.split("requires-python").nth(1)?;
-    // Find the opening quote of the value (`=  "..."` or `= '...'`).
-    let after_eq = after_key.split_once('=')?.1;
-    let trimmed = after_eq.trim_start();
-    let quote_char = trimmed.chars().next().filter(|c| *c == '"' || *c == '\'')?;
-    let value_start = 1; // skip the opening quote
-    let value_end = trimmed[value_start..].find(quote_char)? + value_start;
-    let value = &trimmed[value_start..value_end];
+    // Walk lines; track whether we are inside the [project] table.
+    let mut in_project_table = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
 
-    // Scan each comma-separated specifier for a free-threaded suffix: ends with \d+t.
-    for spec in value.split(',') {
-        let spec = spec.trim();
-        // Strip leading operator characters to get to the version part.
-        let version_part = spec.trim_start_matches(|c: char| !c.is_ascii_digit());
-        if version_part.ends_with('t')
-            && version_part[..version_part.len() - 1]
-                .chars()
-                .next_back()
-                .is_some_and(|c| c.is_ascii_digit())
-        {
-            return Some(version_part.to_string());
+        // Skip comment lines.
+        if trimmed.starts_with('#') {
+            continue;
         }
+
+        // Detect table headers.
+        if trimmed.starts_with('[') {
+            // `[project]` (but not `[project.something]`).
+            in_project_table = trimmed == "[project]";
+            continue;
+        }
+
+        if !in_project_table {
+            continue;
+        }
+
+        // Match a bare `requires-python = "..."` or `requires-python = '...'` assignment.
+        // Strip inline comments after the value.
+        let Some(rest) = trimmed.strip_prefix("requires-python") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(rest) = rest.strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim_start();
+
+        // Extract the quoted value.
+        let quote_char = rest.chars().next().filter(|c| *c == '"' || *c == '\'')?;
+        let value_start = 1;
+        let value_end = rest[value_start..].find(quote_char)? + value_start;
+        let value = &rest[value_start..value_end];
+
+        // Scan each comma-separated specifier for a free-threaded suffix (digit followed by `t`).
+        for spec in value.split(',') {
+            let spec = spec.trim();
+            // Strip leading operator characters to get to the version part.
+            let version_part = spec.trim_start_matches(|c: char| !c.is_ascii_digit());
+            if version_part.ends_with('t')
+                && version_part[..version_part.len() - 1]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_ascii_digit())
+            {
+                return Some(version_part.to_string());
+            }
+        }
+
+        // Found the `requires-python` key but no free-threaded specifier — stop scanning.
+        return None;
     }
     None
 }
@@ -178,14 +213,17 @@ impl PyProjectToml {
             .transpose()?;
 
         let mut pyproject: Self = toml::from_str(&raw).map_err(|err| {
-            // If the TOML error is caused by a free-threaded selector in `requires-python`
-            // (e.g. `>=3.14t`), return a dedicated, actionable error variant instead of the
-            // generic TOML parse error, which would otherwise be cryptic.
-            if let Some(version) = extract_free_threaded_selector(&raw) {
-                PyprojectTomlError::FreeThreadedSelector(version)
-            } else {
-                PyprojectTomlError::Toml(err)
+            // Only emit `FreeThreadedSelector` when the TOML error is actually caused by the
+            // `requires-python` field (i.e. the error message references that key) AND the raw
+            // file contains a free-threaded specifier in that field.  This avoids masking
+            // unrelated parse errors that happen to co-exist with a `t`-suffixed specifier.
+            let err_msg = err.to_string();
+            if err_msg.contains("requires-python") {
+                if let Some(version) = extract_free_threaded_selector(&raw) {
+                    return PyprojectTomlError::FreeThreadedSelector(version);
+                }
             }
+            PyprojectTomlError::Toml(err)
         })?;
         if let Some(sources) = sources {
             let tool_uv = pyproject
@@ -2198,22 +2236,49 @@ name = "foo"
     }
 
     #[test]
-    fn test_extract_free_threaded_selector_trailing_t_not_digit_before() {
-        // `t` suffix where the character before `t` is not a digit — must not match.
-        // e.g. a hypothetical `>=3.13.post1t` where last-before-t is not a digit.
+    fn test_extract_free_threaded_selector_in_comment_ignored() {
+        // `requires-python` with a `t` suffix appears only in a comment — must return None.
+        let raw = r#"
+[project]
+name = "foo"
+# requires-python = ">=3.13t"
+requires-python = ">=3.13"
+"#;
+        assert_eq!(extract_free_threaded_selector(raw), None);
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_in_other_table_ignored() {
+        // `requires-python` with a `t` suffix appears in a non-[project] table — must return None.
+        let raw = r#"
+[tool.something]
+requires-python = ">=3.13t"
+
+[project]
+requires-python = ">=3.13"
+"#;
+        assert_eq!(extract_free_threaded_selector(raw), None);
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_letter_before_t_no_match() {        // `>=3.13at` — the character immediately before `t` is a letter, not a digit.
+        // Must return None so we don't false-positive on arbitrary strings ending in `t`.
+        let raw = r#"
+[project]
+requires-python = ">=3.13at"
+"#;
+        assert_eq!(extract_free_threaded_selector(raw), None);
+    }
+
+    #[test]
+    fn test_extract_free_threaded_selector_post_release_digit_before_t_matches() {
+        // `>=3.13.post1t` — the character before `t` is the digit `1`.
+        // Our heuristic matches digit-before-t, so this is treated as a free-threaded selector.
+        // In practice nobody writes this, but the test documents the boundary behaviour.
         let raw = r#"
 [project]
 requires-python = ">=3.13.post1t"
 "#;
-        // "post1t" — last char before 't' is '1' which IS a digit, so this DOES match.
-        // Adjust to a case where it genuinely shouldn't: letter before t.
-        let raw2 = r#"
-[project]
-requires-python = ">=3.13at"
-"#;
-        // "at" — char before 't' is 'a', not a digit → no match.
-        assert_eq!(extract_free_threaded_selector(raw2), None);
-        // "post1t" → last digit before 't' is '1' → matches (expected behaviour).
         assert_eq!(
             extract_free_threaded_selector(raw),
             Some("3.13.post1t".to_string())
@@ -2245,6 +2310,31 @@ requires-python = ">=3.13at"
     }
 
     // --- PyProjectToml::from_string integration ---
+
+    #[test]
+    fn test_from_string_unrelated_toml_error_not_masked() {
+        // A genuine TOML syntax error unrelated to `requires-python` must not be swallowed
+        // by FreeThreadedSelector even if the file also has a `t`-suffixed specifier.
+        let raw = r#"
+[project]
+name = "myapp"
+version = "0.1.0"
+requires-python = ">=3.13t"
+invalid syntax !!!
+"#;
+        let err = PyProjectToml::from_string(raw.to_string(), Path::new("pyproject.toml"))
+            .expect_err("should fail to parse");
+        // The error may be FreeThreadedSelector (if toml errors on requires-python first)
+        // or Toml (if it errors on the syntax line first) — what must NOT happen is silently
+        // returning Ok or panicking.
+        assert!(
+            matches!(
+                err,
+                PyprojectTomlError::FreeThreadedSelector(_) | PyprojectTomlError::Toml(_)
+            ),
+            "unexpected error variant: {err:?}"
+        );
+    }
 
     #[test]
     fn test_from_string_free_threaded_selector_returns_dedicated_error() {

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2205,10 +2205,10 @@ requires-python = ">=3.12, <3.14t"
     #[test]
     fn test_extract_free_threaded_selector_single_quoted() {
         // Single-quoted TOML value.
-        let raw = r#"
+        let raw = r"
 [project]
 requires-python = '>=3.13t'
-"#;
+";
         assert_eq!(
             extract_free_threaded_selector(raw),
             Some("3.13t".to_string())
@@ -2291,7 +2291,11 @@ requires-python = ">=3.13.post1t"
     #[test]
     fn test_hint_free_threaded_selector() {
         let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
-        let hint_text = err.hints().into_iter().next().expect("expected at least one hint");
+        let hint_text = err
+            .hints()
+            .into_iter()
+            .next()
+            .expect("expected at least one hint");
         assert!(
             hint_text.contains("uv python pin 3.13t"),
             "hint should suggest `uv python pin 3.13t`, got: {hint_text}"
@@ -2381,7 +2385,11 @@ requires-python = "==3.13t"
             "expected FreeThreadedSelector(\"3.13t\"), got: {err:?}"
         );
         // Also verify the hint points to the right pin command.
-        let hint_text = err.hints().into_iter().next().expect("expected a hint");
+        let hint_text = err
+            .hints()
+            .into_iter()
+            .next()
+            .expect("expected a hint");
         assert!(hint_text.contains("uv python pin 3.13t"));
     }
 }

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -2146,7 +2146,7 @@ mod tests {
 
     use uv_errors::Hint;
 
-    use super::{PyprojectTomlError, PyProjectToml, extract_free_threaded_selector};
+    use super::{PyProjectToml, PyprojectTomlError, extract_free_threaded_selector};
 
     // --- extract_free_threaded_selector ---
 
@@ -2261,7 +2261,8 @@ requires-python = ">=3.13"
     }
 
     #[test]
-    fn test_extract_free_threaded_selector_letter_before_t_no_match() {        // `>=3.13at` — the character immediately before `t` is a letter, not a digit.
+    fn test_extract_free_threaded_selector_letter_before_t_no_match() {
+        // `>=3.13at` — the character immediately before `t` is a letter, not a digit.
         // Must return None so we don't false-positive on arbitrary strings ending in `t`.
         let raw = r#"
 [project]
@@ -2290,8 +2291,7 @@ requires-python = ">=3.13.post1t"
     #[test]
     fn test_hint_free_threaded_selector() {
         let err = PyprojectTomlError::FreeThreadedSelector("3.13t".to_string());
-        let hints = err.hints();
-        let hint_text = hints.iter().next().expect("expected at least one hint");
+        let hint_text = err.hints().into_iter().next().expect("expected at least one hint");
         assert!(
             hint_text.contains("uv python pin 3.13t"),
             "hint should suggest `uv python pin 3.13t`, got: {hint_text}"
@@ -2306,7 +2306,7 @@ requires-python = ">=3.13.post1t"
     fn test_hint_other_errors_are_empty() {
         // Non-FreeThreadedSelector variants must not emit hints.
         let err = PyprojectTomlError::MissingName;
-        assert!(err.hints().iter().next().is_none());
+        assert!(err.hints().is_empty());
     }
 
     // --- PyProjectToml::from_string integration ---
@@ -2381,8 +2381,7 @@ requires-python = "==3.13t"
             "expected FreeThreadedSelector(\"3.13t\"), got: {err:?}"
         );
         // Also verify the hint points to the right pin command.
-        let hints = err.hints();
-        let hint_text = hints.iter().next().expect("expected a hint");
+        let hint_text = err.hints().into_iter().next().expect("expected a hint");
         assert!(hint_text.contains("uv python pin 3.13t"));
     }
 }

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -89,43 +89,10 @@ pub enum WorkspaceError {
 
 impl uv_errors::Hint for WorkspaceError {
     fn hints(&self) -> uv_errors::Hints<'_> {
-        // When a `requires-python` field contains a free-threaded selector (e.g. `>=3.14t`),
-        // TOML parsing fails with a cryptic "not part of a valid version" message. Surface a
-        // actionable hint pointing the user toward `uv python pin` instead.
-        if let Self::Toml(_, err) = self {
-            let msg = err.to_string();
-            if msg.contains("not part of a valid version") {
-                // Try to extract the offending version string (the part before the `t` suffix).
-                // The error message contains "after parsing `<version>`, found `<remaining>`".
-                // We look for a `t` in the remaining segment to confirm it is a free-threaded
-                // selector, then reconstruct the full specifier for the hint.
-                if let Some(remaining_start) = msg.find("found `") {
-                    let after = &msg[remaining_start + "found `".len()..];
-                    let remaining = after.split('`').next().unwrap_or("");
-                    if remaining.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.') == "t"
-                        || remaining == "t"
-                    {
-                        // Extract the already-parsed version part.
-                        if let Some(version_start) = msg.find("after parsing `") {
-                            let after_v = &msg[version_start + "after parsing `".len()..];
-                            let parsed_version = after_v.split('`').next().unwrap_or("");
-                            let full_version =
-                                format!("{parsed_version}{remaining}");
-                            return uv_errors::Hints::from(format!(
-                                "`requires-python` cannot include a free-threaded selector; \
-                                 consider using `uv python pin {full_version}` instead"
-                            ));
-                        }
-                        return uv_errors::Hints::from(
-                            "`requires-python` cannot include a free-threaded selector (e.g. \
-                             `3.14t`); consider using `uv python pin 3.14t` instead"
-                                .to_string(),
-                        );
-                    }
-                }
-            }
+        match self {
+            Self::Toml(_, err) => err.hints(),
+            _ => uv_errors::Hints::none(),
         }
-        uv_errors::Hints::none()
     }
 }
 

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -87,6 +87,48 @@ pub enum WorkspaceError {
     Normalize(#[source] std::io::Error),
 }
 
+impl uv_errors::Hint for WorkspaceError {
+    fn hints(&self) -> uv_errors::Hints<'_> {
+        // When a `requires-python` field contains a free-threaded selector (e.g. `>=3.14t`),
+        // TOML parsing fails with a cryptic "not part of a valid version" message. Surface a
+        // actionable hint pointing the user toward `uv python pin` instead.
+        if let Self::Toml(_, err) = self {
+            let msg = err.to_string();
+            if msg.contains("not part of a valid version") {
+                // Try to extract the offending version string (the part before the `t` suffix).
+                // The error message contains "after parsing `<version>`, found `<remaining>`".
+                // We look for a `t` in the remaining segment to confirm it is a free-threaded
+                // selector, then reconstruct the full specifier for the hint.
+                if let Some(remaining_start) = msg.find("found `") {
+                    let after = &msg[remaining_start + "found `".len()..];
+                    let remaining = after.split('`').next().unwrap_or("");
+                    if remaining.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.') == "t"
+                        || remaining == "t"
+                    {
+                        // Extract the already-parsed version part.
+                        if let Some(version_start) = msg.find("after parsing `") {
+                            let after_v = &msg[version_start + "after parsing `".len()..];
+                            let parsed_version = after_v.split('`').next().unwrap_or("");
+                            let full_version =
+                                format!("{parsed_version}{remaining}");
+                            return uv_errors::Hints::from(format!(
+                                "`requires-python` cannot include a free-threaded selector; \
+                                 consider using `uv python pin {full_version}` instead"
+                            ));
+                        }
+                        return uv_errors::Hints::from(
+                            "`requires-python` cannot include a free-threaded selector (e.g. \
+                             `3.14t`); consider using `uv python pin 3.14t` instead"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+        uv_errors::Hints::none()
+    }
+}
+
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub enum MemberDiscovery {
     /// Discover all workspace members.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -397,6 +397,7 @@ impl uv_errors::Hint for ProjectError {
             Self::Lock(err) => err.hints(),
             Self::Python(err) => err.hints(),
             Self::Operation(err) => err.hints(),
+            Self::Workspace(err) => err.hints(),
             _ => uv_errors::Hints::none(),
         }
     }


### PR DESCRIPTION
## Summary

When someone puts `requires-python = ">=3.13t"` in their pyproject.toml, uv crashes with a cryptic TOML parse error. 

The "**t**" suffix is the free-threaded Python notation but isn't valid PEP 440, so the TOML parser just fails silently.

This PR adds a check before the parse error bubbles up, it also scans the raw string for a version ending in a digit followed by "**t**", and if found, returns a specific error with a hint pointing to uv python instead.

Fixes #16963.

## Test Plan

I added unit tests at the bottom of `pyproject.rs` in a `cfg(test)` module.

The main thing I wanted to cover was extract_free_threaded_selector to make sure it catches the **t** suffix in the common cases (eg: >=3.13t, ==3.13t, ~=3.13t, single quotes, comma-separated specifiers) and equally important, that it doesn't false-positive on a normal >=3.13 or something like >=3.13**at** where the char before t isn't a digit.

I also have a couple of tests checking the hint message which actually says uv python pin 3.13t and mentions requires-python, since that's the whole point of the error.

And three integration tests through `from_string` to make sure the full path works end to end in a toml with >=3.13t comes back as `FreeThreadedSelector` and not a generic toml error, and that a valid specifier still parses fine.

To run the tests, execute `cargo test -p uv-workspace --lib pyproject::tests`