### PR TITLE
Reject running inside the cache

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -538,6 +538,24 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         debug!("Disabling the uv cache due to `--no-cache`");
     }
     let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
+    let cache_dir = std::path::absolute(cache.root())?;
+    if CWD.starts_with(&cache_dir) {
+        bail!(
+            "The current directory `{}` is inside the cache directory `{}`",
+            CWD.user_display(),
+            cache_dir.user_display()
+        );
+    } else if let Ok(cache_dir) = fs_err::canonicalize(&cache_dir)
+        && let Ok(current_dir) = fs_err::canonicalize(&*CWD)
+        && current_dir.starts_with(&cache_dir)
+    {
+        bail!(
+            "The current directory `{}` is inside the cache directory `{}`",
+            current_dir.user_display(),
+            cache_dir.user_display()
+        );
+    };
+
     let workspace_cache = WorkspaceCache::default();
 
     // Configure the global network settings.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -554,7 +554,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             current_dir.user_display(),
             cache_dir.user_display()
         );
-    };
+    }
 
     let workspace_cache = WorkspaceCache::default();
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -538,19 +538,22 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         debug!("Disabling the uv cache due to `--no-cache`");
     }
     let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
+    // This check happens after the first (fallible) workspace discovery, which we need to resolve
+    // the settings that go into the cache constructor, but the check happens before the first
+    // workspace discovery that's used beyond settings discovery.
     let cache_dir = std::path::absolute(cache.root())?;
-    if CWD.starts_with(&cache_dir) {
+    if project_dir.starts_with(&cache_dir) {
         bail!(
-            "The current directory `{}` is inside the cache directory `{}`",
-            CWD.user_display(),
+            "The project directory `{}` is inside the cache directory `{}`",
+            project_dir.user_display(),
             cache_dir.user_display()
         );
     } else if let Ok(cache_dir) = fs_err::canonicalize(&cache_dir)
-        && let Ok(current_dir) = fs_err::canonicalize(&*CWD)
+        && let Ok(current_dir) = fs_err::canonicalize(&*project_dir)
         && current_dir.starts_with(&cache_dir)
     {
         bail!(
-            "The current directory `{}` is inside the cache directory `{}`",
+            "The project directory `{}` is inside the cache directory `{}`",
             current_dir.user_display(),
             cache_dir.user_display()
         );

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -549,12 +549,12 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             cache_dir.user_display()
         );
     } else if let Ok(cache_dir) = fs_err::canonicalize(&cache_dir)
-        && let Ok(current_dir) = fs_err::canonicalize(&*project_dir)
-        && current_dir.starts_with(&cache_dir)
+        && let Ok(project_dir) = fs_err::canonicalize(&*project_dir)
+        && project_dir.starts_with(&cache_dir)
     {
         bail!(
             "The project directory `{}` is inside the cache directory `{}`",
-            current_dir.user_display(),
+            project_dir.user_display(),
             cache_dir.user_display()
         );
     }

--- a/crates/uv/tests/build/cache.rs
+++ b/crates/uv/tests/build/cache.rs
@@ -1,12 +1,83 @@
-#[cfg(unix)]
 use anyhow::Result;
-#[cfg(unix)]
 use assert_fs::prelude::*;
 #[cfg(unix)]
 use std::process::Command;
 
 #[cfg(unix)]
