### PR TITLE
Remove a bunch of duplication in `show_settings` tests by using diffs

### DIFF
--- a/crates/uv-test/src/lib.rs
+++ b/crates/uv-test/src/lib.rs
@@ -1980,6 +1980,40 @@ pub fn diff_snapshot(old: &str, new: &str) -> String {
         .into_owned()
 }
 
+/// Assert a snapshot of the diff between `old` and a command's output.
+///
+/// Returns the command's snapshot, this is useful for chaining diffs.
+#[macro_export]
+macro_rules! diff_uv_snapshot {
+    ($filters:expr, $old:expr, $spawnable:expr, @$snapshot:literal) => {{
+        let (new, _) = $crate::run_and_format(
+            $spawnable,
+            &$filters,
+            $crate::function_name!(),
+            Some($crate::WindowsFilters::Platform),
+            None,
+        );
+        ::insta::assert_snapshot!($crate::diff_snapshot($old, &new), @$snapshot);
+        new
+    }};
+}
+
+/// Assert and capture a snapshot of a command's output.
+#[macro_export]
+macro_rules! capture_uv_snapshot {
+    ($filters:expr, $spawnable:expr, @$snapshot:literal) => {{
+        let (snapshot, _) = $crate::run_and_format(
+            $spawnable,
+            &$filters,
+            $crate::function_name!(),
+            Some($crate::WindowsFilters::Platform),
+            None,
+        );
+        ::insta::assert_snapshot!(snapshot, @$snapshot);
+        snapshot
+    }};
+}
+
 pub fn site_packages_path(venv: &Path, python: &str) -> PathBuf {
     if cfg!(unix) {
         venv.join("lib").join(python).join("site-packages")

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -8890,7 +8890,7 @@ fn upgrade_pip_cli_config_interaction() -> anyhow::Result<()> {
 
     // `--no-upgrade` overrides `--upgrade-package`.
     // TODO(charlie): This should mark `sniffio` for upgrade, but it doesn't.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
+    let no_upgrade = capture_uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
         .arg("--no-upgrade")
         .arg("--upgrade-package")
         .arg("sniffio")
@@ -9084,181 +9084,44 @@ fn upgrade_pip_cli_config_interaction() -> anyhow::Result<()> {
     "})?;
 
     // Despite `upgrade = false` in the configuration file, we should mark `idna` for upgrade.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--upgrade-package")
-        .arg("idna")
-        .arg("--show-settings")
-        .arg("requirements.in"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.pip_compile())
+            .arg("--upgrade-package")
+            .arg("idna")
+            .arg("--show-settings")
+            .arg("requirements.in"),
+        @r#"
+    --- old
+    +++ new
+    @@ -153,25 +153,18 @@
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+             hash_checking: Some(
+                 Verify,
+             ),
+             upgrade: Upgrade {
+    -            strategy: Some(
+    -                {
+    -                    PackageName(
+    -                        "sniffio",
+    -                    ),
+    -                },
+    -                {},
+    -            ),
+    +            strategy: None,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
@@ -9270,181 +9133,44 @@ fn upgrade_pip_cli_config_interaction() -> anyhow::Result<()> {
     "})?;
 
     // Despite `--upgrade-package idna` in the command line, we should upgrade all packages.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--upgrade-package")
-        .arg("idna")
-        .arg("--show-settings")
-        .arg("requirements.in"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: All,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.pip_compile())
+            .arg("--upgrade-package")
+            .arg("idna")
+            .arg("--show-settings")
+            .arg("requirements.in"),
+        @r#"
+    --- old
+    +++ new
+    @@ -153,25 +153,18 @@
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+             hash_checking: Some(
+                 Verify,
+             ),
+             upgrade: Upgrade {
+    -            strategy: Some(
+    -                {
+    -                    PackageName(
+    -                        "sniffio",
+    -                    ),
+    -                },
+    -                {},
+    -            ),
+    +            strategy: All,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
@@ -9455,561 +9181,113 @@ fn upgrade_pip_cli_config_interaction() -> anyhow::Result<()> {
     "#})?;
 
     // Despite `upgrade-package = ["idna"]` in the configuration file, we should disable upgrades.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--no-upgrade")
-        .arg("--show-settings")
-        .arg("requirements.in"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.pip_compile())
+            .arg("--no-upgrade")
+            .arg("--show-settings")
+            .arg("requirements.in"),
+        @r#"
+    --- old
+    +++ new
+    @@ -156,21 +156,21 @@
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+             hash_checking: Some(
+                 Verify,
+             ),
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+    -                        "sniffio",
+    +                        "idna",
+                         ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
     "#
     );
 
     // Despite `upgrade-package = ["idna"]` in the configuration file, we should enable all upgrades.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--upgrade")
-        .arg("--show-settings")
-        .arg("requirements.in"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.pip_compile())
+            .arg("--upgrade")
+            .arg("--show-settings")
+            .arg("requirements.in"),
+        @r#"
+    --- old
+    +++ new
+    @@ -156,21 +156,21 @@
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+             hash_checking: Some(
+                 Verify,
+             ),
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+    -                        "sniffio",
+    +                        "idna",
+                         ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
     "#
     );
 
     // Mark both `sniffio` and `idna` for upgrade.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--upgrade-package")
-        .arg("sniffio")
-        .arg("--show-settings")
-        .arg("requirements.in"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "sniffio",
-                        ),
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.pip_compile())
+            .arg("--upgrade-package")
+            .arg("sniffio")
+            .arg("--show-settings")
+            .arg("requirements.in"),
+        @r#"
+    --- old
+    +++ new
+    @@ -158,20 +158,23 @@
+             sources: None,
+             hash_checking: Some(
+                 Verify,
+             ),
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+                             "sniffio",
+                         ),
+    +                    PackageName(
+    +                        "idna",
+    +                    ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use assert_fs::prelude::*;
 use uv_static::EnvVars;
 
-use uv_test::uv_snapshot;
+use uv_test::{capture_uv_snapshot, diff_uv_snapshot, uv_snapshot};
 
 /// Add shared arguments to a command.
 ///
@@ -47,7 +47,7 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
     requirements_in.write_str("anyio>3.0.0")?;
 
     // Resolution should use the lowest direct version, and generate hashes.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
+    let default = capture_uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
         .arg("--show-settings")
         .arg("requirements.in"), @r#"
     success: true
@@ -262,436 +262,78 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
     );
 
     // Resolution should use the highest version, and generate hashes.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--show-settings")
-        .arg("requirements.in")
-        .arg("--resolution=highest"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [
-                    Index {
-                        name: None,
-                        url: Pypi(
-                            VerbatimUrl {
-                                url: DisplaySafeUrl {
-                                    scheme: "https",
-                                    cannot_be_a_base: false,
-                                    username: "",
-                                    password: None,
-                                    host: Some(
-                                        Domain(
-                                            "pypi.org",
-                                        ),
-                                    ),
-                                    port: None,
-                                    path: "/simple",
-                                    query: None,
-                                    fragment: None,
-                                },
-                                given: Some(
-                                    "https://pypi.org/simple",
-                                ),
-                                expanded: false,
-                            },
-                        ),
-                        explicit: false,
-                        default: true,
-                        origin: Some(
-                            Project,
-                        ),
-                        format: Simple,
-                        publish_url: None,
-                        authenticate: Auto,
-                        ignore_error_codes: None,
-                        cache_control: None,
-                        exclude_newer: None,
-                    },
-                ],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: true,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
-    "#
+    let highest = diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_compile())
+            .arg("--show-settings")
+            .arg("requirements.in")
+            .arg("--resolution=highest"),
+        @"
+    --- old
+    +++ new
+    @@ -149,21 +149,21 @@
+             extra_build_variables: ExtraBuildVariables(
+                 {},
+             ),
+             build_options: BuildOptions {
+                 no_binary: None,
+                 no_build: None,
+             },
+             allow_empty_requirements: false,
+             strict: false,
+             dependency_mode: Transitive,
+    -        resolution: LowestDirect,
+    +        resolution: Highest,
+             prerelease: IfNecessaryOrExplicit,
+             fork_strategy: RequiresPython,
+             dependency_metadata: DependencyMetadata(
+                 {},
+             ),
+             output_file: None,
+             no_strip_extras: false,
+             no_strip_markers: false,
+             no_annotate: false,
+             no_header: false,
+    "
     );
 
     // Resolution should use the highest version, and omit hashes.
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--show-settings")
-        .arg("requirements.in")
-        .arg("--resolution=highest")
-        .arg("--no-generate-hashes"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [
-                    Index {
-                        name: None,
-                        url: Pypi(
-                            VerbatimUrl {
-                                url: DisplaySafeUrl {
-                                    scheme: "https",
-                                    cannot_be_a_base: false,
-                                    username: "",
-                                    password: None,
-                                    host: Some(
-                                        Domain(
-                                            "pypi.org",
-                                        ),
-                                    ),
-                                    port: None,
-                                    path: "/simple",
-                                    query: None,
-                                    fragment: None,
-                                },
-                                given: Some(
-                                    "https://pypi.org/simple",
-                                ),
-                                expanded: false,
-                            },
-                        ),
-                        explicit: false,
-                        default: true,
-                        origin: Some(
-                            Project,
-                        ),
-                        format: Simple,
-                        publish_url: None,
-                        authenticate: Auto,
-                        ignore_error_codes: None,
-                        cache_control: None,
-                        exclude_newer: None,
-                    },
-                ],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
-    "#
+    diff_uv_snapshot!(
+        context.filters(),
+        &highest,
+        add_shared_args(context.pip_compile())
+            .arg("--show-settings")
+            .arg("requirements.in")
+            .arg("--resolution=highest")
+            .arg("--no-generate-hashes"),
+        @"
+    --- old
+    +++ new
+    @@ -161,21 +161,21 @@
+             fork_strategy: RequiresPython,
+             dependency_metadata: DependencyMetadata(
+                 {},
+             ),
+             output_file: None,
+             no_strip_extras: false,
+             no_strip_markers: false,
+             no_annotate: false,
+             no_header: false,
+             custom_compile_command: None,
+    -        generate_hashes: true,
+    +        generate_hashes: false,
+             config_setting: ConfigSettings(
+                 {},
+             ),
+             config_settings_package: PackageConfigSettings(
+                 {},
+             ),
+             python_version: None,
+             python_platform: None,
+             universal: false,
+             exclude_newer: ExcludeNewer {
+    "
     );
 
     Ok(())

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -9679,7 +9679,7 @@ fn build_isolation_override() -> anyhow::Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("numpy")?;
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
+    let shared = capture_uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
         .arg("--show-settings")
         .arg("requirements.in")
         .arg("--no-build-isolation-package").arg("numpy"), @r#"
@@ -9860,186 +9860,45 @@ fn build_isolation_override() -> anyhow::Result<()> {
         no-build-isolation = false
     "})?;
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_compile())
-        .arg("--show-settings")
-        .arg("requirements.in")
-        .arg("--no-build-isolation-package").arg("numpy"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipCompileSettings {
-        format: None,
-        src_file: [
-            "requirements.in",
-        ],
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        environments: SupportedEnvironments(
-            [],
-        ),
-        required_environments: SupportedEnvironments(
-            [],
-        ),
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: SharedPackage(
-                [
-                    PackageName(
-                        "numpy",
-                    ),
-                ],
-            ),
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
+    diff_uv_snapshot!(
+        context.filters(),
+        &shared,
+        add_shared_args(context.pip_compile())
+            .arg("--show-settings")
+            .arg("requirements.in")
+            .arg("--no-build-isolation-package").arg("numpy"),
+        @r#"
+    --- old
+    +++ new
+    @@ -97,21 +97,27 @@
+                     },
+                 },
+             ),
+             groups: [],
+             break_system_packages: false,
+             target: None,
+             prefix: None,
+             index_strategy: FirstIndex,
+             keyring_provider: Disabled,
+             torch_backend: None,
+    -        build_isolation: Shared,
+    +        build_isolation: SharedPackage(
+    +            [
+    +                PackageName(
+    +                    "numpy",
+    +                ),
+    +            ],
+    +        ),
+             extra_build_dependencies: ExtraBuildDependencies(
+                 {},
+             ),
+             extra_build_variables: ExtraBuildVariables(
+                 {},
+             ),
+             build_options: BuildOptions {
+                 no_binary: None,
+                 no_build: None,
+             },
     "#);
 
     Ok(())

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -9314,7 +9314,7 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
 
     // `--no-upgrade` overrides `--upgrade-package`.
     // TODO(charlie): This should mark `sniffio` for upgrade, but it doesn't.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
+    let no_upgrade = capture_uv_snapshot!(context.filters(), add_shared_args(context.lock())
         .arg("--no-upgrade")
         .arg("--upgrade-package")
         .arg("sniffio")
@@ -9448,117 +9448,42 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
     "#})?;
 
     // Despite `upgrade = false` in the configuration file, we should mark `idna` for upgrade.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
-        .arg("--upgrade-package")
-        .arg("idna")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    LockSettings {
-        lock_check: Disabled,
-        frozen: None,
-        dry_run: Disabled,
-        script: None,
-        python: None,
-        install_mirrors: PythonInstallMirrors {
-            python_install_mirror: None,
-            pypy_install_mirror: None,
-            python_downloads_json_url: None,
-        },
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: ResolverSettings {
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            fork_strategy: RequiresPython,
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            link_mode: Clone,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            prerelease: IfNecessaryOrExplicit,
-            resolution: Highest,
-            sources: None,
-            torch_backend: None,
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.lock())
+            .arg("--upgrade-package")
+            .arg("idna")
+            .arg("--show-settings"),
+        @r#"
+    --- old
+    +++ new
+    @@ -91,24 +91,17 @@
+                 {},
+             ),
+             extra_build_variables: ExtraBuildVariables(
+                 {},
+             ),
+             prerelease: IfNecessaryOrExplicit,
+             resolution: Highest,
+             sources: None,
+             torch_backend: None,
+             upgrade: Upgrade {
+    -            strategy: Some(
+    -                {
+    -                    PackageName(
+    -                        "sniffio",
+    -                    ),
+    -                },
+    -                {},
+    -            ),
+    +            strategy: None,
+                 constraints: {},
+             },
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
@@ -9574,117 +9499,42 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
     "#})?;
 
     // Despite `--upgrade-package idna` on the CLI, we should upgrade all packages.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
-        .arg("--upgrade-package")
-        .arg("idna")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    LockSettings {
-        lock_check: Disabled,
-        frozen: None,
-        dry_run: Disabled,
-        script: None,
-        python: None,
-        install_mirrors: PythonInstallMirrors {
-            python_install_mirror: None,
-            pypy_install_mirror: None,
-            python_downloads_json_url: None,
-        },
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: ResolverSettings {
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            fork_strategy: RequiresPython,
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            link_mode: Clone,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            prerelease: IfNecessaryOrExplicit,
-            resolution: Highest,
-            sources: None,
-            torch_backend: None,
-            upgrade: Upgrade {
-                strategy: All,
-                constraints: {},
-            },
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.lock())
+            .arg("--upgrade-package")
+            .arg("idna")
+            .arg("--show-settings"),
+        @r#"
+    --- old
+    +++ new
+    @@ -91,24 +91,17 @@
+                 {},
+             ),
+             extra_build_variables: ExtraBuildVariables(
+                 {},
+             ),
+             prerelease: IfNecessaryOrExplicit,
+             resolution: Highest,
+             sources: None,
+             torch_backend: None,
+             upgrade: Upgrade {
+    -            strategy: Some(
+    -                {
+    -                    PackageName(
+    -                        "sniffio",
+    -                    ),
+    -                },
+    -                {},
+    -            ),
+    +            strategy: All,
+                 constraints: {},
+             },
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
@@ -9699,369 +9549,111 @@ fn upgrade_project_cli_config_interaction() -> anyhow::Result<()> {
     "#})?;
 
     // Despite `upgrade-package = ["idna"]` in the configuration file, we should disable upgrades.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
-        .arg("--no-upgrade")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    LockSettings {
-        lock_check: Disabled,
-        frozen: None,
-        dry_run: Disabled,
-        script: None,
-        python: None,
-        install_mirrors: PythonInstallMirrors {
-            python_install_mirror: None,
-            pypy_install_mirror: None,
-            python_downloads_json_url: None,
-        },
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: ResolverSettings {
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            fork_strategy: RequiresPython,
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            link_mode: Clone,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            prerelease: IfNecessaryOrExplicit,
-            resolution: Highest,
-            sources: None,
-            torch_backend: None,
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.lock())
+            .arg("--no-upgrade")
+            .arg("--show-settings"),
+        @r#"
+    --- old
+    +++ new
+    @@ -94,21 +94,21 @@
+                 {},
+             ),
+             prerelease: IfNecessaryOrExplicit,
+             resolution: Highest,
+             sources: None,
+             torch_backend: None,
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+    -                        "sniffio",
+    +                        "idna",
+                         ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
     // Despite `upgrade-package = ["idna"]` in the configuration file, we should enable all upgrades.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
-        .arg("--upgrade")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    LockSettings {
-        lock_check: Disabled,
-        frozen: None,
-        dry_run: Disabled,
-        script: None,
-        python: None,
-        install_mirrors: PythonInstallMirrors {
-            python_install_mirror: None,
-            pypy_install_mirror: None,
-            python_downloads_json_url: None,
-        },
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: ResolverSettings {
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            fork_strategy: RequiresPython,
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            link_mode: Clone,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            prerelease: IfNecessaryOrExplicit,
-            resolution: Highest,
-            sources: None,
-            torch_backend: None,
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.lock())
+            .arg("--upgrade")
+            .arg("--show-settings"),
+        @r#"
+    --- old
+    +++ new
+    @@ -94,21 +94,21 @@
+                 {},
+             ),
+             prerelease: IfNecessaryOrExplicit,
+             resolution: Highest,
+             sources: None,
+             torch_backend: None,
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+    -                        "sniffio",
+    +                        "idna",
+                         ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 
     // Mark both `sniffio` and `idna` for upgrade.
-    uv_snapshot!(context.filters(), add_shared_args(context.lock())
-        .arg("--upgrade-package")
-        .arg("sniffio")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    LockSettings {
-        lock_check: Disabled,
-        frozen: None,
-        dry_run: Disabled,
-        script: None,
-        python: None,
-        install_mirrors: PythonInstallMirrors {
-            python_install_mirror: None,
-            pypy_install_mirror: None,
-            python_downloads_json_url: None,
-        },
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: ResolverSettings {
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            fork_strategy: RequiresPython,
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            link_mode: Clone,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            prerelease: IfNecessaryOrExplicit,
-            resolution: Highest,
-            sources: None,
-            torch_backend: None,
-            upgrade: Upgrade {
-                strategy: Some(
-                    {
-                        PackageName(
-                            "sniffio",
-                        ),
-                        PackageName(
-                            "idna",
-                        ),
-                    },
-                    {},
-                ),
-                constraints: {},
-            },
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &no_upgrade,
+        add_shared_args(context.lock())
+            .arg("--upgrade-package")
+            .arg("sniffio")
+            .arg("--show-settings"),
+        @r#"
+    --- old
+    +++ new
+    @@ -96,19 +96,22 @@
+             prerelease: IfNecessaryOrExplicit,
+             resolution: Highest,
+             sources: None,
+             torch_backend: None,
+             upgrade: Upgrade {
+                 strategy: Some(
+                     {
+                         PackageName(
+                             "sniffio",
+                         ),
+    +                    PackageName(
+    +                        "idna",
+    +                    ),
+                     },
+                     {},
+                 ),
+                 constraints: {},
+             },
+         },
+     }
 
-    ----- stderr -----
+     ----- stderr -----
     "#
     );
 

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -7151,7 +7151,7 @@ fn verify_hashes() -> anyhow::Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("anyio>3.0.0")?;
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
+    let default = capture_uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
         .arg("-r")
         .arg("requirements.in")
         .arg("--show-settings"), @r#"
@@ -7326,879 +7326,167 @@ fn verify_hashes() -> anyhow::Result<()> {
     "#
     );
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
-        .arg("-r")
-        .arg("requirements.in")
-        .arg("--no-verify-hashes")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipInstallSettings {
-        package: [],
-        requirements: [
-            "requirements.in",
-        ],
-        editables: [],
-        editable: None,
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        dry_run: Disabled,
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        modifications: Sufficient,
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: None,
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_install())
+            .arg("-r")
+            .arg("requirements.in")
+            .arg("--no-verify-hashes")
+            .arg("--show-settings"),
+        @"
+    --- old
+    +++ new
+    @@ -147,22 +147,20 @@
+             no_emit_package: [],
+             emit_index_url: false,
+             emit_find_links: false,
+             emit_build_options: false,
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+    -        hash_checking: Some(
+    -            Verify,
+    -        ),
+    +        hash_checking: None,
+             upgrade: Upgrade {
+                 strategy: None,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
-    "#
+     ----- stderr -----
+    "
     );
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
-        .arg("-r")
-        .arg("requirements.in")
-        .arg("--require-hashes")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipInstallSettings {
-        package: [],
-        requirements: [
-            "requirements.in",
-        ],
-        editables: [],
-        editable: None,
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        dry_run: Disabled,
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        modifications: Sufficient,
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Require,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_install())
+            .arg("-r")
+            .arg("requirements.in")
+            .arg("--require-hashes")
+            .arg("--show-settings"),
+        @"
+    --- old
+    +++ new
+    @@ -148,21 +148,21 @@
+             emit_index_url: false,
+             emit_find_links: false,
+             emit_build_options: false,
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+             hash_checking: Some(
+    -            Verify,
+    +            Require,
+             ),
+             upgrade: Upgrade {
+                 strategy: None,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
-    "#
+     ----- stderr -----
+    "
     );
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
-        .arg("-r")
-        .arg("requirements.in")
-        .arg("--no-require-hashes")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipInstallSettings {
-        package: [],
-        requirements: [
-            "requirements.in",
-        ],
-        editables: [],
-        editable: None,
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        dry_run: Disabled,
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        modifications: Sufficient,
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: None,
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_install())
+            .arg("-r")
+            .arg("requirements.in")
+            .arg("--no-require-hashes")
+            .arg("--show-settings"),
+        @"
+    --- old
+    +++ new
+    @@ -147,22 +147,20 @@
+             no_emit_package: [],
+             emit_index_url: false,
+             emit_find_links: false,
+             emit_build_options: false,
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+    -        hash_checking: Some(
+    -            Verify,
+    -        ),
+    +        hash_checking: None,
+             upgrade: Upgrade {
+                 strategy: None,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
-    "#
+     ----- stderr -----
+    "
     );
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
-        .arg("-r")
-        .arg("requirements.in")
-        .env(EnvVars::UV_NO_VERIFY_HASHES, "1")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipInstallSettings {
-        package: [],
-        requirements: [
-            "requirements.in",
-        ],
-        editables: [],
-        editable: None,
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        dry_run: Disabled,
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        modifications: Sufficient,
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: None,
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
+    diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_install())
+            .arg("-r")
+            .arg("requirements.in")
+            .env(EnvVars::UV_NO_VERIFY_HASHES, "1")
+            .arg("--show-settings"),
+        @"
+    --- old
+    +++ new
+    @@ -147,22 +147,20 @@
+             no_emit_package: [],
+             emit_index_url: false,
+             emit_find_links: false,
+             emit_build_options: false,
+             emit_marker_expression: false,
+             emit_index_annotation: false,
+             annotation_style: Split,
+             link_mode: Clone,
+             compile_bytecode: false,
+             sources: None,
+    -        hash_checking: Some(
+    -            Verify,
+    -        ),
+    +        hash_checking: None,
+             upgrade: Upgrade {
+                 strategy: None,
+                 constraints: {},
+             },
+             reinstall: None,
+         },
+     }
 
-    ----- stderr -----
-    "#
+     ----- stderr -----
+    "
     );
 
-    uv_snapshot!(context.filters(), add_shared_args(context.pip_install())
-        .arg("-r")
-        .arg("requirements.in")
-        .arg("--verify-hashes")
-        .arg("--no-require-hashes")
-        .arg("--show-settings"), @r#"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    GlobalSettings {
-        required_version: None,
-        quiet: 0,
-        verbose: 0,
-        color: Auto,
-        network_settings: NetworkSettings {
-            connectivity: Online,
-            offline: Disabled,
-            system_certs: false,
-            http_proxy: None,
-            https_proxy: None,
-            no_proxy: None,
-            allow_insecure_host: [],
-            read_timeout: [TIME],
-            connect_timeout: [TIME],
-            retries: 3,
-        },
-        concurrency: Concurrency {
-            downloads: 50,
-            builds: 16,
-            installs: 8,
-        },
-        show_settings: true,
-        preview: Preview {
-            flags: [],
-        },
-        python_preference: Managed,
-        python_downloads: Automatic,
-        no_progress: false,
-        installer_metadata: true,
-    }
-    CacheSettings {
-        no_cache: false,
-        cache_dir: Some(
-            "[CACHE_DIR]/",
-        ),
-    }
-    PipInstallSettings {
-        package: [],
-        requirements: [
-            "requirements.in",
-        ],
-        editables: [],
-        editable: None,
-        constraints: [],
-        overrides: [],
-        excludes: [],
-        build_constraints: [],
-        dry_run: Disabled,
-        constraints_from_workspace: [],
-        overrides_from_workspace: [],
-        excludes_from_workspace: [],
-        build_constraints_from_workspace: [],
-        modifications: Sufficient,
-        refresh: None(
-            Timestamp(
-                SystemTime {
-                    tv_sec: [TIME],
-                    tv_nsec: [TIME],
-                },
-            ),
-        ),
-        settings: PipSettings {
-            index_locations: IndexLocations {
-                indexes: [],
-                flat_index: [],
-                no_index: false,
-            },
-            python: None,
-            install_mirrors: PythonInstallMirrors {
-                python_install_mirror: None,
-                pypy_install_mirror: None,
-                python_downloads_json_url: None,
-            },
-            system: false,
-            extras: ExtrasSpecification(
-                ExtrasSpecificationInner {
-                    include: Some(
-                        [],
-                    ),
-                    exclude: [],
-                    only_extras: false,
-                    history: ExtrasSpecificationHistory {
-                        extra: [],
-                        only_extra: [],
-                        no_extra: [],
-                        all_extras: false,
-                        no_default_extras: false,
-                        defaults: List(
-                            [],
-                        ),
-                    },
-                },
-            ),
-            groups: [],
-            break_system_packages: false,
-            target: None,
-            prefix: None,
-            index_strategy: FirstIndex,
-            keyring_provider: Disabled,
-            torch_backend: None,
-            build_isolation: Isolate,
-            extra_build_dependencies: ExtraBuildDependencies(
-                {},
-            ),
-            extra_build_variables: ExtraBuildVariables(
-                {},
-            ),
-            build_options: BuildOptions {
-                no_binary: None,
-                no_build: None,
-            },
-            allow_empty_requirements: false,
-            strict: false,
-            dependency_mode: Transitive,
-            resolution: Highest,
-            prerelease: IfNecessaryOrExplicit,
-            fork_strategy: RequiresPython,
-            dependency_metadata: DependencyMetadata(
-                {},
-            ),
-            output_file: None,
-            no_strip_extras: false,
-            no_strip_markers: false,
-            no_annotate: false,
-            no_header: false,
-            custom_compile_command: None,
-            generate_hashes: false,
-            config_setting: ConfigSettings(
-                {},
-            ),
-            config_settings_package: PackageConfigSettings(
-                {},
-            ),
-            python_version: None,
-            python_platform: None,
-            universal: false,
-            exclude_newer: ExcludeNewer {
-                global: None,
-                package: ExcludeNewerPackage(
-                    {},
-                ),
-            },
-            no_emit_package: [],
-            emit_index_url: false,
-            emit_find_links: false,
-            emit_build_options: false,
-            emit_marker_expression: false,
-            emit_index_annotation: false,
-            annotation_style: Split,
-            link_mode: Clone,
-            compile_bytecode: false,
-            sources: None,
-            hash_checking: Some(
-                Verify,
-            ),
-            upgrade: Upgrade {
-                strategy: None,
-                constraints: {},
-            },
-            reinstall: None,
-        },
-    }
-
-    ----- stderr -----
-    "#
+    diff_uv_snapshot!(
+        context.filters(),
+        &default,
+        add_shared_args(context.pip_install())
+            .arg("-r")
+            .arg("requirements.in")
+            .arg("--verify-hashes")
+            .arg("--no-require-hashes")
+            .arg("--show-settings"),
+        @""
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

The `show_settings` tests are kind of a volumetric nightmare to look at and work with.

This PR reduces a bunch of their bulk by using diffs between consecutive snapshots to highlight differences in output rather than snapshotting the same gigantic settings dump every time.

The next step would be to use some common baseline "default" output and diff against that for the initial snapshots, but one thing at a time...

I've carefully checked that the tests are fully preserved and no test case has been lost or mangled...

## Test Plan

N/A