### PR TITLE
Add `environment.root` to `uv workspace metadata --sync`

### DIFF
--- a/crates/uv-resolver/src/lock/export/metadata.rs
+++ b/crates/uv-resolver/src/lock/export/metadata.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Display;
+use std::path::Path;
 
 use uv_distribution_filename::WheelFilename;
 use uv_distribution_types::{Name, RequiresPython, ResolvedDist, UrlString};
@@ -62,6 +63,9 @@ pub struct Metadata {
     /// Ideally absolute paths to things that are found in subdirs of this should have exactly
     /// this as a prefix so it can be stripped to get relative paths if one wants.
     workspace_root: PortablePathBuf,
+    /// Information about the synchronized environment, when `--sync` was used.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    environment: Option<MetadataEnvironment>,
     /// The version of python required by the workspace
     ///
     /// Every `marker` we emit implicitly assumes this constraint to keep things clean
@@ -95,6 +99,13 @@ enum SchemaVersion {
 struct SchemaReport {
     /// The version of the schema.
     version: SchemaVersion,
+}
+
+/// Information about the environment synchronized for the workspace.
+#[derive(Debug, serde::Serialize)]
+struct MetadataEnvironment {
+    /// Absolute path to the environment root.
+    root: PortablePathBuf,
 }
 
 /// Info for looking up workspace members, most information is stored in the node behind `id`
@@ -830,6 +841,7 @@ impl Metadata {
                 version: SchemaVersion::Preview,
             },
             conflicts,
+            environment: None,
             module_owners: BTreeMap::new(),
             workspace_root,
             requires_python: lock.requires_python.clone(),
@@ -850,6 +862,14 @@ impl Metadata {
             kind: MetadataNodeKind::Package,
         }
         .to_flat())
+    }
+
+    #[must_use]
+    pub fn with_environment_root(mut self, environment_root: &Path) -> Self {
+        self.environment = Some(MetadataEnvironment {
+            root: PortablePathBuf::from(environment_root),
+        });
+        self
     }
 
     #[must_use]

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -158,7 +158,9 @@ pub(crate) async fn metadata(
                 )
                 .await
                 .context("Failed to collect module owners")?;
-                export = export.with_module_owners(module_owners);
+                export = export
+                    .with_environment_root(environment.root())
+                    .with_module_owners(module_owners);
             }
 
             print_metadata(&export, printer)

--- a/crates/uv/tests/it/workspace_metadata.rs
+++ b/crates/uv/tests/it/workspace_metadata.rs
@@ -162,6 +162,9 @@ dependencies = [
         "version": "preview"
       },
       "workspace_root": "[TEMP_DIR]/",
+      "environment": {
+        "root": "[VENV]/"
+      },
       "requires_python": ">=3.12",
       "conflicts": {
         "sets": []

--- a/docs/reference/internals/metadata.md
+++ b/docs/reference/internals/metadata.md
@@ -142,6 +142,11 @@ Here is a human-readable annotated example:
 	},
 	// The directory the uv.lock can be found in
 	"workspace_root": "/workspace",
+	// Information about the environment synchronized by `--sync`; omitted otherwise
+	"environment": {
+		// The absolute path to the environment root
+		"root": "/workspace/.venv"
+	},
 	// Any requirements on the python version this workspace has
   //
   // `marker` fields all have this as an implicit constraint that is omitted for cleanliness

--- a/docs/reference/internals/metadata.md
+++ b/docs/reference/internals/metadata.md
@@ -135,24 +135,24 @@ Here is a human-readable annotated example:
 
 ```js
 {
-	// Information about the schema of this output
-	"schema": {
-		// The version of this output, currently "preview"
-		"version": "preview"
-	},
-	// The directory the uv.lock can be found in
-	"workspace_root": "/workspace",
-	// Information about the environment synchronized by `--sync`; omitted otherwise
-	"environment": {
-		// The absolute path to the environment root
-		"root": "/workspace/.venv"
-	},
-	// Any requirements on the python version this workspace has
+  // Information about the schema of this output
+  "schema": {
+    // The version of this output, currently "preview"
+    "version": "preview"
+  },
+  // The directory the uv.lock can be found in
+  "workspace_root": "/workspace",
+  // Information about the environment, currently only available with `--sync`
+  "environment": {
+    // The absolute path to the environment root
+    "root": "/workspace/.venv"
+  },
+  // Any requirements on the python version this workspace has
   //
   // `marker` fields all have this as an implicit constraint that is omitted for cleanliness
-	"requires_python": ">=3.12",
-	// A list of workspace members
-	"members": [
+  "requires_python": ">=3.12",
+  // A list of workspace members
+  "members": [
     {
       // The name of the package
       "name": "mypackage",
@@ -161,7 +161,7 @@ Here is a human-readable annotated example:
       // The id of this package's info in the `resolution` map below
       "id": "mypackage==0.1.0@editable+/workspace/packages/mypackage"
     },
-	],
+  ],
   // A list-of-sets of workspace items that are mutually-exclusive to install,
   // presumably because they need to install different versions of the same package.
   //


### PR DESCRIPTION
This is a field of particular interest to `ty`, especially if `--isolated` or `--script` stuff is going on. Possibly also enables a future where we don't necessarily store the workspace venv in the project dir.

Adding it here first to establish it in the schema, further integrations will be in followups.