### PR TITLE
fix feature-gates on `format` and `check` tests to specify they access r2

### DIFF
--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -39,7 +39,7 @@ mod edit;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod export;
 
-#[cfg(feature = "test-python")]
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod check;
 
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -39,10 +39,10 @@ mod edit;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod export;
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(feature = "test-python", feature = "test-r2"))]
 mod check;
 
-#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+#[cfg(all(feature = "test-python", feature = "test-r2"))]
 mod format;
 
 mod help;


### PR DESCRIPTION
The test-pypi feature was used as a proxy for "this test does networking" so people running in offline scenarios don't run them, but the more accurate gate is on r2.

Fixes #19658