### PR TITLE
Group executable install errors during `uv python install`

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -999,6 +999,10 @@ fn create_bin_links(
         vec![installation.key().executable_name_minor()]
     };
 
+    // Collect the executables that already exist and aren't managed by uv, so they can be
+    // reported together as a single error below.
+    let mut existing_unmanaged: Vec<String> = Vec::new();
+
     for target in targets {
         let target = bin.join(target);
         if upgrade && !target.try_exists().unwrap_or_default() {
@@ -1074,14 +1078,8 @@ fn create_bin_links(
                                         installation.key().variant().display_suffix()
                                     );
                                 } else {
-                                    errors.push((
-                                        InstallErrorKind::Bin,
-                                        installation.key().clone(),
-                                        anyhow::anyhow!(
-                                            "Executable already exists at `{}` but is not managed by uv; use `--force` to replace it",
-                                            target.simplified_display()
-                                        ),
-                                    ));
+                                    existing_unmanaged
+                                        .push(target.simplified_display().to_string());
                                 }
                                 continue;
                             }
@@ -1204,6 +1202,32 @@ fn create_bin_links(
                     Error::new(err),
                 ));
             }
+        }
+    }
+
+    // Report the executables that already exist and aren't managed by uv as a single grouped
+    // error, rather than one near-identical error per executable
+    // (https://github.com/astral-sh/uv/issues/9707).
+    match existing_unmanaged.as_slice() {
+        [] => {}
+        [executable] => {
+            errors.push((
+                InstallErrorKind::Bin,
+                installation.key().clone(),
+                anyhow::anyhow!(
+                    "Executable already exists at `{executable}` but is not managed by uv; use `--force` to replace it"
+                ),
+            ));
+        }
+        executables => {
+            errors.push((
+                InstallErrorKind::Bin,
+                installation.key().clone(),
+                anyhow::anyhow!(
+                    "Executables already exist but are not managed by uv; use `--force` to replace them:\n- {}",
+                    executables.join("\n- ")
+                ),
+            ));
         }
     }
 }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -40,7 +40,7 @@ use uv_warnings::warn_user;
 
 use crate::commands::python::{ChangeEvent, ChangeEventKind};
 use crate::commands::reporters::PythonDownloadReporter;
-use crate::commands::{ExitStatus, elapsed};
+use crate::commands::{ExitStatus, conjunction, elapsed};
 use crate::printer::Printer;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -999,9 +999,7 @@ fn create_bin_links(
         vec![installation.key().executable_name_minor()]
     };
 
-    // Collect the executables that already exist and aren't managed by uv, so they can be
-    // reported together as a single error below.
-    let mut existing_unmanaged: Vec<String> = Vec::new();
+    let mut existing_unmanaged = Vec::new();
 
     for target in targets {
         let target = bin.join(target);
@@ -1078,8 +1076,9 @@ fn create_bin_links(
                                         installation.key().variant().display_suffix()
                                     );
                                 } else {
-                                    existing_unmanaged
-                                        .push(target.simplified_display().to_string());
+                                    // Defer reporting to allow grouping.
+
+                                    existing_unmanaged.push(target.clone());
                                 }
                                 continue;
                             }
@@ -1205,30 +1204,31 @@ fn create_bin_links(
         }
     }
 
-    // Report the executables that already exist and aren't managed by uv as a single grouped
-    // error, rather than one near-identical error per executable
-    // (https://github.com/astral-sh/uv/issues/9707).
     match existing_unmanaged.as_slice() {
         [] => {}
-        [executable] => {
-            errors.push((
-                InstallErrorKind::Bin,
-                installation.key().clone(),
-                anyhow::anyhow!(
-                    "Executable already exists at `{executable}` but is not managed by uv; use `--force` to replace it"
+        [executable] => errors.push((
+            InstallErrorKind::Bin,
+            installation.key().clone(),
+            anyhow::anyhow!(
+                "Executable already exists at `{}` but is not managed by uv; use `--force` to replace it",
+                executable.simplified_display()
+            ),
+        )),
+        executables => errors.push((
+            InstallErrorKind::Bin,
+            installation.key().clone(),
+            anyhow::anyhow!(
+                "Executables {} already exist in `{}` but are not managed by uv; use `--force` to replace them",
+                conjunction(
+                    executables
+                        .iter()
+                        .filter_map(|path| path.file_name())
+                        .map(|name| format!("`{}`", name.to_string_lossy()))
+                        .collect(),
                 ),
-            ));
-        }
-        executables => {
-            errors.push((
-                InstallErrorKind::Bin,
-                installation.key().clone(),
-                anyhow::anyhow!(
-                    "Executables already exist but are not managed by uv; use `--force` to replace them:\n- {}",
-                    executables.join("\n- ")
-                ),
-            ));
-        }
+                bin.simplified_display()
+            ),
+        )),
     }
 }
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -1077,7 +1077,6 @@ fn create_bin_links(
                                     );
                                 } else {
                                     // Defer reporting to allow grouping.
-
                                     existing_unmanaged.push(target.clone());
                                 }
                                 continue;

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -862,6 +862,63 @@ fn python_install_preview() {
     }
 }
 
