### PR TITLE
Avoid stack overflows in resolver error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,6 +3002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,6 +3483,16 @@ checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags",
  "hex",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -4736,6 +4764,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "statrs"
@@ -7094,6 +7135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "stacker",
  "textwrap",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,6 +257,7 @@ serde_json = { version = "1.0.128" }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
 spdx = { version = "0.13.0" }
+stacker = { version = "0.1.24" }
 syn = { version = "2.0.77" }
 target-lexicon = { version = "0.13.0" }
 tempfile = { version = "3.14.0" }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -69,6 +69,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
+stacker = { workspace = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -172,10 +172,10 @@ pub type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableR
 
 const DERIVATION_TREE_RED_ZONE: usize = 64 * 1024;
 
-/// Run one recursive derivation-tree step with enough stack to reach the next growth point.
+/// Run a recursive derivation-tree function with enough stack to reach the next growth point.
 ///
-/// Recursive tree walkers should call this at every child edge so no individual stack segment
-/// needs to accommodate the full depth of the derivation tree.
+/// Recursive tree walkers should call this at every recursive descent so no individual stack
+/// segment needs to accommodate the full depth of the derivation tree.
 pub(crate) fn with_growing_stack<R>(callback: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(DERIVATION_TREE_RED_ZONE, min_stack_size(), callback)
 }
@@ -237,6 +237,7 @@ fn drop_derivation_tree(derivation_tree: ErrorTree) {
 ///
 /// The `Option` allows [`Drop`] to take ownership of the tree and applies the same iterative
 /// teardown during normal returns and unwinding.
+#[derive(Clone)]
 struct StackSafeErrorTree(Option<ErrorTree>);
 
 impl StackSafeErrorTree {
@@ -268,6 +269,12 @@ impl Drop for StackSafeErrorTree {
         if let Some(derivation_tree) = self.0.take() {
             drop_derivation_tree(derivation_tree);
         }
+    }
+}
+
+impl Debug for StackSafeErrorTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        StackSafeDebugErrorTree(self).fmt(f)
     }
 }
 
@@ -310,7 +317,7 @@ impl Debug for StackSafeDebugDerived<'_> {
 
 /// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
 pub struct NoSolutionError {
-    error: Option<pubgrub::NoSolutionError<UvDependencyProvider>>,
+    error: StackSafeErrorTree,
     index: InMemoryIndex,
     /// The versions that were available for each package after `exclude-newer` filtering.
     ///
@@ -365,7 +372,7 @@ impl NoSolutionError {
         options: Options,
     ) -> Self {
         Self {
-            error: Some(error),
+            error: StackSafeErrorTree::new(error),
             index,
             included_versions,
             available_versions,
@@ -385,12 +392,6 @@ impl NoSolutionError {
             options,
             cached: OnceLock::new(),
         }
-    }
-
-    fn error(&self) -> &ErrorTree {
-        self.error
-            .as_ref()
-            .expect("no-solution error is only taken during drop")
     }
 
     /// Get the cached report and hints, computing them on first access.
@@ -526,10 +527,14 @@ impl NoSolutionError {
     /// Given a [`DerivationTree`], identify the largest required Python version that is missing.
     pub fn find_requires_python(&self) -> LowerBound {
         fn find(derivation_tree: &ErrorTree, minimum: &mut LowerBound) {
+            with_growing_stack(|| find_inner(derivation_tree, minimum));
+        }
+
+        fn find_inner(derivation_tree: &ErrorTree, minimum: &mut LowerBound) {
             match derivation_tree {
                 DerivationTree::Derived(derived) => {
-                    with_growing_stack(|| find(derived.cause1.as_ref(), minimum));
-                    with_growing_stack(|| find(derived.cause2.as_ref(), minimum));
+                    find(derived.cause1.as_ref(), minimum);
+                    find(derived.cause2.as_ref(), minimum);
                 }
                 DerivationTree::External(External::FromDependencyOf(.., package, version)) => {
                     if let PubGrubPackageInner::Python(_) = &**package {
@@ -546,7 +551,7 @@ impl NoSolutionError {
         }
 
         let mut minimum = LowerBound::default();
-        find(self.error(), &mut minimum);
+        find(&self.error, &mut minimum);
         minimum
     }
 
@@ -557,7 +562,7 @@ impl NoSolutionError {
 
     /// Get the packages that are involved in this error.
     pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
-        derivation_tree_packages(self.error())
+        derivation_tree_packages(&self.error)
             .filter_map(|p| p.name())
             .unique()
     }
@@ -588,7 +593,7 @@ impl NoSolutionError {
         };
 
         // Transform the error tree for reporting
-        let mut tree = StackSafeErrorTree::new(self.error().clone());
+        let mut tree = self.error.clone();
         simplify_derivation_tree_markers(&self.python_requirement, &mut tree);
         let should_display_tree = std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE)
             .is_some()
@@ -679,14 +684,7 @@ impl std::fmt::Debug for NoSolutionError {
             cached: _,
         } = self;
         f.debug_struct("NoSolutionError")
-            .field(
-                "error",
-                &StackSafeDebugErrorTree(
-                    error
-                        .as_ref()
-                        .expect("no-solution error is only taken during drop"),
-                ),
-            )
+            .field("error", error)
             .field("included_versions", included_versions)
             .field("available_versions", available_versions)
             .field("available_indexes", available_indexes)
@@ -704,14 +702,6 @@ impl std::fmt::Debug for NoSolutionError {
             .field("workspace_members", workspace_members)
             .field("options", options)
             .finish()
-    }
-}
-
-impl Drop for NoSolutionError {
-    fn drop(&mut self) {
-        if let Some(error) = self.error.take() {
-            drop_derivation_tree(error);
-        }
     }
 }
 
@@ -761,11 +751,19 @@ fn display_tree_inner(
     lines: &mut Vec<String>,
     depth: usize,
 ) {
+    with_growing_stack(|| display_tree_inner_impl(error, lines, depth));
+}
+
+fn display_tree_inner_impl(
+    error: &DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    lines: &mut Vec<String>,
+    depth: usize,
+) {
     let prefix = "  ".repeat(depth);
     match error {
         DerivationTree::Derived(derived) => {
-            with_growing_stack(|| display_tree_inner(&derived.cause1, lines, depth + 1));
-            with_growing_stack(|| display_tree_inner(&derived.cause2, lines, depth + 1));
+            display_tree_inner(&derived.cause1, lines, depth + 1);
+            display_tree_inner(&derived.cause2, lines, depth + 1);
             for (package, term) in &derived.terms {
                 match term {
                     Term::Positive(versions) => {
@@ -804,6 +802,12 @@ fn display_tree_inner(
 fn collapse_redundant_no_versions(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
 ) {
+    with_growing_stack(|| collapse_redundant_no_versions_inner(tree));
+}
+
+fn collapse_redundant_no_versions_inner(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+) {
     match tree {
         DerivationTree::External(_) => {}
         DerivationTree::Derived(derived) => {
@@ -821,7 +825,7 @@ fn collapse_redundant_no_versions(
                     DerivationTree::External(External::NoVersions(package, versions)),
                 ) => {
                     // First, always recursively visit the other side of the tree
-                    with_growing_stack(|| collapse_redundant_no_versions(other));
+                    collapse_redundant_no_versions(other);
 
                     // Retrieve the nearest terms, either alongside this node or from the parent.
                     let package_terms = if let DerivationTree::Derived(derived) = other {
@@ -853,12 +857,8 @@ fn collapse_redundant_no_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause1));
-                    });
-                    with_growing_stack(|| {
-                        collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause2));
-                    });
+                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause1));
+                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause2));
                 }
             }
         }
@@ -902,6 +902,12 @@ fn collapse_redundant_no_versions(
 fn collapse_redundant_no_versions_tree(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
 ) -> bool {
+    with_growing_stack(|| collapse_redundant_no_versions_tree_inner(tree))
+}
+
+fn collapse_redundant_no_versions_tree_inner(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+) -> bool {
     match tree {
         DerivationTree::External(_) => false,
         DerivationTree::Derived(derived) => {
@@ -932,11 +938,8 @@ fn collapse_redundant_no_versions_tree(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause1))
-                    }) || with_growing_stack(|| {
-                        collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause2))
-                    })
+                    collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause1))
+                        || collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause2))
                 }
             }
         }
