### PR TITLE
Pass `VIRTUAL_ENV` through `cygpath` inside `fish` on Windows

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate.fish
+++ b/crates/uv-virtualenv/src/activator/activate.fish
@@ -80,8 +80,8 @@ end
 deactivate nondestructive
 
 set -gx VIRTUAL_ENV '{{ VIRTUAL_ENV_DIR }}'
-if string match -qr 'CYGWIN|MSYS|MINGW' (uname)
-    set -gx VIRTUAL_ENV (cygpath -u $VIRTUAL_ENV)
+if string match -qr 'CYGWIN|MSYS|MINGW' (uname); and command -s cygpath >/dev/null
+    set -gx VIRTUAL_ENV (cygpath -u "$VIRTUAL_ENV")
 end
 
 # https://github.com/fish-shell/fish-shell/issues/436 altered PATH handling

--- a/crates/uv-virtualenv/src/activator/activate.fish
+++ b/crates/uv-virtualenv/src/activator/activate.fish
@@ -80,6 +80,9 @@ end
 deactivate nondestructive
 
 set -gx VIRTUAL_ENV '{{ VIRTUAL_ENV_DIR }}'
+if string match -qr 'CYGWIN|MSYS|MINGW' (uname)
+    set -gx VIRTUAL_ENV (cygpath -u $VIRTUAL_ENV)
+end
 
 # https://github.com/fish-shell/fish-shell/issues/436 altered PATH handling
 if test (string sub -s 1 -l 1 $FISH_VERSION) -lt 3

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -1392,6 +1392,12 @@ fn verify_pyvenv_cfg_relocatable() {
     let activate_fish = scripts.child("activate.fish");
     activate_fish.assert(predicates::path::is_file());
     activate_fish.assert(predicates::str::contains(r#"set -gx VIRTUAL_ENV ''"$(dirname -- "$(cd "$(dirname -- "$(status -f)")"; and pwd)")"''"#));
+    activate_fish.assert(predicates::str::contains(
+        "if string match -qr 'CYGWIN|MSYS|MINGW' (uname); and command -s cygpath >/dev/null",
+    ));
+    activate_fish.assert(predicates::str::contains(
+        r#"set -gx VIRTUAL_ENV (cygpath -u "$VIRTUAL_ENV")"#,
+    ));
 
     let activate_nu = scripts.child("activate.nu");
     activate_nu.assert(predicates::path::is_file());


### PR DESCRIPTION
## Summary
Closes #19702.
This PR fixes venv exporting mixed directory path styles to PATH on Windows inside fish (via Cygwin, MinGW or MSYS2).
It now instead runs cygpath on the generated VIRTUAL_ENV which unifies the directories path style.

## Test Plan

Behavior was tested locally by changing the generated activate.fish to include this PRs diff and observing that when previously `source .venv/Scripts/activate.fish` would break $PATH, it now no longer breaks it.
