### PR TITLE
Validate egg top-level entries as identifiers

### DIFF
--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -218,7 +218,7 @@ fn is_path_in_scheme(
 /// egg's base location, not arbitrary paths. Treating them as paths can make uninstall delete
 /// directories outside `site-packages`.
 fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
-    if is_safe_top_level_entry(entry) {
+    if entry.parse::<Identifier>().is_ok() {
         true
     } else {
         if WARNED_FOR_EGG_TOP_LEVEL_PACKAGE
@@ -235,10 +235,6 @@ fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
         }
         false
     }
-}
-
-fn is_safe_top_level_entry(entry: &str) -> bool {
-    entry.parse::<Identifier>().is_ok()
 }
 
 /// Uninstall the egg represented by the `.egg-info` directory.
@@ -462,25 +458,27 @@ mod tests {
     use uv_pypi_types::Scheme;
 
     use crate::Layout;
-    use crate::uninstall::{is_safe_top_level_entry, uninstall_egg, uninstall_wheel};
+    use crate::uninstall::{is_valid_top_level_entry, uninstall_egg, uninstall_wheel};
 
     #[test]
     fn test_top_level_entry_safe_name() {
-        assert!(is_safe_top_level_entry("package"));
-        assert!(is_safe_top_level_entry("_package2"));
+        let is_valid = |entry| is_valid_top_level_entry(entry, "package");
 
-        assert!(!is_safe_top_level_entry(""));
-        assert!(!is_safe_top_level_entry("."));
-        assert!(!is_safe_top_level_entry(".."));
-        assert!(!is_safe_top_level_entry("1package"));
-        assert!(!is_safe_top_level_entry("package-name"));
-        assert!(!is_safe_top_level_entry("package.name"));
-        assert!(!is_safe_top_level_entry("../package"));
-        assert!(!is_safe_top_level_entry("package/name"));
-        assert!(!is_safe_top_level_entry(r"package\name"));
-        assert!(!is_safe_top_level_entry("C:target"));
-        assert!(!is_safe_top_level_entry("C:."));
-        assert!(!is_safe_top_level_entry("C:.."));
+        assert!(is_valid("package"));
+        assert!(is_valid("_package2"));
+
+        assert!(!is_valid(""));
+        assert!(!is_valid("."));
+        assert!(!is_valid(".."));
+        assert!(!is_valid("1package"));
+        assert!(!is_valid("package-name"));
+        assert!(!is_valid("package.name"));
+        assert!(!is_valid("../package"));
+        assert!(!is_valid("package/name"));
+        assert!(!is_valid(r"package\name"));
+        assert!(!is_valid("C:target"));
+        assert!(!is_valid("C:."));
+        assert!(!is_valid("C:.."));
     }
 
     /// Uninstall must not remove files outside the install scheme.

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -6,6 +6,7 @@ use std::sync::{LazyLock, Mutex, OnceLock};
 use tracing::trace;
 
 use uv_fs::write_atomic_sync;
+use uv_pypi_types::Identifier;
 use uv_warnings::warn_user;
 
 use crate::wheel::read_record;
@@ -237,7 +238,7 @@ fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
 }
 
 fn is_safe_top_level_entry(entry: &str) -> bool {
-    !entry.is_empty() && entry != "." && entry != ".." && !entry.contains(['/', '\\'])
+    entry.parse::<Identifier>().is_ok()
 }
 
 /// Uninstall the egg represented by the `.egg-info` directory.
@@ -466,13 +467,20 @@ mod tests {
     #[test]
     fn test_top_level_entry_safe_name() {
         assert!(is_safe_top_level_entry("package"));
+        assert!(is_safe_top_level_entry("_package2"));
 
         assert!(!is_safe_top_level_entry(""));
         assert!(!is_safe_top_level_entry("."));
         assert!(!is_safe_top_level_entry(".."));
+        assert!(!is_safe_top_level_entry("1package"));
+        assert!(!is_safe_top_level_entry("package-name"));
+        assert!(!is_safe_top_level_entry("package.name"));
         assert!(!is_safe_top_level_entry("../package"));
         assert!(!is_safe_top_level_entry("package/name"));
         assert!(!is_safe_top_level_entry(r"package\name"));
+        assert!(!is_safe_top_level_entry("C:target"));
+        assert!(!is_safe_top_level_entry("C:."));
+        assert!(!is_safe_top_level_entry("C:.."));
     }
 
     /// Uninstall must not remove files outside the install scheme.

--- a/crates/uv/tests/it/pip_uninstall.rs
+++ b/crates/uv/tests/it/pip_uninstall.rs
@@ -1,3 +1,6 @@
+#[cfg(windows)]
+use std::path::{Component, Prefix};
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
@@ -629,6 +632,59 @@ fn uninstall_egg_info_top_level_path_traversal() -> Result<()> {
     ");
 
     assert!(target_dir.exists());
+    assert!(target_file.exists());
+    assert!(!init_py.exists());
+    assert!(!egg_info.exists());
+
+    Ok(())
+}
+
+/// Windows drive-relative paths are not valid `top_level.txt` entries.
+#[cfg(windows)]
+#[test]
+fn uninstall_egg_info_top_level_drive_relative() -> Result<()> {
+    let context = uv_test::test_context!("3.12")
+        .with_filter((r"[A-Za-z]:traversal_target", "[DRIVE]:traversal_target"));
+    let site_packages = ChildPath::new(context.site_packages());
+
+    let egg_info = site_packages.child("evilpkg-0.1.0.egg-info");
+    egg_info.create_dir_all()?;
+
+    let drive = match context.temp_dir.path().components().next() {
+        Some(Component::Prefix(prefix)) => match prefix.kind() {
+            Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => drive,
+            prefix => anyhow::bail!("expected a disk path, found {prefix:?}"),
+        },
+        component => anyhow::bail!("expected a Windows path prefix, found {component:?}"),
+    };
+    let traversal_entry = format!("{}:traversal_target", char::from(drive));
+
+    // Commands run from `context.temp_dir`, so this drive-relative path resolves there rather than
+    // below `site-packages`.
+    let target_file = context
+        .temp_dir
+        .child("traversal_target")
+        .child("secret.txt");
+    target_file.write_str("I should not be deleted")?;
+    egg_info
+        .child("top_level.txt")
+        .write_str(&format!("evilpkg\n{traversal_entry}\n"))?;
+
+    let init_py = site_packages.child("evilpkg").child("__init__.py");
+    init_py.touch()?;
+
+    uv_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("evilpkg"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Invalid `top_level.txt` entry in evilpkg==0.1.0 that is not a top-level module or package, skipping: [DRIVE]:traversal_target
+    Uninstalled 1 package in [TIME]
+     - evilpkg==0.1.0
+    ");
+
     assert!(target_file.exists());
     assert!(!init_py.exists());
     assert!(!egg_info.exists());


### PR DESCRIPTION
## Summary

Prior to this change, we accepted any non-empty egg `top_level.txt` entry without path separators. On Windows, drive-relative paths such as `C:target` contain no separators, so they passed validation even though they do not represent a top-level module or package name.

This PR validates each entry as a Python identifier before using it to remove an installed module or package. This matches the `top_level.txt` format and skips drive-relative and other malformed entries. It also adds focused unit coverage and a Windows integration test that confirms an invalid drive-relative entry is ignored while the egg is otherwise uninstalled normally.
