### PR TITLE
Reject Git revisions in `uv upgrade`

### DIFF
--- a/crates/uv/src/commands/project/upgrade.rs
+++ b/crates/uv/src/commands/project/upgrade.rs
@@ -11,7 +11,7 @@ use uv_distribution::{ArchiveMetadata, Metadata};
 use uv_distribution_types::Identifier;
 use uv_normalize::PackageName;
 use uv_pep440::{Operator, VersionSpecifier, VersionSpecifiers};
-use uv_pep508::{Requirement, VerbatimUrl, VersionOrUrl};
+use uv_pep508::{MarkerTree, Requirement, VerbatimUrl, VersionOrUrl};
 use uv_preview::Preview;
 use uv_pypi_types::{PyProjectToml, ResolutionMetadata, VerbatimParsedUrl};
 use uv_python::{PythonDownloads, PythonPreference};
@@ -112,14 +112,19 @@ pub(crate) async fn upgrade(
         .and_then(|uv| uv.sources.as_ref())
         .and_then(|sources| sources.inner().get(&package))
         .or_else(|| project.workspace().sources().get(&package));
-    let extra = requirement.marker.top_level_extra_name();
     if sources.is_some_and(|sources| {
         sources.iter().any(|source| {
-            source
-                .extra()
-                .is_none_or(|target| extra.as_deref() == Some(target))
-                && source.group().is_none()
-                && !source.marker().is_disjoint(requirement.marker)
+            source_is_applicable(source, requirement.marker)
+                && matches!(source, Source::Git { rev: Some(_), .. })
+        })
+    }) {
+        bail!(
+            "Dependency `{package}` is pinned to a Git revision and cannot be upgraded commit-to-commit"
+        );
+    }
+    if sources.is_some_and(|sources| {
+        sources.iter().any(|source| {
+            source_is_applicable(source, requirement.marker)
                 && !matches!(source, Source::Registry { .. })
         })
     }) {
@@ -268,6 +273,15 @@ pub(crate) async fn upgrade(
     }
 
     Ok(ExitStatus::Success)
+}
+
+fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool {
+    let extra = requirement_marker.top_level_extra_name();
+    source
+        .extra()
+        .is_none_or(|target| extra.as_deref() == Some(target))
+        && source.group().is_none()
+        && !source.marker().is_disjoint(requirement_marker)
 }
 
 fn relax_requirement(

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -449,7 +449,7 @@ fn upgrade_rejects_git_revision() -> Result<()> {
         dependencies = ["requests>=2"]
 
         [tool.uv.sources]
-        requests = { git = "https://github.com/psf/requests", rev = "main" }
+        requests = { git = "https://github.com/psf/requests", rev = "6f205ff422bccd5e4c4fc0b64c5f3e7df5181db6" }
     "#;
     context
         .temp_dir

--- a/crates/uv/tests/it/upgrade.rs
+++ b/crates/uv/tests/it/upgrade.rs
@@ -440,6 +440,39 @@ fn upgrade_rejects_self_dependency() -> Result<()> {
 }
 
 #[test]
+fn upgrade_rejects_git_revision() -> Result<()> {
+    let context = uv_test::test_context_with_versions!(&[]);
+    let pyproject_toml = r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        dependencies = ["requests>=2"]
+
+        [tool.uv.sources]
+        requests = { git = "https://github.com/psf/requests", rev = "main" }
+    "#;
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(pyproject_toml)?;
+
+    uv_snapshot!(
+        context.filters(),
+        context.upgrade().arg("requests"),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Dependency `requests` is pinned to a Git revision and cannot be upgraded commit-to-commit
+    "
+    );
+
+    assert_project_unchanged(&context, pyproject_toml)
+}
+
+#[test]
 fn upgrade_rejects_non_registry_sources() -> Result<()> {
     let context = uv_test::test_context_with_versions!(&[]);
 


### PR DESCRIPTION
## Summary

`uv upgrade` cannot meaningfully upgrade a Git dependency that specifies `rev`: the revision may name a commit, branch, or tag, but there is no registry version constraint for the command to relax. Previously, these dependencies fell through to the generic non-registry-source error, which obscured that commit-to-commit upgrades are unsupported.

This follow-up to #19678 detects applicable Git sources with `rev` before the generic source check and reports a dedicated error. It also extracts the shared source-applicability check into a helper and adds an integration snapshot covering the new diagnostic.