@@ -946,6 +949,13 @@ fn collapse_redundant_no_versions_tree(
 /// Given a [`DerivationTree`], collapse any `NoVersion` incompatibilities for workspace members
 /// to avoid saying things like "only <workspace-member>==0.1.0 is available".
 fn collapse_no_versions_of_workspace_members(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    workspace_members: &BTreeSet<PackageName>,
+) {
+    with_growing_stack(|| collapse_no_versions_of_workspace_members_inner(tree, workspace_members));
+}
+
+fn collapse_no_versions_of_workspace_members_inner(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
     workspace_members: &BTreeSet<PackageName>,
 ) {
@@ -960,9 +970,7 @@ fn collapse_no_versions_of_workspace_members(
                 (DerivationTree::External(External::NoVersions(package, _)), ref mut other)
                 | (ref mut other, DerivationTree::External(External::NoVersions(package, _))) => {
                     // First, always recursively visit the other side of the tree
-                    with_growing_stack(|| {
-                        collapse_no_versions_of_workspace_members(other, workspace_members);
-                    });
+                    collapse_no_versions_of_workspace_members(other, workspace_members);
 
                     // Then, if the package is a workspace member...
                     let (PubGrubPackageInner::Package { name, .. }
@@ -980,18 +988,14 @@ fn collapse_no_versions_of_workspace_members(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_no_versions_of_workspace_members(
-                            Arc::make_mut(&mut derived.cause1),
-                            workspace_members,
-                        );
-                    });
-                    with_growing_stack(|| {
-                        collapse_no_versions_of_workspace_members(
-                            Arc::make_mut(&mut derived.cause2),
-                            workspace_members,
-                        );
-                    });
+                    collapse_no_versions_of_workspace_members(
+                        Arc::make_mut(&mut derived.cause1),
+                        workspace_members,
+                    );
+                    collapse_no_versions_of_workspace_members(
+                        Arc::make_mut(&mut derived.cause2),
+                        workspace_members,
+                    );
                 }
             }
         }
@@ -1022,6 +1026,12 @@ fn collapse_no_versions_of_workspace_members(
 fn collapse_redundant_depends_on_no_versions(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
 ) {
+    with_growing_stack(|| collapse_redundant_depends_on_no_versions_impl(tree));
+}
+
+fn collapse_redundant_depends_on_no_versions_impl(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+) {
     match tree {
         DerivationTree::External(_) => {}
         DerivationTree::Derived(derived) => {
@@ -1043,16 +1053,8 @@ fn collapse_redundant_depends_on_no_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
-                            &mut derived.cause1,
-                        ));
-                    });
-                    with_growing_stack(|| {
-                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
-                            &mut derived.cause2,
-                        ));
-                    });
+                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause1));
+                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause2));
                 }
             }
         }
@@ -1061,6 +1063,16 @@ fn collapse_redundant_depends_on_no_versions(
 
 /// Helper for [`collapse_redundant_depends_on_no_versions`].
 fn collapse_redundant_depends_on_no_versions_inner(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    package: &PubGrubPackage,
+    versions: &Range<Version>,
+) {
+    with_growing_stack(|| {
+        collapse_redundant_depends_on_no_versions_inner_impl(tree, package, versions);
+    });
+}
+
+fn collapse_redundant_depends_on_no_versions_inner_impl(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
     package: &PubGrubPackage,
     versions: &Range<Version>,
@@ -1103,16 +1115,12 @@ fn collapse_redundant_depends_on_no_versions_inner(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
-                            &mut derived.cause1,
-                        ));
-                    });
-                    with_growing_stack(|| {
-                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
-                            &mut derived.cause2,
-                        ));
-                    });
+                    collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                        &mut derived.cause1,
+                    ));
+                    collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                        &mut derived.cause2,
+                    ));
                 }
             }
         }
@@ -1128,6 +1136,13 @@ fn collapse_redundant_depends_on_no_versions_inner(
 /// the `requires-python` setting. This simplifies error messages by reducing
 /// noise.
 fn simplify_derivation_tree_markers(
+    python_requirement: &PythonRequirement,
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+) {
+    with_growing_stack(|| simplify_derivation_tree_markers_inner(python_requirement, tree));
+}
+
+fn simplify_derivation_tree_markers_inner(
     python_requirement: &PythonRequirement,
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
 ) {
@@ -1153,18 +1168,14 @@ fn simplify_derivation_tree_markers(
                     (pkg, term)
                 })
                 .collect();
-            with_growing_stack(|| {
-                simplify_derivation_tree_markers(
-                    python_requirement,
-                    Arc::make_mut(&mut derived.cause1),
-                );
-            });
-            with_growing_stack(|| {
-                simplify_derivation_tree_markers(
-                    python_requirement,
-                    Arc::make_mut(&mut derived.cause2),
-                );
-            });
+            simplify_derivation_tree_markers(
+                python_requirement,
+                Arc::make_mut(&mut derived.cause1),
+            );
+            simplify_derivation_tree_markers(
+                python_requirement,
+                Arc::make_mut(&mut derived.cause2),
+            );
         }
     }
 }
@@ -1173,6 +1184,12 @@ fn simplify_derivation_tree_markers(
 /// unavailable for the same reason to avoid repeating the same message for every unavailable
 /// version.
 fn collapse_unavailable_versions(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+) {
+    with_growing_stack(|| collapse_unavailable_versions_inner(tree));
+}
+
+fn collapse_unavailable_versions_inner(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
 ) {
     match tree {
@@ -1192,7 +1209,7 @@ fn collapse_unavailable_versions(
                     DerivationTree::External(External::Custom(package, versions, reason)),
                 ) => {
                     // First, recursively collapse the other side of the tree
-                    with_growing_stack(|| collapse_unavailable_versions(other));
+                    collapse_unavailable_versions(other);
 
                     // If it's not a derived tree, nothing to do.
                     let DerivationTree::Derived(Derived {
@@ -1264,12 +1281,8 @@ fn collapse_unavailable_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        collapse_unavailable_versions(Arc::make_mut(&mut derived.cause1));
-                    });
-                    with_growing_stack(|| {
-                        collapse_unavailable_versions(Arc::make_mut(&mut derived.cause2));
-                    });
+                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause1));
+                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause2));
                 }
             }
         }
@@ -1284,6 +1297,13 @@ fn collapse_unavailable_versions(
 /// requires your project, we can conclude that your project's requirements are
 /// unsatisfiable."
 fn drop_root_dependency_on_project(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    project: &PackageName,
+) {
+    with_growing_stack(|| drop_root_dependency_on_project_inner(tree, project));
+}
+
+fn drop_root_dependency_on_project_inner(
     tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
     project: &PackageName,
 ) {
@@ -1317,25 +1337,15 @@ fn drop_root_dependency_on_project(
                     }
 
                     // Recursively collapse the other side of the tree
-                    with_growing_stack(|| drop_root_dependency_on_project(other, project));
+                    drop_root_dependency_on_project(other, project);
 
                     // Then, replace this node with the other tree
                     *tree = other.clone();
                 }
                 // If not, just recurse
                 _ => {
-                    with_growing_stack(|| {
-                        drop_root_dependency_on_project(
-                            Arc::make_mut(&mut derived.cause1),
-                            project,
-                        );
-                    });
-                    with_growing_stack(|| {
-                        drop_root_dependency_on_project(
-                            Arc::make_mut(&mut derived.cause2),
-                            project,
-                        );
-                    });
+                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause1), project);
+                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause2), project);
                 }
             }
         }