-use uv_test::{get_bin, uv_snapshot};
+use uv_fs::create_symlink;
+#[cfg(unix)]
+use uv_test::get_bin;
+use uv_test::uv_snapshot;
+
+/// When the current directory is inside the cache directory, we should error before using the
+/// cache.
+#[test]
+fn cache_current_dir_inside_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.command()
+        .arg("cache")
+        .arg("dir")
+        .current_dir(context.cache_dir.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The current directory `.` is inside the cache directory `.`
+    ");
+
+    let child = context.cache_dir.child("child");
+    child.create_dir_all()?;
+
+    uv_snapshot!(context.filters(), context.command()
+        .arg("cache")
+        .arg("dir")
+        .current_dir(child.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The current directory `.` is inside the cache directory `[CACHE_DIR]/`
+    ");
+
+    Ok(())
+}
+
+/// When the current directory is inside a symlinked cache directory, we should error before using
+/// the cache.
+#[test]
+#[cfg(unix)]
+fn cache_current_dir_inside_symlinked_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let cache_link = context.temp_dir.child("cache-link");
+    create_symlink(context.cache_dir.path(), cache_link.path())?;
+
+    let child = context.cache_dir.child("child");
+    child.create_dir_all()?;
+
+    let mut command = Command::new(get_bin!());
+    command
+        .arg("cache")
+        .arg("dir")
+        .arg("--cache-dir")
+        .arg(cache_link.path());
+    context.add_shared_env(&mut command, false);
+    command.current_dir(child.path());
+
+    uv_snapshot!(context.filters(), command, @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The current directory `.` is inside the cache directory `[CACHE_DIR]/`
+    ");
+
+    Ok(())
+}
 
 /// When the cache directory cannot be created (e.g., due to permissions), we should show a
 /// chained error message that indicates we failed to initialize the cache.

--- a/crates/uv/tests/build/cache.rs
+++ b/crates/uv/tests/build/cache.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
 use assert_fs::prelude::*;
-#[cfg(unix)]
 use std::process::Command;
 
 #[cfg(unix)]
 use uv_fs::create_symlink;
-#[cfg(unix)]
-use uv_test::get_bin;
-use uv_test::uv_snapshot;
+use uv_test::{get_bin, uv_snapshot};
 
-/// When the current directory is inside the cache directory, we should error before using the
-/// cache.
+/// When the project directory defaults to a current directory inside the cache directory, we should
+/// error before using the cache.
 #[test]
 fn cache_current_dir_inside_cache() -> Result<()> {
     let context = uv_test::test_context!("3.12");
@@ -24,7 +21,7 @@ fn cache_current_dir_inside_cache() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: The current directory `.` is inside the cache directory `.`
+    error: The project directory `.` is inside the cache directory `.`
     ");
 
     let child = context.cache_dir.child("child");
@@ -39,13 +36,13 @@ fn cache_current_dir_inside_cache() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: The current directory `.` is inside the cache directory `[CACHE_DIR]/`
+    error: The project directory `.` is inside the cache directory `[CACHE_DIR]/`
     ");
 
     Ok(())
 }
 
-/// When the current directory is inside a symlinked cache directory, we should error before using
+/// When the project directory is inside a symlinked cache directory, we should error before using
 /// the cache.
 #[test]
 #[cfg(unix)]
@@ -73,7 +70,107 @@ fn cache_current_dir_inside_symlinked_cache() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: The current directory `.` is inside the cache directory `[CACHE_DIR]/`
+    error: The project directory `.` is inside the cache directory `[CACHE_DIR]/`
+    ");
+
+    Ok(())
+}
+
+/// When a workspace is inside the cache directory, we should error before locking the workspace.
+#[test]
+fn cache_workspace_inside_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let workspace = context.cache_dir.child("workspace");
+    workspace.child("pyproject.toml").write_str(
+        r#"
+        [tool.uv.workspace]
+        members = ["member"]
+        "#,
+    )?;
+    workspace
+        .child("member")
+        .child("pyproject.toml")
+        .write_str(
+            r#"
+        [project]
+        name = "member"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+        )?;
+
+    uv_snapshot!(context.filters(), context.lock()
+        .arg("--project")
+        .arg(workspace.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The project directory `[CACHE_DIR]/workspace` is inside the cache directory `[CACHE_DIR]/`
+    ");
+
+    Ok(())
+}
+
+/// When the cache directory is a non-canonical parent of the project directory, we should still
+/// detect that the project is inside the cache.
+#[test]
+fn cache_project_inside_relative_parent_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.temp_dir.child("project");
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    let mut command = Command::new(get_bin!());
+    command.arg("lock").arg("--cache-dir").arg("..");
+    context.add_shared_env(&mut command, false);
+    command.current_dir(project.path());
+
+    uv_snapshot!(context.filters(), command, @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The project directory `.` is inside the cache directory `[TEMP_DIR]/`
+    ");
+
+    Ok(())
+}
+
+/// When `--no-cache` is enabled, running from a project inside the configured cache directory
+/// should not trip the persistent cache guard.
+#[test]
+fn cache_project_inside_cache_no_cache() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    let project = context.cache_dir.child("project");
+    project.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--no-cache").current_dir(&project), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 1 package in [TIME]
     ");
 
     Ok(())

--- a/crates/uv/tests/workspace/workspace_dir.rs
+++ b/crates/uv/tests/workspace/workspace_dir.rs
@@ -83,9 +83,10 @@ fn workspace_metadata_from_member() -> Result<()> {
     Ok(())
 }
 
-/// Test that a cached project matched by an outer workspace glob remains isolated.
+/// Test that a project inside the configured cache directory is rejected before workspace
+/// discovery.
 #[test]
-fn workspace_dir_cached_project_ignores_outer_workspace() -> Result<()> {
+fn workspace_dir_rejects_project_inside_cache() -> Result<()> {
     let mut context = uv_test::test_context!("3.12");
     let workspace = context.temp_dir.child("workspace");
     let cache_dir = workspace.child("cache");
@@ -109,12 +110,12 @@ fn workspace_dir_cached_project_ignores_outer_workspace() -> Result<()> {
     context.cache_dir = cache_dir;
 
     uv_snapshot!(context.filters(), context.workspace_dir().current_dir(&cached_project), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 2
     ----- stdout -----
-    [TEMP_DIR]/workspace/cache/cached-project
 
     ----- stderr -----
+    error: The project directory `.` is inside the cache directory `[TEMP_DIR]/workspace/cache`
     "
     );
 


### PR DESCRIPTION
Reject running inside the cache

uv assumes that the current directory is not inside its cache, and if it is, strange things can happen. Inversely, it is allowed and supported that the cache is inside the current directory (but please don't have any paths pointing into the cache manually).

It's technically still possible to run uv inside a uv cache, as long as it's not the currently configured cache (which is the one that can cause problems with workspaces).