### PR TITLE
Handle invalid tool receipts on uninstall

### DIFF
--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -133,26 +133,30 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let Some(receipt) = installed_tools.get_tool_receipt(&name)? else {
-                // If the tool is not installed properly, attempt to remove the environment anyway.
-                match installed_tools.remove_environment(&name) {
-                    Ok(()) => {
-                        dangling = true;
-                        writeln!(
-                            printer.stderr(),
-                            "Removed dangling environment for `{name}`"
-                        )?;
-                        continue;
-                    }
-                    Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
-                        if err.kind() == std::io::ErrorKind::NotFound =>
-                    {
-                        bail!("`{name}` is not installed");
-                    }
-                    Err(err) => {
-                        return Err(err.into());
+            let receipt = match installed_tools.get_tool_receipt(&name) {
+                Ok(Some(receipt)) => receipt,
+                Ok(None) | Err(uv_tool::Error::ReceiptRead(_, _)) => {
+                    // If the tool is not installed properly, attempt to remove the environment anyway.
+                    match installed_tools.remove_environment(&name) {
+                        Ok(()) => {
+                            dangling = true;
+                            writeln!(
+                                printer.stderr(),
+                                "Removed dangling environment for `{name}`"
+                            )?;
+                            continue;
+                        }
+                        Err(uv_tool::Error::VirtualEnvError(uv_virtualenv::Error::Io(err)))
+                            if err.kind() == std::io::ErrorKind::NotFound =>
+                        {
+                            bail!("`{name}` is not installed");
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
                     }
                 }
+                Err(err) => return Err(err.into()),
             };
 
             entrypoints.extend(uninstall_tool(&name, &receipt, installed_tools).await?);

--- a/crates/uv/tests/it/tool_uninstall.rs
+++ b/crates/uv/tests/it/tool_uninstall.rs
@@ -161,6 +161,35 @@ fn tool_uninstall_missing_receipt() {
 }
 
 #[test]
+fn tool_uninstall_invalid_receipt() {
+    let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    context
+        .tool_install()
+        .arg("black==24.2.0")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
+        .assert()
+        .success();
+
+    fs_err::write(tool_dir.join("black").join("uv-receipt.toml"), "invalid").unwrap();
+
+    uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed dangling environment for `black`
+    ");
+}
+
+#[test]
 fn tool_uninstall_multiple_names_with_missing_receipt() {
     let context = uv_test::test_context!("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");


### PR DESCRIPTION
## Summary

Fixes #19630.

When uninstalling a named tool, treat a malformed `uv-receipt.toml` the same way as a missing receipt: remove the dangling tool environment instead of failing while reading the receipt. This makes the `uv tool list` recovery hint actionable.

## Test plan

- `cargo test --package uv --test it tool_uninstall::tool_uninstall_invalid_receipt -- --exact`
- `cargo test --package uv --test it tool_uninstall::tool_uninstall_missing_receipt -- --exact`
- `cargo fmt --all -- --check`
- `git diff --check`