### PR TITLE
Hint when a build failure is caused by a requires-python mismatch

### DIFF
--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -8,7 +8,9 @@ use crate::metadata::MetadataError;
 use uv_cache::Error as CacheError;
 use uv_client::WrappedReqwestError;
 use uv_distribution_filename::{WheelFilename, WheelFilenameError};
-use uv_distribution_types::{InstalledDist, InstalledDistError, IsBuildBackendError};
+use uv_distribution_types::{
+    InstalledDist, InstalledDistError, IsBuildBackendError, RequiresPython,
+};
 use uv_fs::Simplified;
 use uv_git::GitError;
 use uv_normalize::PackageName;
@@ -29,6 +31,69 @@ impl fmt::Display for PythonVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (major, minor) = self.version;
         write!(f, "{major}.{minor}{}", self.variant.executable_suffix())
+    }
+}
+
+/// A source distribution build failure and its Python compatibility context.
+#[derive(Debug)]
+pub struct BuildError {
+    error: AnyErrorBuild,
+    requires_python: Option<RequiresPython>,
+    python_version: Version,
+}
+
+impl BuildError {
+    pub(crate) fn new(
+        error: AnyErrorBuild,
+        requires_python: Option<RequiresPython>,
+        python_version: Version,
+    ) -> Self {
+        Self {
+            error,
+            requires_python,
+            python_version,
+        }
+    }
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.error, formatter)
+    }
+}
+
+impl std::error::Error for BuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        std::error::Error::source(&self.error)
+    }
+}
+
+impl uv_errors::Hint for BuildError {
+    fn hints(&self) -> uv_errors::Hints<'_> {
+        let Some(requires_python) = &self.requires_python else {
+            return self.error.hints();
+        };
+
+        if requires_python.contains(&self.python_version) {
+            return self.error.hints();
+        }
+
+        // The patch component is irrelevant for `requires-python` and varies by environment.
+        let python_version = self
+            .python_version
+            .only_release_at_precision(2)
+            .unwrap_or_else(|| self.python_version.clone());
+        let mut hints = uv_errors::Hints::from(format!(
+            "The build requires Python {requires_python}, but Python {python_version} is used."
+        ));
+        hints.extend(self.error.hints());
+        hints
+    }
+}
+
+impl IsBuildBackendError for BuildError {
+    fn is_build_backend_error(&self) -> bool {
+        self.error.is_build_backend_error()
     }
 }
 
@@ -71,7 +136,7 @@ pub enum Error {
 
     // Build error
     #[error(transparent)]
-    Build(AnyErrorBuild),
+    Build(BuildError),
     #[error("Built wheel has an invalid filename")]
     WheelFilename(#[from] WheelFilenameError),
     #[error("Package metadata name `{metadata}` does not match given name `{given}`")]

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -41,7 +41,7 @@ use uv_git::{Fetch, GIT_LFS, GitError, GitHttpSettings, GitResolver};
 use uv_git_types::{GitHubRepository, GitOid, GitUrl};
 use uv_metadata::read_archive_metadata;
 use uv_normalize::PackageName;
-use uv_pep440::{Version, release_specifiers_to_ranges};
+use uv_pep440::{Version, VersionSpecifiers, release_specifiers_to_ranges};
 use uv_platform_tags::Tags;
 use uv_pypi_types::{HashAlgorithm, HashDigest, HashDigests, PyProjectToml, ResolutionMetadata};
 use uv_redacted::DisplaySafeUrl;
@@ -49,7 +49,7 @@ use uv_types::{BuildContext, BuildKey, BuildStack, SourceBuildTrait};
 use uv_workspace::pyproject::ToolUvSources;
 
 use crate::distribution_database::ManagedClient;
-use crate::error::Error;
+use crate::error::{BuildError, Error};
 use crate::hash::http_hash_algorithms;
 use crate::metadata::{ArchiveMetadata, GitWorkspaceMember, Metadata};
 use crate::source::built_wheel_metadata::{BuiltWheelFile, BuiltWheelMetadata};
@@ -3014,6 +3014,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             }
         }
 
+        let requires_python = self
+            .build_requires_python(source, source_root, subdirectory)
+            .await
+            .map(RequiresPython::from_specifiers);
+        let python_version = self.build_context.interpreter().await.python_version();
+        let build_error = |error| {
+            Error::Build(BuildError::new(
+                error,
+                requires_python.clone(),
+                python_version.clone(),
+            ))
+        };
+
         // Build into a temporary directory, to prevent partial builds.
         let temp_dir = self
             .build_context
@@ -3042,7 +3055,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 Some(&source.to_string()),
             )
             .await