@@ -1583,6 +1593,22 @@ fn simplify_derivation_tree_ranges(
     candidate_selector: &CandidateSelector,
     resolver_environment: &ResolverEnvironment,
 ) {
+    with_growing_stack(|| {
+        simplify_derivation_tree_ranges_inner(
+            tree,
+            included_versions,
+            candidate_selector,
+            resolver_environment,
+        );
+    });
+}
+
+fn simplify_derivation_tree_ranges_inner(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    included_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
+    candidate_selector: &CandidateSelector,
+    resolver_environment: &ResolverEnvironment,
+) {
     match tree {
         DerivationTree::External(external) => match external {
             External::FromDependencyOf(package1, versions1, package2, versions2) => {
@@ -1631,22 +1657,18 @@ fn simplify_derivation_tree_ranges(
         },
         DerivationTree::Derived(derived) => {
             // Recursively simplify both sides of the tree
-            with_growing_stack(|| {
-                simplify_derivation_tree_ranges(
-                    Arc::make_mut(&mut derived.cause1),
-                    included_versions,
-                    candidate_selector,
-                    resolver_environment,
-                );
-            });
-            with_growing_stack(|| {
-                simplify_derivation_tree_ranges(
-                    Arc::make_mut(&mut derived.cause2),
-                    included_versions,
-                    candidate_selector,
-                    resolver_environment,
-                );
-            });
+            simplify_derivation_tree_ranges(
+                Arc::make_mut(&mut derived.cause1),
+                included_versions,
+                candidate_selector,
+                resolver_environment,
+            );
+            simplify_derivation_tree_ranges(
+                Arc::make_mut(&mut derived.cause2),
+                included_versions,
+                candidate_selector,
+                resolver_environment,
+            );
 
             // Simplify the terms
             derived.terms = std::mem::take(&mut derived.terms)
@@ -1815,7 +1837,7 @@ mod tests {
             .stack_size(256 * 1024)
             .spawn(|| {
                 let tree = StackSafeErrorTree::new(deep_derivation_tree());
-                let _formatted = format!("{:?}", StackSafeDebugErrorTree(&tree));
+                let _formatted = format!("{tree:?}");
             })?;
 
         assert!(thread.join().is_ok());
@@ -1826,16 +1848,13 @@ mod tests {
     fn stack_safe_debug_matches_pubgrub_debug() {
         let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
         let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
-        let tree = ErrorTree::Derived(Derived {
+        let tree = StackSafeErrorTree::new(ErrorTree::Derived(Derived {
             terms: pubgrub::Map::default(),
             shared_id: Some(1),
             cause1: Arc::new(leaf.clone()),
             cause2: Arc::new(leaf),
-        });
+        }));
 
-        assert_eq!(
-            format!("{tree:?}"),
-            format!("{:?}", StackSafeDebugErrorTree(&tree))
-        );
+        assert_eq!(format!("{:?}", &*tree), format!("{tree:?}"));
     }
 }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -5,12 +5,11 @@ use std::sync::{Arc, OnceLock};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use pubgrub::{
-    DefaultStringReporter, DerivationTree, Derived, External, Range, Ranges, Reporter, Term,
-};
+use pubgrub::{DerivationTree, Derived, External, Range, Ranges, Term};
 use rustc_hash::FxHashMap;
 use tracing::trace;
 
+use uv_configuration::min_stack_size;
 use uv_distribution_types::{
     DerivationChain, DistErrorKind, IndexCapabilities, IndexLocations, IndexUrl, RequestedDist,
 };
@@ -27,7 +26,10 @@ use crate::dependency_provider::UvDependencyProvider;
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
-use crate::pubgrub::{PubGrubHint, PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter};
+use crate::pubgrub::{
+    PubGrubHint, PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter,
+    report_derivation_tree,
+};
 use crate::python_requirement::PythonRequirement;
 use crate::resolution::ConflictingDistributionError;
 use crate::resolver::{
@@ -167,9 +169,60 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
 
 pub type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>;
 
+const DERIVATION_TREE_RED_ZONE: usize = 64 * 1024;
+
+/// Run one recursive derivation-tree step with enough stack to reach the next growth point.
+pub(crate) fn with_growing_stack<R>(callback: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(DERIVATION_TREE_RED_ZONE, min_stack_size(), callback)
+}
+
+/// Visit the packages in a derivation tree without recursive calls.
+pub(crate) fn derivation_tree_packages(
+    derivation_tree: &ErrorTree,
+) -> impl Iterator<Item = &PubGrubPackage> {
+    let mut packages = Vec::new();
+    let mut trees = vec![derivation_tree];
+
+    while let Some(tree) = trees.pop() {
+        match tree {
+            DerivationTree::External(external) => match external {
+                External::FromDependencyOf(package, _, dependency, _) => {
+                    packages.push(package);
+                    packages.push(dependency);
+                }
+                External::NoVersions(package, _)
+                | External::NotRoot(package, _)
+                | External::Custom(package, _, _) => packages.push(package),
+            },
+            DerivationTree::Derived(derived) => {
+                packages.extend(derived.terms.keys());
+                trees.push(&derived.cause1);
+                trees.push(&derived.cause2);
+            }
+        }
+    }
+
+    packages.into_iter()
+}
+
+fn drop_derivation_tree(derivation_tree: ErrorTree) {
+    let mut trees = vec![derivation_tree];
+
+    while let Some(tree) = trees.pop() {
+        if let DerivationTree::Derived(derived) = tree {
+            if let Ok(cause1) = Arc::try_unwrap(derived.cause1) {
+                trees.push(cause1);
+            }
+            if let Ok(cause2) = Arc::try_unwrap(derived.cause2) {
+                trees.push(cause2);
+            }
+        }
+    }
+}
+
 /// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
 pub struct NoSolutionError {
-    error: pubgrub::NoSolutionError<UvDependencyProvider>,
+    error: Option<pubgrub::NoSolutionError<UvDependencyProvider>>,
     index: InMemoryIndex,
     /// The versions that were available for each package after `exclude-newer` filtering.
     ///
@@ -224,7 +277,7 @@ impl NoSolutionError {
         options: Options,
     ) -> Self {
         Self {
-            error,
+            error: Some(error),
             index,
             included_versions,
             available_versions,
@@ -246,6 +299,12 @@ impl NoSolutionError {
         }
     }
 
+    fn error(&self) -> &ErrorTree {
+        self.error
+            .as_ref()
+            .expect("no-solution error is only taken during drop")
+    }
+
     /// Get the cached report and hints, computing them on first access.
     fn cached(&self) -> &(String, IndexSet<PubGrubHint>) {
         self.cached.get_or_init(|| self.compute_report_and_hints())
@@ -255,7 +314,7 @@ impl NoSolutionError {
     /// wrap an [`PubGrubPackageInner::Extra`] package.
     pub(crate) fn collapse_proxies(derivation_tree: ErrorTree) -> ErrorTree {
         fn collapse(derivation_tree: ErrorTree) -> Option<ErrorTree> {
-            match derivation_tree {
+            with_growing_stack(|| match derivation_tree {
                 DerivationTree::Derived(derived) => {
                     match (&*derived.cause1, &*derived.cause2) {
                         (
@@ -288,7 +347,7 @@ impl NoSolutionError {
                     }
                 }
                 DerivationTree::External(_) => Some(derivation_tree),
-            }
+            })
         }
 
         collapse(derivation_tree)
@@ -302,7 +361,7 @@ impl NoSolutionError {
     /// satisfy `==1.0.0`.
     pub(crate) fn collapse_local_version_segments(derivation_tree: ErrorTree) -> ErrorTree {
         fn strip(derivation_tree: ErrorTree) -> Option<ErrorTree> {
-            match derivation_tree {
+            with_growing_stack(|| match derivation_tree {
                 DerivationTree::External(External::NotRoot(_, _)) => Some(derivation_tree),
                 DerivationTree::External(External::NoVersions(package, versions)) => {
                     if SentinelRange::from(&versions).is_complement() {
@@ -359,7 +418,7 @@ impl NoSolutionError {
                         _ => None,
                     }
                 }
-            }
+            })
         }
 
         strip(derivation_tree).expect("derivation tree should contain at least one term")
@@ -370,8 +429,8 @@ impl NoSolutionError {
         fn find(derivation_tree: &ErrorTree, minimum: &mut LowerBound) {
             match derivation_tree {
                 DerivationTree::Derived(derived) => {
-                    find(derived.cause1.as_ref(), minimum);
-                    find(derived.cause2.as_ref(), minimum);
+                    with_growing_stack(|| find(derived.cause1.as_ref(), minimum));
+                    with_growing_stack(|| find(derived.cause2.as_ref(), minimum));
                 }
                 DerivationTree::External(External::FromDependencyOf(.., package, version)) => {
                     if let PubGrubPackageInner::Python(_) = &**package {
@@ -388,7 +447,7 @@ impl NoSolutionError {
         }
 
         let mut minimum = LowerBound::default();
-        find(&self.error, &mut minimum);
+        find(self.error(), &mut minimum);
         minimum
     }
 
@@ -399,9 +458,7 @@ impl NoSolutionError {
 
     /// Get the packages that are involved in this error.
     pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
-        self.error
-            .packages()
-            .into_iter()
+        derivation_tree_packages(self.error())
             .filter_map(|p| p.name())
             .unique()
     }
@@ -432,7 +489,7 @@ impl NoSolutionError {
         };
 
         // Transform the error tree for reporting
-        let mut tree = self.error.clone();
+        let mut tree = self.error().clone();
         simplify_derivation_tree_markers(&self.python_requirement, &mut tree);
         let should_display_tree = std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE)
             .is_some()
@@ -470,7 +527,7 @@ impl NoSolutionError {
             display_tree(&tree, "Resolver derivation tree after reduction");
         }
 
-        let report = DefaultStringReporter::report_with_formatter(&tree, &formatter);
+        let report = report_derivation_tree(&tree, &formatter);
 
         let inherited_exclude_newer_ranges = FxHashMap::default();
         let mut hints = IndexSet::default();
@@ -523,7 +580,12 @@ impl std::fmt::Debug for NoSolutionError {
             cached: _,
         } = self;
         f.debug_struct("NoSolutionError")
-            .field("error", error)
+            .field(
+                "error",
+                error
+                    .as_ref()
+                    .expect("no-solution error is only taken during drop"),
+            )
             .field("included_versions", included_versions)
             .field("available_versions", available_versions)
             .field("available_indexes", available_indexes)
@@ -541,6 +603,14 @@ impl std::fmt::Debug for NoSolutionError {
             .field("workspace_members", workspace_members)
             .field("options", options)
             .finish()
+    }
+}
+
+impl Drop for NoSolutionError {
+    fn drop(&mut self) {
+        if let Some(error) = self.error.take() {
+            drop_derivation_tree(error);
+        }
     }
 }
 
@@ -593,8 +663,8 @@ fn display_tree_inner(
     let prefix = "  ".repeat(depth);
     match error {
         DerivationTree::Derived(derived) => {
-            display_tree_inner(&derived.cause1, lines, depth + 1);
-            display_tree_inner(&derived.cause2, lines, depth + 1);
+            with_growing_stack(|| display_tree_inner(&derived.cause1, lines, depth + 1));
+            with_growing_stack(|| display_tree_inner(&derived.cause2, lines, depth + 1));
             for (package, term) in &derived.terms {
                 match term {
                     Term::Positive(versions) => {
@@ -650,7 +720,7 @@ fn collapse_redundant_no_versions(
                     DerivationTree::External(External::NoVersions(package, versions)),
                 ) => {
                     // First, always recursively visit the other side of the tree
-                    collapse_redundant_no_versions(other);
+                    with_growing_stack(|| collapse_redundant_no_versions(other));
 
                     // Retrieve the nearest terms, either alongside this node or from the parent.
                     let package_terms = if let DerivationTree::Derived(derived) = other {
@@ -682,8 +752,12 @@ fn collapse_redundant_no_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause2));
+                    with_growing_stack(|| {
+                        collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause1));
+                    });
+                    with_growing_stack(|| {
+                        collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause2));
+                    });
                 }
             }
         }
@@ -757,8 +831,11 @@ fn collapse_redundant_no_versions_tree(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause1))
-                        || collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause2))
+                    with_growing_stack(|| {
+                        collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause1))
+                    }) || with_growing_stack(|| {
+                        collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause2))
+                    })
                 }
             }
         }
@@ -782,7 +859,9 @@ fn collapse_no_versions_of_workspace_members(
                 (DerivationTree::External(External::NoVersions(package, _)), ref mut other)
                 | (ref mut other, DerivationTree::External(External::NoVersions(package, _))) => {
                     // First, always recursively visit the other side of the tree
-                    collapse_no_versions_of_workspace_members(other, workspace_members);
+                    with_growing_stack(|| {
+                        collapse_no_versions_of_workspace_members(other, workspace_members);
+                    });
 
                     // Then, if the package is a workspace member...
                     let (PubGrubPackageInner::Package { name, .. }
@@ -800,14 +879,18 @@ fn collapse_no_versions_of_workspace_members(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_no_versions_of_workspace_members(
-                        Arc::make_mut(&mut derived.cause1),
-                        workspace_members,
-                    );
-                    collapse_no_versions_of_workspace_members(
-                        Arc::make_mut(&mut derived.cause2),
-                        workspace_members,
-                    );
+                    with_growing_stack(|| {
+                        collapse_no_versions_of_workspace_members(
+                            Arc::make_mut(&mut derived.cause1),
+                            workspace_members,
+                        );
+                    });
+                    with_growing_stack(|| {
+                        collapse_no_versions_of_workspace_members(
+                            Arc::make_mut(&mut derived.cause2),
+                            workspace_members,
+                        );
+                    });
                 }
             }
         }
@@ -859,8 +942,16 @@ fn collapse_redundant_depends_on_no_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause2));
+                    with_growing_stack(|| {
+                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                            &mut derived.cause1,
+                        ));
+                    });
+                    with_growing_stack(|| {
+                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                            &mut derived.cause2,
+                        ));
+                    });
                 }
             }
         }
