### PR TITLE
Use global preview in `CondaEnvironmentKind::from_prefix_path`

### DIFF
--- a/crates/uv-dev/src/compile.rs
+++ b/crates/uv-dev/src/compile.rs
@@ -5,7 +5,6 @@ use tracing::info;
 
 use uv_cache::{Cache, CacheArgs};
 use uv_configuration::Concurrency;
-use uv_preview::Preview;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
 
 #[derive(Parser)]
@@ -28,7 +27,6 @@ pub(crate) async fn compile(args: CompileArgs) -> anyhow::Result<()> {
             EnvironmentPreference::OnlyVirtual,
             PythonPreference::default(),
             &cache,
-            Preview::default(),
         )?
         .into_interpreter();
         interpreter.sys_executable().to_path_buf()

--- a/crates/uv-dev/src/lib.rs
+++ b/crates/uv-dev/src/lib.rs
@@ -70,6 +70,9 @@ enum Cli {
 
 #[instrument] // Anchor span to check for overhead
 pub async fn run() -> Result<()> {
+    uv_preview::set(uv_preview::Preview::default())?;
+    uv_preview::finalize()?;
+
     let cli = Cli::parse();
     let environment = EnvironmentOptions::new()?;
     match cli {

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -55,5 +55,7 @@ url = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
+uv-preview = { workspace = true, features = ["testing"] }
+
 anstream = { workspace = true }
 insta = { workspace = true }

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -222,13 +222,13 @@ mod tests {
     use super::Installer;
 
     fn environment() -> PythonEnvironment {
+        let _preview = uv_preview::test::with_features(&[]);
         let cache = Cache::temp().expect("cache should be available");
         PythonEnvironment::find(
             &PythonRequest::Any,
             EnvironmentPreference::Any,
             PythonPreference::System,
             &cache,
-            Preview::default(),
         )
         .expect("Python environment should be available")
     }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -73,6 +73,8 @@ windows-registry = { workspace = true }
 windows = { workspace = true }
 
 [dev-dependencies]
+uv-preview = { workspace = true, features = ["testing"] }
+
 anyhow = { workspace = true }
 assert_fs = { workspace = true }
 indoc = { workspace = true }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -18,7 +18,6 @@ use uv_pep440::{
     LowerBound, Prerelease, UpperBound, Version, VersionSpecifier, VersionSpecifiers,
     release_specifiers_to_ranges,
 };
-use uv_preview::Preview;
 use uv_static::EnvVars;
 use uv_warnings::{warn_user_once, write_warning_chain};
 use which::{which, which_all};
@@ -308,9 +307,8 @@ impl uv_errors::Hint for Error {
 /// - Discovered virtual environment (e.g. `.venv` in a parent directory)
 ///
 /// Notably, "system" environments are excluded. See [`python_executables_from_installed`].
-fn python_executables_from_virtual_environments<'a>(
-    preview: Preview,
-) -> impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a {
+fn python_executables_from_virtual_environments<'a>()
+-> impl Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a {
     let from_active_environment = iter::once_with(|| {
         virtualenv_from_env()
             .into_iter()
@@ -321,7 +319,7 @@ fn python_executables_from_virtual_environments<'a>(
 
     // N.B. we prefer the conda environment over discovered virtual environments
     let from_conda_environment = iter::once_with(move || {
-        conda_environment_from_env(CondaEnvironmentKind::Child, preview)
+        conda_environment_from_env(CondaEnvironmentKind::Child)
             .into_iter()
             .map(virtualenv_python_executable)
             .map(|path| Ok((PythonSource::CondaPrefix, path)))
@@ -536,7 +534,6 @@ fn python_executables<'a>(
     platform: PlatformRequest,
     environments: EnvironmentPreference,
     preference: PythonPreference,
-    preview: Preview,
 ) -> Box<dyn Iterator<Item = Result<(PythonSource, PathBuf), Error>> + 'a> {
     // Always read from `UV_INTERNAL__PARENT_INTERPRETER` — it could be a system interpreter
     let from_parent_interpreter = iter::once_with(|| {
@@ -548,14 +545,14 @@ fn python_executables<'a>(
 
     // Check if the base conda environment is active
     let from_base_conda_environment = iter::once_with(move || {
-        conda_environment_from_env(CondaEnvironmentKind::Base, preview)
+        conda_environment_from_env(CondaEnvironmentKind::Base)
             .into_iter()
             .map(virtualenv_python_executable)
             .map(|path| Ok((PythonSource::BaseCondaPrefix, path)))
     })
     .flatten();
 
-    let from_virtual_environments = python_executables_from_virtual_environments(preview);
+    let from_virtual_environments = python_executables_from_virtual_environments();
     let from_installed =
         python_executables_from_installed(version, implementation, platform, preference);
 
@@ -757,23 +754,16 @@ fn python_installations<'a>(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &'a Cache,
-    preview: Preview,
 ) -> impl Iterator<Item = Result<PythonInstallation, Error>> + 'a {
     let installations = python_installations_from_executables(
         // Perform filtering on the discovered executables based on their source. This avoids
         // unnecessary interpreter queries, which are generally expensive. We'll filter again
         // with `interpreter_satisfies_environment_preference` after querying.
-        python_executables(
-            version,
-            implementation,
-            platform,
-            environments,
-            preference,
-            preview,
-        )
-        .filter_ok(move |(source, path)| {
-            source_satisfies_environment_preference(*source, path, environments)
-        }),
+        python_executables(version, implementation, platform, environments, preference).filter_ok(
+            move |(source, path)| {
+                source_satisfies_environment_preference(*source, path, environments)
+            },
+        ),
         cache,
     )
     .filter_ok(move |installation| {
@@ -1044,7 +1034,6 @@ pub fn find_python_installations<'a>(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &'a Cache,
-    preview: Preview,
 ) -> Box<dyn Iterator<Item = Result<FindPythonResult, Error>> + 'a> {
     let sources = DiscoveryPreferences {
         python_preference: preference,
@@ -1136,7 +1125,6 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
-                preview,
             )
             .map_ok(Ok)
         }),
@@ -1149,7 +1137,6 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
-                preview,
             )
             .map_ok(Ok)
         }),
@@ -1166,7 +1153,6 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
-                    preview,
                 )
                 .map_ok(Ok)
             })
@@ -1180,7 +1166,6 @@ pub fn find_python_installations<'a>(
                 environments,
                 preference,
                 cache,
-                preview,
             )
             .filter_ok(|installation| implementation.matches_interpreter(&installation.interpreter))
             .map_ok(Ok)
@@ -1198,7 +1183,6 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
-                    preview,
                 )
                 .filter_ok(|installation| {
                     implementation.matches_interpreter(&installation.interpreter)
@@ -1222,7 +1206,6 @@ pub fn find_python_installations<'a>(
                     environments,
                     preference,
                     cache,
-                    preview,
                 )
                 .filter_ok(move |installation| {
                     request.satisfied_by_interpreter(&installation.interpreter)
@@ -1242,10 +1225,8 @@ pub(crate) fn find_python_installation(
     environments: EnvironmentPreference,
     preference: PythonPreference,
     cache: &Cache,
-    preview: Preview,
 ) -> Result<FindPythonResult, Error> {
-    let installations =
-        find_python_installations(request, environments, preference, cache, preview);
+    let installations = find_python_installations(request, environments, preference, cache);
     let mut first_prerelease = None;
     let mut first_debug = None;
     let mut first_managed = None;
@@ -1403,7 +1384,6 @@ pub(crate) async fn find_best_python_installation(
     python_install_mirror: Option<&str>,
     pypy_install_mirror: Option<&str>,
     python_downloads_json_url: Option<&str>,
-    preview: Preview,
 ) -> Result<PythonInstallation, crate::Error> {
     debug!("Starting Python discovery for {request}");
     let original_request = request;
@@ -1438,7 +1418,7 @@ pub(crate) async fn find_best_python_installation(
                 String::new()
             }
         );
-        let result = find_python_installation(request, environments, preference, cache, preview);
+        let result = find_python_installation(request, environments, preference, cache);
         let error = match result {
             Ok(Ok(installation)) => {
                 warn_on_unsupported_python(installation.interpreter());

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -9,7 +9,6 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_fs::{LockedFile, LockedFileError, Simplified};
 use uv_pep440::Version;
-use uv_preview::Preview;
 
 use crate::discovery::find_python_installation;
 use crate::installation::PythonInstallation;
@@ -154,11 +153,9 @@ impl PythonEnvironment {
         preference: EnvironmentPreference,
         python_preference: PythonPreference,
         cache: &Cache,
-        preview: Preview,
     ) -> Result<Self, Error> {
         let installation =
-            match find_python_installation(request, preference, python_preference, cache, preview)?
-            {
+            match find_python_installation(request, preference, python_preference, cache)? {
                 Ok(installation) => installation,
                 Err(err) => return Err(EnvironmentNotFound::from(err).into()),
             };

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -13,7 +13,6 @@ use uv_cache::Cache;
 use uv_client::{BaseClient, BaseClientBuilder};
 use uv_pep440::{Prerelease, Version};
 use uv_platform::{Arch, Libc, Os, Platform};
-use uv_preview::Preview;
 
 use crate::discovery::{
     EnvironmentPreference, PythonRequest, find_best_python_installation, find_python_installation,
@@ -64,9 +63,8 @@ impl PythonInstallation {
         preference: PythonPreference,
         download_list: &ManagedPythonDownloadList,
         cache: &Cache,
-        preview: Preview,
     ) -> Result<Self, Error> {
-        let installation = Self::find_existing(request, environments, preference, cache, preview)?;
+        let installation = Self::find_existing(request, environments, preference, cache)?;
         installation.warn_if_outdated_prerelease(request, download_list);
         Ok(installation)
     }
@@ -77,14 +75,12 @@ impl PythonInstallation {
         environments: EnvironmentPreference,
         preference: PythonPreference,
         cache: &Cache,
-        preview: Preview,
     ) -> Result<Self, Error> {
         Ok(find_python_installation(
             request,
             environments,
             preference,
             cache,
-            preview,
         )??)
     }
 
@@ -101,7 +97,6 @@ impl PythonInstallation {
         python_install_mirror: Option<&str>,
         pypy_install_mirror: Option<&str>,
         python_downloads_json_url: Option<&str>,
-        preview: Preview,
     ) -> Result<Self, Error> {
         let downloads_enabled = preference.allows_managed()
             && python_downloads.is_automatic()
@@ -117,7 +112,6 @@ impl PythonInstallation {
             python_install_mirror,
             pypy_install_mirror,
             python_downloads_json_url,
-            preview,
         )
         .await?;
         installation
@@ -144,11 +138,10 @@ impl PythonInstallation {
         python_install_mirror: Option<&str>,
         pypy_install_mirror: Option<&str>,
         python_downloads_json_url: Option<&str>,
-        preview: Preview,
     ) -> Result<Self, Error> {
         let request = request.unwrap_or(&PythonRequest::Default);
 
-        let err = match Self::find_existing(request, environments, preference, cache, preview) {
+        let err = match Self::find_existing(request, environments, preference, cache) {
             Ok(installation) => {
                 installation
                     .download_and_warn_if_outdated_prerelease(

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -214,7 +214,7 @@ mod tests {
     use temp_env::with_vars;
     use test_log::test;
     use uv_client::BaseClientBuilder;
-    use uv_preview::{Preview, PreviewFeature};
+    use uv_preview::PreviewFeature;
     use uv_static::EnvVars;
 
     use uv_cache::Cache;
@@ -311,6 +311,19 @@ mod tests {
                 run_vars.push((key, *value));
             }
             with_vars(&run_vars, closure)
+        }
+
+        fn run_with_vars_and_preview<F, R>(
+            &self,
+            vars: &[(&str, Option<&OsStr>)],
+            preview_features: &[PreviewFeature],
+            closure: F,
+        ) -> R
+        where
+            F: FnOnce() -> R,
+        {
+            let _preview = uv_preview::test::with_features(preview_features);
+            self.run_with_vars(vars, closure)
         }
 
         /// Create a fake Python interpreter executable which returns fixed metadata mocking our interpreter
@@ -655,7 +668,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         });
         assert!(
@@ -670,7 +682,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         });
         assert!(
@@ -695,7 +706,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         });
         assert!(
@@ -717,7 +727,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert!(
@@ -759,7 +768,6 @@ mod tests {
                     None,
                     None,
                     missing_downloads.path().to_str(),
-                    Preview::default(),
                 ))
         })?;
 
@@ -827,7 +835,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert!(
@@ -859,7 +866,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         });
         assert!(
@@ -896,7 +902,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert!(
@@ -928,7 +933,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -950,7 +954,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -976,7 +979,6 @@ mod tests {
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -1002,7 +1004,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -1025,7 +1026,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -1059,7 +1059,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -1093,7 +1092,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -1115,7 +1113,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -1131,7 +1128,6 @@ mod tests {
         environments: EnvironmentPreference,
         preference: PythonPreference,
         cache: &Cache,
-        preview: Preview,
     ) -> Result<PythonInstallation, crate::Error> {
         let client_builder = BaseClientBuilder::default();
         tokio::runtime::Builder::new_current_thread()
@@ -1149,7 +1145,6 @@ mod tests {
                 None,
                 None,
                 None,
-                preview,
             ))
     }
 
@@ -1164,7 +1159,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
 
@@ -1198,7 +1192,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
 
@@ -1235,7 +1228,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })?;
         assert!(
@@ -1266,7 +1258,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })?;
         assert!(
@@ -1301,7 +1292,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })??;
         assert_eq!(
@@ -1327,7 +1317,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })??;
         assert_eq!(
@@ -1355,7 +1344,6 @@ mod tests {
                         EnvironmentPreference::OnlyVirtual,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::default(),
                     )
                 },
             )?
@@ -1370,19 +1358,19 @@ mod tests {
         TestContext::mock_conda_prefix(&baseenv, "3.12.1")?;
 
         // But not if it's a base environment
-        let result = context.run_with_vars(
+        let result = context.run_with_vars_and_preview(
             &[
                 (EnvVars::CONDA_PREFIX, Some(baseenv.as_os_str())),
                 (EnvVars::CONDA_DEFAULT_ENV, Some(&OsString::from("base"))),
                 (EnvVars::CONDA_ROOT, None),
             ],
+            &[],
             || {
                 find_python_installation(
                     &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )?;
@@ -1394,19 +1382,19 @@ mod tests {
 
         // Unless, system interpreters are included...
         let python = context
-            .run_with_vars(
+            .run_with_vars_and_preview(
                 &[
                     (EnvVars::CONDA_PREFIX, Some(baseenv.as_os_str())),
                     (EnvVars::CONDA_DEFAULT_ENV, Some(&OsString::from("base"))),
                     (EnvVars::CONDA_ROOT, None),
                 ],
+                &[],
                 || {
                     find_python_installation(
                         &PythonRequest::Default,
                         EnvironmentPreference::OnlySystem,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::default(),
                     )
                 },
             )?
@@ -1420,7 +1408,7 @@ mod tests {
 
         // If the environment name doesn't match the default, we should not treat it as system
         let python = context
-            .run_with_vars(
+            .run_with_vars_and_preview(
                 &[
                     (EnvVars::CONDA_PREFIX, Some(condaenv.as_os_str())),
                     (
@@ -1428,13 +1416,13 @@ mod tests {
                         Some(&OsString::from("condaenv")),
                     ),
                 ],
+                &[],
                 || {
                     find_python_installation(
                         &PythonRequest::Default,
                         EnvironmentPreference::OnlyVirtual,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::default(),
                     )
                 },
             )?
@@ -1447,18 +1435,18 @@ mod tests {
         );
 
         // When CONDA_DEFAULT_ENV is "base", it should always be treated as base environment
-        let result = context.run_with_vars(
+        let result = context.run_with_vars_and_preview(
             &[
                 (EnvVars::CONDA_PREFIX, Some(condaenv.as_os_str())),
                 (EnvVars::CONDA_DEFAULT_ENV, Some(&OsString::from("base"))),
             ],
+            &[],
             || {
                 find_python_installation(
                     &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )?;
@@ -1474,19 +1462,19 @@ mod tests {
         let base_dir = context.tempdir.child("base");
         TestContext::mock_conda_prefix(&base_dir, "3.12.6")?;
         let python = context
-            .run_with_vars(
+            .run_with_vars_and_preview(
                 &[
                     (EnvVars::CONDA_PREFIX, Some(base_dir.as_os_str())),
                     (EnvVars::CONDA_DEFAULT_ENV, Some(&OsString::from("base"))),
                     (EnvVars::CONDA_ROOT, None),
                 ],
+                &[PreviewFeature::SpecialCondaEnvNames],
                 || {
                     find_python_installation(
                         &PythonRequest::Default,
                         EnvironmentPreference::OnlyVirtual,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::new(&[PreviewFeature::SpecialCondaEnvNames]),
                     )
                 },
             )?
@@ -1502,18 +1490,18 @@ mod tests {
         let myenv_dir = context.tempdir.child("myenv");
         TestContext::mock_conda_prefix(&myenv_dir, "3.12.5")?;
         let python = context
-            .run_with_vars(
+            .run_with_vars_and_preview(
                 &[
                     (EnvVars::CONDA_PREFIX, Some(myenv_dir.as_os_str())),
                     (EnvVars::CONDA_DEFAULT_ENV, Some(&OsString::from("myenv"))),
                 ],
+                &[],
                 || {
                     find_python_installation(
                         &PythonRequest::Default,
                         EnvironmentPreference::OnlyVirtual,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::default(),
                     )
                 },
             )?
@@ -1545,7 +1533,6 @@ mod tests {
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )?;
@@ -1560,7 +1547,7 @@ mod tests {
         TestContext::mock_conda_prefix(&other_conda_env, "3.12.3")?;
 
         let python = context
-            .run_with_vars(
+            .run_with_vars_and_preview(
                 &[
                     (EnvVars::CONDA_PREFIX, Some(other_conda_env.as_os_str())),
                     (EnvVars::CONDA_ROOT, Some(conda_root_env.as_os_str())),
@@ -1569,13 +1556,13 @@ mod tests {
                         Some(&OsString::from("other-conda")),
                     ),
                 ],
+                &[],
                 || {
                     find_python_installation(
                         &PythonRequest::Default,
                         EnvironmentPreference::OnlyVirtual,
                         PythonPreference::OnlySystem,
                         &context.cache,
-                        Preview::default(),
                     )
                 },
             )?
@@ -1606,7 +1593,6 @@ mod tests {
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1639,7 +1625,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1660,7 +1645,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1687,7 +1671,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -1705,7 +1688,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -1734,7 +1716,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })??;
         assert_eq!(
@@ -1772,7 +1753,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1800,7 +1780,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1825,7 +1804,6 @@ mod tests {
                     EnvironmentPreference::ExplicitSystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1850,7 +1828,6 @@ mod tests {
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1875,7 +1852,6 @@ mod tests {
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1913,7 +1889,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -1941,7 +1916,6 @@ mod tests {
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })??;
         assert_eq!(
@@ -1958,7 +1932,6 @@ mod tests {
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })??;
         assert_eq!(
@@ -1975,7 +1948,6 @@ mod tests {
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })?;
         assert!(
@@ -1997,7 +1969,6 @@ mod tests {
                 EnvironmentPreference::OnlyVirtual,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2014,7 +1985,6 @@ mod tests {
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )?;
@@ -2036,7 +2006,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2051,7 +2020,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2065,7 +2033,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2094,7 +2061,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2110,7 +2076,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2140,7 +2105,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2156,7 +2120,6 @@ mod tests {
                 EnvironmentPreference::ExplicitSystem,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2172,7 +2135,6 @@ mod tests {
                 EnvironmentPreference::OnlyVirtual,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2188,7 +2150,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2212,7 +2173,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2227,7 +2187,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2251,7 +2210,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2271,7 +2229,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             },
         )??;
@@ -2300,7 +2257,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2322,7 +2278,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2352,7 +2307,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2368,7 +2322,6 @@ mod tests {
                 EnvironmentPreference::ExplicitSystem,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2395,7 +2348,6 @@ mod tests {
                     EnvironmentPreference::ExplicitSystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2420,7 +2372,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2437,7 +2388,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2452,7 +2402,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2478,7 +2427,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2493,7 +2441,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2519,7 +2466,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2546,7 +2492,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2573,7 +2518,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2600,7 +2544,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2627,7 +2570,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2655,7 +2597,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -2677,7 +2618,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2692,7 +2632,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2718,7 +2657,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2733,7 +2671,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -2771,7 +2708,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2789,7 +2725,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2831,7 +2766,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2849,7 +2783,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2886,7 +2819,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2909,7 +2841,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2932,7 +2863,6 @@ mod tests {
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
-                    Preview::default(),
                 )
             })
             .unwrap()
@@ -2971,7 +2901,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -3024,7 +2953,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
 
@@ -3064,7 +2992,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })?;
         assert!(
@@ -3079,7 +3006,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(
@@ -3096,7 +3022,6 @@ mod tests {
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
-                Preview::default(),
             )
         })??;
         assert_eq!(

--- a/crates/uv-python/src/virtualenv.rs
+++ b/crates/uv-python/src/virtualenv.rs
@@ -8,7 +8,7 @@ use std::{
 use fs_err as fs;
 use thiserror::Error;
 
-use uv_preview::{Preview, PreviewFeature};
+use uv_preview::PreviewFeature;
 use uv_pypi_types::Scheme;
 use uv_static::EnvVars;
 
@@ -88,7 +88,7 @@ impl CondaEnvironmentKind {
     /// name, e.g., `base`, which does not match the `CONDA_PREFIX`, e.g., `/usr/local` instead of
     /// `/usr/local/conda/envs/<name>`. Note the name `CONDA_DEFAULT_ENV` is misleading, it's the
     /// active environment name, not a constant base environment name.
-    fn from_prefix_path(path: &Path, preview: Preview) -> Self {
+    fn from_prefix_path(path: &Path) -> Self {
         // Pixi never creates true "base" envs and names project envs "default", confusing our
         // heuristics, so treat Pixi prefixes as child envs outright.
         if is_pixi_environment(path) {
@@ -117,7 +117,7 @@ impl CondaEnvironmentKind {
         //
         // These are the expected names for the base environment; and is retained for backwards
         // compatibility, but can be removed with the `special-conda-env-names` preview feature.
-        if !preview.is_enabled(PreviewFeature::SpecialCondaEnvNames)
+        if !uv_preview::is_enabled(PreviewFeature::SpecialCondaEnvNames)
             && (current_env == "base" || current_env == "root")
         {
             return Self::Base;
@@ -147,14 +147,11 @@ fn is_pixi_environment(path: &Path) -> bool {
 ///
 /// If `base` is true, the active environment must be the base environment or `None` is returned,
 /// and vice-versa.
-pub(crate) fn conda_environment_from_env(
-    kind: CondaEnvironmentKind,
-    preview: Preview,
-) -> Option<PathBuf> {
+pub(crate) fn conda_environment_from_env(kind: CondaEnvironmentKind) -> Option<PathBuf> {
     let dir = env::var_os(EnvVars::CONDA_PREFIX).filter(|value| !value.is_empty())?;
     let path = PathBuf::from(dir);
 
-    if kind != CondaEnvironmentKind::from_prefix_path(&path, preview) {
+    if kind != CondaEnvironmentKind::from_prefix_path(&path) {
         return None;
     }
 
@@ -366,7 +363,7 @@ mod tests {
 
         with_vars(vars, || {
             assert_eq!(
-                CondaEnvironmentKind::from_prefix_path(prefix, Preview::default()),
+                CondaEnvironmentKind::from_prefix_path(prefix),
                 CondaEnvironmentKind::Child
             );
         });

--- a/crates/uv-test/Cargo.toml
+++ b/crates/uv-test/Cargo.toml
@@ -30,7 +30,7 @@ uv-fs = { workspace = true, features = ["tokio"] }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true }
-uv-preview = { workspace = true }
+uv-preview = { workspace = true, features = ["testing"] }
 uv-python = { workspace = true }
 uv-static = { workspace = true }
 uv-version = { workspace = true }

--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -14,7 +14,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output, Stdio};
 use std::str::FromStr;
 use std::{env, io};
-use uv_preview::Preview;
 use uv_python::downloads::ManagedPythonDownloadList;
 
 use assert_cmd::assert::{Assert, OutputAssertExt};
@@ -2064,6 +2063,7 @@ pub fn python_installations_for_versions(
     let cache = Cache::from_path(temp_dir.child("cache").to_path_buf())
         .init_no_wait()?
         .expect("No cache contention when setting up Python in tests");
+    let _preview = uv_preview::test::with_features(&[]);
     let selected_pythons = python_versions
         .iter()
         .map(|python_version| {
@@ -2073,7 +2073,6 @@ pub fn python_installations_for_versions(
                 PythonPreference::Managed,
                 download_list,
                 &cache,
-                Preview::default(),
             ) {
                 python.into_interpreter().sys_executable().to_owned()
             } else {

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -563,7 +563,6 @@ async fn build_package(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await?
     .into_interpreter();

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -8,7 +8,6 @@ use uv_cache::Cache;
 use uv_configuration::TargetTriple;
 use uv_distribution_types::{DependencyMetadata, Diagnostic, InstalledDist};
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest, PythonVersion,
 };
@@ -27,7 +26,6 @@ pub(crate) fn pip_check(
     dependency_metadata: &DependencyMetadata,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let start = Instant::now();
 
@@ -37,7 +35,6 @@ pub(crate) fn pip_check(
         EnvironmentPreference::from_system_flag(system, false),
         PythonPreference::default().with_system_flag(system),
         cache,
-        preview,
     )?;
 
     report_target_environment(&environment, cache, printer)?;

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -301,7 +301,6 @@ pub(crate) async fn pip_compile(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await
     } else {
@@ -324,7 +323,6 @@ pub(crate) async fn pip_compile(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await
     }?

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -12,7 +12,6 @@ use uv_distribution_types::{DependencyMetadata, Diagnostic, InstalledDistKind, N
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_preview::Preview;
 use uv_python::PythonPreference;
 use uv_python::{EnvironmentPreference, Prefix, PythonEnvironment, PythonRequest, Target};
 
@@ -33,7 +32,6 @@ pub(crate) fn pip_freeze(
     paths: Option<Vec<PathBuf>>,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
     let environment = PythonEnvironment::find(
@@ -41,7 +39,6 @@ pub(crate) fn pip_freeze(
         EnvironmentPreference::from_system_flag(system, false),
         PythonPreference::default().with_system_flag(system),
         cache,
-        preview,
     )?;
 
     // Apply any `--target` or `--prefix` directories.

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -225,7 +225,6 @@ pub(crate) async fn pip_install(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?;
         report_interpreter(&installation, true, printer)?;
@@ -239,7 +238,6 @@ pub(crate) async fn pip_install(
             EnvironmentPreference::from_system_flag(system, true),
             PythonPreference::default().with_system_flag(system),
             &cache,
-            preview,
         )?;
         report_target_environment(&environment, &cache, printer)?;
         environment

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -24,7 +24,6 @@ use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
-use uv_preview::Preview;
 use uv_python::PythonRequest;
 use uv_python::{EnvironmentPreference, Prefix, PythonEnvironment, PythonPreference, Target};
 use uv_resolver::{ExcludeNewer, PrereleaseMode};
@@ -56,7 +55,6 @@ pub(crate) async fn pip_list(
     prefix: Option<Prefix>,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     // Disallow `--outdated` with `--format freeze`.
     if outdated && matches!(format, ListFormat::Freeze) {
@@ -69,7 +67,6 @@ pub(crate) async fn pip_list(
         EnvironmentPreference::from_system_flag(system, false),
         PythonPreference::default().with_system_flag(system),
         cache,
-        preview,
     )?;
 
     // Apply any `--target` or `--prefix` directories.

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -13,7 +13,6 @@ use uv_fs::Simplified;
 use uv_install_wheel::read_record;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, Prefix, PythonEnvironment, PythonPreference, PythonRequest, Target,
 };
@@ -34,7 +33,6 @@ pub(crate) fn pip_show(
     files: bool,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     if packages.is_empty() {
         {
@@ -54,7 +52,6 @@ pub(crate) fn pip_show(
         EnvironmentPreference::from_system_flag(system, false),
         PythonPreference::default().with_system_flag(system),
         cache,
-        preview,
     )?;
 
     // Apply any `--target` or `--prefix` directories.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -175,7 +175,6 @@ pub(crate) async fn pip_sync(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?;
         report_interpreter(&installation, true, printer)?;
@@ -189,7 +188,6 @@ pub(crate) async fn pip_sync(
             EnvironmentPreference::from_system_flag(system, true),
             PythonPreference::default().with_system_flag(system),
             &cache,
-            preview,
         )?;
         report_target_environment(&environment, &cache, printer)?;
         environment

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -21,7 +21,6 @@ use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{Requirement, VersionOrUrl};
-use uv_preview::Preview;
 use uv_pypi_types::{ResolutionMetadata, ResolverMarkerEnvironment, VerbatimParsedUrl};
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
 use uv_resolver::{ExcludeNewer, PrereleaseMode};
@@ -55,7 +54,6 @@ pub(crate) async fn pip_tree(
     system: bool,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
     let environment = PythonEnvironment::find(
@@ -63,7 +61,6 @@ pub(crate) async fn pip_tree(
         EnvironmentPreference::from_system_flag(system, false),
         PythonPreference::default().with_system_flag(system),
         cache,
-        preview,
     )?;
 
     report_target_environment(&environment, cache, printer)?;

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -12,7 +12,6 @@ use uv_distribution_types::Requirement;
 use uv_distribution_types::{InstalledMetadata, Name, UnresolvedRequirement};
 use uv_fs::Simplified;
 use uv_pep508::UnnamedRequirement;
-use uv_preview::Preview;
 use uv_pypi_types::VerbatimParsedUrl;
 use uv_python::PythonRequest;
 use uv_python::{EnvironmentPreference, PythonPreference};
@@ -36,7 +35,6 @@ pub(crate) async fn pip_uninstall(
     client_builder: &BaseClientBuilder<'_>,
     dry_run: DryRun,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
 
@@ -54,7 +52,6 @@ pub(crate) async fn pip_uninstall(
         EnvironmentPreference::from_system_flag(system, true),
         PythonPreference::default().with_system_flag(system),
         &cache,
-        preview,
     )?;
 
     report_target_environment(&environment, &cache, printer)?;

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -202,7 +202,6 @@ pub(crate) async fn add(
                     &client_builder,
                     cache,
                     &reporter,
-                    preview,
                 )
                 .await?;
                 Pep723Script::init(&path, requires_python.specifiers()).await?
@@ -225,7 +224,6 @@ pub(crate) async fn add(
             active,
             cache,
             printer,
-            preview,
         )
         .await?
         .into_interpreter();
@@ -298,7 +296,6 @@ pub(crate) async fn add(
                 active,
                 cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter();
@@ -320,7 +317,6 @@ pub(crate) async fn add(
                 cache,
                 DryRun::Disabled,
                 printer,
-                preview,
             )
             .await?
             .into_environment()?;

--- a/crates/uv/src/commands/project/audit.rs
+++ b/crates/uv/src/commands/project/audit.rs
@@ -124,7 +124,6 @@ pub(crate) async fn audit(
                 Some(false),
                 &cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter(),
@@ -149,7 +148,6 @@ pub(crate) async fn audit(
                     Some(false),
                     &cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -138,7 +138,6 @@ pub(crate) async fn check(
             cache,
             DryRun::Disabled,
             printer,
-            preview,
         )
         .await?
         .into_environment()?;

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -159,7 +159,6 @@ pub(crate) async fn export(
                 Some(false),
                 cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter(),
@@ -184,7 +183,6 @@ pub(crate) async fn export(
                     Some(false),
                     cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -20,7 +20,6 @@ use uv_fs::{CWD, Simplified};
 use uv_git::GIT;
 use uv_normalize::PackageName;
 use uv_pep440::Version;
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonEnvironment, PythonInstallation,
     PythonPreference, PythonRequest, PythonVariant, PythonVersionFile, VersionFileDiscoveryOptions,
@@ -63,7 +62,6 @@ pub(crate) async fn init(
     no_config: bool,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     match init_kind {
         InitKind::Script => {
@@ -87,7 +85,6 @@ pub(crate) async fn init(
                 pin_python,
                 package,
                 no_config,
-                preview,
             )
             .await?;
 
@@ -164,7 +161,6 @@ pub(crate) async fn init(
                 no_config,
                 cache,
                 printer,
-                preview,
             ))
             .await?;
 
@@ -216,7 +212,6 @@ async fn init_script(
     pin_python: bool,
     package: bool,
     no_config: bool,
-    preview: Preview,
 ) -> Result<()> {
     if no_workspace {
         warn_user_once!("`--no-workspace` is a no-op for Python scripts, which are standalone");
@@ -269,7 +264,6 @@ async fn init_script(
         client_builder,
         cache,
         &reporter,
-        preview,
     )
     .await?;
 
@@ -306,7 +300,6 @@ async fn init_project(
     no_config: bool,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<()> {
     // Discover the current workspace, if it exists.
     let workspace_cache = WorkspaceCache::default();
@@ -399,7 +392,6 @@ async fn init_project(
         python_preference,
         python_downloads,
         cache,
-        preview,
         workspace.as_ref(),
         &reporter,
         python_request,
@@ -505,7 +497,6 @@ async fn determine_requires_python(
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     cache: &Cache,
-    preview: Preview,
     workspace: Option<&Workspace>,
     reporter: &PythonDownloadReporter,
     python_request: Option<PythonRequest>,
@@ -569,7 +560,6 @@ async fn determine_requires_python(
                         install_mirrors.python_install_mirror.as_deref(),
                         install_mirrors.pypy_install_mirror.as_deref(),
                         install_mirrors.python_downloads_json_url.as_deref(),
-                        preview,
                     )
                     .await?
                     .into_interpreter();
@@ -597,7 +587,6 @@ async fn determine_requires_python(
                     install_mirrors.python_install_mirror.as_deref(),
                     install_mirrors.pypy_install_mirror.as_deref(),
                     install_mirrors.python_downloads_json_url.as_deref(),
-                    preview,
                 )
                 .await?
                 .into_interpreter();
@@ -668,7 +657,6 @@ async fn determine_requires_python(
                 install_mirrors.python_install_mirror.as_deref(),
                 install_mirrors.pypy_install_mirror.as_deref(),
                 install_mirrors.python_downloads_json_url.as_deref(),
-                preview,
             )
             .await?
             .into_interpreter();
@@ -698,7 +686,6 @@ async fn determine_requires_python(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?
         .into_interpreter();

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -116,7 +116,6 @@ pub(crate) async fn lock(
                 &client_builder,
                 cache,
                 &reporter,
-                preview,
             )
             .await?;
             Some(Pep723Script::init(&path, requires_python.specifiers()).await?)
@@ -165,7 +164,6 @@ pub(crate) async fn lock(
                     Some(false),
                     cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter()
@@ -182,7 +180,6 @@ pub(crate) async fn lock(
                 Some(false),
                 cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter(),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -783,7 +783,6 @@ impl ScriptInterpreter {
         active: Option<bool>,
         cache: &Cache,
         printer: Printer,
-        preview: Preview,
     ) -> Result<Self, ProjectError> {
         // For now, we assume that scripts are never evaluated in the context of a workspace.
         let workspace = None;
@@ -837,7 +836,6 @@ impl ScriptInterpreter {
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?
         .into_interpreter();
@@ -1017,7 +1015,6 @@ impl ProjectInterpreter {
         active: Option<bool>,
         cache: &Cache,
         printer: Printer,
-        preview: Preview,
     ) -> Result<Self, ProjectError> {
         let WorkspacePython {
             source,
@@ -1117,7 +1114,6 @@ impl ProjectInterpreter {
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?;
 
@@ -1444,7 +1440,6 @@ impl ProjectEnvironment {
         cache: &Cache,
         dry_run: DryRun,
         printer: Printer,
-        preview: Preview,
     ) -> Result<Self, ProjectError> {
         // Lock the project environment to avoid synchronization issues.
         let _lock = ProjectInterpreter::lock(workspace)
@@ -1480,7 +1475,6 @@ impl ProjectEnvironment {
             active,
             cache,
             printer,
-            preview,
         )
         .await?
         {
@@ -1683,7 +1677,6 @@ impl ScriptEnvironment {
         cache: &Cache,
         dry_run: DryRun,
         printer: Printer,
-        preview: Preview,
     ) -> Result<Self, ProjectError> {
         // Lock the script environment to avoid synchronization issues.
         let _lock = ScriptInterpreter::lock(script)
@@ -1709,7 +1702,6 @@ impl ScriptEnvironment {
             active,
             cache,
             printer,
-            preview,
         )
         .await?
         {
@@ -2691,7 +2683,6 @@ pub(crate) async fn init_script_python_requirement(
     client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
     reporter: &PythonDownloadReporter,
-    preview: Preview,
 ) -> anyhow::Result<RequiresPython> {
     let python_request = if let Some(request) = python {
         // (1) Explicit request from user
@@ -2723,7 +2714,6 @@ pub(crate) async fn init_script_python_requirement(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await?
     .into_interpreter();

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -243,7 +243,6 @@ pub(crate) async fn remove(
                     active,
                     cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter();
@@ -265,7 +264,6 @@ pub(crate) async fn remove(
                     cache,
                     DryRun::Disabled,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_environment()?;
@@ -286,7 +284,6 @@ pub(crate) async fn remove(
                 active,
                 cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter();

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -216,7 +216,6 @@ pub(crate) async fn run(
                 &cache,
                 DryRun::Disabled,
                 printer,
-                preview,
             )
             .await?
             .into_environment()?;
@@ -387,7 +386,6 @@ pub(crate) async fn run(
                     &cache,
                     DryRun::Disabled,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_environment()?;
@@ -473,7 +471,6 @@ pub(crate) async fn run(
                     active.map_or(Some(false), Some),
                     &cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter();
@@ -665,7 +662,6 @@ pub(crate) async fn run(
                     install_mirrors.python_install_mirror.as_deref(),
                     install_mirrors.pypy_install_mirror.as_deref(),
                     install_mirrors.python_downloads_json_url.as_deref(),
-                    preview,
                 )
                 .await?
                 .into_interpreter();
@@ -711,7 +707,6 @@ pub(crate) async fn run(
                     &cache,
                     DryRun::Disabled,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_environment()?
@@ -907,7 +902,6 @@ pub(crate) async fn run(
                     install_mirrors.python_install_mirror.as_deref(),
                     install_mirrors.pypy_install_mirror.as_deref(),
                     install_mirrors.python_downloads_json_url.as_deref(),
-                    preview,
                 )
                 .await?;
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -168,7 +168,6 @@ pub(crate) async fn sync(
                 cache,
                 dry_run,
                 printer,
-                preview,
             )
             .await?,
         ),
@@ -186,7 +185,6 @@ pub(crate) async fn sync(
                 cache,
                 dry_run,
                 printer,
-                preview,
             )
             .await?,
         ),

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -99,7 +99,6 @@ pub(crate) async fn tree(
                 Some(false),
                 cache,
                 printer,
-                preview,
             )
             .await?
             .into_interpreter(),
@@ -124,7 +123,6 @@ pub(crate) async fn tree(
                     Some(false),
                     cache,
                     printer,
-                    preview,
                 )
                 .await?
                 .into_interpreter()

--- a/crates/uv/src/commands/project/version.rs
+++ b/crates/uv/src/commands/project/version.rs
@@ -504,7 +504,6 @@ async fn print_frozen_version(
         active,
         cache,
         printer,
-        preview,
     )
     .await?
     .into_interpreter();
@@ -623,7 +622,6 @@ async fn lock_and_sync(
             active,
             cache,
             printer,
-            preview,
         )
         .await?
         .into_interpreter();
@@ -645,7 +643,6 @@ async fn lock_and_sync(
             cache,
             DryRun::Disabled,
             printer,
-            preview,
         )
         .await?
         .into_environment()?;

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -7,7 +7,6 @@ use uv_client::BaseClientBuilder;
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_errors::ErrorWithHints;
 use uv_fs::Simplified;
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
 };
@@ -38,7 +37,6 @@ pub(crate) async fn find(
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let environment_preference = if system {
         EnvironmentPreference::OnlySystem
@@ -84,7 +82,6 @@ pub(crate) async fn find(
         environment_preference,
         python_preference,
         cache,
-        preview,
     )?;
     python
         .download_and_warn_if_outdated_prerelease(
@@ -138,7 +135,6 @@ pub(crate) async fn find_script(
     no_config: bool,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let interpreter = match ScriptInterpreter::discover(
         script,
@@ -152,7 +148,6 @@ pub(crate) async fn find_script(
         Some(false),
         cache,
         printer,
-        preview,
     )
     .await
     {

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeSet;
 use std::fmt::Write;
 use uv_cli::PythonListFormat;
 use uv_pep440::Version;
-use uv_preview::Preview;
 
 use anyhow::Result;
 use itertools::Either;
@@ -71,7 +70,6 @@ pub(crate) async fn list(
     client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let request = request.as_deref().map(PythonRequest::parse);
     let base_download_request = if python_preference == PythonPreference::OnlySystem {
@@ -155,7 +153,6 @@ pub(crate) async fn list(
                 EnvironmentPreference::OnlySystem,
                 discovery_preference,
                 cache,
-                preview,
             )
             // Raise discovery errors if critical
             .filter(|result| {

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -10,7 +10,6 @@ use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::DependencyGroupsWithDefaults;
 use uv_fs::Simplified;
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, PYTHON_VERSION_FILENAME, PythonDownloads, PythonInstallation,
     PythonPreference, PythonRequest, PythonVersionFile, VersionFileDiscoveryOptions,
@@ -40,7 +39,6 @@ pub(crate) async fn pin(
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
-    preview: Preview,
 ) -> Result<ExitStatus> {
     let virtual_project = if no_project {
         None
@@ -118,7 +116,6 @@ pub(crate) async fn pin(
                         python_preference,
                         download_list,
                         cache,
-                        preview,
                     );
                 }
             }
@@ -145,7 +142,6 @@ pub(crate) async fn pin(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await
     {
@@ -260,7 +256,6 @@ fn warn_if_existing_pin_incompatible_with_project(
     python_preference: PythonPreference,
     downloads_list: &ManagedPythonDownloadList,
     cache: &Cache,
-    preview: Preview,
 ) {
     // Check if the pinned version is compatible with the project.
     if let Some(pin_version) = pin.as_pep440_version() {
@@ -286,7 +281,6 @@ fn warn_if_existing_pin_incompatible_with_project(
         python_preference,
         downloads_list,
         cache,
-        preview,
     ) {
         Ok(python) => {
             let python_version = python.python_version();

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -25,7 +25,6 @@ use uv_git::GitResolver;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifier, VersionSpecifiers};
-use uv_preview::Preview;
 use uv_python::{
     EnvironmentPreference, Interpreter, PythonDownloads, PythonEnvironment, PythonInstallation,
     PythonPreference, PythonRequest, PythonVariant, PythonVersionFile, VersionFileDiscoveryOptions,
@@ -267,7 +266,6 @@ pub(crate) async fn refine_interpreter(
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     cache: &Cache,
-    preview: Preview,
 ) -> anyhow::Result<Option<Interpreter>, ProjectError> {
     let pip::operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(no_solution_err)) =
         err
@@ -331,7 +329,6 @@ pub(crate) async fn refine_interpreter(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await?
     .into_interpreter();

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -141,7 +141,6 @@ pub(crate) async fn install(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await?
     .into_interpreter();
@@ -669,7 +668,6 @@ pub(crate) async fn install(
                         python_preference,
                         python_downloads,
                         &cache,
-                        preview,
                     )
                     .await
                     .ok()

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -761,7 +761,6 @@ async fn get_or_create_environment(
         install_mirrors.python_install_mirror.as_deref(),
         install_mirrors.pypy_install_mirror.as_deref(),
         install_mirrors.python_downloads_json_url.as_deref(),
-        preview,
     )
     .await?
     .into_interpreter();
@@ -1149,7 +1148,6 @@ async fn get_or_create_environment(
                     python_preference,
                     python_downloads,
                     cache,
-                    preview,
                 )
                 .await
                 .ok()

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -102,7 +102,6 @@ pub(crate) async fn upgrade(
                 install_mirrors.python_install_mirror.as_deref(),
                 install_mirrors.pypy_install_mirror.as_deref(),
                 install_mirrors.python_downloads_json_url.as_deref(),
-                preview,
             )
             .await?
             .into_interpreter(),

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -162,7 +162,6 @@ pub(crate) async fn venv(
             install_mirrors.python_install_mirror.as_deref(),
             install_mirrors.pypy_install_mirror.as_deref(),
             install_mirrors.python_downloads_json_url.as_deref(),
-            preview,
         )
         .await?;
         report_interpreter(&python, false, printer)?;

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -88,7 +88,6 @@ pub(crate) async fn metadata(
             Some(false),
             cache,
             printer,
-            preview,
         )
         .await?
         .into_interpreter();
@@ -142,7 +141,6 @@ pub(crate) async fn metadata(
                     cache,
                     DryRun::Disabled,
                     printer,
-                    preview,
                 )
                 .await?;
                 let module_owners = collect_module_owners(

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1014,7 +1014,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &client_builder.subcommand(vec!["pip".to_owned(), "uninstall".to_owned()]),
                 args.dry_run,
                 printer,
-                globals.preview,
             )
             .await
         }
@@ -1040,7 +1039,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.paths,
                 &cache,
                 printer,
-                globals.preview,
             )
         }
         Commands::Pip(PipNamespace {
@@ -1075,7 +1073,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.prefix,
                 &cache,
                 printer,
-                globals.preview,
             )
             .await
         }
@@ -1100,7 +1097,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.files,
                 &cache,
                 printer,
-                globals.preview,
             )
         }
         Commands::Pip(PipNamespace {
@@ -1133,7 +1129,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.system,
                 &cache,
                 printer,
-                globals.preview,
             )
             .await
         }
@@ -1155,7 +1150,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &args.settings.dependency_metadata,
                 &cache,
                 printer,
-                globals.preview,
             )
         }
         Commands::Pip(PipNamespace {
@@ -1717,7 +1711,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &client_builder.subcommand(vec!["python".to_owned(), "list".to_owned()]),
                 &cache,
                 printer,
-                globals.preview,
             )
             .await
         }
@@ -1820,7 +1813,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     cli.top_level.no_config,
                     &cache,
                     printer,
-                    globals.preview,
                 )
                 .await
             } else {
@@ -1838,7 +1830,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                     &cache,
                     &workspace_cache,
                     printer,
-                    globals.preview,
                 )
                 .await
             }
@@ -1866,7 +1857,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 &cache,
                 &workspace_cache,
                 printer,
-                globals.preview,
             ))
             .await
         }
@@ -2154,7 +2144,6 @@ async fn run_project(
                 no_config,
                 &cache,
                 printer,
-                globals.preview,
             ))
             .await
         }


### PR DESCRIPTION
## Summary

This expands the usage of global preview in a key area which has wide-ranging impact.

Key notes:

* uv-dev needs to set up default global preview because of this. Although it seems like it should technically have been setting it up earlier?
* A number of tests no longer pass `Preview::default()` but also don't use the guard. This is because they only call into the preview stuff when the relevant conda environment variables are present. Which we assume they're not (otherwise the tests would be invalid for other reasons). There's really a hermeticity issue here, but I've addressed it in a separate PR.

## Test Plan

Tests have been modified, but existing coverage should be sufficient.