### PR TITLE
Fix uv init layout for stubs packages

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -833,7 +833,7 @@ impl InitProjectKind {
         // Include additional project configuration for packaged applications
         if package {
             // Since it'll be packaged, we can add a `[project.scripts]` entry
-            if !bare {
+            if !bare && stubs_package_module_dir(name).is_none() {
                 pyproject.push('\n');
                 pyproject.push_str(&pyproject_project_scripts(name, name.as_str(), "main"));
             }
@@ -1142,8 +1142,18 @@ fn generate_package_scripts(
     let module_name = package.as_dist_info_name();
 
     let src_dir = path.join("src");
-    let pkg_dir = src_dir.join(&*module_name);
+    let stubs_module_dir = stubs_package_module_dir(package);
+    let pkg_dir = src_dir.join(stubs_module_dir.as_deref().unwrap_or(module_name.as_ref()));
     fs_err::create_dir_all(&pkg_dir)?;
+
+    if stubs_module_dir.is_some() && build_backend == ProjectBuildBackend::Uv {
+        let init_pyi = pkg_dir.join("__init__.pyi");
+        if !init_pyi.try_exists()? {
+            fs_err::write(init_pyi, "")?;
+        }
+
+        return Ok(());
+    }
 
     // Python script for pure-python packaged apps or libs
     let pure_python_script = if is_lib {
@@ -1264,6 +1274,13 @@ fn generate_package_scripts(
     }
 
     Ok(())
+}
+
+fn stubs_package_module_dir(package: &PackageName) -> Option<String> {
+    package
+        .as_dist_info_name()
+        .strip_suffix("_stubs")
+        .map(|stem| format!("{stem}-stubs"))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -832,7 +832,10 @@ impl InitProjectKind {
 
         // Include additional project configuration for packaged applications
         if package {
-            // Since it'll be packaged, we can add a `[project.scripts]` entry
+            // Since it'll be packaged, we can add a `[project.scripts]` entry.
+            //
+            // PEP 561 stub packages are type-only distributions, so they
+            // should not declare a console script for a runtime module.
             if !bare && stubs_package_module_dir(name).is_none() {
                 pyproject.push('\n');
                 pyproject.push_str(&pyproject_project_scripts(name, name.as_str(), "main"));

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -491,6 +491,61 @@ fn init_package() -> Result<()> {
 }
 
 #[test]
+fn init_package_stubs() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    uv_snapshot!(context.filters(), context.init().arg("--package").arg("foo-stubs"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Initialized project `foo-stubs` at `[TEMP_DIR]/foo-stubs`
+    ");
+
+    let child = context.temp_dir.child("foo-stubs");
+    let pyproject = fs_err::read_to_string(child.join("pyproject.toml"))?;
+    let _ = fs_err::read_to_string(child.join("src/foo-stubs/__init__.pyi"))?;
+    child
+        .child("src/foo_stubs/__init__.py")
+        .assert(predicate::path::missing());
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject, @r#"
+        [project]
+        name = "foo-stubs"
+        version = "0.1.0"
+        description = "Add your description here"
+        readme = "README.md"
+        requires-python = ">=3.12"
+        dependencies = []
+
+        [build-system]
+        requires = ["uv_build>=[CURRENT_VERSION],<[NEXT_BREAKING]"]
+        build-backend = "uv_build"
+        "#
+        );
+    });
+
+    uv_snapshot!(context.filters(), context.build().current_dir(&child), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Building source distribution (uv build backend)...
+    Building wheel from source distribution (uv build backend)...
+    Successfully built dist/foo_stubs-0.1.0.tar.gz
+    Successfully built dist/foo_stubs-0.1.0-py3-none-any.whl
+    ");
+
+    Ok(())
+}
+
+#[test]
 fn init_bare_lib() {
     let context = uv_test::test_context!("3.12");
 


### PR DESCRIPTION
## Summary

Fixes #19663.

`uv init --package foo-stubs` now generates the stub-only package layout expected by `uv_build`:

- `src/foo-stubs/__init__.pyi`
- no runtime console script entry point for the stub-only package

## Test plan

- `cargo test --package uv --test it init::init_package_stubs -- --exact`
- `cargo test --package uv --test it init::init_package -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`