### PR TITLE
Centralize index argument handling

### DIFF
--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -4,7 +4,7 @@ use anstream::eprintln;
 
 use uv_cache::Refresh;
 use uv_configuration::{BuildIsolation, Reinstall, Upgrade};
-use uv_distribution_types::{ConfigSettings, PackageConfigSettings, Requirement};
+use uv_distribution_types::{ConfigSettings, Index, PackageConfigSettings, Requirement};
 use uv_resolver::{ExcludeNewer, ExcludeNewerPackage, PrereleaseMode};
 use uv_settings::{Combine, EnvFlag, PipOptions, ResolverInstallerOptions, ResolverOptions};
 use uv_warnings::owo_colors::OwoColorize;
@@ -222,6 +222,27 @@ impl From<RefreshArgs> for Refresh {
 
         Self::from_args(flag(refresh, no_refresh, "no-refresh"), refresh_package)
     }
+}
+
+/// Extract the `--index` and `--default-index` values from [`IndexArgs`].
+pub fn indexes_from_args(
+    default_index: Option<&Maybe<Index>>,
+    index: Option<&[Vec<Maybe<Index>>]>,
+) -> Option<Vec<Index>> {
+    let default_index = default_index
+        .cloned()
+        .and_then(Maybe::into_option)
+        .map(|default_index| vec![default_index]);
+    let index = index.map(|index| {
+        index
+            .iter()
+            .flatten()
+            .cloned()
+            .filter_map(Maybe::into_option)
+            .collect()
+    });
+
+    default_index.combine(index)
 }
 
 impl From<ResolverArgs> for PipOptions {
@@ -454,16 +475,7 @@ impl From<IndexArgs> for PipOptions {
         } = args;
 
         Self {
-            index: default_index
-                .and_then(Maybe::into_option)
-                .map(|default_index| vec![default_index])
-                .combine(index.map(|index| {
-                    index
-                        .iter()
-                        .flat_map(std::clone::Clone::clone)
-                        .filter_map(Maybe::into_option)
-                        .collect()
-                })),
+            index: indexes_from_args(default_index.as_ref(), index.as_deref()),
             index_url: index_url.and_then(Maybe::into_option),
             extra_index_url: extra_index_url.map(|extra_index_urls| {
                 extra_index_urls
@@ -522,17 +534,10 @@ pub fn resolver_options(
     } = build_args;
 
     ResolverOptions {
-        index: index_args
-            .default_index
-            .and_then(Maybe::into_option)
-            .map(|default_index| vec![default_index])
-            .combine(index_args.index.map(|index| {
-                index
-                    .into_iter()
-                    .flat_map(|v| v.clone())
-                    .filter_map(Maybe::into_option)
-                    .collect()
-            })),
+        index: indexes_from_args(
+            index_args.default_index.as_ref(),
+            index_args.index.as_deref(),
+        ),
         index_url: index_args.index_url.and_then(Maybe::into_option),
         extra_index_url: index_args.extra_index_url.map(|extra_index_url| {
             extra_index_url
@@ -611,6 +616,19 @@ pub fn resolver_installer_options(
     resolver_installer_args: ResolverInstallerArgs,
     build_args: BuildOptionsArgs,
 ) -> ResolverInstallerOptions {
+    let index = indexes_from_args(
+        resolver_installer_args.index_args.default_index.as_ref(),
+        resolver_installer_args.index_args.index.as_deref(),
+    );
+    resolver_installer_options_with_indexes(resolver_installer_args, build_args, index)
+}
+
+/// Construct the [`ResolverInstallerOptions`] with a precomputed list of indexes.
+pub fn resolver_installer_options_with_indexes(
+    resolver_installer_args: ResolverInstallerArgs,
+    build_args: BuildOptionsArgs,
+    index: Option<Vec<Index>>,
+) -> ResolverInstallerOptions {
     let ResolverInstallerArgs {
         index_args,
         upgrade,
@@ -649,20 +667,8 @@ pub fn resolver_installer_options(
         no_binary_package,
     } = build_args;
 
-    let default_index = index_args
-        .default_index
-        .and_then(Maybe::into_option)
-        .map(|default_index| vec![default_index]);
-    let index = index_args.index.map(|index| {
-        index
-            .into_iter()
-            .flat_map(|v| v.clone())
-            .filter_map(Maybe::into_option)
-            .collect()
-    });
-
     ResolverInstallerOptions {
-        index: default_index.combine(index),
+        index,
         index_url: index_args.index_url.and_then(Maybe::into_option),
         extra_index_url: index_args.extra_index_url.map(|extra_index_url| {
             extra_index_url

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -25,8 +25,9 @@ use uv_cli::{
     AuthorFrom, BuildArgs, CheckArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
     ResolverInstallerArgs, ToolUpgradeArgs,
     options::{
-        Flag, FlagSource, check_conflicts, flag, resolve_flag, resolve_flag_pair,
-        resolver_installer_options, resolver_options,
+        Flag, FlagSource, check_conflicts, flag, indexes_from_args, resolve_flag,
+        resolve_flag_pair, resolver_installer_options, resolver_installer_options_with_indexes,
+        resolver_options,
     },
 };
 use uv_client::Connectivity;
@@ -2101,23 +2102,11 @@ impl AddSettings {
         };
 
         // Track the `--index` and `--default-index` arguments from the command-line.
-        let indexes = installer
-            .index_args
-            .default_index
-            .clone()
-            .and_then(Maybe::into_option)
-            .into_iter()
-            .chain(
-                installer
-                    .index_args
-                    .index
-                    .clone()
-                    .into_iter()
-                    .flat_map(|v| v.clone())
-                    .flatten()
-                    .filter_map(Maybe::into_option),
-            )
-            .collect::<Vec<_>>();
+        let index = indexes_from_args(
+            installer.index_args.default_index.as_ref(),
+            installer.index_args.index.as_deref(),
+        );
+        let indexes = index.clone().unwrap_or_default();
 
         // Warn user if an ambiguous relative path was passed as a value for
         // `--index` or `--default-index`.
@@ -2220,7 +2209,7 @@ impl AddSettings {
             refresh: Refresh::from(refresh),
             indexes,
             settings: ResolverInstallerSettings::combine(
-                resolver_installer_options(installer, build),
+                resolver_installer_options_with_indexes(installer, build, index),
                 filesystem,
                 &environment,
             ),


### PR DESCRIPTION
## Summary

This PR moves our handling of `--index` and `--default-index` arguments into a single helper and uses that in the 4 places it was previously duplicated in.

There's a small addition as well to simplify the `uv add` flow of this code which previously would duplicate the work twice as part of argument resolution.

This minor refactor simplifies the `--index <name>` implementation.

## Test Plan

Existing test coverage.