### PR TITLE
Document Git requirement for custom Actions images

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -275,6 +275,14 @@ Its effect on performance is dependent on the packages being installed.
     uv cache clean
     ```
 
+!!! note
+
+    If your workflow runs inside a custom container image, ensure the image includes `git` and
+    certificate authorities before using `actions/checkout`. Without `git`, `actions/checkout` may
+    fall back to an archive checkout that does not create a `.git` directory. Tools that rely on
+    Git-aware ignore handling can then miss `.gitignore` files written inside uv-managed
+    directories, including cache directories placed under `${{ github.workspace }}`.
+
 ## Using `uv pip`
 
 If using the `uv pip` interface instead of the uv project interface, uv requires a virtual


### PR DESCRIPTION
## Summary

- Add a GitHub Actions docs note for workflows running in custom container images
- Explain that missing `git` can make `actions/checkout` use an archive checkout without `.git`
- Call out the `.gitignore`/workspace cache interaction from #19681

## Test plan

- `git diff --check`
- `npx prettier --check docs/guides/integration/github.md`

Fixes #19681