### PR TITLE
Allow `uv upgrade` to update a single dependency constraint

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -484,6 +484,23 @@ impl Version {
         self
     }
 
+    /// Return this version's release component at the given precision.
+    ///
+    /// Preserve the epoch, pad missing release segments with zeros, and discard every other
+    /// component. Return `None` for a precision of zero.
+    #[inline]
+    #[must_use]
+    pub fn only_release_at_precision(&self, precision: usize) -> Option<Self> {
+        let release = self
+            .release()
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(0))
+            .take(precision)
+            .collect::<Vec<_>>();
+        (!release.is_empty()).then(|| Self::new(release).with_epoch(self.epoch()))
+    }
+
     /// Push the given release number into this version. It will become the
     /// last number in the release component.
     #[inline]
@@ -4256,6 +4273,21 @@ mod tests {
         let v2: Version = "1.2".parse().unwrap();
         assert_eq!(&*v2.release(), &[1, 2]);
         assert_eq!(v2.to_string(), "1.2");
+    }
+
+    #[test]
+    fn only_release_at_precision_preserves_epoch_and_discards_suffixes() {
+        let version = "1!2.3rc1.post2.dev3+local"
+            .parse::<Version>()
+            .expect("valid version");
+        assert_eq!(
+            version
+                .only_release_at_precision(4)
+                .expect("non-zero precision")
+                .to_string(),
+            "1!2.3.0.0"
+        );
+        assert_eq!(version.only_release_at_precision(0), None);
     }
 
     #[test]

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -3624,6 +3624,15 @@ impl Package {
         self.fork_markers.as_slice()
     }
 
+    /// Returns whether this package is included by the given PEP 508 marker.
+    pub fn is_included_by_marker(&self, marker: MarkerTree) -> bool {
+        self.fork_markers.is_empty()
+            || self
+                .fork_markers
+                .iter()
+                .any(|fork_marker| !fork_marker.pep508().is_disjoint(marker))
+    }
+
     /// Returns the [`IndexUrl`] for the package, if it is a registry source.
     pub fn index(&self, root: &Path) -> Result<Option<IndexUrl>, LockError> {
         match &self.id.source {

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -70,8 +70,7 @@ pub(crate) async fn upgrade(
         }
         Err(err) => return Err(err.into()),
     };
-
-    let requirement = select_requirement(&project, &package)?;
+    let (requirement_text, requirement) = select_requirement(&project, &package)?;
 
     let relaxed_requirement = into_verbatim_requirement(relax_requirement(&requirement), &package)?;
 
@@ -191,6 +190,25 @@ pub(crate) async fn upgrade(
         }
     }
     let proposed_requirement = propose_requirement(&requirement, &resolved_versions)?;
+    let updated_requirement = if proposed_requirement == requirement {
+        None
+    } else {
+        let proposed_requirement = into_verbatim_requirement(proposed_requirement, &package)?;
+        let proposed_text = proposed_requirement.to_string();
+        let mut pyproject = PyProjectTomlMut::from_toml(
+            &project.current_project().pyproject_toml().raw,
+            DependencyTarget::PyProjectToml,
+        )?;
+        if pyproject
+            .replace_dependency(&proposed_requirement, false)?
+            .is_none()
+        {
+            bail!("Dependency `{package}` was not found in `project.dependencies`");
+        }
+        let pyproject_path = project.project_root().join("pyproject.toml");
+        fs_err::write(pyproject_path, pyproject.to_string())?;
+        Some(proposed_text)
+    };
 
     let event = match &result {
         LockResult::Changed(previous, lock) => {
@@ -204,10 +222,10 @@ pub(crate) async fn upgrade(
     } else {
         writeln!(printer.stderr(), "No version change for {package}")?;
     }
-    if proposed_requirement != requirement {
+    if let Some(proposed_text) = updated_requirement {
         writeln!(
             printer.stderr(),
-            "Would update requirement: {requirement} -> {proposed_requirement}"
+            "Updated requirement: `{requirement_text}` -> `{proposed_text}`"
         )?;
     }
 
@@ -218,7 +236,7 @@ pub(crate) async fn upgrade(
 fn select_requirement(
     project: &ProjectWorkspace,
     package: &PackageName,
-) -> Result<Requirement<VerbatimParsedUrl>> {
+) -> Result<(String, Requirement<VerbatimParsedUrl>)> {
     if project.workspace().packages().len() != 1 {
         bail!("`uv upgrade` does not support workspaces with multiple members yet");
     }
@@ -240,13 +258,13 @@ fn select_requirement(
                 )
             })?;
         if requirement.name == *package {
-            matching.push(requirement);
+            matching.push((dependency.clone(), requirement));
         }
     }
 
-    let requirement = match matching.as_slice() {
+    let (requirement_text, requirement) = match matching.as_slice() {
         [] => bail!("Dependency `{package}` was not found in `project.dependencies`"),
-        [requirement] => requirement.clone(),
+        [(requirement_text, requirement)] => (requirement_text.clone(), requirement.clone()),
         _ => bail!("Dependency `{package}` is declared multiple times in `project.dependencies`"),
     };
 
@@ -288,7 +306,7 @@ fn select_requirement(
         );
     }
 
-    Ok(requirement)
+    Ok((requirement_text, requirement))
 }
 
 /// Return whether a source applies to the selected requirement declaration.

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -20,7 +20,9 @@ use uv_resolver::MetadataResponse;
 use uv_settings::PythonInstallMirrors;
 use uv_workspace::pyproject::Source;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
-use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceErrorKind};
+use uv_workspace::{
+    DiscoveryOptions, ProjectWorkspace, VirtualProject, WorkspaceCache, WorkspaceErrorKind,
+};
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::project::lock::{LockEvent, LockMode, LockOperation, LockResult};
@@ -68,95 +70,9 @@ pub(crate) async fn upgrade(
         Err(err) => return Err(err.into()),
     };
 
-    if project.workspace().packages().len() != 1 {
-        bail!("`uv upgrade` does not support workspaces with multiple members yet");
-    }
+    let requirement = select_requirement(&project, &package)?;
 
