### PR TITLE
Add voice-activated plank stopwatch web app

### DIFF
--- a/plank-stopwatch/README.md
+++ b/plank-stopwatch/README.md
@@ -1,0 +1,60 @@
+# Plank Voice Stopwatch
+
+A tiny, zero-dependency web app that times your planks hands-free. Say **"up"**
+or **"start"** to start the clock and **"down"** or **"stop"** to stop it — handy
+when you're in plank position and can't reach your phone.
+
+## Run it
+
+It's a static page, so any of these work:
+
+```bash
+# Option 1: just open the file
+open index.html            # macOS
+xdg-open index.html        # Linux
+
+# Option 2: serve it (recommended — some browsers gate the mic on file://)
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+> **Microphone note:** Browsers only allow microphone access over `https://` or
+> on `http://localhost`. If you open the raw file and the mic doesn't work, use
+> the local server option above, or host it somewhere with HTTPS.
+
+## Use it
+
+1. Tap **Start Listening** and grant microphone permission.
+2. Say **"up"** (or "start"/"go"/"begin") to start timing.
+3. Hold your plank.
+4. Say **"down"** (or "stop"/"rest"/"end") to stop. The hold is saved to the
+   list below with a running total and your best time.
+
+No mic handy? You can drive it with the keyboard for testing:
+
+- **Space** — toggle the clock (start/stop)
+- **R** — reset everything
+
+## How it works
+
+- **Stopwatch** uses `performance.now()` for drift-free timing and
+  `requestAnimationFrame` for a smooth tenths-of-a-second display.
+- **Voice** uses the browser's built-in
+  [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition)
+  (`SpeechRecognition` / `webkitSpeechRecognition`) in continuous mode. Commands
+  are matched on whole words, so "startled" won't trip "start". Recognition
+  auto-restarts when the API ends a session so listening stays continuous.
+
+## Browser support
+
+Works best in **Chrome**, **Edge**, and **Safari** (including iOS Safari).
+Firefox does not currently ship the Web Speech recognition API; the app detects
+this and shows a message, and you can still use the keyboard controls.
+
+## Files
+
+| File         | Purpose                                  |
+| ------------ | ---------------------------------------- |
+| `index.html` | Markup and layout                        |
+| `style.css`  | Styling (dark, mobile-friendly)          |
+| `app.js`     | Stopwatch logic + voice command handling |