@@ -911,8 +1002,16 @@ fn collapse_redundant_depends_on_no_versions_inner(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause2));
+                    with_growing_stack(|| {
+                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                            &mut derived.cause1,
+                        ));
+                    });
+                    with_growing_stack(|| {
+                        collapse_redundant_depends_on_no_versions(Arc::make_mut(
+                            &mut derived.cause2,
+                        ));
+                    });
                 }
             }
         }
@@ -953,14 +1052,18 @@ fn simplify_derivation_tree_markers(
                     (pkg, term)
                 })
                 .collect();
-            simplify_derivation_tree_markers(
-                python_requirement,
-                Arc::make_mut(&mut derived.cause1),
-            );
-            simplify_derivation_tree_markers(
-                python_requirement,
-                Arc::make_mut(&mut derived.cause2),
-            );
+            with_growing_stack(|| {
+                simplify_derivation_tree_markers(
+                    python_requirement,
+                    Arc::make_mut(&mut derived.cause1),
+                );
+            });
+            with_growing_stack(|| {
+                simplify_derivation_tree_markers(
+                    python_requirement,
+                    Arc::make_mut(&mut derived.cause2),
+                );
+            });
         }
     }
 }
@@ -988,7 +1091,7 @@ fn collapse_unavailable_versions(
                     DerivationTree::External(External::Custom(package, versions, reason)),
                 ) => {
                     // First, recursively collapse the other side of the tree
-                    collapse_unavailable_versions(other);
+                    with_growing_stack(|| collapse_unavailable_versions(other));
 
                     // If it's not a derived tree, nothing to do.
                     let DerivationTree::Derived(Derived {
@@ -1060,8 +1163,12 @@ fn collapse_unavailable_versions(
                 }
                 // If not, just recurse
                 _ => {
-                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause2));
+                    with_growing_stack(|| {
+                        collapse_unavailable_versions(Arc::make_mut(&mut derived.cause1));
+                    });
+                    with_growing_stack(|| {
+                        collapse_unavailable_versions(Arc::make_mut(&mut derived.cause2));
+                    });
                 }
             }
         }
@@ -1109,15 +1216,25 @@ fn drop_root_dependency_on_project(
                     }
 
                     // Recursively collapse the other side of the tree
-                    drop_root_dependency_on_project(other, project);
+                    with_growing_stack(|| drop_root_dependency_on_project(other, project));
 
                     // Then, replace this node with the other tree
                     *tree = other.clone();
                 }
                 // If not, just recurse
                 _ => {
-                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause1), project);
-                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause2), project);
+                    with_growing_stack(|| {
+                        drop_root_dependency_on_project(
+                            Arc::make_mut(&mut derived.cause1),
+                            project,
+                        );
+                    });
+                    with_growing_stack(|| {
+                        drop_root_dependency_on_project(
+                            Arc::make_mut(&mut derived.cause2),
+                            project,
+                        );
+                    });
                 }
             }
         }
