### PR TITLE
Fix `scripts/sync-python-version-constants.py` for non-pub consts and clean it up

### DIFF
--- a/scripts/sync-python-version-constants.py
+++ b/scripts/sync-python-version-constants.py
@@ -78,15 +78,15 @@ def main() -> None:
     old_versions: dict[str, str] = {}
     for minor in PYTHON_MINOR_VERSIONS:
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
-        match = re.search(rf'const {const_name}: &str = "([^"]+)";', content)
+        pattern = rf'const {const_name}: &str = "([^"]+)";'
+        match = re.search(pattern, content)
         if match:
             old_versions[minor] = match.group(1)
 
         if minor not in latest_versions:
             continue
-        old_pattern = rf'const {const_name}: &str = "[^"]+";'
         new_value = f'const {const_name}: &str = "{latest_versions[minor]}";'
-        content = re.sub(old_pattern, new_value, content)
+        content = re.sub(pattern, new_value, content)
 
     lib_path.write_text(content)
 

--- a/scripts/sync-python-version-constants.py
+++ b/scripts/sync-python-version-constants.py
@@ -75,7 +75,6 @@ def main() -> None:
     lib_path = ROOT / "crates" / "uv-test" / "src" / "lib.rs"
     content = lib_path.read_text()
 
-    # Extract old values first
     old_versions: dict[str, str] = {}
     for minor in PYTHON_MINOR_VERSIONS:
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
@@ -83,10 +82,8 @@ def main() -> None:
         if match:
             old_versions[minor] = match.group(1)
 
-    for minor in PYTHON_MINOR_VERSIONS:
         if minor not in latest_versions:
             continue
-        const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
         old_pattern = rf'const {const_name}: &str = "[^"]+";'
         new_value = f'const {const_name}: &str = "{latest_versions[minor]}";'
         content = re.sub(old_pattern, new_value, content)

--- a/scripts/sync-python-version-constants.py
+++ b/scripts/sync-python-version-constants.py
@@ -78,7 +78,7 @@ def main() -> None:
     old_versions: dict[str, str] = {}
     for minor in ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10"]:
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
-        match = re.search(rf'pub const {const_name}: &str = "([^"]+)";', content)
+        match = re.search(rf'const {const_name}: &str = "([^"]+)";', content)
         if match:
             old_versions[minor] = match.group(1)
 
@@ -86,8 +86,8 @@ def main() -> None:
         if minor not in latest_versions:
             continue
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
-        old_pattern = rf'pub const {const_name}: &str = "[^"]+";'
-        new_value = f'pub const {const_name}: &str = "{latest_versions[minor]}";'
+        old_pattern = rf'const {const_name}: &str = "[^"]+";'
+        new_value = f'const {const_name}: &str = "{latest_versions[minor]}";'
         content = re.sub(old_pattern, new_value, content)
 
     lib_path.write_text(content)

--- a/scripts/sync-python-version-constants.py
+++ b/scripts/sync-python-version-constants.py
@@ -26,6 +26,7 @@ from packaging.version import Version
 
 SELF_DIR = Path(__file__).parent
 ROOT = SELF_DIR.parent
+PYTHON_MINOR_VERSIONS = ("3.15", "3.14", "3.13", "3.12", "3.11", "3.10")
 
 
 def main() -> None:
@@ -76,13 +77,13 @@ def main() -> None:
 
     # Extract old values first
     old_versions: dict[str, str] = {}
-    for minor in ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10"]:
+    for minor in PYTHON_MINOR_VERSIONS:
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
         match = re.search(rf'const {const_name}: &str = "([^"]+)";', content)
         if match:
             old_versions[minor] = match.group(1)
 
-    for minor in ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10"]:
+    for minor in PYTHON_MINOR_VERSIONS:
         if minor not in latest_versions:
             continue
         const_name = f"LATEST_PYTHON_{minor.replace('.', '_')}"
@@ -93,7 +94,7 @@ def main() -> None:
     lib_path.write_text(content)
 
     updates = []
-    for minor in ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10"]:
+    for minor in PYTHON_MINOR_VERSIONS:
         if minor not in latest_versions:
             continue
         new_version = latest_versions[minor]


### PR DESCRIPTION
## Summary

#19565 made most of the latest Python version constants non-public, but the script only matched `pub const` declarations. As a result, the daily Python release sync workflow silently stopped updating those constants. This PR fixes that.

This PR also cleans up the script a bit (see individual commits for details).

## Test Plan

Manual testing.