+/// Multiple pre-existing, unmanaged executables should be reported as a single grouped error,
+/// rather than one near-identical error per executable.
+///
+/// See: <https://github.com/astral-sh/uv/issues/9707>
+#[test]
+fn python_install_multiple_unmanaged_executables() {
+    let context = uv_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_python_download_cache();
+
+    // Install the latest version, creating the `python`, `python3`, and `python3.14` executables.
+    uv_snapshot!(context.filters(), context.python_install().arg("--preview"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed Python 3.14.[LATEST] in [TIME]
+     + cpython-3.14.[LATEST]-[PLATFORM] (python, python3, python3.14)
+    ");
+
+    // Replace each managed executable with an unmanaged file.
+    for name in ["python", "python3", "python3.14"] {
+        let executable = context
+            .bin_dir
+            .child(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+        fs_err::remove_file(executable.path()).unwrap();
+        executable.touch().unwrap();
+    }
+
+    // Re-installing the default executables without `--force` should report all three conflicts
+    // in a single grouped error, rather than emitting a near-identical message per executable.
+    uv_snapshot!(context.filters(), context.python_install().arg("--default").arg("--preview-features").arg("python-install-default").arg("3.14"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
+      Caused by: Executables already exist but are not managed by uv; use `--force` to replace them:
+    - [BIN]/python3.14
+    - [BIN]/python3
+    - [BIN]/python
+    ");
+
+    // The unmanaged executables should be left untouched.
+    for name in ["python", "python3", "python3.14"] {
+        context
+            .bin_dir
+            .child(format!("{name}{}", std::env::consts::EXE_SUFFIX))
+            .assert(predicate::path::exists());
+    }
+}
+
 #[test]
 fn python_install_preview_no_bin() {
     let context = uv_test::test_context_with_versions!(&[])

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -875,19 +875,19 @@ fn python_install_multiple_unmanaged_executables() {
         .with_managed_python_dirs()
         .with_python_download_cache();
 
-    // Install the latest version, creating the `python`, `python3`, and `python3.14` executables.
-    uv_snapshot!(context.filters(), context.python_install().arg("--preview"), @"
+    // Install a version with the default `python`, `python3`, and `python3.13` executables.
+    uv_snapshot!(context.filters(), context.python_install().arg("--default").arg("--preview-features").arg("python-install-default").arg("3.13"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Installed Python 3.14.[LATEST] in [TIME]
-     + cpython-3.14.[LATEST]-[PLATFORM] (python, python3, python3.14)
+    Installed Python 3.13.[LATEST] in [TIME]
+     + cpython-3.13.[LATEST]-[PLATFORM] (python, python3, python3.13)
     ");
 
-    // Replace each managed executable with an unmanaged file.
-    for name in ["python", "python3", "python3.14"] {
+    // Replace each managed executable with an empty, unmanaged file.
+    for name in ["python", "python3", "python3.13"] {
         let executable = context
             .bin_dir
             .child(format!("{name}{}", std::env::consts::EXE_SUFFIX));
@@ -895,27 +895,23 @@ fn python_install_multiple_unmanaged_executables() {
         executable.touch().unwrap();
     }
 
-    // Re-installing the default executables without `--force` should report all three conflicts
-    // in a single grouped error, rather than emitting a near-identical message per executable.
-    uv_snapshot!(context.filters(), context.python_install().arg("--default").arg("--preview-features").arg("python-install-default").arg("3.14"), @"
+    // Re-installing without `--force` should report all three conflicts in a single grouped error.
+    uv_snapshot!(context.filters(), context.python_install().arg("--default").arg("--preview-features").arg("python-install-default").arg("3.13"), @"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    warning: Failed to install executable for cpython-3.14.[LATEST]-[PLATFORM]
-      Caused by: Executables already exist but are not managed by uv; use `--force` to replace them:
-    - [BIN]/python3.14
-    - [BIN]/python3
-    - [BIN]/python
+    warning: Failed to install executable for cpython-3.13.[LATEST]-[PLATFORM]
+      Caused by: Executables `python3.13`, `python3`, and `python` already exist in `[BIN]/` but are not managed by uv; use `--force` to replace them
     ");
 
-    // The unmanaged executables should be left untouched.
-    for name in ["python", "python3", "python3.14"] {
-        context
+    // The unmanaged executables should be left untouched (still empty).
+    for name in ["python", "python3", "python3.13"] {
+        let executable = context
             .bin_dir
-            .child(format!("{name}{}", std::env::consts::EXE_SUFFIX))
-            .assert(predicate::path::exists());
+            .child(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+        assert_eq!(fs_err::read_to_string(executable.path()).unwrap(), "");
     }
 }
 


### PR DESCRIPTION
Report pre-existing unmanaged executables in a single error instead of one message per executable.

## Summary

When `uv python install` links the default executables (`python`, `python3`, `python3.x`) and more than one of them already exists as a file uv doesn't manage, the output currently repeats almost the same error once per executable.

The change is in `create_bin_links` (`crates/uv/src/commands/python/install.rs`), which links each executable into the bin directory by looping over a list of targets. Instead of pushing an error for every conflicting executable inside the loop, it now collects them and reports once after the loop:

- 0 conflicts: nothing is reported
- 1 conflict: the original single-line message (unchanged)
- 2+ conflicts: one grouped error with the paths as a bulleted list

Other, unrelated failures (e.g. failing to remove or re-link a file) are still reported individually.

Resolves #9707 

## Test Plan

Added `python_install_multiple_unmanaged_executables`: install the default executables, replace all three (`python`, `python3`, `python3.x`) with unmanaged files, reinstall without `--force`, and assert that a single grouped error is shown and the existing files are left untouched. The existing single-conflict tests (`python_install_force`, `python_install_preview`) still pass, so the one-executable output is unchanged.

```bash
cargo nextest run -p uv --test it python_install
cargo clippy -p uv --all-targets
```