-            .map_err(|err| Error::Build(err.into()))?
+            .map_err(|error| build_error(error.into()))?
         {
             // In the uv build backend, the normalized filename and the disk filename are the same.
             name.to_string()
@@ -3087,7 +3100,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
             if let Some(builder) = self.build_context.build_arena().remove(&build_key) {
                 debug!("Reusing existing build environment for: {source}");
-                let wheel = builder.wheel(temp_dir.path()).await.map_err(Error::Build)?;
+                let wheel = builder.wheel(temp_dir.path()).await.map_err(&build_error)?;
 
                 // Store the build context.
                 self.build_context.build_arena().insert(build_key, builder);
@@ -3119,10 +3132,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         self.build_stack.cloned().unwrap_or_default(),
                     )
                     .await
-                    .map_err(|err| Error::Build(err.into()))?;
+                    .map_err(|error| build_error(error.into()))?;
 
                 // Build the wheel.
-                let wheel = builder.wheel(temp_dir.path()).await.map_err(Error::Build)?;
+                let wheel = builder.wheel(temp_dir.path()).await.map_err(&build_error)?;
 
                 // Store the build context.
                 self.build_context.build_arena().insert(build_key, builder);
@@ -3149,6 +3162,35 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         debug!("Built `{source}` into `{disk_filename}`");
         Ok((disk_filename, filename, metadata))
+    }
+
+    /// Resolve the `requires-python` specifier for a buildable source, for all distribution types.
+    ///
+    /// Returns `None` only for source trees, since registry distributions always carry
+    /// `requires-python` in their file metadata. A source tree yields `None` when it has no
+    /// readable `pyproject.toml`, when it declares no `requires-python` or a dynamic one, or when
+    /// the specifier is malformed.
+    async fn build_requires_python(
+        &self,
+        source: &BuildableSource<'_>,
+        source_root: &Path,
+        subdirectory: Option<&Path>,
+    ) -> Option<VersionSpecifiers> {
+        // Registry distributions carry `requires-python` in their file metadata.
+        if let Some(requires_python) = source.requires_python() {
+            return Some(requires_python.clone());
+        }
+
+        // Source trees (path, Git, directory, direct URL) don't, so read it statically from the
+        // `pyproject.toml` at `source_root` instead.
+        let pyproject_toml = read_pyproject_toml(source_root, subdirectory).await.ok()?;
+        match pyproject_toml.requires_python() {
+            Ok(requires_python) => requires_python,
+            Err(err) => {
+                debug!("Ignoring `requires-python` in `{source}`: {err}");
+                None
+            }
+        }
     }
 
     /// Build the metadata for a source distribution.
@@ -3179,25 +3221,38 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         }
 
         // Ensure that the _installed_ Python version is compatible with the `requires-python`
