### PR TITLE
Preserve historical sysconfig compiler mappings

### DIFF
--- a/crates/uv-dev/src/generate_sysconfig_mappings.rs
+++ b/crates/uv-dev/src/generate_sysconfig_mappings.rs
@@ -13,6 +13,16 @@ use crate::generate_all::Mode;
 /// Contains current supported targets
 const TARGETS_YML_URL: &str = "https://raw.githubusercontent.com/astral-sh/python-build-standalone/refs/tags/20260510/cpython-unix/targets.yml";
 
+// Preserve compiler paths embedded in older downloadable python-build-standalone releases.
+const HISTORICAL_CC_VALUES: [&str; 2] = [
+    "/usr/bin/aarch64-linux-gnu-gcc",
+    "/usr/bin/riscv64-linux-gnu-gcc",
+];
+const HISTORICAL_CXX_VALUES: [&str; 2] = [
+    "/usr/bin/aarch64-linux-gnu-g++",
+    "/usr/bin/riscv64-linux-gnu-g++",
+];
+
 #[derive(clap::Args)]
 pub(crate) struct Args {
     #[arg(long, default_value_t, value_enum)]
@@ -121,6 +131,23 @@ async fn generate() -> Result<String> {
                     .or_default()
                     .insert(from_cxx.to_owned(), "c++".to_string());
             }
+        }
+    }
+
+    for sysconfig_cc_entry in ["CC", "LDSHARED", "BLDSHARED", "LINKCC"] {
+        for from_cc in HISTORICAL_CC_VALUES {
+            replacements
+                .entry(sysconfig_cc_entry)
+                .or_default()
+                .insert(from_cc.to_string(), "cc".to_string());
+        }
+    }
+    for sysconfig_cxx_entry in ["CXX", "LDCXXSHARED"] {
+        for from_cxx in HISTORICAL_CXX_VALUES {
+            replacements
+                .entry(sysconfig_cxx_entry)
+                .or_default()
+                .insert(from_cxx.to_string(), "c++".to_string());
         }
     }
 

--- a/crates/uv-python/src/sysconfig/generated_mappings.rs
+++ b/crates/uv-python/src/sysconfig/generated_mappings.rs
@@ -15,6 +15,7 @@ use crate::sysconfig::replacements::{ReplacementEntry, ReplacementMode};
 pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<ReplacementEntry>>> = LazyLock::new(|| {
     BTreeMap::from_iter([
         ("BLDSHARED".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
@@ -28,6 +29,7 @@ pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<Replac
             ReplacementEntry { mode: ReplacementMode::Partial { from: "musl-clang".to_string() }, to: "cc".to_string() },
         ]),
         ("CC".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
@@ -41,6 +43,7 @@ pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<Replac
             ReplacementEntry { mode: ReplacementMode::Partial { from: "musl-clang".to_string() }, to: "cc".to_string() },
         ]),
         ("CXX".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-g++".to_string() }, to: "c++".to_string() },
@@ -53,6 +56,7 @@ pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<Replac
             ReplacementEntry { mode: ReplacementMode::Partial { from: "clang++".to_string() }, to: "c++".to_string() },
         ]),
         ("LDCXXSHARED".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-g++".to_string() }, to: "c++".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-g++".to_string() }, to: "c++".to_string() },
@@ -65,6 +69,7 @@ pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<Replac
             ReplacementEntry { mode: ReplacementMode::Partial { from: "clang++".to_string() }, to: "c++".to_string() },
         ]),
         ("LDSHARED".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
@@ -78,6 +83,7 @@ pub(crate) static DEFAULT_VARIABLE_UPDATES: LazyLock<BTreeMap<String, Vec<Replac
             ReplacementEntry { mode: ReplacementMode::Partial { from: "musl-clang".to_string() }, to: "cc".to_string() },
         ]),
         ("LINKCC".to_string(), vec![
+            ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/aarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabi-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/arm-linux-gnueabihf-gcc".to_string() }, to: "cc".to_string() },
             ReplacementEntry { mode: ReplacementMode::Partial { from: "/usr/bin/loongarch64-linux-gnu-gcc".to_string() }, to: "cc".to_string() },

--- a/crates/uv-python/src/sysconfig/mod.rs
+++ b/crates/uv-python/src/sysconfig/mod.rs
@@ -347,10 +347,14 @@ mod tests {
         }
         "#);
 
-        // Cross-compiles use GNU
+        // Cross-compiles may embed historical compiler paths.
         let sysconfigdata = [
+            ("BLDSHARED", "/usr/bin/aarch64-linux-gnu-gcc"),
             ("CC", "/usr/bin/riscv64-linux-gnu-gcc"),
-            ("CXX", "/usr/bin/x86_64-linux-gnu-g++"),
+            ("CXX", "/usr/bin/riscv64-linux-gnu-g++"),
+            ("LDCXXSHARED", "/usr/bin/aarch64-linux-gnu-g++"),
+            ("LDSHARED", "/usr/bin/aarch64-linux-gnu-gcc"),
+            ("LINKCC", "/usr/bin/riscv64-linux-gnu-gcc"),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), Value::String(v.to_string())))
@@ -362,8 +366,12 @@ mod tests {
         insta::assert_snapshot!(data.to_string_pretty()?, @r#"
         # system configuration generated and used by the sysconfig module
         build_time_vars = {
+            "BLDSHARED": "cc",
             "CC": "cc",
             "CXX": "c++",
+            "LDCXXSHARED": "c++",
+            "LDSHARED": "cc",
+            "LINKCC": "cc",
             "PYTHON_BUILD_STANDALONE": 1
         }
         "#);


### PR DESCRIPTION
## Summary

Keep the sysconfig generator aware of compiler paths that appeared in older downloadable `python-build-standalone` releases, so regenerating the mappings on current `main` does not drop support for previously shipped aarch64 and riscv64 binaries.


## Context

uv patches compiler paths embedded in managed Python `sysconfig` data to use portable `cc` and `c++` commands. These mappings are generated from the current python-build-standalone targets.

Older python-build-standalone releases remain downloadable and retain the compiler paths used when they were built. When a target changes toolchains or is removed from the current targets, regenerating the mappings silently drops support for those releases.

This previously removed the aarch64 GNU mappings. The upcoming python-build-standalone sync in #19531 would similarly replace the riscv64 GNU mappings with LLVM mappings.

## Test plan

I've manually verified, that before this patch, on an arm64 linux box:

```
% uvx python3.12.10 -c 'import sysconfig; print(sysconfig.get_config_var("CC"))'
/usr/bin/aarch64-linux-gnu-gcc -pthread
```

and after (after uninstalling the python version using `uv python uninstall 3.12.10`):

```
% ./target/debug/uvx python3.12.10 -c 'import sysconfig; print(sysconfig.get_config_var("CC"))'
cc -pthread
```