### PR TITLE
Apply dependency exclusions to direct requirements

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1791,6 +1791,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 );
 
                 requirements
+                    .filter(|requirement| !self.excludes.contains(&requirement.name))
                     .flat_map(move |requirement| {
                         PubGrubDependency::from_requirement(
                             &self.conflicts,

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -4306,6 +4306,34 @@ fn override_dependency_from_specific_uv_toml() -> Result<()> {
     Ok(())
 }
 
+/// Check that `exclude-dependencies` in `uv.toml` applies to direct requirements.
+#[test]
+fn exclude_direct_dependency_from_uv_toml() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("werkzeug")?;
+
+    let uv_toml = context.temp_dir.child("uv.toml");
+    uv_toml.write_str(
+        r#"
+        exclude-dependencies = ["werkzeug"]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_compile()
+        .arg("requirements.in")
+        .arg("--no-header"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Black==23.10.1 depends on tomli>=1.1.0 for Python versions below 3.11. Demonstrate that we can
 /// override it with a multi-line override.
 #[test]

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -8136,27 +8136,27 @@ fn install_with_overrides_from_stdin() -> Result<()> {
     Ok(())
 }
 
-/// Install with excludes from stdin.
+/// Install with a direct exclusion from stdin.
 #[test]
 #[expect(clippy::disallowed_types)]
 fn install_with_excludes_from_stdin() -> Result<()> {
     let context = uv_test::test_context!("3.12");
 
     let excludes_txt = context.temp_dir.child("excludes.txt");
-    excludes_txt.write_str("anyio>4.0.0")?;
+    excludes_txt.write_str("anyio")?;
 
     uv_snapshot!(context.pip_install()
         .arg("anyio==4.0.1")
         .arg("--exclude")
         .arg("-")
         .stdin(std::fs::File::open(excludes_txt)?), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-      × No solution found when resolving dependencies:
-      ╰─▶ Because there is no version of anyio==4.0.1 and you require anyio==4.0.1, we can conclude that your requirements are unsatisfiable.
+    Resolved in [TIME]
+    Checked in [TIME]
     "
     );
 


### PR DESCRIPTION
## Summary

Prior to this change, `exclude-dependencies` removed matching transitive dependency edges, but direct requirements were attached to the resolver root without applying the exclusion set. As a result, `uv pip compile` could still resolve an excluded package when it was provided as a direct input.

This PR applies exclusions while constructing the resolver root dependencies, matching the existing behavior for transitive dependencies. It adds integration coverage that confirms a direct excluded requirement is omitted entirely.

Closes https://github.com/astral-sh/uv/issues/4422.