@@ -1413,18 +1530,22 @@ fn simplify_derivation_tree_ranges(
         },
         DerivationTree::Derived(derived) => {
             // Recursively simplify both sides of the tree
-            simplify_derivation_tree_ranges(
-                Arc::make_mut(&mut derived.cause1),
-                included_versions,
-                candidate_selector,
-                resolver_environment,
-            );
-            simplify_derivation_tree_ranges(
-                Arc::make_mut(&mut derived.cause2),
-                included_versions,
-                candidate_selector,
-                resolver_environment,
-            );
+            with_growing_stack(|| {
+                simplify_derivation_tree_ranges(
+                    Arc::make_mut(&mut derived.cause1),
+                    included_versions,
+                    candidate_selector,
+                    resolver_environment,
+                );
+            });
+            with_growing_stack(|| {
+                simplify_derivation_tree_ranges(
+                    Arc::make_mut(&mut derived.cause2),
+                    included_versions,
+                    candidate_selector,
+                    resolver_environment,
+                );
+            });
 
             // Simplify the terms
             derived.terms = std::mem::take(&mut derived.terms)

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -7,7 +7,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use pubgrub::{DerivationTree, Derived, External, Range, Ranges, Term};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::trace;
 
 use uv_configuration::min_stack_size;
@@ -181,19 +181,21 @@ pub(crate) fn with_growing_stack<R>(callback: impl FnOnce() -> R) -> R {
 pub(crate) fn derivation_tree_packages(
     derivation_tree: &ErrorTree,
 ) -> impl Iterator<Item = &PubGrubPackage> {
-    let mut packages = Vec::new();
+    let mut packages = FxHashSet::default();
     let mut trees = vec![derivation_tree];
 
     while let Some(tree) = trees.pop() {
         match tree {
             DerivationTree::External(external) => match external {
                 External::FromDependencyOf(package, _, dependency, _) => {
-                    packages.push(package);
-                    packages.push(dependency);
+                    packages.insert(package);
+                    packages.insert(dependency);
                 }
                 External::NoVersions(package, _)
                 | External::NotRoot(package, _)
-                | External::Custom(package, _, _) => packages.push(package),
+                | External::Custom(package, _, _) => {
+                    packages.insert(package);
+                }
             },
             DerivationTree::Derived(derived) => {
                 packages.extend(derived.terms.keys());
@@ -1757,6 +1759,12 @@ mod tests {
 
         assert!(thread.join().is_ok());
         Ok(())
+    }
+
+    #[test]
+    fn derivation_tree_packages_are_unique() {
+        let tree = StackSafeErrorTree::new(deep_derivation_tree());
+        assert_eq!(derivation_tree_packages(&tree).count(), 1);
     }
 
     #[test]

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, Bound};
 use std::fmt::Formatter;
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, OnceLock};
 
 use indexmap::IndexSet;
@@ -216,6 +217,40 @@ fn drop_derivation_tree(derivation_tree: ErrorTree) {
             if let Ok(cause2) = Arc::try_unwrap(derived.cause2) {
                 trees.push(cause2);
             }
+        }
+    }
+}
+
+struct StackSafeErrorTree(Option<ErrorTree>);
+
+impl StackSafeErrorTree {
+    fn new(derivation_tree: ErrorTree) -> Self {
+        Self(Some(derivation_tree))
+    }
+}
+
+impl Deref for StackSafeErrorTree {
+    type Target = ErrorTree;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+            .as_ref()
+            .expect("derivation tree is only taken during drop")
+    }
+}
+
+impl DerefMut for StackSafeErrorTree {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+            .as_mut()
+            .expect("derivation tree is only taken during drop")
+    }
+}
+
+impl Drop for StackSafeErrorTree {
+    fn drop(&mut self) {
+        if let Some(derivation_tree) = self.0.take() {
+            drop_derivation_tree(derivation_tree);
         }
     }
 }
@@ -489,7 +524,7 @@ impl NoSolutionError {
         };
 
         // Transform the error tree for reporting
-        let mut tree = self.error().clone();
+        let mut tree = StackSafeErrorTree::new(self.error().clone());
         simplify_derivation_tree_markers(&self.python_requirement, &mut tree);
         let should_display_tree = std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE)
             .is_some()
@@ -1641,4 +1676,34 @@ fn simplify_range(
         // Otherwise, include the version
         true
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_transformed_derivation_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+                let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
+                let mut tree = leaf.clone();
+
+                for _ in 0..100_000 {
+                    tree = ErrorTree::Derived(Derived {
+                        terms: pubgrub::Map::default(),
+                        shared_id: None,
+                        cause1: Arc::new(tree),
+                        cause2: Arc::new(leaf.clone()),
+                    });
+                }
+
+                let _tree = StackSafeErrorTree::new(tree);
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
 }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, Bound};
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, OnceLock};
 
@@ -252,6 +252,41 @@ impl Drop for StackSafeErrorTree {
         if let Some(derivation_tree) = self.0.take() {
             drop_derivation_tree(derivation_tree);
         }
+    }
+}
+
+struct StackSafeDebugErrorTree<'a>(&'a ErrorTree);
+
+impl Debug for StackSafeDebugErrorTree<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        with_growing_stack(|| match self.0 {
+            DerivationTree::External(external) => {
+                f.debug_tuple("External").field(external).finish()
+            }
+            DerivationTree::Derived(derived) => f
+                .debug_tuple("Derived")
+                .field(&StackSafeDebugDerived(derived))
+                .finish(),
+        })
+    }
+}
+
+struct StackSafeDebugDerived<'a>(&'a Derived<PubGrubPackage, Range<Version>, UnavailableReason>);
+
+impl Debug for StackSafeDebugDerived<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Derived {
+            terms,
+            shared_id,
+            cause1,
+            cause2,
+        } = self.0;
+        f.debug_struct("Derived")
+            .field("terms", terms)
+            .field("shared_id", shared_id)
+            .field("cause1", &StackSafeDebugErrorTree(cause1))
+            .field("cause2", &StackSafeDebugErrorTree(cause2))
+            .finish()
     }
 }
 
@@ -628,9 +663,11 @@ impl std::fmt::Debug for NoSolutionError {
         f.debug_struct("NoSolutionError")
             .field(
                 "error",
-                error
-                    .as_ref()
-                    .expect("no-solution error is only taken during drop"),
+                &StackSafeDebugErrorTree(
+                    error
+                        .as_ref()
+                        .expect("no-solution error is only taken during drop"),
+                ),
             )
             .field("included_versions", included_versions)
             .field("available_versions", available_versions)
@@ -1746,5 +1783,35 @@ mod tests {
 
         assert!(thread.join().is_ok());
         Ok(())
+    }
+
+    #[test]
+    fn formats_derivation_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = StackSafeErrorTree::new(deep_derivation_tree());
+                let _formatted = format!("{:?}", StackSafeDebugErrorTree(&tree));
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn stack_safe_debug_matches_pubgrub_debug() {
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
+        let tree = ErrorTree::Derived(Derived {
+            terms: pubgrub::Map::default(),
+            shared_id: Some(1),
+            cause1: Arc::new(leaf.clone()),
+            cause2: Arc::new(leaf),
+        });
+
+        assert_eq!(
+            format!("{tree:?}"),
+            format!("{:?}", StackSafeDebugErrorTree(&tree))
+        );
     }
 }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -173,11 +173,17 @@ pub type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableR
 const DERIVATION_TREE_RED_ZONE: usize = 64 * 1024;
 
 /// Run one recursive derivation-tree step with enough stack to reach the next growth point.
+///
+/// Recursive tree walkers should call this at every child edge so no individual stack segment
+/// needs to accommodate the full depth of the derivation tree.
 pub(crate) fn with_growing_stack<R>(callback: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(DERIVATION_TREE_RED_ZONE, min_stack_size(), callback)
 }
 
-/// Visit the packages in a derivation tree without recursive calls.
+/// Visit each distinct package in a derivation tree without recursive calls.
+///
+/// The iteration order is unspecified, matching the set semantics of
+/// [`DerivationTree::packages`].
 pub(crate) fn derivation_tree_packages(
     derivation_tree: &ErrorTree,
 ) -> impl Iterator<Item = &PubGrubPackage> {
@@ -208,6 +214,10 @@ pub(crate) fn derivation_tree_packages(
     packages.into_iter()
 }
 
+/// Drop an exclusively owned derivation tree without recursing through its children.
+///
+/// Shared [`Arc`] children are left for their remaining owners; once the last owner is processed,
+/// [`Arc::try_unwrap`] exposes the child for iterative destruction.
 fn drop_derivation_tree(derivation_tree: ErrorTree) {
     let mut trees = vec![derivation_tree];
 
@@ -223,6 +233,10 @@ fn drop_derivation_tree(derivation_tree: ErrorTree) {
     }
 }
 
+/// Own a derivation tree whose destruction must not recurse through the process stack.
+///
+/// The `Option` allows [`Drop`] to take ownership of the tree and applies the same iterative
+/// teardown during normal returns and unwinding.
 struct StackSafeErrorTree(Option<ErrorTree>);
 
 impl StackSafeErrorTree {
@@ -257,6 +271,7 @@ impl Drop for StackSafeErrorTree {
     }
 }
 
+/// Preserve PubGrub's [`Debug`] representation while growing the stack at each tree edge.
 struct StackSafeDebugErrorTree<'a>(&'a ErrorTree);
 
 impl Debug for StackSafeDebugErrorTree<'_> {