-        // specifier.
-        if let Some(requires_python) = source.requires_python() {
-            let installed = self.build_context.interpreter().await.python_version();
-            let target = release_specifiers_to_ranges(requires_python.clone())
+        // specifier. This applies to all distribution types: registry distributions carry
+        // `requires-python` in their file metadata, while source trees declare it in
+        // `pyproject.toml`.
+        let requires_python = self
+            .build_requires_python(source, source_root, subdirectory)
+            .await
+            .map(RequiresPython::from_specifiers);
+        let python_version = self.build_context.interpreter().await.python_version();
+        if let Some(requires_python) = &requires_python {
+            let target = release_specifiers_to_ranges(requires_python.specifiers().clone())
                 .bounding_range()
                 .map(|bounding_range| bounding_range.0.cloned())
                 .unwrap_or(Bound::Unbounded);
             let is_compatible = match target {
-                Bound::Included(target) => *installed >= target,
-                Bound::Excluded(target) => *installed > target,
+                Bound::Included(target) => *python_version >= target,
+                Bound::Excluded(target) => *python_version > target,
                 Bound::Unbounded => true,
             };
             if !is_compatible {
                 return Err(Error::RequiresPython(
-                    requires_python.clone(),
-                    installed.clone(),
+                    requires_python.specifiers().clone(),
+                    python_version.clone(),
                 ));
             }
         }
+        let build_error = |error| {
+            Error::Build(BuildError::new(
+                error,
+                requires_python.clone(),
+                python_version.clone(),
+            ))
+        };
 
         // Identify the base Python interpreter to use in the cache key.
         let base_python = if cfg!(unix) {
@@ -3249,10 +3304,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 self.build_stack.cloned().unwrap_or_default(),
             )
             .await
-            .map_err(|err| Error::Build(err.into()))?;
+            .map_err(|error| build_error(error.into()))?;
 
         // Build the metadata.
-        let dist_info = builder.metadata().await.map_err(Error::Build)?;
+        let dist_info = builder.metadata().await.map_err(build_error)?;
 
         // Store the build context.
         self.build_context.build_arena().insert(

--- a/crates/uv/tests/pip/pip_sync.rs
+++ b/crates/uv/tests/pip/pip_sync.rs
@@ -4514,6 +4514,8 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
       ├─▶ Failed to resolve requirements from `build-system.requires`
       ├─▶ No solution found when resolving: `uv-build>=0.8.3, <0.9.0`
       ╰─▶ Because uv-build was not found in the package registry and you require uv-build>=0.8.3,<0.9.0, we can conclude that your requirements are unsatisfiable.
+
+    hint: The build requires Python >=3.13, but Python 3.12 is used.
     "
     );
 

--- a/crates/uv/tests/pip_install/pip_install.rs
+++ b/crates/uv/tests/pip_install/pip_install.rs
@@ -4445,6 +4445,45 @@ fn build_transitive_prerelease() -> Result<()> {
     Ok(())
 }
 
+/// A build failure for a source tree whose `requires-python` excludes the interpreter should hint
+/// at the `requires-python` mismatch, even though it's a path dependency (not a registry
+/// distribution). The build is only attempted because the upper bound isn't enforced during
+/// resolution.
+#[test]
+fn build_requires_python_hint() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    // `requires-python = "<3.0"` excludes the 3.12 interpreter, but the build is still attempted.
+    // The build then fails because `build-system.requires` can't be satisfied.
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = "<3.0"
+
+        [build-system]
+        requires = ["this-package-does-not-exist-anywhere"]
+        build-backend = "setuptools.build_meta"
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.pip_install()
+        .arg("."), @"
+    exit_code: 1 (failure)
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to resolve requirements from `build-system.requires`
+      ├─▶ No solution found when resolving: `this-package-does-not-exist-anywhere`
+      ╰─▶ Because this-package-does-not-exist-anywhere was not found in the package registry and you require this-package-does-not-exist-anywhere, we can conclude that your requirements are unsatisfiable.
+
+    hint: The build requires Python <3.0, but Python 3.12 is used.
+    "
+    );
+
+    Ok(())
+}
+
 /// `--prerelease=explicit` should not fall back to a pre-release without a direct pre-release
 /// specifier.
 #[test]


### PR DESCRIPTION
## Summary

This PR closes #7035.

Many transitive build failures on old package versions are caused by the failing distribution's declared requires-python excluding the active interpreter. The underlying build-backend error (often a deep SyntaxError or RuntimeError) doesn't say this directly, and users frequently file confused bug reports as a result.

This PR surfaces a targeted hint when a distribution fails to build and its requires-python doesn't include the interpreter used for the build environment. The hint is attached at the point of the build failure, so it applies to any build path rather than being wired into individual commands. It follows the same approach as #20157: the requires-python context is attached to the build error, and the hint is produced in the error's `Hint` implementation, so the error itself renders unchanged apart from the added hint.

The hint is prepended so it appears before the existing derivation-chain hint and the generic build-failure hint, since it diagnoses the likely root cause.

## Example

Installing `numba==0.53.1` on Python 3.12. Numba transitively depends on `llvmlite==0.36.0`, whose declared requires-python is `>=3.6,<3.10`:

### Before

```
× Failed to build `llvmlite==0.36.0`
... (build backend stderr) ...
RuntimeError: Cannot install on Python version 3.12.4; only versions >=3.6,<3.10 are supported.

hint: `llvmlite` (v0.36.0) was included because `test` (v0.1.0) depends on `numba` (v0.53.1) which depends on `llvmlite`
hint: Build failures usually indicate a problem with the package or the build environment
```

### After

```
× Failed to build `llvmlite==0.36.0`
... (build backend stderr) ...
RuntimeError: Cannot install on Python version 3.12.4; only versions >=3.6,<3.10 are supported.

hint: The build requires Python >=3.6, <3.10, but Python 3.12 is used.
hint: `llvmlite` (v0.36.0) was included because `test` (v0.1.0) depends on `numba` (v0.53.1) which depends on `llvmlite`
hint: Build failures usually indicate a problem with the package or the build environment
```

## Scope

Because the hint is attached at the build-failure site rather than in a specific command, it fires wherever a build fails with a requires-python mismatch, including `uv pip install` and `uv pip sync`. The wording is kept neutral rather than telling the user to go up or down a version, since either direction can be correct depending on the mismatch. The minor version is shown (`3.12`), since `requires-python` is expressed in minor versions; happy to show the full version if you'd prefer.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy` clean on the touched crates
- [x] Added insta snapshot coverage for the hint (`require_hashes_find_links_no_hash` and `build_requires_python_hint`)
- [x] Manual: a build failure with a requires-python mismatch shows the new hint, followed by the existing chain hint and the generic hint, in that order
- [x] Manual: a compatible package shows no spurious hint
