### PR TITLE
Set `TY_UV=1` when invoking `ty` through `uv check`

### DIFF
--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -96,6 +96,8 @@ pub(super) async fn run(
     let mut command = Command::new(&ty_path);
     command.current_dir(target_dir);
     command.arg("check");
+    // Opt into ty querying uv for project metadata.
+    command.env("TY_UV", "1");
 
     if let Some(venv_path) = venv_path {
         command.env("VIRTUAL_ENV", venv_path);


### PR DESCRIPTION
## Summary

I want to use this as the opt-in for an experimental support for ty to try to call into uv. Once we're confident enough in the functionality we can make this the default and e.g. have a TY_NO_UV env-var to opt-out.

