### PR TITLE
Hint Python request formats for missing executables

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -3589,6 +3589,17 @@ impl fmt::Display for PythonNotFound {
     }
 }
 
+impl uv_errors::Hint for PythonNotFound {
+    fn hints(&self) -> uv_errors::Hints<'_> {
+        match self.request {
+            PythonRequest::ExecutableName(_) => {
+                uv_errors::Hints::from("See `uv help python` to view supported request formats")
+            }
+            _ => uv_errors::Hints::none(),
+        }
+    }
+}
+
 /// Join a series of items with `or` separators, making use of commas when necessary.
 fn disjunction(items: &[&str]) -> String {
     match items.len() {

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -175,7 +175,13 @@ impl std::fmt::Display for MissingPythonHint {
 impl uv_errors::Hint for Error {
     fn hints(&self) -> uv_errors::Hints<'_> {
         match self {
-            Self::MissingPython(_, Some(hint)) => uv_errors::Hints::from(hint.to_string()),
+            Self::MissingPython(err, hint) => {
+                let mut hints = uv_errors::Hint::hints(err);
+                if let Some(hint) = hint {
+                    hints.extend(uv_errors::Hints::from(hint.to_string()));
+                }
+                hints
+            }
             Self::Discovery(err) => err.hints(),
             _ => uv_errors::Hints::none(),
         }

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -127,6 +127,18 @@ fn python_find() {
     error: No interpreter found for PyPy in [PYTHON SOURCES]
     ");
 
+    // Request an executable that does not exist
+    uv_snapshot!(context.filters(), context.python_find().arg("foobar"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for executable name `foobar` in [PYTHON SOURCES]
+
+    hint: See `uv help python` to view supported request formats
+    ");
+
     // Swap the order of the Python versions
     context.python_versions.reverse();
 

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -309,6 +309,8 @@ fn python_install_automatic() {
 
     ----- stderr -----
     error: No interpreter found for executable name `foobar` in [PYTHON SOURCES]
+
+    hint: See `uv help python` to view supported request formats
     ");
 
     // Create a "broken" Python executable in the test context `bin`

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -2406,6 +2406,8 @@ fn tool_run_python_at_version() {
 
     ----- stderr -----
     error: No interpreter found for executable name `@311` in [PYTHON SOURCES]
+
+    hint: See `uv help python` to view supported request formats
     ");
 
     // Request a version in the tool and `-p`


### PR DESCRIPTION
## Summary

Closes #4401.

When uv can't find a toolchain and the request falls through to being parsed as an executable name (the final fallback in request parsing), the error now points users at the supported request formats:

```
error: No interpreter found for executable name `foobar` in [PYTHON SOURCES]

hint: See `uv help python` to view supported request formats
```

The hint is gated on `PythonRequest::ExecutableName(_)`, so it only fires for the executable-name fallback — version requests, implementation requests (e.g. `PyPy`), paths, and directories are unaffected.

While wiring this up, the `Error::MissingPython` hint arm was also generalized: it previously surfaced *only* the optional `MissingPythonHint` and dropped the inner `PythonNotFound` hints. It now delegates to the inner error's hints and appends the optional hint, so both compose.

I chose to point at `uv help python` rather than inlining the ~12 format lines into every error, since that command already lists them in full and inlining would be noisy. Happy to inline them instead if you'd prefer.

## Test Plan

- Added a snapshot in `python_find` for requesting a non-existent executable (`foobar`), asserting the new hint.
- Updated existing snapshots in `python_install_automatic` and `tool_run_python_at_version` to reflect the added hint.
- Verified the `PyPy` case in `python_find` still emits no hint (confirming the gating).

Note: I was unable to complete a local test run due to a linker/toolchain issue in my environment unrelated to this change; the change compiles through to linking. Please confirm CI is green.