### PR TITLE
Add performance reporting skill

### DIFF
--- a/.agents/skills/report-performance/SKILL.md
+++ b/.agents/skills/report-performance/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: report-performance
+description:
+  Plan, run, assess, and write performance evidence for pull requests in uv and similar Rust CLI
+  projects. Use when Codex benchmarks a change, investigates a performance regression, compares
+  baseline and candidate builds, writes or reviews a pull request performance claim, summarizes
+  Hyperfine, Criterion, or CodSpeed results, or evaluates runtime, throughput, memory, allocations,
+  binary size, build time, or CI time.
+---
+
+# Report Performance
+
+Produce performance claims that are scoped, reproducible, statistically honest, and useful to
+reviewers. Follow repository-specific benchmarking instructions before applying this workflow.
+
+## Workflow
+
+1. Read the repository guidance and nearby benchmark implementations. Prefer the existing benchmark
+   harness, fixtures, build profiles, and result format.
+2. Define the claim before benchmarking. Name the affected workflow, metric, cache or network state,
+   input scale, and expected mechanism.
+3. Choose a representative workload. Use a real end-to-end workload when practical and a focused
+   microbenchmark when it helps isolate the changed path.
+4. Identify the baseline and candidate precisely. Record revisions or binaries and keep build
+   profiles, features, inputs, and material environment details comparable.
+5. Design the comparison around the expected source of variance. Use warmups and repeated runs for
+   short benchmarks. Interleave baseline and candidate runs when drift is likely. Test multiple
+   scales, states, or platforms when the effect may vary across them.
+6. Run the narrowest benchmark that tests the claim, then broaden only as needed. Preserve the raw
+   output and add or retain a regression benchmark when practical.
+7. Interpret the result conservatively. Separate measured outcomes from explanations and disclose
+   neutral cases, regressions, uncertainty, attribution limits, and tradeoffs.
+8. Draft the performance evidence in the pull request description or test plan. Do not post,
+   comment, or update a pull request unless the user explicitly asks.
+
+## Choose Evidence
+
+- Scope claims to the measured workload. Do not turn a rule-level or parser microbenchmark into a
+  product-wide claim.
+- Explain why the workload represents the changed path. Include relevant fixture revisions, input
+  sizes, command options, and cold, warm, or hot state.
+- Include the benchmark command and required setup. Include the operating system, architecture,
+  hardware, build profile, network controls, or background-load controls when they materially affect
+  interpretation or reproduction.
+- Pair pathological cases with an ordinary workload when practical. For complexity fixes, show how
+  behavior changes across input size.
+- Summarize key results in text or a table. Treat screenshots and transient CodSpeed links as
+  supporting evidence, not the only record of the result.
+- Use profiles or causal counters when they strengthen attribution. Useful counters include file
+  reads, allocations, graph nodes, syscalls, cache entries, and time in the changed span.
+
+## Interpret Results
+
+- Report the absolute baseline and candidate values when both complete and are comparable.
+- Report the metric direction explicitly, such as "31.7% lower wall time", "18% lower peak RSS", or
+  "12% higher throughput".
+- For a lower-is-better metric, compute the reduction as `(baseline - candidate) / baseline`.
+- For a higher-is-better metric, compute the increase as `(candidate - baseline) / baseline`.
+- If reporting a factor for a lower-is-better metric, prefer "the baseline took 1.46x as long" over
+  the ambiguous "1.46x faster".
+- If the baseline times out or exhausts memory, report the bound or outcome instead of inventing a
+  finite ratio.
+- For repeated measurements, report the mean or median, dispersion or confidence interval, and
+  sample count when available.
+- Describe results as marginal or inconclusive when their uncertainty includes no improvement.
+- Label structural measurements such as type size, allocation count, or profile share as proxies
+  unless an end-to-end effect was also measured.
+- Report tradeoffs in the same summary. Consider wall time, CPU time, memory, allocations, cache
+  size, binary size, build time, and CI cost.
+
+## Write the Report
+
+Use any clear section in the pull request description. The following template is optional:
+
+````markdown
+## Performance
+
+**Claim.** On `<workload and state>`, `<metric>` changed from `<baseline result>` to
+`<candidate result>` (`<directional relative change>`).
+
+**Method.** Compared `<baseline revision>` with `<candidate revision>` using
+`<relevant environment and build details>`. `<Cache state, warmups, and run count when applicable.>`
+
+| Workload | Metric   |                  Baseline |                   This PR |                 Change |
+| -------- | -------- | ------------------------: | ------------------------: | ---------------------: |
+| `<case>` | `<name>` | `<value and uncertainty>` | `<value and uncertainty>` | `<directional change>` |
+
+`<State whether lower or higher is better.>` Values are `<statistic>` across `<runs>` runs.
+
+**Mechanism.** `<Why the change affects this workload; include a profile or counter if available.>`
+
+**Caveats.** `<Neutral or regressing cases, noise, scope limits, and tradeoffs.>`
+
+**Reproduction.**
+
+```console
+$ <benchmark command>
+```
+````
+
+Keep the summary compact. Put long Hyperfine, Criterion, profiler, or CodSpeed output after the
+summary or in a collapsible section.
+
+## Exemplary Reports
+
+- [uv #18311](https://github.com/astral-sh/uv/pull/18311): scope a whole-stack result correctly and
+  connect it to a causal reduction in file reads.
+- [uv #18094](https://github.com/astral-sh/uv/pull/18094): show scaling across input sizes and use a
+  lower bound when the baseline times out.
+- [uv #11894](https://github.com/astral-sh/uv/pull/11894): report an improvement on one platform and
+  a neutral result on another.
+- [Ruff #25266](https://github.com/astral-sh/ruff/pull/25266): give an exact microbenchmark command,
+  absolute values, confidence intervals, and an unambiguous time reduction.
+- [Ruff #20098](https://github.com/astral-sh/ruff/pull/20098): combine mechanism, synthetic scaling,
+  a real pathological input, causal counters, and broader benchmarks.
+- [Ruff #3439](https://github.com/astral-sh/ruff/pull/3439): compare alternatives using both wall
+  time and peak memory before explaining the chosen tradeoff.
+- [Ruff #21749](https://github.com/astral-sh/ruff/pull/21749): disclose a large memory improvement
+  alongside a wall-time regression.
+- [Ruff #15731](https://github.com/astral-sh/ruff/pull/15731): describe a small result as noisy when
+  some runs are neutral or favor the baseline.
+
+The [`performance` pull requests for uv][uv-performance-pulls] and [Ruff][ruff-performance-pulls]
+provide more examples, but labels are not a complete archive.
+
+[uv-performance-pulls]: https://github.com/astral-sh/uv/pulls?q=label%3Aperformance+is%3Amerged
+[ruff-performance-pulls]: https://github.com/astral-sh/ruff/pulls?q=label%3Aperformance+is%3Amerged
+
+## Final Check
+
+Before presenting the report:
+
+- Confirm the claim names the measured workload and metric.
+- Confirm the baseline and candidate are identifiable and comparable.
+- Confirm the absolute result, relative result or bound, and metric direction agree.
+- Confirm uncertainty and sample count are included when applicable.
+- Confirm microbenchmark results are not generalized beyond their scope.
+- Confirm neutral cases, regressions, attribution limits, and tradeoffs are disclosed.
+- Confirm another contributor can reproduce the comparison from the recorded setup.

--- a/.agents/skills/report-performance/SKILL.md
+++ b/.agents/skills/report-performance/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: report-performance
 description:
-  Plan, run, assess, and write performance evidence for pull requests in uv and similar Rust CLI
-  projects. Use when Codex benchmarks a change, investigates a performance regression, compares
-  baseline and candidate builds, writes or reviews a pull request performance claim, summarizes
-  Hyperfine, Criterion, or CodSpeed results, or evaluates runtime, throughput, memory, allocations,
-  binary size, build time, or CI time.
+  Plan, run, assess, and write performance evidence for pull requests in uv. Use when Codex
+  benchmarks a change, investigates a performance regression, compares baseline and candidate
+  builds, writes or reviews a pull request performance claim, summarizes Hyperfine, Criterion, or
+  CodSpeed results, or evaluates runtime, throughput, memory, allocations, binary size, build time,
+  or CI time.
 ---
 
 # Report Performance
@@ -13,56 +13,100 @@ description:
 Produce performance claims that are scoped, reproducible, statistically honest, and useful to
 reviewers. Follow repository-specific benchmarking instructions before applying this workflow.
 
+Never convert a timeout or OOM outcome into a speedup factor unless the measurement protocol
+provides valid bounds for both operands. Reject a requested factor that does not meet this rule.
+
+## Select a Mode
+
+- **Plan and run:** Design and execute a comparison, then report it.
+- **Audit:** Review existing evidence for correctness, comparability, calculations, uncertainty,
+  scope, and missing data. Do not silently rerun benchmarks.
+- **Report supplied results:** Calculate and write from the provided artifacts. Clearly label inputs
+  that were not independently verified.
+
+Respect the requested mode. Reviewing or summarizing results does not by itself authorize builds,
+benchmark runs, or pull request updates.
+
 ## Workflow
 
-1. Read the repository guidance and nearby benchmark implementations. Prefer the existing benchmark
-   harness, fixtures, build profiles, and result format.
-2. Define the claim before benchmarking. Name the affected workflow, metric, cache or network state,
-   input scale, and expected mechanism.
+1. Read the repository guidance and nearby benchmark implementations. Prefer the existing harness,
+   fixtures, build profiles, and result format.
+2. Before inspecting results, define the hypothesis, primary workload and metric, metric direction,
+   minimum meaningful effect, workload matrix, sample count or stopping rule, and exclusion policy.
 3. Choose a representative workload. Use a real end-to-end workload when practical and a focused
-   microbenchmark when it helps isolate the changed path.
-4. Identify the baseline and candidate precisely. Record revisions or binaries and keep build
-   profiles, features, inputs, and material environment details comparable.
-5. Design the comparison around the expected source of variance. Use warmups and repeated runs for
-   short benchmarks. Interleave baseline and candidate runs when drift is likely. Test multiple
-   scales, states, or platforms when the effect may vary across them.
-6. Run the narrowest benchmark that tests the claim, then broaden only as needed. Preserve the raw
-   output and add or retain a regression benchmark when practical.
-7. Interpret the result conservatively. Separate measured outcomes from explanations and disclose
-   neutral cases, regressions, uncertainty, attribution limits, and tradeoffs.
-8. Draft the performance evidence in the pull request description or test plan. Do not post,
-   comment, or update a pull request unless the user explicitly asks.
+   microbenchmark to isolate the changed path. Pair pathological cases with ordinary workloads
+   before making user-facing claims.
+4. Verify equivalent work before timing. Compare exit status, output, diagnostics, generated
+   artifacts, relevant side effects, and completed work. Record intentional semantic differences.
+5. Build and identify the baseline and candidate precisely. Keep the toolchain, dependencies,
+   profile, features, and build procedure identical except for the intended change. Record commits,
+   build commands, and executable paths, and confirm that each benchmark invokes the intended
+   binary.
+6. Control measurement state. Define cold, warm, or hot state and reset it independently before
+   every observation. Prevent cross-variant contamination of application, filesystem, build, DNS,
+   and network caches. Freeze or replay network inputs when feasible.
+7. Repeat measurements enough to estimate uncertainty when feasible. Use paired randomized,
+   alternating, or counterbalanced baseline/candidate order by default on the same host. Label an
+   unavoidable single-run result as anecdotal.
+8. Run the predefined matrix and stopping rule. Preserve raw output and report all planned and
+   executed cases, including failures, neutral results, regressions, and justified exclusions. Add
+   or retain a regression benchmark when practical.
+9. Interpret the result conservatively. Separate measured outcomes from attribution evidence and
+   disclose uncertainty, scope limits, alternative explanations, and tradeoffs.
+10. Draft the evidence in the pull request description or test plan. Do not post, comment, or update
+    a pull request unless the user explicitly asks.
 
 ## Choose Evidence
 
 - Scope claims to the measured workload. Do not turn a rule-level or parser microbenchmark into a
   product-wide claim.
-- Explain why the workload represents the changed path. Include relevant fixture revisions, input
-  sizes, command options, and cold, warm, or hot state.
-- Include the benchmark command and required setup. Include the operating system, architecture,
-  hardware, build profile, network controls, or background-load controls when they materially affect
-  interpretation or reproduction.
-- Pair pathological cases with an ordinary workload when practical. For complexity fixes, show how
-  behavior changes across input size.
+- Explain why the workload represents the changed path. Include fixture revisions, input sizes,
+  command options, and cache state.
+- Record the host, operating system, architecture, power mode, compiler, build profile, benchmark
+  order, relevant background load, and CPU-affinity policy. Explain uncontrolled differences.
+- Include warmups, attempted and accepted sample counts, failures, exclusions, and the predefined
+  exclusion rule.
 - Summarize key results in text or a table. Treat screenshots and transient CodSpeed links as
-  supporting evidence, not the only record of the result.
-- Use profiles or causal counters when they strengthen attribution. Useful counters include file
-  reads, allocations, graph nodes, syscalls, cache entries, and time in the changed span.
+  supporting evidence, not the only record.
+- Use profiles or mechanism-relevant counters when they strengthen attribution. File reads,
+  allocations, graph nodes, syscalls, cache entries, and time in the changed span are useful, but
+  they are not proof of causality unless a controlled intervention isolates the mechanism.
+- For CI, distinguish queue time, critical-path latency, job or step duration, and summed runner
+  time. Compare retained runs with equivalent runner types, cache states, and workflow concurrency;
+  do not infer an improvement from a single before-and-after run.
 
 ## Interpret Results
 
 - Report the absolute baseline and candidate values when both complete and are comparable.
-- Report the metric direction explicitly, such as "31.7% lower wall time", "18% lower peak RSS", or
-  "12% higher throughput".
+- Report metric direction explicitly, such as "31.7% lower wall time", "18% lower peak RSS", or "12%
+  higher throughput".
 - For a lower-is-better metric, compute the reduction as `(baseline - candidate) / baseline`.
 - For a higher-is-better metric, compute the increase as `(candidate - baseline) / baseline`.
-- If reporting a factor for a lower-is-better metric, prefer "the baseline took 1.46x as long" over
-  the ambiguous "1.46x faster".
-- If the baseline times out or exhausts memory, report the bound or outcome instead of inventing a
-  finite ratio.
-- For repeated measurements, report the mean or median, dispersion or confidence interval, and
-  sample count when available.
-- Describe results as marginal or inconclusive when their uncertainty includes no improvement.
+- Compute a relative change only when the baseline is nonzero and meaningful; otherwise report the
+  absolute change.
+- For a lower-is-better factor, prefer "the baseline took 1.46x as long" over the ambiguous "1.46x
+  faster".
+- If the baseline exceeds a timeout, report `baseline > T` directly. Do not divide the timeout by a
+  candidate mean, median, point estimate, or observed sample maximum. For example, if the baseline
+  exceeds 60 seconds and the candidate median is 29 ms, report those two facts without a `>2,000x`
+  factor. Derive a ratio lower bound only when the measurement protocol provides a defensible
+  candidate upper bound. For OOM, report a memory bound only when the enforced limit is known.
+
+  **Hard rule:** A timeout plus finite candidate samples supports two separate statements, not a
+  factor. Never call their quotient an observed, conservative, or timeout-derived speedup bound. If
+  a supplied draft or user request contains such a factor, remove it, state that the bound is
+  unsupported, and report only the timeout and candidate measurements.
+
+- For repeated measurements, use the harness-defined or preselected estimator consistently. Report
+  sample count, an appropriate dispersion measure, and uncertainty for the baseline-to-candidate
+  difference or ratio. Analyze paired runs as pairs.
+- Call a comparison inconclusive when its effect interval includes the null: `0` for a difference or
+  percent change and `1` for a ratio. Do not infer significance from overlap between separate
+  baseline and candidate intervals. Without effect-level uncertainty, describe the comparison as
+  descriptive rather than statistically conclusive.
+- Keep per-workload results. Never arithmetic-average percentages across heterogeneous workloads.
+  Use weighted totals for total cost or a geometric mean of ratios for a normalized suite, and
+  explain the weighting and aggregation.
 - Label structural measurements such as type size, allocation count, or profile share as proxies
   unless an end-to-end effect was also measured.
 - Report tradeoffs in the same summary. Consider wall time, CPU time, memory, allocations, cache
@@ -76,64 +120,51 @@ Use any clear section in the pull request description. The following template is
 ## Performance
 
 **Claim.** On `<workload and state>`, `<metric>` changed from `<baseline result>` to
-`<candidate result>` (`<directional relative change>`).
+`<candidate result>` (`<directional relative change or bound>`).
 
-**Method.** Compared `<baseline revision>` with `<candidate revision>` using
-`<relevant environment and build details>`. `<Cache state, warmups, and run count when applicable.>`
+**Method.** Compared `<baseline revision and binary>` with `<candidate revision and binary>` using
+`<environment and build details>`. Used `<state reset>`, `<order strategy>`, `<warmups>`, and
+`<attempted/accepted runs and exclusion rule>`.
 
-| Workload | Metric   |                  Baseline |                   This PR |                 Change |
-| -------- | -------- | ------------------------: | ------------------------: | ---------------------: |
-| `<case>` | `<name>` | `<value and uncertainty>` | `<value and uncertainty>` | `<directional change>` |
+| Workload | Metric   |                 Baseline |                  This PR |                  Change |
+| -------- | -------- | -----------------------: | -----------------------: | ----------------------: |
+| `<case>` | `<name>` | `<value and dispersion>` | `<value and dispersion>` | `<effect and interval>` |
 
-`<State whether lower or higher is better.>` Values are `<statistic>` across `<runs>` runs.
+`<State whether lower or higher is better.>` Values are `<preselected statistic>` across `<runs>`.
 
-**Mechanism.** `<Why the change affects this workload; include a profile or counter if available.>`
+**Attribution evidence.**
+`<State the hypothesized mechanism and supporting profiles, counters, or controlled comparisons. Identify remaining alternative explanations.>`
 
-**Caveats.** `<Neutral or regressing cases, noise, scope limits, and tradeoffs.>`
+**Caveats.** `<Neutral or regressing cases, uncertainty, scope limits, and tradeoffs.>`
 
 **Reproduction.**
 
 ```console
-$ <benchmark command>
+$ <build baseline and candidate>
+$ <prepare fixture and environment>
+$ <reset state>
+$ <run benchmark>
+$ <analyze raw results>
 ```
 ````
 
 Keep the summary compact. Put long Hyperfine, Criterion, profiler, or CodSpeed output after the
 summary or in a collapsible section.
 
-## Exemplary Reports
-
-- [uv #18311](https://github.com/astral-sh/uv/pull/18311): scope a whole-stack result correctly and
-  connect it to a causal reduction in file reads.
-- [uv #18094](https://github.com/astral-sh/uv/pull/18094): show scaling across input sizes and use a
-  lower bound when the baseline times out.
-- [uv #11894](https://github.com/astral-sh/uv/pull/11894): report an improvement on one platform and
-  a neutral result on another.
-- [Ruff #25266](https://github.com/astral-sh/ruff/pull/25266): give an exact microbenchmark command,
-  absolute values, confidence intervals, and an unambiguous time reduction.
-- [Ruff #20098](https://github.com/astral-sh/ruff/pull/20098): combine mechanism, synthetic scaling,
-  a real pathological input, causal counters, and broader benchmarks.
-- [Ruff #3439](https://github.com/astral-sh/ruff/pull/3439): compare alternatives using both wall
-  time and peak memory before explaining the chosen tradeoff.
-- [Ruff #21749](https://github.com/astral-sh/ruff/pull/21749): disclose a large memory improvement
-  alongside a wall-time regression.
-- [Ruff #15731](https://github.com/astral-sh/ruff/pull/15731): describe a small result as noisy when
-  some runs are neutral or favor the baseline.
-
-The [`performance` pull requests for uv][uv-performance-pulls] and [Ruff][ruff-performance-pulls]
-provide more examples, but labels are not a complete archive.
-
-[uv-performance-pulls]: https://github.com/astral-sh/uv/pulls?q=label%3Aperformance+is%3Amerged
-[ruff-performance-pulls]: https://github.com/astral-sh/ruff/pulls?q=label%3Aperformance+is%3Amerged
+For examples of individual reporting techniques and their limitations, read
+[Useful Report Patterns](references/useful-report-patterns.md).
 
 ## Final Check
 
 Before presenting the report:
 
+- Confirm baseline and candidate perform equivalent work or disclose the semantic difference.
 - Confirm the claim names the measured workload and metric.
-- Confirm the baseline and candidate are identifiable and comparable.
+- Confirm the builds, binaries, environment, state reset, and execution order are reproducible.
+- Confirm all planned and executed cases, failures, and exclusions are accounted for.
 - Confirm the absolute result, relative result or bound, and metric direction agree.
-- Confirm uncertainty and sample count are included when applicable.
+- Confirm the sample count, dispersion, and effect-level uncertainty are included when applicable.
+- Confirm a timeout or OOM result is not converted into a factor without a protocol-defined bound.
 - Confirm microbenchmark results are not generalized beyond their scope.
 - Confirm neutral cases, regressions, attribution limits, and tradeoffs are disclosed.
 - Confirm another contributor can reproduce the comparison from the recorded setup.

--- a/.agents/skills/report-performance/SKILL.md
+++ b/.agents/skills/report-performance/SKILL.md
@@ -2,169 +2,129 @@
 name: report-performance
 description:
   Plan, run, assess, and write performance evidence for pull requests in uv. Use when Codex
-  benchmarks a change, investigates a performance regression, compares baseline and candidate
-  builds, writes or reviews a pull request performance claim, summarizes Hyperfine, Criterion, or
-  CodSpeed results, or evaluates runtime, throughput, memory, allocations, binary size, build time,
-  or CI time.
+  benchmarks a change, investigates a performance regression, compares revisions or binaries, writes
+  or reviews a pull request performance claim, summarizes Hyperfine, Criterion, or CodSpeed results,
+  or evaluates runtime, throughput, memory, allocations, binary size, build time, or CI time.
 ---
 
 # Report Performance
 
-Produce performance claims that are scoped, reproducible, statistically honest, and useful to
-reviewers. Follow repository-specific benchmarking instructions before applying this workflow.
-
-Never convert a timeout or OOM outcome into a speedup factor unless the measurement protocol
-provides valid bounds for both operands. Reject a requested factor that does not meet this rule.
+Produce concise performance claims that are scoped, reproducible, and honest about uncertainty.
+Follow repository-specific benchmarking instructions and use the existing harness when one exists.
 
 ## Select a Mode
 
-- **Plan and run:** Design and execute a comparison, then report it.
-- **Audit:** Review existing evidence for correctness, comparability, calculations, uncertainty,
-  scope, and missing data. Do not silently rerun benchmarks.
-- **Report supplied results:** Calculate and write from the provided artifacts. Clearly label inputs
-  that were not independently verified.
+- **Plan and run:** Design and execute a comparison, then report it. Before reading results, record
+  the expected effect, primary workload and metric, smallest meaningful change, cases to run, sample
+  count or stopping rule, and permitted exclusions.
+- **Audit:** Review existing evidence for equivalent work, comparable builds, calculations,
+  uncertainty, scope, missing data, and tradeoffs. Report which choices were predetermined and flag
+  missing protocol or post-hoc choices. Distinguish calculations you verified from measurements you
+  did not reproduce; do not invent preregistration or silently rerun benchmarks.
+- **Report supplied results:** Calculate and write from the provided artifacts. Label inputs and
+  claims that were not independently verified.
 
-Respect the requested mode. Reviewing or summarizing results does not by itself authorize builds,
-benchmark runs, or pull request updates.
+Respect the requested mode. Reviewing results does not authorize builds, benchmark runs, or pull
+request updates.
 
-## Workflow
+## Run a Comparison
 
-1. Read the repository guidance and nearby benchmark implementations. Prefer the existing harness,
-   fixtures, build profiles, and result format.
-2. Before inspecting results, define the hypothesis, primary workload and metric, metric direction,
-   minimum meaningful effect, workload matrix, sample count or stopping rule, and exclusion policy.
-3. Choose a representative workload. Use a real end-to-end workload when practical and a focused
-   microbenchmark to isolate the changed path. Pair pathological cases with ordinary workloads
-   before making user-facing claims.
-4. Verify equivalent work before timing. Compare exit status, output, diagnostics, generated
-   artifacts, relevant side effects, and completed work. Record intentional semantic differences.
-5. Build and identify the baseline and candidate precisely. Keep the toolchain, dependencies,
-   profile, features, and build procedure identical except for the intended change. Record commits,
-   build commands, and executable paths, and confirm that each benchmark invokes the intended
-   binary.
-6. Control measurement state. Define cold, warm, or hot state and reset it independently before
-   every observation. Prevent cross-variant contamination of application, filesystem, build, DNS,
-   and network caches. Freeze or replay network inputs when feasible.
-7. Repeat measurements enough to estimate uncertainty when feasible. Use paired randomized,
-   alternating, or counterbalanced baseline/candidate order by default on the same host. Label an
-   unavoidable single-run result as anecdotal.
-8. Run the predefined matrix and stopping rule. Preserve raw output and report all planned and
-   executed cases, including failures, neutral results, regressions, and justified exclusions. Add
-   or retain a regression benchmark when practical.
-9. Interpret the result conservatively. Separate measured outcomes from attribution evidence and
-   disclose uncertainty, scope limits, alternative explanations, and tradeoffs.
-10. Draft the evidence in the pull request description or test plan. Do not post, comment, or update
-    a pull request unless the user explicitly asks.
+1. Read the repository guidance and nearby benchmarks. Prefer their harness, fixtures, profiles,
+   warmups, sampling model, and output format.
+2. Choose a workload that exercises the changed path. Use an end-to-end workload when practical; use
+   a focused benchmark to explain the mechanism. Pair pathological cases with ordinary ones before
+   making broad claims.
+3. Confirm that the compared variants perform equivalent work. Compare exit status, output,
+   diagnostics, generated artifacts, and relevant side effects. Disclose intentional differences.
+4. Identify the exact revisions, binaries, and build commands. Keep toolchain, dependencies,
+   features, profile, and build procedure identical except for the intended change.
+5. Define the measured state, such as cold or warm caches, and prevent one variant from warming the
+   other. Use the harness's sampling and warmup model. Interleave their execution order when drift
+   could matter and the harness does not already control ordering.
+6. Preserve raw output and account for every planned and executed case, including neutral results,
+   regressions, failures, and exclusions. Add or retain a regression benchmark when practical.
 
-## Choose Evidence
+## Document the Evidence
 
-- Scope claims to the measured workload. Do not turn a rule-level or parser microbenchmark into a
-  product-wide claim.
-- Explain why the workload represents the changed path. Include fixture revisions, input sizes,
-  command options, and cache state.
-- Record the host, operating system, architecture, power mode, compiler, build profile, benchmark
-  order, relevant background load, and CPU-affinity policy. Explain uncontrolled differences.
-- Include warmups, attempted and accepted sample counts, failures, exclusions, and the predefined
-  exclusion rule.
-- Summarize key results in text or a table. Treat screenshots and transient CodSpeed links as
-  supporting evidence, not the only record.
-- Use profiles or mechanism-relevant counters when they strengthen attribution. File reads,
-  allocations, graph nodes, syscalls, cache entries, and time in the changed span are useful, but
-  they are not proof of causality unless a controlled intervention isolates the mechanism.
-- For CI, distinguish queue time, critical-path latency, job or step duration, and summed runner
-  time. Compare retained runs with equivalent runner types, cache states, and workflow concurrency;
-  do not infer an improvement from a single before-and-after run.
+When running a comparison, record:
 
-## Interpret Results
+- exact revisions, binaries, build profile, and build commands;
+- benchmark command, fixture revision or input size, options, cache state, and material harness
+  configuration;
+- host, operating system, and architecture;
+- attempted and accepted run counts, failures, and exclusions.
 
-- Report the absolute baseline and candidate values when both complete and are comparable.
-- Report metric direction explicitly, such as "31.7% lower wall time", "18% lower peak RSS", or "12%
-  higher throughput".
-- For a lower-is-better metric, compute the reduction as `(baseline - candidate) / baseline`.
-- For a higher-is-better metric, compute the increase as `(candidate - baseline) / baseline`.
-- Compute a relative change only when the baseline is nonzero and meaningful; otherwise report the
-  absolute change.
-- For a lower-is-better factor, prefer "the baseline took 1.46x as long" over the ambiguous "1.46x
-  faster".
-- If the baseline exceeds a timeout, report `baseline > T` directly. Do not divide the timeout by a
-  candidate mean, median, point estimate, or observed sample maximum. For example, if the baseline
-  exceeds 60 seconds and the candidate median is 29 ms, report those two facts without a `>2,000x`
-  factor. Derive a ratio lower bound only when the measurement protocol provides a defensible
-  candidate upper bound. For OOM, report a memory bound only when the enforced limit is known.
+When auditing or reporting supplied results, include the available details and flag material
+omissions rather than inventing them.
 
-  **Hard rule:** A timeout plus finite candidate samples supports two separate statements, not a
-  factor. Never call their quotient an observed, conservative, or timeout-derived speedup bound. If
-  a supplied draft or user request contains such a factor, remove it, state that the bound is
-  unsupported, and report only the timeout and candidate measurements.
+Include other controls, such as power mode, CPU affinity, background load, or network replay, only
+when they were used or could materially affect the result. The report itself may omit immaterial
+setup details as long as the retained artifacts make the comparison reproducible.
 
-- For repeated measurements, use the harness-defined or preselected estimator consistently. Report
-  sample count, an appropriate dispersion measure, and uncertainty for the baseline-to-candidate
-  difference or ratio. Analyze paired runs as pairs.
-- Call a comparison inconclusive when its effect interval includes the null: `0` for a difference or
-  percent change and `1` for a ratio. Do not infer significance from overlap between separate
-  baseline and candidate intervals. Without effect-level uncertainty, describe the comparison as
-  descriptive rather than statistically conclusive.
-- Keep per-workload results. Never arithmetic-average percentages across heterogeneous workloads.
-  Use weighted totals for total cost or a geometric mean of ratios for a normalized suite, and
-  explain the weighting and aggregation.
-- Label structural measurements such as type size, allocation count, or profile share as proxies
-  unless an end-to-end effect was also measured.
-- Report tradeoffs in the same summary. Consider wall time, CPU time, memory, allocations, cache
-  size, binary size, build time, and CI cost.
+Use profiles or relevant counters when they help explain the result, but do not present correlation
+as proof. For CI changes, distinguish queue time, elapsed workflow time, job or step duration, and
+summed runner time. Compare equivalent runner types, cache states, and concurrency.
+
+## Interpret the Result
+
+- Lead with absolute values and a directional change: for example, "wall time decreased from 412 ms
+  on main to 361 ms on the branch (12.4% lower)."
+- For a lower-is-better metric, calculate `(baseline - comparison) / baseline`. For a
+  higher-is-better metric, calculate `(comparison - baseline) / baseline`. Do not calculate a
+  relative change from a zero or meaningless denominator.
+- Prefer uncertainty for the change when the harness reports it; do not treat separate variation for
+  each variant as uncertainty for their difference. Otherwise present repeated results and their
+  variability descriptively. If runs were paired, analyze the pairs together. Label a single run as
+  anecdotal.
+- Keep workloads separate. Aggregate them only when the total or weighting has clear practical
+  meaning, and explain that meaning. Do not arithmetic-average percentage changes across unrelated
+  workloads; use weighted absolute totals for total-cost claims or a geometric mean of ratios for a
+  normalized suite.
+- Scope the claim to what was measured. Structural measurements such as allocations, type size, or
+  profile share are supporting evidence unless an end-to-end effect was also measured.
+- Report regressions and tradeoffs beside the improvement, including relevant changes in memory, CPU
+  time, cache size, binary size, build time, or CI cost.
+
+Never convert a timeout or OOM into a speedup factor unless the protocol provides valid bounds for
+both values. If main exceeds 60 seconds and the branch completes in 29 ms, report those facts
+separately; their quotient is not an observed or conservative speedup bound. For OOM, report a
+memory bound only when the enforced limit is known.
 
 ## Write the Report
 
-Use any clear section in the pull request description. The following template is optional:
+Lead with the result and material tradeoffs. For one workload, prefer two to four sentences followed
+by the exact command:
 
 ````markdown
 ## Performance
 
-**Claim.** On `<workload and state>`, `<metric>` changed from `<baseline result>` to
-`<candidate result>` (`<directional relative change or bound>`).
-
-**Method.** Compared `<baseline revision and binary>` with `<candidate revision and binary>` using
-`<environment and build details>`. Used `<state reset>`, `<order strategy>`, `<warmups>`, and
-`<attempted/accepted runs and exclusion rule>`.
-
-| Workload | Metric   |                 Baseline |                  This PR |                  Change |
-| -------- | -------- | -----------------------: | -----------------------: | ----------------------: |
-| `<case>` | `<name>` | `<value and dispersion>` | `<value and dispersion>` | `<effect and interval>` |
-
-`<State whether lower or higher is better.>` Values are `<preselected statistic>` across `<runs>`.
-
-**Attribution evidence.**
-`<State the hypothesized mechanism and supporting profiles, counters, or controlled comparisons. Identify remaining alternative explanations.>`
-
-**Caveats.** `<Neutral or regressing cases, uncertainty, scope limits, and tradeoffs.>`
-
-**Reproduction.**
+On `<workload and state>`, `<statistic and metric>` changed from `<main result>` on main
+(`<revision>`) to `<branch result>` on the branch (`<revision>`), `<directional change>`. Across
+`<run count>`, `<brief uncertainty or variability statement>`.
+`<Correctness check and material tradeoff.>`
 
 ```console
-$ <build baseline and candidate>
-$ <prepare fixture and environment>
-$ <reset state>
-$ <run benchmark>
-$ <analyze raw results>
+$ <build or preparation command, when needed>
+$ <benchmark command>
 ```
 ````
 
-Keep the summary compact. Put long Hyperfine, Criterion, profiler, or CodSpeed output after the
-summary or in a collapsible section.
+For several workloads, use a compact table. When comparing a pull request to main, prefer `main` and
+`branch` over "This PR"; otherwise use labels that identify the actual revisions or binaries:
 
-For examples of individual reporting techniques and their limitations, read
-[Useful Report Patterns](references/useful-report-patterns.md).
+```markdown
+| Benchmark |      main |    branch |                 Change |
+| --------- | --------: | --------: | ---------------------: |
+| `<case>`  | `<value>` | `<value>` | `<directional change>` |
+```
+
+Put setup details and long Hyperfine, Criterion, profiler, or CodSpeed output after the summary or
+in a collapsible section. Read [Useful Report Patterns](references/useful-report-patterns.md) when
+choosing how to present scaling, uncertainty, attribution, or tradeoffs.
 
 ## Final Check
 
-Before presenting the report:
-
-- Confirm baseline and candidate perform equivalent work or disclose the semantic difference.
-- Confirm the claim names the measured workload and metric.
-- Confirm the builds, binaries, environment, state reset, and execution order are reproducible.
-- Confirm all planned and executed cases, failures, and exclusions are accounted for.
-- Confirm the absolute result, relative result or bound, and metric direction agree.
-- Confirm the sample count, dispersion, and effect-level uncertainty are included when applicable.
-- Confirm a timeout or OOM result is not converted into a factor without a protocol-defined bound.
-- Confirm microbenchmark results are not generalized beyond their scope.
-- Confirm neutral cases, regressions, attribution limits, and tradeoffs are disclosed.
-- Confirm another contributor can reproduce the comparison from the recorded setup.
+- The compared variants performed equivalent work, or the difference is disclosed.
+- The claim names the workload, metric, absolute results, direction, and relevant uncertainty.
+- The commands, revisions, state, and run counts are reproducible.
+- Neutral results, regressions, failures, exclusions, scope limits, and tradeoffs are visible.

--- a/.agents/skills/report-performance/agents/openai.yaml
+++ b/.agents/skills/report-performance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Report Performance"
   short_description: "Benchmark and report performance changes"
-  default_prompt: "Use $report-performance to assess this change and draft reproducible, appropriately scoped performance evidence."
+  default_prompt: "Use $report-performance in the mode requested by the user to plan, audit, or draft concise performance evidence. Do not run benchmarks unless requested."

--- a/.agents/skills/report-performance/agents/openai.yaml
+++ b/.agents/skills/report-performance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Report Performance"
   short_description: "Benchmark and report performance changes"
-  default_prompt: "Use $report-performance to benchmark this change and write a precise performance report."
+  default_prompt: "Use $report-performance to assess this change and draft reproducible, appropriately scoped performance evidence."

--- a/.agents/skills/report-performance/agents/openai.yaml
+++ b/.agents/skills/report-performance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Report Performance"
+  short_description: "Benchmark and report performance changes"
+  default_prompt: "Use $report-performance to benchmark this change and write a precise performance report."

--- a/.agents/skills/report-performance/references/useful-report-patterns.md
+++ b/.agents/skills/report-performance/references/useful-report-patterns.md
@@ -1,39 +1,38 @@
 # Useful Report Patterns
 
-These pull requests illustrate individual reporting choices. They are not complete templates, and
-some predate or intentionally omit parts of the workflow in this skill.
+These pull requests show useful reporting techniques rather than complete templates. Performance
+labels are not complete archives; browse the merged [`uv` performance pull requests][uv-performance]
+and [`Ruff` performance pull requests][ruff-performance] for more examples.
 
-## uv
+## Scope and Attribution
 
-- [uv #18311](https://github.com/astral-sh/uv/pull/18311): scopes an aggregate whole-stack result
-  and supports the proposed mechanism with file-read counters.
-- [uv #18094](https://github.com/astral-sh/uv/pull/18094): shows scaling across input sizes and a
-  timeout outcome. Its reported `>2,000x` factor is not a rigorous bound because the candidate value
-  is a point estimate; prefer reporting `baseline > 60s` unless a defensible candidate upper bound
-  is available.
-- [uv #11894](https://github.com/astral-sh/uv/pull/11894): reports a faster ARM point estimate whose
-  uncertainty includes no change, alongside a neutral x86 Windows result. Treat the ARM comparison
-  as inconclusive rather than a demonstrated platform improvement.
+- [uv #18311](https://github.com/astral-sh/uv/pull/18311) scopes a whole-stack result to the
+  measured workflow and uses file-read counts to support the proposed explanation.
+- [Ruff #20098](https://github.com/astral-sh/ruff/pull/20098) combines synthetic scaling, a real
+  pathological input, mechanism-relevant counters, and broader benchmarks.
 
-The [`performance` pull requests for uv][uv-performance-pulls] provide more examples, but labels are
-not a complete archive.
+## Scaling and Limits
 
-[uv-performance-pulls]: https://github.com/astral-sh/uv/pulls?q=label%3Aperformance+is%3Amerged
+- [uv #18094](https://github.com/astral-sh/uv/pull/18094) shows how behavior changes across input
+  sizes and includes a timeout outcome. When one side times out, report the threshold and the
+  completed measurement separately unless the protocol provides bounds for both values.
 
-## Ruff
+## Uncertainty
 
-- [Ruff #25266](https://github.com/astral-sh/ruff/pull/25266): gives an exact microbenchmark
-  command, absolute values, confidence intervals, and an unambiguous time reduction.
-- [Ruff #20098](https://github.com/astral-sh/ruff/pull/20098): combines a proposed mechanism,
-  synthetic scaling, a real pathological input, mechanism-relevant counters, and broader benchmarks.
-- [Ruff #3439](https://github.com/astral-sh/ruff/pull/3439): compares alternatives using wall time
-  and peak memory, then selects the lower-memory design when timing differences are inconclusive.
-- [Ruff #21749](https://github.com/astral-sh/ruff/pull/21749): discloses a large memory improvement
+- [Ruff #25266](https://github.com/astral-sh/ruff/pull/25266) includes the exact benchmark command,
+  absolute values, confidence intervals, and an unambiguous time reduction.
+- [uv #11894](https://github.com/astral-sh/uv/pull/11894) shows results for multiple platforms,
+  including a small change whose reported uncertainty includes no change, making the improvement
+  inconclusive, and a neutral result elsewhere.
+- [Ruff #15731](https://github.com/astral-sh/ruff/pull/15731) notes when a small local result varies
+  across comparisons, including neutral runs and runs that favor main.
+
+## Tradeoffs
+
+- [Ruff #3439](https://github.com/astral-sh/ruff/pull/3439) compares wall time and peak memory, then
+  chooses the lower-memory design when timing differences are inconclusive.
+- [Ruff #21749](https://github.com/astral-sh/ruff/pull/21749) presents a large memory improvement
   alongside a wall-time regression.
-- [Ruff #15731](https://github.com/astral-sh/ruff/pull/15731): discloses that a small local result
-  varies across comparisons, with some runs neutral or favoring the baseline.
 
-The [`performance` pull requests for Ruff][ruff-performance-pulls] provide more examples, but labels
-are not a complete archive.
-
-[ruff-performance-pulls]: https://github.com/astral-sh/ruff/pulls?q=label%3Aperformance+is%3Amerged
+[ruff-performance]: https://github.com/astral-sh/ruff/pulls?q=label%3Aperformance+is%3Amerged
+[uv-performance]: https://github.com/astral-sh/uv/pulls?q=label%3Aperformance+is%3Amerged

--- a/.agents/skills/report-performance/references/useful-report-patterns.md
+++ b/.agents/skills/report-performance/references/useful-report-patterns.md
@@ -1,0 +1,39 @@
+# Useful Report Patterns
+
+These pull requests illustrate individual reporting choices. They are not complete templates, and
+some predate or intentionally omit parts of the workflow in this skill.
+
+## uv
+
+- [uv #18311](https://github.com/astral-sh/uv/pull/18311): scopes an aggregate whole-stack result
+  and supports the proposed mechanism with file-read counters.
+- [uv #18094](https://github.com/astral-sh/uv/pull/18094): shows scaling across input sizes and a
+  timeout outcome. Its reported `>2,000x` factor is not a rigorous bound because the candidate value
+  is a point estimate; prefer reporting `baseline > 60s` unless a defensible candidate upper bound
+  is available.
+- [uv #11894](https://github.com/astral-sh/uv/pull/11894): reports a faster ARM point estimate whose
+  uncertainty includes no change, alongside a neutral x86 Windows result. Treat the ARM comparison
+  as inconclusive rather than a demonstrated platform improvement.
+
+The [`performance` pull requests for uv][uv-performance-pulls] provide more examples, but labels are
+not a complete archive.
+
+[uv-performance-pulls]: https://github.com/astral-sh/uv/pulls?q=label%3Aperformance+is%3Amerged
+
+## Ruff
+
+- [Ruff #25266](https://github.com/astral-sh/ruff/pull/25266): gives an exact microbenchmark
+  command, absolute values, confidence intervals, and an unambiguous time reduction.
+- [Ruff #20098](https://github.com/astral-sh/ruff/pull/20098): combines a proposed mechanism,
+  synthetic scaling, a real pathological input, mechanism-relevant counters, and broader benchmarks.
+- [Ruff #3439](https://github.com/astral-sh/ruff/pull/3439): compares alternatives using wall time
+  and peak memory, then selects the lower-memory design when timing differences are inconclusive.
+- [Ruff #21749](https://github.com/astral-sh/ruff/pull/21749): discloses a large memory improvement
+  alongside a wall-time regression.
+- [Ruff #15731](https://github.com/astral-sh/ruff/pull/15731): discloses that a small local result
+  varies across comparisons, with some runs neutral or favoring the baseline.
+
+The [`performance` pull requests for Ruff][ruff-performance-pulls] provide more examples, but labels
+are not a complete archive.
+
+[ruff-performance-pulls]: https://github.com/astral-sh/ruff/pulls?q=label%3Aperformance+is%3Amerged


### PR DESCRIPTION
## Summary

Adds a repository-local skill for planning benchmarks, auditing existing evidence, and writing concise performance reports for uv pull requests.

The skill:

- separates plan-and-run, audit, and supplied-results workflows
- defers to existing benchmark harnesses and records reproducible comparison details
- scopes claims and handles uncertainty, timeouts, OOM outcomes, neutral results, regressions, and tradeoffs
- defaults to result-first reports with `main | branch | Change` for pull request comparisons
- links annotated reporting patterns from merged uv and Ruff pull requests

## Test Plan

- `npx prettier --check .agents/skills/report-performance/SKILL.md .agents/skills/report-performance/references/useful-report-patterns.md .agents/skills/report-performance/agents/openai.yaml`
- `quick_validate.py .agents/skills/report-performance`
- Generated a supplied-results report from a warm-cache `uv lock` comparison and confirmed result-first wording, `main` and `branch` labels, visible memory tradeoffs, and unverified-input labeling.