@@ -273,6 +288,7 @@ impl Debug for StackSafeDebugErrorTree<'_> {
     }
 }
 
+/// Format a derived incompatibility with stack-safe wrappers around its recursive causes.
 struct StackSafeDebugDerived<'a>(&'a Derived<PubGrubPackage, Range<Version>, UnavailableReason>);
 
 impl Debug for StackSafeDebugDerived<'_> {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -348,7 +348,7 @@ impl NoSolutionError {
     /// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
     /// wrap an [`PubGrubPackageInner::Extra`] package.
     pub(crate) fn collapse_proxies(derivation_tree: ErrorTree) -> ErrorTree {
-        fn collapse(derivation_tree: ErrorTree) -> Option<ErrorTree> {
+        fn collapse(derivation_tree: &ErrorTree) -> Option<ErrorTree> {
             with_growing_stack(|| match derivation_tree {
                 DerivationTree::Derived(derived) => {
                     match (&*derived.cause1, &*derived.cause2) {
@@ -359,20 +359,21 @@ impl NoSolutionError {
                         (
                             DerivationTree::External(External::FromDependencyOf(package, ..)),
                             cause,
-                        ) if package.is_proxy() => collapse(cause.clone()),
+                        ) if package.is_proxy() => collapse(cause),
                         (
                             cause,
                             DerivationTree::External(External::FromDependencyOf(package, ..)),
-                        ) if package.is_proxy() => collapse(cause.clone()),
+                        ) if package.is_proxy() => collapse(cause),
                         (cause1, cause2) => {
-                            let cause1 = collapse(cause1.clone());
-                            let cause2 = collapse(cause2.clone());
+                            let cause1 = collapse(cause1);
+                            let cause2 = collapse(cause2);
                             match (cause1, cause2) {
                                 (Some(cause1), Some(cause2)) => {
                                     Some(DerivationTree::Derived(Derived {
                                         cause1: Arc::new(cause1),
                                         cause2: Arc::new(cause2),
-                                        ..derived
+                                        terms: derived.terms.clone(),
+                                        shared_id: derived.shared_id,
                                     }))
                                 }
                                 (Some(cause), None) | (None, Some(cause)) => Some(cause),
@@ -381,11 +382,12 @@ impl NoSolutionError {
                         }
                     }
                 }
-                DerivationTree::External(_) => Some(derivation_tree),
+                DerivationTree::External(_) => Some(derivation_tree.clone()),
             })
         }
 
-        collapse(derivation_tree)
+        let derivation_tree = StackSafeErrorTree::new(derivation_tree);
+        collapse(&derivation_tree)
             .expect("derivation tree should contain at least one external term")
     }
 
@@ -395,17 +397,18 @@ impl NoSolutionError {
     /// implement PEP 440 semantics for local version equality. For example, `1.0.0+foo` needs to
     /// satisfy `==1.0.0`.
     pub(crate) fn collapse_local_version_segments(derivation_tree: ErrorTree) -> ErrorTree {
-        fn strip(derivation_tree: ErrorTree) -> Option<ErrorTree> {
+        fn strip(derivation_tree: &ErrorTree) -> Option<ErrorTree> {
             with_growing_stack(|| match derivation_tree {
-                DerivationTree::External(External::NotRoot(_, _)) => Some(derivation_tree),
+                DerivationTree::External(External::NotRoot(_, _)) => Some(derivation_tree.clone()),
                 DerivationTree::External(External::NoVersions(package, versions)) => {
-                    if SentinelRange::from(&versions).is_complement() {
+                    if SentinelRange::from(versions).is_complement() {
                         return None;
                     }
 
-                    let versions = SentinelRange::from(&versions).strip();
+                    let versions = SentinelRange::from(versions).strip();
                     Some(DerivationTree::External(External::NoVersions(
-                        package, versions,
+                        package.clone(),
+                        versions,
                     )))
                 }
                 DerivationTree::External(External::FromDependencyOf(
@@ -414,26 +417,33 @@ impl NoSolutionError {
                     package2,
                     versions2,
                 )) => {
-                    let versions1 = SentinelRange::from(&versions1).strip();
-                    let versions2 = SentinelRange::from(&versions2).strip();
+                    let versions1 = SentinelRange::from(versions1).strip();
+                    let versions2 = SentinelRange::from(versions2).strip();
                     Some(DerivationTree::External(External::FromDependencyOf(
-                        package1, versions1, package2, versions2,
+                        package1.clone(),
+                        versions1,
+                        package2.clone(),
+                        versions2,
                     )))
                 }
                 DerivationTree::External(External::Custom(package, versions, reason)) => {
-                    let versions = SentinelRange::from(&versions).strip();
+                    let versions = SentinelRange::from(versions).strip();
                     Some(DerivationTree::External(External::Custom(
-                        package, versions, reason,
+                        package.clone(),
+                        versions,
+                        reason.clone(),
                     )))
                 }
-                DerivationTree::Derived(mut derived) => {
-                    let cause1 = strip((*derived.cause1).clone());
-                    let cause2 = strip((*derived.cause2).clone());
+                DerivationTree::Derived(derived) => {
+                    let cause1 = strip(&derived.cause1);
+                    let cause2 = strip(&derived.cause2);
                     match (cause1, cause2) {
                         (Some(cause1), Some(cause2)) => Some(DerivationTree::Derived(Derived {
                             cause1: Arc::new(cause1),
                             cause2: Arc::new(cause2),
-                            terms: std::mem::take(&mut derived.terms)
+                            terms: derived
+                                .terms
+                                .clone()
                                 .into_iter()
                                 .map(|(pkg, term)| {
                                     let term = match term {
@@ -456,7 +466,8 @@ impl NoSolutionError {
             })
         }
 
-        strip(derivation_tree).expect("derivation tree should contain at least one term")
+        let derivation_tree = StackSafeErrorTree::new(derivation_tree);
+        strip(&derivation_tree).expect("derivation tree should contain at least one term")
     }
 
     /// Given a [`DerivationTree`], identify the largest required Python version that is missing.
@@ -1682,25 +1693,55 @@ fn simplify_range(
 mod tests {
     use super::*;
 
+    fn deep_derivation_tree() -> ErrorTree {
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
+        let mut tree = leaf.clone();
+
+        for _ in 0..100_000 {
+            tree = ErrorTree::Derived(Derived {
+                terms: pubgrub::Map::default(),
+                shared_id: None,
+                cause1: Arc::new(tree),
+                cause2: Arc::new(leaf.clone()),
+            });
+        }
+
+        tree
+    }
+
     #[test]
     fn drops_transformed_derivation_tree_without_recursion() -> std::io::Result<()> {
         let thread = std::thread::Builder::new()
             .stack_size(256 * 1024)
             .spawn(|| {
-                let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
-                let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
-                let mut tree = leaf.clone();
+                let _tree = StackSafeErrorTree::new(deep_derivation_tree());
+            })?;
 
-                for _ in 0..100_000 {
-                    tree = ErrorTree::Derived(Derived {
-                        terms: pubgrub::Map::default(),
-                        shared_id: None,
-                        cause1: Arc::new(tree),
-                        cause2: Arc::new(leaf.clone()),
-                    });
-                }
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
 
-                let _tree = StackSafeErrorTree::new(tree);
+    #[test]
+    fn collapse_proxies_drops_source_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = NoSolutionError::collapse_proxies(deep_derivation_tree());
+                drop_derivation_tree(tree);
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn collapse_local_versions_drops_source_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = NoSolutionError::collapse_local_version_segments(deep_derivation_tree());
+                drop_derivation_tree(tree);
             })?;
 
         assert!(thread.join().is_ok());

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -2,7 +2,7 @@ pub(crate) use crate::pubgrub::dependencies::{DependencySource, PubGrubDependenc
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority, PubGrubTiebreaker};
 pub use crate::pubgrub::report::PubGrubHint;
-pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
+pub(crate) use crate::pubgrub::report::{PubGrubReportFormatter, report as report_derivation_tree};
 
 mod dependencies;
 mod package;

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -20,7 +20,7 @@ use uv_pep508::{MarkerEnvironment, MarkerExpression, MarkerTree, MarkerValueVers
 use uv_platform_tags::{AbiTag, IncompatibleTag, LanguageTag, PlatformTag, Tags};
 
 use crate::candidate_selector::CandidateSelector;
-use crate::error::{ErrorTree, PrefixMatch};
+use crate::error::{ErrorTree, PrefixMatch, with_growing_stack};
 use crate::exclude_newer::EffectiveExcludeNewerSource;
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
@@ -49,6 +49,170 @@ pub(crate) struct PubGrubReportFormatter<'a> {
 
     /// The compatible tags for the resolution.
     pub(crate) tags: Option<&'a Tags>,
+}
+
+/// Render a PubGrub report while growing the stack between recursive steps.
+///
+/// This mirrors [`pubgrub::DefaultStringReporter`], whose recursive entry point is private.
+pub(crate) fn report(
+    derivation_tree: &ErrorTree,
+    formatter: &PubGrubReportFormatter<'_>,
+) -> String {
+    match derivation_tree {
+        DerivationTree::External(external) => formatter.format_external(external),
+        DerivationTree::Derived(derived) => {
+            let mut reporter = StackSafeReporter::default();
+            reporter.build_recursive(derived, formatter);
+            reporter.lines.join("\n")
+        }
+    }
+}
+
+#[derive(Default)]
+struct StackSafeReporter {
+    ref_count: usize,
+    shared_with_ref: Map<usize, usize>,
+    lines: Vec<String>,
+}
+
+impl StackSafeReporter {
+    fn build_recursive(
+        &mut self,
+        derived: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,
+        formatter: &PubGrubReportFormatter<'_>,
+    ) {
+        with_growing_stack(|| self.build_recursive_inner(derived, formatter));
+    }
+
+    fn build_recursive_inner(
+        &mut self,
+        derived: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,
+        formatter: &PubGrubReportFormatter<'_>,
+    ) {
+        self.build_recursive_helper(derived, formatter);
+        if let Some(id) = derived.shared_id
+            && !self.shared_with_ref.contains_key(&id)
+        {
+            self.add_line_ref();
+            self.shared_with_ref.insert(id, self.ref_count);
+        }
+    }
+
+    fn build_recursive_helper(
+        &mut self,
+        current: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,
+        formatter: &PubGrubReportFormatter<'_>,
+    ) {
+        match (current.cause1.as_ref(), current.cause2.as_ref()) {
+            (DerivationTree::External(external1), DerivationTree::External(external2)) => {
+                self.lines.push(formatter.explain_both_external(
+                    external1,
+                    external2,
+                    &current.terms,
+                ));
+            }
+            (DerivationTree::Derived(derived), DerivationTree::External(external))
+            | (DerivationTree::External(external), DerivationTree::Derived(derived)) => {
+                self.report_one_each(derived, external, &current.terms, formatter);
+            }
+            (DerivationTree::Derived(derived1), DerivationTree::Derived(derived2)) => {
+                match (
+                    self.line_ref_of(derived1.shared_id),
+                    self.line_ref_of(derived2.shared_id),
+                ) {
+                    (Some(ref1), Some(ref2)) => self.lines.push(formatter.explain_both_ref(
+                        ref1,
+                        derived1,
+                        ref2,
+                        derived2,
+                        &current.terms,
+                    )),
+                    (Some(ref1), None) => {
+                        self.build_recursive(derived2, formatter);
+                        self.lines
+                            .push(formatter.and_explain_ref(ref1, derived1, &current.terms));
+                    }
+                    (None, Some(ref2)) => {
+                        self.build_recursive(derived1, formatter);
+                        self.lines
+                            .push(formatter.and_explain_ref(ref2, derived2, &current.terms));
+                    }
+                    (None, None) => {
+                        self.build_recursive(derived1, formatter);
+                        if derived1.shared_id.is_some() {
+                            self.lines.push(String::new());
+                            self.build_recursive(current, formatter);
+                        } else {
+                            self.add_line_ref();
+                            let ref1 = self.ref_count;
+                            self.lines.push(String::new());
+                            self.build_recursive(derived2, formatter);
+                            self.lines.push(formatter.and_explain_ref(
+                                ref1,
+                                derived1,
+                                &current.terms,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn report_one_each(
+        &mut self,
+        derived: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,
+        external: &External<PubGrubPackage, Range<Version>, UnavailableReason>,
+        current_terms: &Map<PubGrubPackage, Term<Range<Version>>>,
+        formatter: &PubGrubReportFormatter<'_>,
+    ) {
+        if let Some(ref_id) = self.line_ref_of(derived.shared_id) {
+            self.lines.push(formatter.explain_ref_and_external(
+                ref_id,
+                derived,
+                external,
+                current_terms,
+            ));
+        } else {
+            self.report_recurse_one_each(derived, external, current_terms, formatter);
+        }
+    }
+
+    fn report_recurse_one_each(
+        &mut self,
+        derived: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,
+        external: &External<PubGrubPackage, Range<Version>, UnavailableReason>,
+        current_terms: &Map<PubGrubPackage, Term<Range<Version>>>,
+        formatter: &PubGrubReportFormatter<'_>,
+    ) {
+        match (derived.cause1.as_ref(), derived.cause2.as_ref()) {
+            (DerivationTree::Derived(prior_derived), DerivationTree::External(prior_external))
+            | (DerivationTree::External(prior_external), DerivationTree::Derived(prior_derived)) => {
+                self.build_recursive(prior_derived, formatter);
+                self.lines.push(formatter.and_explain_prior_and_external(
+                    prior_external,
+                    external,
+                    current_terms,
+                ));
+            }
+            _ => {
+                self.build_recursive(derived, formatter);
+                self.lines
+                    .push(formatter.and_explain_external(external, current_terms));
+            }
+        }
+    }
+
+    fn add_line_ref(&mut self) {
+        self.ref_count += 1;
+        if let Some(line) = self.lines.last_mut() {
+            *line = format!("{line} ({})", self.ref_count);
+        }
+    }
+
+    fn line_ref_of(&self, shared_id: Option<usize>) -> Option<usize> {
+        shared_id.and_then(|id| self.shared_with_ref.get(&id).copied())
+    }
 }
 
 impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
@@ -770,44 +934,48 @@ impl PubGrubReportFormatter<'_> {
                         .or_insert_with(|| range.clone());
                 }
 
-                self.generate_hints(
-                    &derived.cause1,
-                    index,
-                    selector,
-                    index_locations,
-                    index_capabilities,
-                    available_indexes,
-                    unavailable_packages,
-                    incomplete_packages,
-                    fork_urls,
-                    fork_indexes,
-                    env,
-                    current_environment,
-                    tags,
-                    workspace_members,
-                    options,
-                    &cause1_inherited_exclude_newer_ranges,
-                    output_hints,
-                );
-                self.generate_hints(
-                    &derived.cause2,
-                    index,
-                    selector,
-                    index_locations,
-                    index_capabilities,
-                    available_indexes,
-                    unavailable_packages,
-                    incomplete_packages,
-                    fork_urls,
-                    fork_indexes,
-                    env,
-                    current_environment,
-                    tags,
-                    workspace_members,
-                    options,
-                    &cause2_inherited_exclude_newer_ranges,
-                    output_hints,
-                );
+                with_growing_stack(|| {
+                    self.generate_hints(
+                        &derived.cause1,
+                        index,
+                        selector,
+                        index_locations,
+                        index_capabilities,
+                        available_indexes,
+                        unavailable_packages,
+                        incomplete_packages,
+                        fork_urls,
+                        fork_indexes,
+                        env,
+                        current_environment,
+                        tags,
+                        workspace_members,
+                        options,
+                        &cause1_inherited_exclude_newer_ranges,
+                        output_hints,
+                    );
+                });
+                with_growing_stack(|| {
+                    self.generate_hints(
+                        &derived.cause2,
+                        index,
+                        selector,
+                        index_locations,
+                        index_capabilities,
+                        available_indexes,
+                        unavailable_packages,
+                        incomplete_packages,
+                        fork_urls,
+                        fork_indexes,
+                        env,
+                        current_environment,
+                        tags,
+                        workspace_members,
+                        options,
+                        &cause2_inherited_exclude_newer_ranges,
+                        output_hints,
+                    );
+                });
             }
         }
     }
@@ -840,8 +1008,8 @@ impl PubGrubReportFormatter<'_> {
                 }
                 DerivationTree::External(_) => {}
                 DerivationTree::Derived(derived) => {
-                    collect(&derived.cause1, exclude_newer_ranges);
-                    collect(&derived.cause2, exclude_newer_ranges);
+                    with_growing_stack(|| collect(&derived.cause1, exclude_newer_ranges));
+                    with_growing_stack(|| collect(&derived.cause2, exclude_newer_ranges));
                 }
             }
         }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -2605,3 +2605,80 @@ fn padded<'a, T: std::fmt::Display + ?Sized>(
         Ok(())
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use pubgrub::{DefaultStringReporter, Reporter};
+    use uv_distribution_types::RequiresPython;
+    use uv_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
+
+    use super::*;
+
+    fn derived(
+        cause1: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+        cause2: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+        shared_id: Option<usize>,
+    ) -> DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason> {
+        DerivationTree::Derived(Derived {
+            terms: Map::default(),
+            shared_id,
+            cause1: cause1.into(),
+            cause2: cause2.into(),
+        })
+    }
+
+    #[test]
+    fn stack_safe_reporter_matches_pubgrub_for_shared_nodes() {
+        let marker_environment = MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+            implementation_name: "cpython",
+            implementation_version: "3.12.0",
+            os_name: "posix",
+            platform_machine: "x86_64",
+            platform_python_implementation: "CPython",
+            platform_release: "",
+            platform_system: "Linux",
+            platform_version: "",
+            python_full_version: "3.12.0",
+            python_version: "3.12",
+            sys_platform: "linux",
+        })
+        .expect("valid marker environment");
+        let python_requirement = PythonRequirement::from_marker_environment(
+            &marker_environment,
+            RequiresPython::greater_than_equal_version(&Version::new([3_u64, 12])),
+        );
+        let included_versions = FxHashMap::default();
+        let available_versions = FxHashMap::default();
+        let workspace_members = BTreeSet::default();
+        let formatter = PubGrubReportFormatter {
+            included_versions: &included_versions,
+            available_versions: &available_versions,
+            python_requirement: &python_requirement,
+            workspace_members: &workspace_members,
+            tags: None,
+        };
+
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let external1 =
+            DerivationTree::External(External::NotRoot(package.clone(), Version::new([1_u64])));
+        let external2 =
+            DerivationTree::External(External::NotRoot(package.clone(), Version::new([2_u64])));
+        let external3 = DerivationTree::External(External::NotRoot(package, Version::new([3_u64])));
+        let shared = derived(external1.clone(), external2.clone(), Some(1));
+        let unshared = derived(external2.clone(), external3.clone(), None);
+
+        let trees = [
+            derived(shared.clone(), external3.clone(), None),
+            derived(external3.clone(), shared.clone(), None),
+            derived(shared.clone(), unshared, None),
+            derived(shared.clone(), shared, None),
+        ];
+
+        for tree in trees {
+            assert_eq!(
+                report(&tree, &formatter),
+                DefaultStringReporter::report_with_formatter(&tree, &formatter)
+            );
+        }
+    }
+}

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -53,7 +53,8 @@ pub(crate) struct PubGrubReportFormatter<'a> {
 
 /// Render a PubGrub report while growing the stack between recursive steps.
 ///
-/// This mirrors [`pubgrub::DefaultStringReporter`], whose recursive entry point is private.
+/// This preserves the output and shared-node reference behavior of
+/// [`pubgrub::DefaultStringReporter`], whose recursive entry point is private.
 pub(crate) fn report(
     derivation_tree: &ErrorTree,
     formatter: &PubGrubReportFormatter<'_>,
@@ -68,6 +69,7 @@ pub(crate) fn report(
     }
 }
 
+/// Accumulates the report state used by [`report`] while bounding recursion depth per stack.
 #[derive(Default)]
 struct StackSafeReporter {
     ref_count: usize,
@@ -76,6 +78,7 @@ struct StackSafeReporter {
 }
 
 impl StackSafeReporter {
+    /// Render one derived incompatibility, growing the stack before descending further.
     fn build_recursive(
         &mut self,
         derived: &Derived<PubGrubPackage, Range<Version>, UnavailableReason>,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -43,7 +43,7 @@ use uv_warnings::warn_user_once;
 
 use crate::candidate_selector::{Candidate, CandidateDist, CandidateSelector};
 use crate::dependency_provider::UvDependencyProvider;
-use crate::error::{NoSolutionError, ResolveError};
+use crate::error::{NoSolutionError, ResolveError, derivation_tree_packages};
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_strategy::ForkStrategy;
 use crate::fork_urls::ForkUrls;
@@ -2699,7 +2699,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         ));
 
         let mut unavailable_packages = FxHashMap::default();
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             if let PubGrubPackageInner::Package { name, .. } = &**package {
                 if let Some(reason) = self.unavailable_packages.get(name) {
                     unavailable_packages.insert(name.clone(), reason.clone());
@@ -2708,7 +2708,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         }
 
         let mut incomplete_packages = FxHashMap::default();
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             if let PubGrubPackageInner::Package { name, .. } = &**package {
                 if let Some(versions) = self.incomplete_packages.get(name) {
                     for entry in versions.iter() {
@@ -2731,7 +2731,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .ok()
                 .and_then(|s| s.parse().ok());
 
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             let Some(name) = package.name() else { continue };
             if !visited.contains(name) {
                 // Avoid including version data for packages that exist in the derivation

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -1,8 +1,10 @@
 #![expect(clippy::disallowed_types)]
 
+use std::collections::BTreeMap;
 use std::env::current_dir;
 use std::fs;
 use std::io::Cursor;
+use std::str::FromStr;
 
 use anyhow::Result;
 use assert_fs::prelude::*;
@@ -18,8 +20,13 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use uv_fs::Simplified;
+use uv_normalize::PackageName;
+use uv_pep440::Version;
+use uv_pep508::Requirement;
 use uv_static::EnvVars;
 
+use uv_test::packse::PackseServer;
+use uv_test::packse::scenario::{Package, PackageMetadata, Scenario};
 use uv_test::{DEFAULT_PYTHON_VERSION, TestContext, download_to_disk, uv_snapshot};
 
 fn write_tar_gz(file: File, entries: &[(&str, &str)]) -> Result<()> {
@@ -386,6 +393,77 @@ fn compile_constraints_txt() -> Result<()> {
     Resolved 3 packages in [TIME]
     "
     );
+
+    Ok(())
+}
+
+/// <https://github.com/astral-sh/uv/issues/19672>
+#[test]
+fn compile_constraints_many_versions() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let mut package_versions = BTreeMap::new();
+    for patch in 0..1_000 {
+        let version = Version::from_str(&format!("1.0.{patch}"))?;
+        package_versions.insert(
+            version.clone(),
+            PackageMetadata {
+                requires: vec![Requirement::from_str(&format!("dependency=={version}"))?],
+                sdist: false,
+                wheel: true,
+                ..PackageMetadata::default()
+            },
+        );
+    }
+
+    let mut scenario = Scenario::empty();
+    scenario.packages.insert(
+        PackageName::from_str("package")?,
+        Package {
+            versions: package_versions,
+        },
+    );
+    scenario.packages.insert(
+        PackageName::from_str("dependency")?,
+        Package {
+            versions: BTreeMap::from([(
+                Version::from_str("2.0.0")?,
+                PackageMetadata {
+                    sdist: false,
+                    wheel: true,
+                    ..PackageMetadata::default()
+                },
+            )]),
+        },
+    );
+    let server = PackseServer::from_scenario(&scenario);
+
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("package<2")?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str("dependency>=2")?;
+
+    let mut filters = context.filters();
+    filters.push((r"WARN Range requests not supported.*\n", ""));
+    filters.push((
+        r"(?s)  × No solution found when resolving dependencies:.*requirements are unsatisfiable\.",
+        "  × No solution found when resolving dependencies: [LONG DERIVATION]",
+    ));
+
+    uv_snapshot!(filters, context.pip_compile()
+            .arg("requirements.in")
+            .arg("--constraint")
+            .arg("constraints.txt")
+            .arg("--index-url")
+            .arg(server.index_url())
+            .env(EnvVars::UV_STACK_SIZE, (4 * 1024 * 1024).to_string()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies: [LONG DERIVATION]
+    ");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Prior to this change, resolving an unsatisfiable dependency graph with many candidate versions could overflow the process stack while constructing and displaying the resolver error.

This PR makes derivation-tree error handling stack-safe by growing the stack during recursive transformations, hint generation, debugging, and report formatting. Tree traversal and destruction use iterative implementations where possible (avoiding another overflow when large intermediate trees are inspected or dropped).

Since PubGrub's recursive reporting entry point is private, we mirror its reporter for now while preserving its output and shared-node references.

Closes https://github.com/astral-sh/uv/issues/19672.