--- a/plank-stopwatch/app.js
+++ b/plank-stopwatch/app.js
@@ -1,0 +1,318 @@
+/* Plank Voice Stopwatch
+ * Starts the clock on "up"/"start" and stops on "down"/"stop",
+ * using the browser's Web Speech API for recognition.
+ */
+
+(function () {
+  "use strict";
+
+  // ---- Stopwatch state ----
+  var running = false;
+  var startTimestamp = 0; // performance.now() when the current run started
+  var accumulated = 0; // ms carried over (always 0 here; we reset on each run)
+  var rafId = null;
+  var laps = []; // completed plank durations in ms
+
+  // ---- Voice command vocabulary ----
+  var START_WORDS = ["up", "start", "go", "begin"];
+  var STOP_WORDS = ["down", "stop", "rest", "end"];
+
+  // ---- DOM ----
+  var timeEl = document.getElementById("time");
+  var statusEl = document.getElementById("status");
+  var micBtn = document.getElementById("mic");
+  var resetBtn = document.getElementById("reset");
+  var lapsEl = document.getElementById("laps");
+  var lapCountEl = document.getElementById("lapCount");
+  var lapsSummaryEl = document.getElementById("lapsSummary");
+  var heardEl = document.getElementById("heard");
+
+  // ---- Time formatting ----
+  function elapsedMs() {
+    if (!running) {
+      return accumulated;
+    }
+    return accumulated + (performance.now() - startTimestamp);
+  }
+
+  function formatTime(ms) {
+    var totalTenths = Math.floor(ms / 100);
+    var tenths = totalTenths % 10;
+    var totalSeconds = Math.floor(totalTenths / 10);
+    var seconds = totalSeconds % 60;
+    var minutes = Math.floor(totalSeconds / 60);
+    return (
+      pad2(minutes) + ":" + pad2(seconds) + "." + tenths
+    );
+  }
+
+  function pad2(n) {
+    return n < 10 ? "0" + n : String(n);
+  }
+
+  function render() {
+    timeEl.textContent = formatTime(elapsedMs());
+    if (running) {
+      rafId = requestAnimationFrame(render);
+    }
+  }
+
+  // ---- Stopwatch controls ----
+  function startClock() {
+    if (running) {
+      return;
+    }
+    running = true;
+    accumulated = 0;
+    startTimestamp = performance.now();
+    timeEl.classList.add("running");
+    setStatus('Counting… say <b>"down"</b> to stop.');
+    render();
+  }
+
+  function stopClock() {
+    if (!running) {
+      return;
+    }
+    var duration = elapsedMs();
+    running = false;
+    accumulated = duration;
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    timeEl.classList.remove("running");
+    timeEl.textContent = formatTime(duration);
+    recordLap(duration);
+    setStatus('Nice hold! Say <b>"up"</b> to go again.');
+  }
+
+  function resetClock() {
+    running = false;
+    accumulated = 0;
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    timeEl.classList.remove("running");
+    timeEl.textContent = formatTime(0);
+    laps = [];
+    renderLaps();
+    setStatus('Reset. Say <b>"up"</b> to start.');
+  }
+
+  // ---- Laps ----
+  function recordLap(ms) {
+    laps.push(ms);
+    renderLaps();
+  }
+
+  function renderLaps() {
+    lapsEl.innerHTML = "";
+    laps.forEach(function (ms, i) {
+      var li = document.createElement("li");
+      var idx = document.createElement("span");
+      idx.className = "lap-index";
+      idx.textContent = "#" + (i + 1);
+      var val = document.createElement("span");
+      val.textContent = formatTime(ms);
+      li.appendChild(idx);
+      li.appendChild(val);
+      lapsEl.appendChild(li);
+    });
+
+    if (laps.length === 0) {
+      lapCountEl.textContent = "";
+      lapsSummaryEl.textContent = "";
+      return;
+    }
+
+    lapCountEl.textContent = "(" + laps.length + ")";
+    var total = laps.reduce(function (a, b) {
+      return a + b;
+    }, 0);
+    var best = laps.reduce(function (a, b) {
+      return Math.max(a, b);
+    }, 0);
+    lapsSummaryEl.textContent =
+      "Total " + formatTime(total) + " · Best " + formatTime(best);
+  }
+
+  // ---- Status helper ----
+  function setStatus(html, isError) {
+    statusEl.innerHTML = html;
+    statusEl.classList.toggle("error", !!isError);
+  }
+
+  // ---- Command matching ----
+  // Matches whole words so "startled" won't trigger "start".
+  function containsWord(transcript, words) {
+    var tokens = transcript.toLowerCase().split(/[^a-z]+/);
+    for (var i = 0; i < words.length; i++) {
+      if (tokens.indexOf(words[i]) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function handleTranscript(transcript) {
+    heardEl.textContent = "heard: " + transcript;
+    var wantsStart = containsWord(transcript, START_WORDS);
+    var wantsStop = containsWord(transcript, STOP_WORDS);
+
+    // If both appear in one utterance, act on current state sensibly.
+    if (wantsStart && wantsStop) {
+      if (running) {
+        stopClock();
+      } else {
+        startClock();
+      }
+      return;
+    }
+    if (wantsStart) {
+      startClock();
+    } else if (wantsStop) {
+      stopClock();
+    }
+  }
+
+  // ---- Speech recognition ----
+  var SpeechRecognition =
+    window.SpeechRecognition || window.webkitSpeechRecognition;
+  var recognition = null;
+  var listening = false;
+  var wantListening = false; // user intent; used to auto-restart
+
+  function setupRecognition() {
+    if (!SpeechRecognition) {
+      micBtn.disabled = true;
+      setStatus(
+        "Voice recognition isn't supported in this browser. Try Chrome, Edge, or Safari.",
+        true
+      );
+      return false;
+    }
+    recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onresult = function (event) {
+      for (var i = event.resultIndex; i < event.results.length; i++) {
+        var transcript = event.results[i][0].transcript.trim();
+        if (transcript) {
+          handleTranscript(transcript);
+        }
+      }
+    };
+
+    recognition.onerror = function (event) {
+      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        wantListening = false;
+        setMicUI(false);
+        setStatus(
+          "Microphone access was blocked. Allow mic permission and tap “Start Listening” again.",
+          true
+        );
+      } else if (event.error === "no-speech") {
+        // Benign; recognition will be restarted by onend.
+      } else if (event.error === "aborted") {
+        // Usually from our own stop; ignore.
+      } else {
+        setStatus("Speech error: " + event.error, true);
+      }
+    };
+
+    recognition.onend = function () {
+      listening = false;
+      // The API stops on its own periodically; restart if the user
+      // still wants to be listening.
+      if (wantListening) {
+        try {
+          recognition.start();
+          listening = true;
+        } catch (e) {
+          // start() throws if called too soon; retry shortly.
+          setTimeout(function () {
+            if (wantListening) {
+              try {
+                recognition.start();
+                listening = true;
+              } catch (e2) {
+                /* give up silently; user can retap */
+              }
+            }
+          }, 300);
+        }
+      } else {
+        setMicUI(false);
+      }
+    };
+
+    return true;
+  }
+
+  function startListening() {
+    if (!recognition && !setupRecognition()) {
+      return;
+    }
+    wantListening = true;
+    try {
+      recognition.start();
+      listening = true;
+      setMicUI(true);
+      setStatus('Listening… say <b>"up"</b> to start.');
+    } catch (e) {
+      // Already started — fine.
+      setMicUI(true);
+    }
+  }
+
+  function stopListening() {
+    wantListening = false;
+    if (recognition) {
+      recognition.stop();
+    }
+    setMicUI(false);
+    setStatus("Stopped listening.");
+  }
+
+  function setMicUI(on) {
+    micBtn.classList.toggle("listening", on);
+    micBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    micBtn.textContent = on ? "⏹ Stop Listening" : "🎙️ Start Listening";
+  }
+
+  // ---- Wire up UI ----
+  micBtn.addEventListener("click", function () {
+    if (wantListening) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  });
+
+  resetBtn.addEventListener("click", resetClock);
+
+  // Keyboard fallback for testing without a mic:
+  // Space = toggle clock, R = reset.
+  document.addEventListener("keydown", function (e) {
+    if (e.code === "Space") {
+      e.preventDefault();
+      if (running) {
+        stopClock();
+      } else {
+        startClock();
+      }
+    } else if (e.key === "r" || e.key === "R") {
+      resetClock();
+    }
+  });
+
+  // Initial paint.
+  timeEl.textContent = formatTime(0);
+  if (!SpeechRecognition) {
+    setupRecognition();
+  }
+})();

--- a/plank-stopwatch/index.html
+++ b/plank-stopwatch/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="theme-color" content="#0f172a" />
+  <title>Plank Voice Stopwatch</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="app">
+    <h1 class="title">Plank Stopwatch</h1>
+
+    <div class="time" id="time" aria-live="off">00:00.0</div>
+
+    <div class="status" id="status">Tap “Listening” and say <b>“up”</b> to start.</div>
+
+    <div class="controls">
+      <button id="mic" class="btn btn-mic" type="button" aria-pressed="false">
+        🎙️ Start Listening
+      </button>
+      <button id="reset" class="btn btn-ghost" type="button">Reset</button>
+    </div>
+
+    <ul class="hints">
+      <li>Say <b>“up”</b> or <b>“start”</b> to start the clock.</li>
+      <li>Say <b>“down”</b> or <b>“stop”</b> to stop it.</li>
+    </ul>
+
+    <section class="laps" aria-label="Completed planks">
+      <h2 class="laps-title">Completed planks <span id="lapCount" class="muted"></span></h2>
+      <ol id="laps" class="laps-list"></ol>
+      <div class="laps-summary" id="lapsSummary"></div>
+    </section>
+
+    <div class="heard" id="heard" aria-live="polite"></div>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/plank-stopwatch/style.css
+++ b/plank-stopwatch/style.css
@@ -1,0 +1,196 @@
+:root {
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --accent: #22d3ee;
+  --accent-strong: #06b6d4;
+  --danger: #f43f5e;
+  --ok: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+
+body {
+  background: radial-gradient(circle at 50% 0%, #15243f 0%, var(--bg) 60%);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.app {
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 28px 20px 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  text-align: center;
+}
+
+.title {
+  margin: 8px 0 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.time {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  font-size: clamp(3.2rem, 18vw, 5.5rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  padding: 10px 0;
+  transition: color 0.2s ease;
+}
+
+.time.running {
+  color: var(--ok);
+}
+
+.status {
+  min-height: 1.4em;
+  color: var(--muted);
+  font-size: 0.98rem;
+}
+
+.status b {
+  color: var(--accent);
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: 100%;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 14px 22px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.06s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn-mic {
+  background: var(--accent-strong);
+  color: #06222a;
+  box-shadow: 0 6px 18px rgba(6, 182, 212, 0.35);
+}
+
+.btn-mic.listening {
+  background: var(--danger);
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(244, 63, 94, 0.4);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 6px 18px rgba(244, 63, 94, 0.4);
+  }
+  50% {
+    box-shadow: 0 6px 26px rgba(244, 63, 94, 0.7);
+  }
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid #334155;
+}
+
+.hints {
+  list-style: none;
+  padding: 14px 18px;
+  margin: 0;
+  background: var(--panel);
+  border-radius: 14px;
+  width: 100%;
+  text-align: left;
+  font-size: 0.92rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hints b {
+  color: var(--text);
+}
+
+.laps {
+  width: 100%;
+  text-align: left;
+}
+
+.laps-title {
+  font-size: 1rem;
+  margin: 4px 0 8px;
+}
+
+.muted {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.laps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.laps-list li {
+  display: flex;
+  justify-content: space-between;
+  background: var(--panel);
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.laps-list li .lap-index {
+  color: var(--muted);
+}
+
+.laps-summary {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.heard {
+  min-height: 1.2em;
+  font-size: 0.82rem;
+  color: #475569;
+  font-style: italic;
+}
+
+.error {
+  color: var(--danger);
+  font-style: normal;
+}


### PR DESCRIPTION
A zero-dependency static web app that times planks hands-free using the browser's Web Speech API. Say "up"/"start" to start the clock and "down"/"stop" to stop it; completed holds are logged with a running total and best time. Includes keyboard fallback (Space/R) for testing without a microphone.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
