### PR TITLE
Make `run_with_vars` drop more environment variables

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -291,13 +291,14 @@ mod tests {
                 .as_ref()
                 .map(|paths| env::join_paths(paths).unwrap());
 
-            let mut run_vars = vec![
-                // Ensure `PATH` is used
-                (EnvVars::UV_PYTHON_SEARCH_PATH, None),
+            let mut run_vars: Vec<(&str, Option<&OsStr>)> = EnvVars::all_names()
+                .iter()
+                .copied()
+                .map(|name| (name, None))
+                .collect();
+            run_vars.extend([
                 // Keep discovery hermetic by disabling registry-based sources unless a test opts in.
                 (EnvVars::UV_PYTHON_NO_REGISTRY, Some(OsStr::new("1"))),
-                // Ignore active virtual environments (i.e. that the dev is using)
-                (EnvVars::VIRTUAL_ENV, None),
                 (EnvVars::PATH, path.as_deref()),
                 // Use the temporary python directory
                 (
@@ -306,10 +307,8 @@ mod tests {
                 ),
                 // Set a working directory
                 (EnvVars::PWD, Some(self.workdir.path().as_os_str())),
-            ];
-            for (key, value) in vars {
-                run_vars.push((key, *value));
-            }
+            ]);
+            run_vars.extend(vars.iter().copied());
             with_vars(&run_vars, closure)
         }
 


### PR DESCRIPTION
## Summary

`uv-python` has some unit tests for python discovery. Python discovery is sensitive to various environment variables. The code tries to be "hermetic" by dropping some significant ones and setting others to fixed values, but it misses some conda specific environment variables.

This PR fixes this gap by just using `EnvVars::all_names` to drop all environment variables that uv cares about eagerly to avoid this and similar future gaps.

## Test Plan

Existing coverage.