### PR TITLE
Add `assert_diff_snapshot` test helper

### DIFF
--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1980,6 +1980,18 @@ pub fn diff_snapshot(old: &str, new: &str) -> String {
         .into_owned()
 }
 
+/// Assert a snapshot of the diff of `old` and `new`.
+///
+/// Returns `new`, this is useful for chaining diffs.
+#[macro_export]
+macro_rules! assert_diff_snapshot {
+    ($old:expr, $new:expr, @$snapshot:literal) => {{
+        let new = $new;
+        ::insta::assert_snapshot!($crate::diff_snapshot($old, new.as_ref()), @$snapshot);
+        new
+    }};
+}
+
 pub fn site_packages_path(venv: &Path, python: &str) -> PathBuf {
     if cfg!(unix) {
         venv.join("lib").join(python).join("site-packages")

--- a/crates/uv/tests/it/workflow.rs
+++ b/crates/uv/tests/it/workflow.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use insta::assert_snapshot;
-use uv_test::{diff_snapshot, uv_snapshot};
+use uv_test::{assert_diff_snapshot, uv_snapshot};
 
 #[test]
 fn packse_add_remove_one_package() {
@@ -202,12 +202,10 @@ fn packse_add_remove_one_package() {
     });
 
     // Back to where we started.
-    let new_lock = context.read("uv.lock");
-    let diff = diff_snapshot(&lock, &new_lock);
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(diff, @"");
+        assert_diff_snapshot!(&lock, context.read("uv.lock"), @"");
     });
 }
 
@@ -386,12 +384,10 @@ fn packse_promote_transitive_to_direct_then_remove() {
     });
 
     // Back to where we started.
-    let new_lock = context.read("uv.lock");
-    let diff = diff_snapshot(&lock, &new_lock);
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(diff, @"");
+        assert_diff_snapshot!(&lock, context.read("uv.lock"), @"");
     });
 }
 
@@ -570,12 +566,10 @@ fn jax_instability() -> Result<()> {
     //
     // See: https://github.com/astral-sh/uv/issues/6063
     // See: https://github.com/astral-sh/uv/issues/6158
-    let new_lock = context.read("uv.lock");
-    let diff = diff_snapshot(&lock, &new_lock);
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(diff, @r#"
+        assert_diff_snapshot!(&lock, context.read("uv.lock"), @r#"
         --- old
         +++ new
         @@ -9,21 +9,21 @@


### PR DESCRIPTION
## Summary

This is more of a base change which doesn't seem very worth it on its own, but a couple of different PRs will be stacked on top with more to come in the future, and I promise it will bring a bunch of improvements in the show_settings tests and more places.

Current stacked PRs:

* #19654

## Test Plan

N/A