### PR TITLE
Add a small documentation section for malware checks

### DIFF
--- a/docs/concepts/projects/sync.md
+++ b/docs/concepts/projects/sync.md
@@ -220,3 +220,17 @@ When these options are used, all the dependencies of the target are still instal
 
 If used improperly, these flags can result in a broken environment since a package can be missing
 its dependencies.
+
+## Malware checks
+
+!!! important
+
+    On-sync malware checking is in [preview](../preview.md), and is subject to change until stabilized.
+
+While syncing, uv can perform a lightweight scan of your lockfile for known malware by checking it
+against [OSV](https://osv.dev). OSV references MAL advisories from the OpenSSF's
+[malicious packages database](https://github.com/ossf/malicious-packages).
+
+If a locked dependency matches a malware advisory, the sync will be terminated.
+
+To enable malware checks, set `UV_MALWARE_CHECK=1` in your environment.

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+
 [[package]]
 name = "babel"
 version = "2.18.0"


### PR DESCRIPTION
## Summary

We landed this with #18936, so it probably makes sense to have _some_ docs for it. Not 100% sure if this is the best place, but it seems pretty close 🙂 

See #18781 

Closes https://github.com/astral-sh/uv/issues/19519.

## Test Plan

NFC, docs only.