-    let dependencies = project
-        .current_project()
-        .project()
-        .dependencies
-        .as_deref()
-        .unwrap_or_default();
-    let mut matching = Vec::new();
-    for dependency in dependencies {
-        let requirement =
-            Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
-                format!("Failed to parse dependency `{dependency}` in `project.dependencies`")
-            })?;
-        if requirement.name == package {
-            matching.push(requirement);
-        }
-    }
-
-    let requirement = match matching.as_slice() {
-        [] => bail!("Dependency `{package}` was not found in `project.dependencies`"),
-        [requirement] => requirement,
-        _ => bail!("Dependency `{package}` is declared multiple times in `project.dependencies`"),
-    };
-
-    if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
-        bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
-    }
-
-    if &requirement.name == project.project_name() {
-        bail!("Dependency `{package}` refers to the current project and cannot be upgraded");
-    }
-
-    let sources = project
-        .current_project()
-        .pyproject_toml()
-        .tool
-        .as_ref()
-        .and_then(|tool| tool.uv.as_ref())
-        .and_then(|uv| uv.sources.as_ref())
-        .and_then(|sources| sources.inner().get(&package))
-        .or_else(|| project.workspace().sources().get(&package));
-    if sources.is_some_and(|sources| {
-        sources.iter().any(|source| {
-            source_is_applicable(source, requirement.marker)
-                && matches!(source, Source::Git { rev: Some(_), .. })
-        })
-    }) {
-        bail!(
-            "Dependency `{package}` is pinned to a Git revision and cannot be upgraded commit-to-commit"
-        );
-    }
-    if sources.is_some_and(|sources| {
-        sources.iter().any(|source| {
-            source_is_applicable(source, requirement.marker)
-                && !matches!(source, Source::Registry { .. })
-        })
-    }) {
-        bail!(
-            "Dependency `{package}` uses a non-registry source in `tool.uv.sources` and cannot be upgraded"
-        );
-    }
-
-    let relaxed_requirement = relax_requirement(requirement);
-    let Requirement {
-        name,
-        extras,
-        version_or_url,
-        marker,
-        origin,
-    } = relaxed_requirement;
-    let version_or_url = match version_or_url {
-        Some(VersionOrUrl::VersionSpecifier(specifiers)) => {
-            Some(VersionOrUrl::VersionSpecifier(specifiers))
-        }
-        Some(VersionOrUrl::Url(_)) => {
-            bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
-        }
-        None => None,
-    };
-    let relaxed_requirement = Requirement::<VerbatimUrl> {
-        name,
-        extras,
-        version_or_url,
-        marker,
-        origin,
-    };
+    let relaxed_requirement = into_verbatim_requirement(relax_requirement(&requirement), &package)?;
 
     let mut pyproject = PyProjectTomlMut::from_toml(
         &project.current_project().pyproject_toml().raw,
@@ -275,6 +191,83 @@ pub(crate) async fn upgrade(
     Ok(ExitStatus::Success)
 }
 
+/// Select the single production dependency declaration targeted by `uv upgrade`.
+fn select_requirement(
+    project: &ProjectWorkspace,
+    package: &PackageName,
+) -> Result<Requirement<VerbatimParsedUrl>> {
+    if project.workspace().packages().len() != 1 {
+        bail!("`uv upgrade` does not support workspaces with multiple members yet");
+    }
+
+    let dependencies = project
+        .current_project()
+        .project()
+        .dependencies
+        .as_deref()
+        .unwrap_or_default();
+    let pyproject_path = project.project_root().join("pyproject.toml");
+    let mut matching = Vec::new();
+    for dependency in dependencies {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
+                format!(
+                    "Failed to parse dependency `{dependency}` from `project.dependencies` in `{}`",
+                    pyproject_path.display()
+                )
+            })?;
+        if requirement.name == *package {
+            matching.push(requirement);
+        }
+    }
+
+    let requirement = match matching.as_slice() {
+        [] => bail!("Dependency `{package}` was not found in `project.dependencies`"),
+        [requirement] => requirement.clone(),
+        _ => bail!("Dependency `{package}` is declared multiple times in `project.dependencies`"),
+    };
+
+    if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
+        bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
+    }
+
+    if requirement.name == *project.project_name() {
+        bail!("Dependency `{package}` refers to the current project and cannot be upgraded");
+    }
+
+    let sources = project
+        .current_project()
+        .pyproject_toml()
+        .tool
+        .as_ref()
+        .and_then(|tool| tool.uv.as_ref())
+        .and_then(|uv| uv.sources.as_ref())
+        .and_then(|sources| sources.inner().get(package))
+        .or_else(|| project.workspace().sources().get(package));
+    if sources.is_some_and(|sources| {
+        sources.iter().any(|source| {
+            source_is_applicable(source, requirement.marker)
+                && matches!(source, Source::Git { rev: Some(_), .. })
+        })
+    }) {
+        bail!(
+            "Dependency `{package}` is pinned to a Git revision and cannot be upgraded commit-to-commit"
+        );
+    }
+    if sources.is_some_and(|sources| {
+        sources.iter().any(|source| {
+            source_is_applicable(source, requirement.marker)
+                && !matches!(source, Source::Registry { .. })
+        })
+    }) {
+        bail!(
+            "Dependency `{package}` uses a non-registry source in `tool.uv.sources` and cannot be upgraded"
+        );
+    }
+
+    Ok(requirement)
+}
+
 fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool {
     let extra = requirement_marker.top_level_extra_name();
     source
@@ -282,6 +275,36 @@ fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool
         .is_none_or(|target| extra.as_deref() == Some(target))
         && source.group().is_none()
         && !source.marker().is_disjoint(requirement_marker)
+}
+
+/// Convert a parsed requirement into the representation used by the mutable manifest.
+fn into_verbatim_requirement(
+    requirement: Requirement<VerbatimParsedUrl>,
+    package: &PackageName,
+) -> Result<Requirement<VerbatimUrl>> {
+    let Requirement {
+        name,
+        extras,
+        version_or_url,
+        marker,
+        origin,
+    } = requirement;
+    let version_or_url = match version_or_url {
+        Some(VersionOrUrl::VersionSpecifier(specifiers)) => {
+            Some(VersionOrUrl::VersionSpecifier(specifiers))
+        }
+        Some(VersionOrUrl::Url(_)) => {
+            bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
+        }
+        None => None,
+    };
+    Ok(Requirement::<VerbatimUrl> {
+        name,
+        extras,
+        version_or_url,
+        marker,
+        origin,
+    })
 }
 
 fn relax_requirement(

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::path::Path;
 use std::str::FromStr;
@@ -10,7 +11,7 @@ use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
 use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::Identifier;
 use uv_normalize::PackageName;
-use uv_pep440::{Operator, VersionSpecifier, VersionSpecifiers};
+use uv_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use uv_pep508::{MarkerTree, Requirement, VerbatimUrl, VersionOrUrl};
 use uv_preview::Preview;
 use uv_pypi_types::{PyProjectToml, ResolutionMetadata, VerbatimParsedUrl};
@@ -175,6 +176,22 @@ pub(crate) async fn upgrade(
         Err(err) => return Err(err.into()),
     };
 
+    let mut resolved_versions = BTreeSet::new();
+    for resolved_package in result.lock().packages() {
+        // A universal lock can contain versions from disjoint forks, so only collect versions
+        // from forks where the selected requirement applies.
+        if resolved_package.name() == &package
+            && resolved_package
+                .index(project.workspace().install_path())?
+                .is_some()
+            && resolved_package.is_included_by_marker(requirement.marker)
+            && let Some(version) = resolved_package.version()
+        {
+            resolved_versions.insert(version.clone());
+        }
+    }
+    let proposed_requirement = propose_requirement(&requirement, &resolved_versions)?;
+
     let event = match &result {
         LockResult::Changed(previous, lock) => {
             LockEvent::detect_changes(previous.as_ref(), lock, DryRun::Enabled)
@@ -186,6 +203,12 @@ pub(crate) async fn upgrade(
         writeln!(printer.stderr(), "{event}")?;
     } else {
         writeln!(printer.stderr(), "No version change for {package}")?;
+    }
+    if proposed_requirement != requirement {
+        writeln!(
+            printer.stderr(),
+            "Would update requirement: {requirement} -> {proposed_requirement}"
+        )?;
     }
 
     Ok(ExitStatus::Success)
@@ -268,6 +291,7 @@ fn select_requirement(
     Ok(requirement)
 }
 
+/// Return whether a source applies to the selected requirement declaration.
 fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool {
     let extra = requirement_marker.top_level_extra_name();
     source
@@ -307,6 +331,130 @@ fn into_verbatim_requirement(
     })
 }
 
+/// Return a requirement that admits every applicable resolved version.
+///
+/// For example, `foo>=1,<2` resolving to `2.4` becomes `foo>=1,<3`. Preserve
+/// [`VersionSpecifier`]s that already admit the resolution, and rewrite only the specifiers that
+/// exclude it. If a requirement resolves to multiple versions, preserve it when it admits all of
+/// them; otherwise, reject the ambiguous rewrite.
+fn propose_requirement(
+    requirement: &Requirement<VerbatimParsedUrl>,
+    resolved_versions: &BTreeSet<Version>,
+) -> Result<Requirement<VerbatimParsedUrl>> {
+    if resolved_versions.is_empty() {
+        return Ok(requirement.clone());
+    }
+
+    let Some(VersionOrUrl::VersionSpecifier(specifiers)) = &requirement.version_or_url else {
+        return Ok(requirement.clone());
+    };
+    if resolved_versions
+        .iter()
+        .all(|version| specifiers.contains(version))
+    {
+        return Ok(requirement.clone());
+    }
+    if resolved_versions.len() > 1 {
+        bail!(
+            "Dependency `{}` resolves to multiple versions that require different constraints; this is not supported yet",
+            requirement.name
+        );
+    }
+    let Some(resolved_version) = resolved_versions.first() else {
+        return Ok(requirement.clone());
+    };
+
+    let specifiers = specifiers
+        .iter()
+        .cloned()
+        .map(|specifier| rewrite_specifier(specifier, resolved_version))
+        .collect::<Result<VersionSpecifiers>>()?;
+    if !specifiers.contains(resolved_version) {
+        bail!(
+            "Dependency `{}` resolved to version `{resolved_version}` which cannot be represented by the upgraded requirement; this is not supported yet",
+            requirement.name
+        );
+    }
+    let mut proposed = requirement.clone();
+    proposed.version_or_url = Some(VersionOrUrl::VersionSpecifier(specifiers));
+    Ok(proposed)
+}
+
+/// Rewrite a [`VersionSpecifier`] that excludes the resolved version according to its operator.
+///
+/// Return the specifier unchanged if it already admits the resolved version.
+fn rewrite_specifier(
+    specifier: VersionSpecifier,
+    resolved_version: &Version,
+) -> Result<VersionSpecifier> {
+    if specifier.contains(resolved_version) {
+        return Ok(specifier);
+    }
+
+    Ok(match specifier.operator() {
+        Operator::GreaterThan
+        | Operator::GreaterThanEqual
+        | Operator::NotEqual
+        | Operator::NotEqualStar => specifier,
+        Operator::TildeEqual => VersionSpecifier::from_version(
+            Operator::TildeEqual,
+            compatible_version_at_precision(resolved_version, specifier.version().release().len())?,
+        )?,
+        Operator::Equal => VersionSpecifier::equals_version(resolved_version.clone()),
+        Operator::EqualStar => VersionSpecifier::equals_star_version(
+            resolved_version
+                .only_release_at_precision(specifier.version().release().len())
+                .context("Cannot rewrite a version constraint without a release segment")?,
+        ),
+        Operator::ExactEqual => {
+            VersionSpecifier::from_version(Operator::ExactEqual, resolved_version.clone())?
+        }
+        Operator::LessThan => VersionSpecifier::less_than_version(increment_version_at_precision(
+            resolved_version,
+            specifier.version().release().len(),
+        )?),
+        Operator::LessThanEqual => VersionSpecifier::from_version(
+            Operator::LessThanEqual,
+            resolved_version.clone().without_local(),
+        )?,
+    })
+}
+
+/// Project a version to the given precision while preserving its compatible-release suffixes.
+fn compatible_version_at_precision(version: &Version, precision: usize) -> Result<Version> {
+    let release = version
+        .release()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(0))
+        .take(precision)
+        .collect::<Vec<_>>();
+    if release.is_empty() {
+        bail!("Cannot rewrite a version constraint without a release segment");
+    }
+    Ok(version.clone().with_release(release).without_local())
+}
+
+/// Increment the last release segment after projecting a version to the given precision.
+fn increment_version_at_precision(version: &Version, precision: usize) -> Result<Version> {
+    let projected = version
+        .only_release_at_precision(precision)
+        .context("Cannot rewrite a version constraint without a release segment")?;
+    let mut release = projected.release().to_vec();
+    let segment_index = release.len();
+    let Some(last) = release.last_mut() else {
+        bail!("Cannot rewrite a version constraint without a release segment");
+    };
+    let segment = *last;
+    *last = segment.checked_add(1).with_context(|| {
+        format!(
+            "Cannot expand version `{version}` at release segment {segment_index} (`{segment}`) beyond its maximum value"
+        )
+    })?;
+    Ok(projected.with_release(release))
+}
+
+/// Remove upper and exact constraints while retaining lower bounds and exclusions.
 fn relax_requirement(
     requirement: &Requirement<VerbatimParsedUrl>,
 ) -> Requirement<VerbatimParsedUrl> {
@@ -343,12 +491,163 @@ fn relax_requirement(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::str::FromStr;
 
+    use uv_pep440::Version;
     use uv_pep508::Requirement;
     use uv_pypi_types::VerbatimParsedUrl;
 
-    use super::relax_requirement;
+    use super::{increment_version_at_precision, propose_requirement, relax_requirement};
+
+    fn resolved_versions(versions: &[&str]) -> BTreeSet<Version> {
+        versions
+            .iter()
+            .map(|version| Version::from_str(version).expect("valid version"))
+            .collect()
+    }
+
+    #[test]
+    fn propose_requirement_preserves_satisfied_constraints() {
+        for requirement in ["requests", "requests>=1.2", "requests!=2.3"] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+
+            let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
+                .expect("requirement can be proposed");
+
+            assert_eq!(proposed, requirement);
+        }
+    }
+
+    #[test]
+    fn propose_requirement_expands_exclusive_upper_bounds_at_existing_precision() {
+        for (requirement, version, expected) in [
+            ("requests>=1.2,<2", "2.4.0", "requests>=1.2,<3"),
+            ("requests>=1.2,<1.3", "1.4.2", "requests>=1.2,<1.5"),
+        ] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+
+            let proposed = propose_requirement(&requirement, &resolved_versions(&[version]))
+                .expect("requirement can be proposed");
+
+            assert_eq!(proposed.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn propose_requirement_only_rewrites_blocking_specifiers() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests>=1,<2,<4")
+            .expect("valid requirement");
+
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
+            .expect("requirement can be proposed");
+
+        assert_eq!(proposed.to_string(), "requests>=1,<3,<4");
+    }
+
+    #[test]
+    fn propose_requirement_preserves_operator_style() {
+        for (requirement, version, expected) in [
+            ("requests==1.2.3", "2.4.5", "requests==2.4.5"),
+            ("requests===1.2.3", "2.4.5", "requests===2.4.5"),
+            ("requests==1.2.*", "2.4.5", "requests==2.4.*"),
+            ("requests~=1.2", "2.4.5", "requests~=2.4"),
+            ("requests~=1.2.3", "2.4.5", "requests~=2.4.5"),
+            ("requests<=1.2.3", "2.4.5", "requests<=2.4.5"),
+        ] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+
+            let proposed = propose_requirement(&requirement, &resolved_versions(&[version]))
+                .expect("requirement can be proposed");
+
+            assert_eq!(proposed.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn propose_requirement_preserves_compatible_release_suffixes() {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str("requests~=1.2").expect("valid requirement");
+
+        let proposed = propose_requirement(
+            &requirement,
+            &resolved_versions(&["1!2.4rc1.post2.dev3+local"]),
+        )
+        .expect("requirement can be proposed");
+
+        assert_eq!(proposed.to_string(), "requests~=1!2.4rc1.post2.dev3");
+    }
+
+    #[test]
+    fn propose_requirement_strips_local_version_from_inclusive_upper_bound() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests<=1.2.3")
+            .expect("valid requirement");
+
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.5+local"]))
+            .expect("requirement can be proposed");
+
+        assert_eq!(proposed.to_string(), "requests<=2.4.5");
+    }
+
+    #[test]
+    fn propose_requirement_rejects_constraint_that_still_excludes_resolved_version() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests!=2.4,<2")
+            .expect("valid requirement");
+
+        let error = propose_requirement(&requirement, &resolved_versions(&["2.4"]))
+            .expect_err("rewritten requirement must admit the resolved version");
+
+        assert_eq!(
+            error.to_string(),
+            "Dependency `requests` resolved to version `2.4` which cannot be represented by the upgraded requirement; this is not supported yet"
+        );
+    }
+
+    #[test]
+    fn propose_requirement_preserves_metadata_lower_bounds_and_exclusions() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str(
+            "Requests_Plus[security,tests]>=1.2,!=2.3,<2 ; python_version >= '3.12'",
+        )
+        .expect("valid requirement");
+
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
+            .expect("requirement can be proposed");
+
+        assert_eq!(
+            proposed.to_string(),
+            "requests-plus[security,tests]>=1.2,!=2.3,<3 ; python_full_version >= '3.12'"
+        );
+    }
+
+    #[test]
+    fn propose_requirement_rejects_ambiguous_multiple_versions() {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str("requests<2").expect("valid requirement");
+
+        let error = propose_requirement(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
+            .expect_err("multiple versions cannot be rewritten yet");
+
+        assert_eq!(
+            error.to_string(),
+            "Dependency `requests` resolves to multiple versions that require different constraints; this is not supported yet"
+        );
+    }
+
+    #[test]
+    fn increment_version_at_precision_reports_upper_bound_overflow() {
+        let version = Version::new([1, 2, u64::MAX]);
+
+        let error = increment_version_at_precision(&version, 3)
+            .expect_err("maximum release segment cannot be incremented");
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot expand version `1.2.18446744073709551615` at release segment 3 (`18446744073709551615`) beyond its maximum value"
+        );
+    }
 
     #[test]
     fn relax_requirement_preserves_lower_bounds_and_exclusions() {

--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -353,8 +353,9 @@ fn into_verbatim_requirement(
 ///
 /// For example, `foo>=1,<2` resolving to `2.4` becomes `foo>=1,<3`. Preserve
 /// [`VersionSpecifier`]s that already admit the resolution, and rewrite only the specifiers that
-/// exclude it. If a requirement resolves to multiple versions, preserve it when it admits all of
-/// them; otherwise, reject the ambiguous rewrite.
+/// exclude it. If a requirement resolves to multiple versions, rewrite each specifier using the
+/// appropriate version boundary for its operator, then verify that the result admits every
+/// resolved version.
 fn propose_requirement(
     requirement: &Requirement<VerbatimParsedUrl>,
     resolved_versions: &BTreeSet<Version>,
@@ -372,24 +373,38 @@ fn propose_requirement(
     {
         return Ok(requirement.clone());
     }
-    if resolved_versions.len() > 1 {
-        bail!(
-            "Dependency `{}` resolves to multiple versions that require different constraints; this is not supported yet",
-            requirement.name
-        );
-    }
-    let Some(resolved_version) = resolved_versions.first() else {
+    let Some(highest_resolved_version) = resolved_versions.last() else {
         return Ok(requirement.clone());
     };
 
     let specifiers = specifiers
         .iter()
         .cloned()
-        .map(|specifier| rewrite_specifier(specifier, resolved_version))
+        .map(|specifier| rewrite_specifier(specifier, resolved_versions))
         .collect::<Result<VersionSpecifiers>>()?;
-    if !specifiers.contains(resolved_version) {
+    if !resolved_versions
+        .iter()
+        .all(|version| specifiers.contains(version))
+    {
+        tracing::debug!(
+            dependency = %requirement.name,
+            resolved_versions = ?resolved_versions,
+            rewritten_specifiers = %specifiers,
+            "Rewritten dependency constraint does not admit every resolved version"
+        );
+        if resolved_versions.len() == 1 {
+            bail!(
+                "Dependency `{}` resolved to version `{highest_resolved_version}` which cannot be represented by the upgraded requirement; this is not supported yet",
+                requirement.name
+            );
+        }
+        let resolved_versions = resolved_versions
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("`, `");
         bail!(
-            "Dependency `{}` resolved to version `{resolved_version}` which cannot be represented by the upgraded requirement; this is not supported yet",
+            "Dependency `{}` resolved to versions `{resolved_versions}` which cannot be represented by the upgraded requirement; this is not supported yet",
             requirement.name
         );
     }
@@ -398,16 +413,23 @@ fn propose_requirement(
     Ok(proposed)
 }
 
-/// Rewrite a [`VersionSpecifier`] that excludes the resolved version according to its operator.
-///
-/// Return the specifier unchanged if it already admits the resolved version.
+/// Attempt to rewrite a [`VersionSpecifier`] to admit all resolved versions while preserving its
+/// operator.
 fn rewrite_specifier(
     specifier: VersionSpecifier,
-    resolved_version: &Version,
+    resolved_versions: &BTreeSet<Version>,
 ) -> Result<VersionSpecifier> {
-    if specifier.contains(resolved_version) {
+    if resolved_versions
+        .iter()
+        .all(|version| specifier.contains(version))
+    {
         return Ok(specifier);
     }
+    let (Some(lowest_resolved_version), Some(highest_resolved_version)) =
+        (resolved_versions.first(), resolved_versions.last())
+    else {
+        return Ok(specifier);
+    };
 
     Ok(match specifier.operator() {
         Operator::GreaterThan
@@ -416,24 +438,27 @@ fn rewrite_specifier(
         | Operator::NotEqualStar => specifier,
         Operator::TildeEqual => VersionSpecifier::from_version(
             Operator::TildeEqual,
-            compatible_version_at_precision(resolved_version, specifier.version().release().len())?,
+            compatible_version_at_precision(
+                lowest_resolved_version,
+                specifier.version().release().len(),
+            )?,
         )?,
-        Operator::Equal => VersionSpecifier::equals_version(resolved_version.clone()),
+        Operator::Equal => VersionSpecifier::equals_version(lowest_resolved_version.clone()),
         Operator::EqualStar => VersionSpecifier::equals_star_version(
-            resolved_version
+            lowest_resolved_version
                 .only_release_at_precision(specifier.version().release().len())
                 .context("Cannot rewrite a version constraint without a release segment")?,
         ),
         Operator::ExactEqual => {
-            VersionSpecifier::from_version(Operator::ExactEqual, resolved_version.clone())?
+            VersionSpecifier::from_version(Operator::ExactEqual, lowest_resolved_version.clone())?
         }
         Operator::LessThan => VersionSpecifier::less_than_version(increment_version_at_precision(
-            resolved_version,
+            highest_resolved_version,
             specifier.version().release().len(),
         )?),
         Operator::LessThanEqual => VersionSpecifier::from_version(
             Operator::LessThanEqual,
-            resolved_version.clone().without_local(),
+            highest_resolved_version.clone().without_local(),
         )?,
     })
 }
@@ -641,16 +666,38 @@ mod tests {
     }
 
     #[test]
-    fn propose_requirement_rejects_ambiguous_multiple_versions() {
+    fn propose_requirement_expands_upper_bound_for_multiple_versions() {
         let requirement =
             Requirement::<VerbatimParsedUrl>::from_str("requests<2").expect("valid requirement");
 
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
+            .expect("upper bound can admit both versions");
+
+        assert_eq!(proposed.to_string(), "requests<3");
+    }
+
+    #[test]
+    fn propose_requirement_uses_lowest_compatible_version_for_multiple_versions() {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str("requests~=1.2").expect("valid requirement");
+
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4", "2.5"]))
+            .expect("compatible release can admit both versions");
+
+        assert_eq!(proposed.to_string(), "requests~=2.4");
+    }
+
+    #[test]
+    fn propose_requirement_rejects_unrepresentable_multiple_versions() {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str("requests==1.*").expect("valid requirement");
+
         let error = propose_requirement(&requirement, &resolved_versions(&["1.5.0", "2.4.0"]))
-            .expect_err("multiple versions cannot be rewritten yet");
+            .expect_err("wildcard cannot admit versions from different major lines");
 
         assert_eq!(
             error.to_string(),
-            "Dependency `requests` resolves to multiple versions that require different constraints; this is not supported yet"
+            "Dependency `requests` resolved to versions `1.5.0`, `2.4.0` which cannot be represented by the upgraded requirement; this is not supported yet"
         );
     }
 

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -4,6 +4,7 @@ use insta::allow_duplicates;
 use url::Url;
 
 use uv_static::EnvVars;
+use uv_test::packse::PackseServer;
 use uv_test::{TestContext, uv_snapshot};
 
 fn assert_project_unchanged(context: &TestContext, expected: &str) -> Result<()> {
@@ -16,57 +17,32 @@ fn assert_project_unchanged(context: &TestContext, expected: &str) -> Result<()>
     Ok(())
 }
 
-/// Write path dependencies that deterministically force marker-exclusive `anyio` forks.
-///
-/// The target remains a single direct requirement because duplicate direct requirements are not
-/// supported by `uv upgrade` yet.
-fn write_forked_anyio_project(
-    context: &TestContext,
-    selected_requirement: &str,
-    darwin_requirement: &str,
-    other_requirement: &str,
-) -> Result<String> {
-    let darwin_dependency = context.temp_dir.child("darwin-dependency");
-    fs_err::create_dir_all(&darwin_dependency)?;
-    darwin_dependency
-        .child("pyproject.toml")
-        .write_str(&format!(
-            r#"
-        [project]
-        name = "dependency"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["{darwin_requirement}"]
-        "#,
-        ))?;
-    let other_dependency = context.temp_dir.child("other-dependency");
-    fs_err::create_dir_all(&other_dependency)?;
-    other_dependency
-        .child("pyproject.toml")
-        .write_str(&format!(
-            r#"
-        [project]
-        name = "dependency"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["{other_requirement}"]
-        "#,
-        ))?;
+/// Return snapshot filters for metadata fetched from a [`PackseServer`].
+fn packse_filters(context: &TestContext) -> Vec<(&str, &str)> {
+    let mut filters = context.filters();
+    filters.push((r"(?m)^WARN Range requests not supported[^\n]*\n", ""));
+    filters
+}
 
+/// Write a project where `foo==1` resolves two versions of `bar` in platform forks.
+fn write_fork_upgrade_project(
+    context: &TestContext,
+    server: &PackseServer,
+    bar_requirement: &str,
+) -> Result<String> {
     let pyproject_toml = format!(
         r#"
         [project]
         name = "project"
         version = "0.1.0"
         requires-python = ">=3.12"
-        dependencies = [
-            "{selected_requirement}",
-            "dependency @ {} ; sys_platform == 'darwin'",
-            "dependency @ {} ; sys_platform != 'darwin'",
-        ]
+        dependencies = ["{bar_requirement}", "foo==1"]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
     "#,
-        Url::from_file_path(&darwin_dependency).map_err(|()| anyhow!("invalid dependency path"))?,
-        Url::from_file_path(&other_dependency).map_err(|()| anyhow!("invalid dependency path"))?
+        server.index_url()
     );
     context
         .temp_dir
@@ -193,16 +169,16 @@ exclude-newer = "2024-03-25T00:00:00Z"
 #[test]
 fn upgrade_ignores_disjoint_fork_version_for_selected_requirement() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let pyproject_toml = write_forked_anyio_project(
-        &context,
-        "anyio>=3.7 ; sys_platform == 'darwin'",
-        "anyio>=3.7",
-        "anyio==3.0.0",
-    )?;
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml =
+        write_fork_upgrade_project(&context, &server, "bar==2 ; sys_platform != 'linux'")?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("anyio"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
     success: true
     exit_code: 0
@@ -210,8 +186,8 @@ fn upgrade_ignores_disjoint_fork_version_for_selected_requirement() -> Result<()
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 7 packages in [TIME]
-    Add anyio v3.0.0, v4.3.0
+    Resolved 4 packages in [TIME]
+    Add bar v1.0.0, v2.0.0
     "
     );
 
@@ -221,12 +197,15 @@ fn upgrade_ignores_disjoint_fork_version_for_selected_requirement() -> Result<()
 #[test]
 fn upgrade_preserves_constraint_that_admits_multiple_fork_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let pyproject_toml =
-        write_forked_anyio_project(&context, "anyio>=3", "anyio==3.0.0", "anyio==4.3.0")?;
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = write_fork_upgrade_project(&context, &server, "bar>=1")?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("anyio"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
     success: true
     exit_code: 0
@@ -234,8 +213,8 @@ fn upgrade_preserves_constraint_that_admits_multiple_fork_versions() -> Result<(
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 7 packages in [TIME]
-    Add anyio v3.0.0, v4.3.0
+    Resolved 4 packages in [TIME]
+    Add bar v1.0.0, v2.0.0
     "
     );
 
@@ -275,12 +254,15 @@ fn upgrade_preserves_inapplicable_marked_dependency() -> Result<()> {
 #[test]
 fn upgrade_expands_constraint_for_multiple_fork_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let pyproject_toml =
-        write_forked_anyio_project(&context, "anyio<4", "anyio==3.0.0", "anyio==4.3.0")?;
+    let server = PackseServer::new("fork/fork-upgrade.toml");
+    let pyproject_toml = write_fork_upgrade_project(&context, &server, "bar<2")?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("anyio"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("bar")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
     success: true
     exit_code: 0
@@ -288,15 +270,15 @@ fn upgrade_expands_constraint_for_multiple_fork_versions() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 7 packages in [TIME]
-    Add anyio v3.0.0, v4.3.0
-    Updated requirement: `anyio<4` -> `anyio<5`
+    Resolved 4 packages in [TIME]
+    Add bar v1.0.0, v2.0.0
+    Updated requirement: `bar<2` -> `bar<3`
     "
     );
 
     assert_eq!(
         fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
-        pyproject_toml.replace("anyio<4", "anyio<5")
+        pyproject_toml.replace("bar<2", "bar<3")
     );
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());
@@ -306,12 +288,39 @@ fn upgrade_expands_constraint_for_multiple_fork_versions() -> Result<()> {
 #[test]
 fn upgrade_expands_compatible_constraint_for_multiple_fork_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
-    let pyproject_toml =
-        write_forked_anyio_project(&context, "anyio~=3.0", "anyio==4.2.0", "anyio==4.3.0")?;
+    let server = PackseServer::new("fork/filter-sibling-dependencies.toml");
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["a~=3.0"]
+
+        [tool.uv]
+        constraint-dependencies = [
+            "a==4.3.0 ; sys_platform == 'darwin'",
+            "a==4.4.0 ; sys_platform != 'darwin'",
+        ]
+
+        [[tool.uv.index]]
+        url = "{}"
+        default = true
+    "#,
+        server.index_url()
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
 
     uv_snapshot!(
-        context.filters(),
-        context.upgrade().arg("anyio"),
+        packse_filters(&context),
+        context
+            .upgrade()
+            .arg("a")
+            .env_remove(EnvVars::UV_EXCLUDE_NEWER),
         @"
     success: true
     exit_code: 0
@@ -319,15 +328,15 @@ fn upgrade_expands_compatible_constraint_for_multiple_fork_versions() -> Result<
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    Resolved 7 packages in [TIME]
-    Add anyio v4.2.0, v4.3.0
-    Updated requirement: `anyio~=3.0` -> `anyio~=4.2`
+    Resolved 3 packages in [TIME]
+    Add a v4.3.0, v4.4.0
+    Updated requirement: `a~=3.0` -> `a~=4.3`
     "
     );
 
     assert_eq!(
         fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
-        pyproject_toml.replace("anyio~=3.0", "anyio~=4.2")
+        pyproject_toml.replace("a~=3.0", "a~=4.3")
     );
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -16,6 +16,66 @@ fn assert_project_unchanged(context: &TestContext, expected: &str) -> Result<()>
     Ok(())
 }
 
+/// Write path dependencies that deterministically force marker-exclusive `anyio` forks.
+///
+/// The target remains a single direct requirement because duplicate direct requirements are not
+/// supported by `uv upgrade` yet.
+fn write_forked_anyio_project(
+    context: &TestContext,
+    selected_requirement: &str,
+    darwin_requirement: &str,
+    other_requirement: &str,
+) -> Result<String> {
+    let darwin_dependency = context.temp_dir.child("darwin-dependency");
+    fs_err::create_dir_all(&darwin_dependency)?;
+    darwin_dependency
+        .child("pyproject.toml")
+        .write_str(&format!(
+            r#"
+        [project]
+        name = "dependency"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["{darwin_requirement}"]
+        "#,
+        ))?;
+    let other_dependency = context.temp_dir.child("other-dependency");
+    fs_err::create_dir_all(&other_dependency)?;
+    other_dependency
+        .child("pyproject.toml")
+        .write_str(&format!(
+            r#"
+        [project]
+        name = "dependency"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["{other_requirement}"]
+        "#,
+        ))?;
+
+    let pyproject_toml = format!(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "{selected_requirement}",
+            "dependency @ {} ; sys_platform == 'darwin'",
+            "dependency @ {} ; sys_platform != 'darwin'",
+        ]
+    "#,
+        Url::from_file_path(&darwin_dependency).map_err(|()| anyhow!("invalid dependency path"))?,
+        Url::from_file_path(&other_dependency).map_err(|()| anyhow!("invalid dependency path"))?
+    );
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(&pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+    Ok(pyproject_toml)
+}
+
 #[test]
 fn upgrade_help() {
     let context = uv_test::test_context_with_versions!(&[]);
@@ -108,10 +168,117 @@ fn upgrade_selects_normalized_production_dependency() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
+    Would update requirement: anyio>=2,!=2.1,<3 ; python_full_version >= '3.12' -> anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'
     "
     );
 
     assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+fn upgrade_ignores_disjoint_fork_version_for_selected_requirement() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = write_forked_anyio_project(
+        &context,
+        "anyio>=3.7 ; sys_platform == 'darwin'",
+        "anyio>=3.7",
+        "anyio==3.0.0",
+    )?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("anyio"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    Add anyio v3.0.0, v4.3.0
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_preserves_constraint_that_admits_multiple_fork_versions() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml =
+        write_forked_anyio_project(&context, "anyio>=3", "anyio==3.0.0", "anyio==4.3.0")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("anyio"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    Add anyio v3.0.0, v4.3.0
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
+}
+
+#[test]
+fn upgrade_preserves_inapplicable_marked_dependency() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml = r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio<3 ; python_version < '3.12'"]
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+    fs_err::remove_dir_all(&context.venv)?;
+
+    uv_snapshot!(context.filters(), context.upgrade().arg("anyio"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 1 package in [TIME]
+    No version change for anyio
+    ");
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
+fn upgrade_rejects_ambiguous_multiple_fork_versions() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml =
+        write_forked_anyio_project(&context, "anyio<4", "anyio==3.0.0", "anyio==4.3.0")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("anyio"),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    error: Dependency `anyio` resolves to multiple versions that require different constraints; this is not supported yet
+    "
+    );
+
+    assert_project_unchanged(&context, &pyproject_toml)
 }
 
 #[test]
@@ -171,6 +338,7 @@ fn upgrade_resolves_selected_dependency_without_mutation() -> Result<()> {
     Resolving despite existing lockfile due to change of exclude newer timestamp from `2021-01-01T00:00:00Z` to `2024-03-25T00:00:00Z`
     Resolved 4 packages in [TIME]
     Update anyio v2.0.0 -> v4.3.0
+    Would update requirement: anyio<=2 -> anyio<=4.3.0
     ");
 
     assert_eq!(
@@ -349,15 +517,15 @@ fn upgrade_requires_production_dependency() -> Result<()> {
 }
 
 #[test]
-fn upgrade_rejects_duplicate_production_dependencies() -> Result<()> {
+fn upgrade_rejects_duplicate_marked_production_dependencies() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
     let pyproject_toml = r#"
         [project]
         name = "example"
         version = "0.1.0"
         dependencies = [
-            "Requests>=2",
-            "requests<3",
+            "Requests>=2 ; sys_platform == 'darwin'",
+            "requests<3 ; sys_platform != 'darwin'",
         ]
     "#;
     context
@@ -604,6 +772,7 @@ fn upgrade_allows_registry_source() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 2 packages in [TIME]
     Add idna v3.6
+    Would update requirement: idna>=2,<3 -> idna>=2,<4
     "
     );
 
@@ -644,6 +813,7 @@ fn upgrade_ignores_inapplicable_non_registry_source() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
+    Would update requirement: anyio>=2,<3 ; python_full_version >= '3.12' -> anyio>=2,<5 ; python_full_version >= '3.12'
     "
     );
 
@@ -747,6 +917,7 @@ fn upgrade_resolves_nested_workspace_member_without_mutation() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
+    Would update requirement: anyio<=2 -> anyio<=4.3.0
     "
     );
 

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -168,11 +168,26 @@ fn upgrade_selects_normalized_production_dependency() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
-    Would update requirement: anyio>=2,!=2.1,<3 ; python_full_version >= '3.12' -> anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'
+    Updated requirement: `AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'` -> `anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'`
     "
     );
 
-    assert_project_unchanged(&context, pyproject_toml)
+    insta::assert_snapshot!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        @r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'"]
+
+[tool.uv]
+exclude-newer = "2024-03-25T00:00:00Z"
+"#
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]
@@ -282,7 +297,7 @@ fn upgrade_rejects_ambiguous_multiple_fork_versions() -> Result<()> {
 }
 
 #[test]
-fn upgrade_resolves_selected_dependency_without_mutation() -> Result<()> {
+fn upgrade_updates_requirement_without_updating_lockfile_or_environment() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let initial_pyproject_toml = r#"
         [project]
@@ -317,9 +332,9 @@ fn upgrade_resolves_selected_dependency_without_mutation() -> Result<()> {
         .temp_dir
         .child("pyproject.toml")
         .write_str(&pyproject_toml)?;
-    fs_err::remove_dir_all(&context.venv)?;
+    let environment_sentinel = context.venv.child("sentinel");
+    environment_sentinel.write_str("present")?;
 
-    let pyproject = fs_err::read(context.temp_dir.child("pyproject.toml"))?;
     let lock = fs_err::read(context.temp_dir.child("uv.lock"))?;
 
     uv_snapshot!(
@@ -334,16 +349,15 @@ fn upgrade_resolves_selected_dependency_without_mutation() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolving despite existing lockfile due to change of exclude newer timestamp from `2021-01-01T00:00:00Z` to `2024-03-25T00:00:00Z`
     Resolved 4 packages in [TIME]
     Update anyio v2.0.0 -> v4.3.0
-    Would update requirement: anyio<=2 -> anyio<=4.3.0
+    Updated requirement: `anyio<=2` -> `anyio<=4.3.0`
     ");
 
     assert_eq!(
-        fs_err::read(context.temp_dir.child("pyproject.toml"))?,
-        pyproject
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("anyio<=2", "anyio<=4.3.0")
     );
     assert_eq!(fs_err::read(context.temp_dir.child("uv.lock"))?, lock);
     let lock_contents = context.read("uv.lock");
@@ -351,7 +365,7 @@ fn upgrade_resolves_selected_dependency_without_mutation() -> Result<()> {
         lock_contents.contains("name = \"idna\"\nversion = \"2.10\""),
         "{lock_contents}"
     );
-    assert!(!context.temp_dir.child(".venv").exists());
+    assert!(environment_sentinel.exists());
     Ok(())
 }
 
@@ -772,11 +786,17 @@ fn upgrade_allows_registry_source() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 2 packages in [TIME]
     Add idna v3.6
-    Would update requirement: idna>=2,<3 -> idna>=2,<4
+    Updated requirement: `idna>=2,<3` -> `idna>=2,<4`
     "
     );
 
-    assert_project_unchanged(&context, &pyproject_toml)
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("idna>=2,<3", "idna>=2,<4")
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]
@@ -813,11 +833,20 @@ fn upgrade_ignores_inapplicable_non_registry_source() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
-    Would update requirement: anyio>=2,<3 ; python_full_version >= '3.12' -> anyio>=2,<5 ; python_full_version >= '3.12'
+    Updated requirement: `anyio>=2,<3 ; python_version >= '3.12'` -> `anyio>=2,<5 ; python_full_version >= '3.12'`
     "
     );
 
-    assert_project_unchanged(&context, pyproject_toml)
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace(
+            "anyio>=2,<3 ; python_version >= '3.12'",
+            "anyio>=2,<5 ; python_full_version >= '3.12'"
+        )
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]
@@ -877,7 +906,7 @@ fn upgrade_rejects_workspace_root_non_registry_source() -> Result<()> {
 }
 
 #[test]
-fn upgrade_resolves_nested_workspace_member_without_mutation() -> Result<()> {
+fn upgrade_updates_nested_workspace_member_only() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let workspace_pyproject_toml = r#"
         [tool.uv.workspace]
@@ -917,7 +946,7 @@ fn upgrade_resolves_nested_workspace_member_without_mutation() -> Result<()> {
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 4 packages in [TIME]
     Add anyio v4.3.0
-    Would update requirement: anyio<=2 -> anyio<=4.3.0
+    Updated requirement: `anyio<=2` -> `anyio<=4.3.0`
     "
     );
 
@@ -927,7 +956,7 @@ fn upgrade_resolves_nested_workspace_member_without_mutation() -> Result<()> {
     );
     assert_eq!(
         fs_err::read_to_string(project.child("pyproject.toml"))?,
-        project_pyproject_toml
+        project_pyproject_toml.replace("anyio<=2", "anyio<=4.3.0")
     );
     assert!(!context.temp_dir.child("uv.lock").exists());
     assert!(!context.temp_dir.child(".venv").exists());

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -273,7 +273,7 @@ fn upgrade_preserves_inapplicable_marked_dependency() -> Result<()> {
 }
 
 #[test]
-fn upgrade_rejects_ambiguous_multiple_fork_versions() -> Result<()> {
+fn upgrade_expands_constraint_for_multiple_fork_versions() -> Result<()> {
     let context = uv_test::test_context!("3.12");
     let pyproject_toml =
         write_forked_anyio_project(&context, "anyio<4", "anyio==3.0.0", "anyio==4.3.0")?;
@@ -282,18 +282,56 @@ fn upgrade_rejects_ambiguous_multiple_fork_versions() -> Result<()> {
         context.filters(),
         context.upgrade().arg("anyio"),
         @"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 7 packages in [TIME]
-    error: Dependency `anyio` resolves to multiple versions that require different constraints; this is not supported yet
+    Add anyio v3.0.0, v4.3.0
+    Updated requirement: `anyio<4` -> `anyio<5`
     "
     );
 
-    assert_project_unchanged(&context, &pyproject_toml)
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("anyio<4", "anyio<5")
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn upgrade_expands_compatible_constraint_for_multiple_fork_versions() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+    let pyproject_toml =
+        write_forked_anyio_project(&context, "anyio~=3.0", "anyio==4.2.0", "anyio==4.3.0")?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("anyio"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 7 packages in [TIME]
+    Add anyio v4.2.0, v4.3.0
+    Updated requirement: `anyio~=3.0` -> `anyio~=4.2`
+    "
+    );
+
+    assert_eq!(
+        fs_err::read_to_string(context.temp_dir.child("pyproject.toml"))?,
+        pyproject_toml.replace("anyio~=3.0", "anyio~=4.2")
+    );
+    assert!(!context.temp_dir.child("uv.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #19678, which introduced a hidden, read-only `uv upgrade <package>` command.

This PR makes the targeted upgrade actionable by updating a single production dependency constraint in `pyproject.toml`. It intentionally leaves `uv.lock` and the project environment unchanged; lockfile synchronization will be handled later as part of `--tighten`.

After resolving with the dependency’s blocking constraints relaxed, `uv upgrade` now:

- rewrites only specifiers that exclude applicable resolved versions
- chooses the appropriate lowest or highest resolved version for each operator
- validates that the proposed constraint admits every applicable resolved version
- rejects rewrites that cannot be represented safely by a single constraint
- preserves lower bounds, exclusions, extras, markers, and operator style where possible
- leaves constraints unchanged when they already admit every applicable resolved version

Universal resolutions may select different versions in different forks, including forks introduced by transitive dependencies. The proposed constraint accounts for every fork where the selected declaration applies while ignoring disjoint forks.

The selected declaration is updated using uv’s standard mutable manifest machinery. Requirement formatting may be normalized during the update.

The existing scope remains unchanged: only uniquely declared, registry-backed production dependencies in single-member workspaces are supported. Dynamic project versions, direct URLs, non-registry sources, self-dependencies, and other unsupported cases continue to fail without mutation.

> [!TIP]
> This PR is organized into separate helper extraction, constraint planning, manifest application, and fork-handling commits for review.