### PR TITLE
Compute and pass `uv workspace metadata` payload in `ty check`

### DIFF
--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -22,6 +22,7 @@ use crate::commands::pip::loggers::{SummaryInstallLogger, SummaryResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::LockMode;
+use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
     ProjectEnvironment, ProjectError, UniversalState, WorkspacePython, default_dependency_groups,
     validate_project_requires_python,
@@ -201,6 +202,7 @@ pub(crate) async fn check(
     };
 
     // Select an environment and, if we found a project, sync it before running checks.
+    let mut workspace_metadata = None;
     let venv_path = if let Some(project) = &project {
         let extras = extras.with_defaults(DefaultExtras::default());
 
@@ -226,8 +228,14 @@ pub(crate) async fn check(
             .into_environment()?
         };
 
-        if no_sync {
+        let state = UniversalState::default();
+        let (lock, environment) = if no_sync {
             debug!("Skipping environment synchronization due to `--no-sync`");
+
+            (
+                LockTarget::Workspace(project.workspace()).read().await?,
+                None,
+            )
         } else {
             let _lock = venv
                 .lock()
@@ -237,8 +245,7 @@ pub(crate) async fn check(
                 })
                 .ok();
 
-            let lock_state = UniversalState::default();
-            let sync_state = lock_state.fork();
+            let sync_state = state.fork();
 
             let mode = if let Some(frozen_source) = frozen {
                 LockMode::Frozen(frozen_source.into())
@@ -255,7 +262,7 @@ pub(crate) async fn check(
                     mode,
                     &settings.resolver,
                     &client_builder,
-                    &lock_state,
+                    &state,
                     Box::new(SummaryResolveLogger),
                     &concurrency,
                     cache,
@@ -327,6 +334,29 @@ pub(crate) async fn check(
                 }
                 Err(err) => return Err(err.into()),
             }
+
+            (Some(result.into_lock()), Some(&venv))
+        };
+
+        if let Some(lock) = lock {
+            let metadata = crate::commands::workspace::metadata::export_metadata(
+                project.workspace(),
+                &lock,
+                environment,
+                false,
+                &settings.resolver,
+                &client_builder,
+                &state,
+                &concurrency,
+                cache,
+                workspace_cache,
+                preview,
+                &malware_settings,
+            )
+            .await?;
+            let mut metadata = metadata.to_json()?;
+            metadata.push('\n');
+            workspace_metadata = Some(metadata);
         }
 
         Some(venv.root().to_owned())
@@ -344,6 +374,7 @@ pub(crate) async fn check(
         ty_version,
         &target_dir,
         venv_path.as_deref(),
+        workspace_metadata,
         exclude_newer,
         &client_builder,
         cache,

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -339,21 +339,12 @@ pub(crate) async fn check(
         };
 
         if let Some(lock) = lock {
-            let metadata = crate::commands::workspace::metadata::export_metadata(
+            let metadata = crate::commands::workspace::metadata::metadata_from_lock(
                 project.workspace(),
                 &lock,
                 environment,
-                false,
                 &settings.resolver,
-                &client_builder,
-                &state,
-                &concurrency,
-                cache,
-                workspace_cache,
-                preview,
-                &malware_settings,
-            )
-            .await?;
+            )?;
             let mut metadata = metadata.to_json()?;
             metadata.push('\n');
             workspace_metadata = Some(metadata);

--- a/crates/uv/src/commands/project/check.rs
+++ b/crates/uv/src/commands/project/check.rs
@@ -229,15 +229,20 @@ pub(crate) async fn check(
         };
 
         let state = UniversalState::default();
-        let (lock, environment) = if no_sync {
+        let _environment_lock;
+        let lock = if no_sync {
             debug!("Skipping environment synchronization due to `--no-sync`");
 
-            (
-                LockTarget::Workspace(project.workspace()).read().await?,
-                None,
-            )
+            match LockTarget::Workspace(project.workspace()).read().await {
+                Ok(lock) => lock,
+                Err(err) => {
+                    debug!("Failed to read lockfile; skipping workspace metadata: {err}");
+                    None
+                }
+            }
         } else {
-            let _lock = venv
+            // Keep the environment locked through synchronization and metadata collection.
+            _environment_lock = venv
                 .lock()
                 .await
                 .inspect_err(|err| {
@@ -335,14 +340,27 @@ pub(crate) async fn check(
                 Err(err) => return Err(err.into()),
             }
 
-            (Some(result.into_lock()), Some(&venv))
+            Some(result.into_lock())
         };
 
         if let Some(lock) = lock {
-            let metadata = crate::commands::workspace::metadata::metadata_from_lock(
+            let target = match project {
+                VirtualProject::Project(project) => InstallTarget::Project {
+                    workspace: project.workspace(),
+                    name: project.project_name(),
+                    lock: &lock,
+                },
+                VirtualProject::NonProject(workspace) => InstallTarget::NonProjectWorkspace {
+                    workspace,
+                    lock: &lock,
+                },
+            };
+            let metadata = crate::commands::workspace::metadata::metadata_from_target(
                 project.workspace(),
-                &lock,
-                environment,
+                (!no_sync).then_some(&venv),
+                target,
+                &extras,
+                &groups,
                 &settings.resolver,
             )?;
             let mut metadata = metadata.to_json()?;

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 use std::process::Stdio;
 use std::str::FromStr;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
+use tokio::process::{ChildStdin, Command};
 use tracing::debug;
 
 use uv_bin_install::{BinVersion, Binary, ResolvedVersion, bin_install, find_matching_version};
@@ -15,6 +16,23 @@ use crate::child::run_to_completion;
 use crate::commands::ExitStatus;
 use crate::commands::reporters::BinaryDownloadReporter;
 use crate::printer::Printer;
+
+/// Limit how long uv can block if a version of ty does not consume metadata from stdin.
+const WORKSPACE_METADATA_WRITE_TIMEOUT: Duration = Duration::from_mins(1);
+
+async fn write_workspace_metadata(mut stdin: ChildStdin, workspace_metadata: String) -> Result<()> {
+    match tokio::time::timeout(
+        WORKSPACE_METADATA_WRITE_TIMEOUT,
+        stdin.write_all(workspace_metadata.as_bytes()),
+    )
+    .await
+    {
+        Err(err) => Err(err).context("Timed out while writing workspace metadata to `ty check`"),
+        Ok(Err(err)) if err.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Ok(Err(err)) => Err(err).context("Failed to write workspace metadata to `ty check`"),
+        Ok(Ok(())) => Ok(()),
+    }
+}
 
 /// Run a type check powered by ty.
 pub(super) async fn run(
@@ -111,28 +129,28 @@ pub(super) async fn run(
         // This is an environment variable so older ty's don't complain about an unknown CLI flag.
         command.env("TY_UV_METADATA", "1");
         command.stdin(Stdio::piped());
+        command.kill_on_drop(true);
+    } else {
+        // Do not let the calling environment opt ty into a protocol uv cannot supply.
+        command.env_remove("TY_UV_METADATA");
     }
 
     let mut handle = command.spawn().context("Failed to spawn `ty check`")?;
     let writer = if let Some(workspace_metadata) = workspace_metadata {
         debug!("Passing workspace metadata to `ty check` via stdin");
-        let mut stdin = handle
+        let stdin = handle
             .stdin
             .take()
             .context("Failed to open stdin for `ty check`")?;
-        Some(tokio::spawn(async move {
-            stdin.write_all(workspace_metadata.as_bytes()).await
-        }))
+        Some(write_workspace_metadata(stdin, workspace_metadata))
     } else {
         None
     };
 
-    let status = run_to_completion(handle).await;
-    if let Some(writer) = writer
-        && let Err(err) = writer.await?
-        && err.kind() != std::io::ErrorKind::BrokenPipe
-    {
-        return Err(err).context("Failed to write workspace metadata to `ty check`");
+    if let Some(writer) = writer {
+        let (status, ()) = tokio::try_join!(run_to_completion(handle), writer)?;
+        Ok(status)
+    } else {
+        run_to_completion(handle).await
     }
-    status
 }

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
+use std::process::Stdio;
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tracing::debug;
 
@@ -19,6 +21,7 @@ pub(super) async fn run(
     version: Option<String>,
     target_dir: &Path,
     venv_path: Option<&Path>,
+    workspace_metadata: Option<String>,
     exclude_newer: Option<jiff::Timestamp>,
     client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
@@ -103,6 +106,30 @@ pub(super) async fn run(
         command.env("VIRTUAL_ENV", venv_path);
     }
 
-    let handle = command.spawn().context("Failed to spawn `ty check`")?;
-    run_to_completion(handle).await
+    if workspace_metadata.is_some() {
+        command.stdin(Stdio::piped());
+    }
+
+    let mut handle = command.spawn().context("Failed to spawn `ty check`")?;
+    let writer = if let Some(workspace_metadata) = workspace_metadata {
+        debug!("Passing workspace metadata to `ty check` via stdin");
+        let mut stdin = handle
+            .stdin
+            .take()
+            .context("Failed to open stdin for `ty check`")?;
+        Some(tokio::spawn(async move {
+            stdin.write_all(workspace_metadata.as_bytes()).await
+        }))
+    } else {
+        None
+    };
+
+    let status = run_to_completion(handle).await;
+    if let Some(writer) = writer
+        && let Err(err) = writer.await?
+        && err.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(err).context("Failed to write workspace metadata to `ty check`");
+    }
+    status
 }

--- a/crates/uv/src/commands/project/check/ty.rs
+++ b/crates/uv/src/commands/project/check/ty.rs
@@ -107,6 +107,9 @@ pub(super) async fn run(
     }
 
     if workspace_metadata.is_some() {
+        // Tell `ty` to expect uv metadata on stdin.
+        // This is an environment variable so older ty's don't complain about an unknown CLI flag.
+        command.env("TY_UV_METADATA", "1");
         command.stdin(Stdio::piped());
     }
 

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -6,15 +6,18 @@ use owo_colors::OwoColorize;
 
 use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
-use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
+use uv_configuration::{
+    Concurrency, DependencyGroupsWithDefaults, DryRun, ExtrasSpecificationWithDefaults,
+};
 use uv_preview::{Preview, PreviewFeature};
 use uv_python::{PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
-use uv_resolver::{Lock, Metadata};
+use uv_resolver::{Installable, Metadata};
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
 use uv_warnings::warn_user;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
+use crate::commands::project::install_target::InstallTarget;
 use crate::commands::project::lock::{LockMode, LockOperation};
 use crate::commands::project::lock_target::LockTarget;
 use crate::commands::project::{
@@ -183,15 +186,17 @@ pub(crate) async fn metadata(
 }
 
 /// Build workspace metadata from an existing lock and environment without synchronizing it.
-pub(crate) fn metadata_from_lock(
+pub(crate) fn metadata_from_target(
     workspace: &Workspace,
-    lock: &Lock,
     environment: Option<&PythonEnvironment>,
+    target: InstallTarget<'_>,
+    extras: &ExtrasSpecificationWithDefaults,
+    groups: &DependencyGroupsWithDefaults,
     settings: &ResolverSettings,
 ) -> Result<Metadata> {
-    let mut export = Metadata::from_lock(workspace, lock)?;
+    let mut export = Metadata::from_lock(workspace, target.lock())?;
     if let Some(environment) = environment {
-        let module_owners = find_module_owners(workspace, lock, environment, settings)
+        let module_owners = find_module_owners(target, environment, extras, groups, settings)
             .context("Failed to collect module owners")?;
         export = export
             .with_environment_root(environment.root())

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -129,43 +129,43 @@ pub(crate) async fn metadata(
     {
         Ok(lock) => {
             let lock = lock.into_lock();
-            let environment = if sync {
-                Some(
-                    ProjectEnvironment::get_or_init(
-                        virtual_project.workspace(),
-                        &groups,
-                        python.as_deref().map(PythonRequest::parse),
-                        &install_mirrors,
-                        &client_builder,
-                        python_preference,
-                        python_downloads,
-                        false,
-                        no_config,
-                        Some(false),
-                        cache,
-                        DryRun::Disabled,
-                        printer,
-                    )
-                    .await?,
+            let mut export = Metadata::from_lock(virtual_project.workspace(), &lock)?;
+            if sync {
+                let environment = ProjectEnvironment::get_or_init(
+                    virtual_project.workspace(),
+                    &groups,
+                    python.as_deref().map(PythonRequest::parse),
+                    &install_mirrors,
+                    &client_builder,
+                    python_preference,
+                    python_downloads,
+                    false,
+                    no_config,
+                    Some(false),
+                    cache,
+                    DryRun::Disabled,
+                    printer,
                 )
-            } else {
-                None
-            };
-            let export = export_metadata(
-                virtual_project.workspace(),
-                &lock,
-                environment.as_deref(),
-                true,
-                &settings,
-                &client_builder,
-                &state,
-                &concurrency,
-                cache,
-                workspace_cache,
-                preview,
-                &malware_settings,
-            )
-            .await?;
+                .await?;
+                let module_owners = collect_module_owners(
+                    virtual_project.workspace(),
+                    &lock,
+                    &environment,
+                    &settings,
+                    &client_builder,
+                    &state,
+                    &concurrency,
+                    cache,
+                    workspace_cache,
+                    preview,
+                    &malware_settings,
+                )
+                .await
+                .context("Failed to collect module owners")?;
+                export = export
+                    .with_environment_root(environment.root())
+                    .with_module_owners(module_owners);
+            }
 
             print_metadata(&export, printer)
         }
@@ -182,42 +182,17 @@ pub(crate) async fn metadata(
     }
 }
 
-/// Build the metadata exported by `uv workspace metadata` from an existing lock and environment.
-pub(crate) async fn export_metadata(
+/// Build workspace metadata from an existing lock and environment without synchronizing it.
+pub(crate) fn metadata_from_lock(
     workspace: &Workspace,
     lock: &Lock,
     environment: Option<&PythonEnvironment>,
-    sync_module_owners: bool,
     settings: &ResolverSettings,
-    client_builder: &BaseClientBuilder<'_>,
-    state: &UniversalState,
-    concurrency: &Concurrency,
-    cache: &Cache,
-    workspace_cache: &WorkspaceCache,
-    preview: Preview,
-    malware_settings: &MalwareCheckSettings,
 ) -> Result<Metadata> {
     let mut export = Metadata::from_lock(workspace, lock)?;
     if let Some(environment) = environment {
-        let module_owners = if sync_module_owners {
-            collect_module_owners(
-                workspace,
-                lock,
-                environment,
-                settings,
-                client_builder,
-                state,
-                concurrency,
-                cache,
-                workspace_cache,
-                preview,
-                malware_settings,
-            )
-            .await
-        } else {
-            find_module_owners(workspace, lock, environment, settings)
-        }
-        .context("Failed to collect module owners")?;
+        let module_owners = find_module_owners(workspace, lock, environment, settings)
+            .context("Failed to collect module owners")?;
         export = export
             .with_environment_root(environment.root())
             .with_module_owners(module_owners);

--- a/crates/uv/src/commands/workspace/metadata.rs
+++ b/crates/uv/src/commands/workspace/metadata.rs
@@ -8,11 +8,11 @@ use uv_cache::{Cache, Refresh};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{Concurrency, DependencyGroupsWithDefaults, DryRun};
 use uv_preview::{Preview, PreviewFeature};
-use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
-use uv_resolver::Metadata;
+use uv_python::{PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
+use uv_resolver::{Lock, Metadata};
 use uv_settings::{MalwareCheckSettings, PythonInstallMirrors};
 use uv_warnings::warn_user;
-use uv_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
+use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache};
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::project::lock::{LockMode, LockOperation};
@@ -24,7 +24,7 @@ use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverSettings};
 
-use super::module_owners::collect_module_owners;
+use super::module_owners::{collect_module_owners, find_module_owners};
 
 /// Display metadata about the workspace.
 pub(crate) async fn metadata(
@@ -129,43 +129,43 @@ pub(crate) async fn metadata(
     {
         Ok(lock) => {
             let lock = lock.into_lock();
-            let mut export = Metadata::from_lock(virtual_project.workspace(), &lock)?;
-            if sync {
-                let environment = ProjectEnvironment::get_or_init(
-                    virtual_project.workspace(),
-                    &groups,
-                    python.as_deref().map(PythonRequest::parse),
-                    &install_mirrors,
-                    &client_builder,
-                    python_preference,
-                    python_downloads,
-                    false,
-                    no_config,
-                    Some(false),
-                    cache,
-                    DryRun::Disabled,
-                    printer,
+            let environment = if sync {
+                Some(
+                    ProjectEnvironment::get_or_init(
+                        virtual_project.workspace(),
+                        &groups,
+                        python.as_deref().map(PythonRequest::parse),
+                        &install_mirrors,
+                        &client_builder,
+                        python_preference,
+                        python_downloads,
+                        false,
+                        no_config,
+                        Some(false),
+                        cache,
+                        DryRun::Disabled,
+                        printer,
+                    )
+                    .await?,
                 )
-                .await?;
-                let module_owners = collect_module_owners(
-                    virtual_project.workspace(),
-                    &lock,
-                    &environment,
-                    &settings,
-                    &client_builder,
-                    &state,
-                    &concurrency,
-                    cache,
-                    workspace_cache,
-                    preview,
-                    &malware_settings,
-                )
-                .await
-                .context("Failed to collect module owners")?;
-                export = export
-                    .with_environment_root(environment.root())
-                    .with_module_owners(module_owners);
-            }
+            } else {
+                None
+            };
+            let export = export_metadata(
+                virtual_project.workspace(),
+                &lock,
+                environment.as_deref(),
+                true,
+                &settings,
+                &client_builder,
+                &state,
+                &concurrency,
+                cache,
+                workspace_cache,
+                preview,
+                &malware_settings,
+            )
+            .await?;
 
             print_metadata(&export, printer)
         }
@@ -180,6 +180,50 @@ pub(crate) async fn metadata(
         }
         Err(err) => Err(err.into()),
     }
+}
+
+/// Build the metadata exported by `uv workspace metadata` from an existing lock and environment.
+pub(crate) async fn export_metadata(
+    workspace: &Workspace,
+    lock: &Lock,
+    environment: Option<&PythonEnvironment>,
+    sync_module_owners: bool,
+    settings: &ResolverSettings,
+    client_builder: &BaseClientBuilder<'_>,
+    state: &UniversalState,
+    concurrency: &Concurrency,
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
+    preview: Preview,
+    malware_settings: &MalwareCheckSettings,
+) -> Result<Metadata> {
+    let mut export = Metadata::from_lock(workspace, lock)?;
+    if let Some(environment) = environment {
+        let module_owners = if sync_module_owners {
+            collect_module_owners(
+                workspace,
+                lock,
+                environment,
+                settings,
+                client_builder,
+                state,
+                concurrency,
+                cache,
+                workspace_cache,
+                preview,
+                malware_settings,
+            )
+            .await
+        } else {
+            find_module_owners(workspace, lock, environment, settings)
+        }
+        .context("Failed to collect module owners")?;
+        export = export
+            .with_environment_root(environment.root())
+            .with_module_owners(module_owners);
+    }
+
+    Ok(export)
 }
 
 fn print_metadata(export: &Metadata, printer: Printer) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/workspace/module_owners.rs
+++ b/crates/uv/src/commands/workspace/module_owners.rs
@@ -45,31 +45,8 @@ pub(crate) async fn collect_module_owners(
     malware_settings: &MalwareCheckSettings,
 ) -> Result<BTreeMap<ModuleName, Vec<String>>> {
     let target = InstallTarget::Workspace { workspace, lock };
-    let marker_env = resolution_markers(None, None, venv.interpreter());
-    let tags = resolution_tags(None, None, venv.interpreter())?;
     let extras = ExtrasSpecification::from_all_extras().with_defaults(DefaultExtras::default());
     let groups = DependencyGroups::from_all_groups().with_defaults(DefaultGroups::default());
-
-    let resolution = target.to_resolution(
-        &marker_env,
-        &tags,
-        &extras,
-        &groups,
-        &settings.build_options,
-        &InstallOptions::default(),
-    )?;
-    if resolution.is_empty() {
-        return Ok(BTreeMap::new());
-    }
-
-    let workspace_root = PortablePathBuf::from(workspace.install_path().as_path());
-    let mut package_ids = BTreeMap::<PackageName, String>::new();
-    for dist in resolution.distributions().filter(|dist| !is_virtual(dist)) {
-        package_ids.insert(
-            dist.name().clone(),
-            Metadata::package_node_id(&workspace_root, dist)?,
-        );
-    }
 
     let reinstall = Reinstall::None;
     let installer_settings = InstallerSettingsRef {
@@ -113,6 +90,43 @@ pub(crate) async fn collect_module_owners(
         malware_settings,
     )
     .await?;
+
+    find_module_owners(workspace, lock, venv, settings)
+}
+
+/// Map the modules in an existing environment to package IDs from the lockfile.
+pub(crate) fn find_module_owners(
+    workspace: &Workspace,
+    lock: &Lock,
+    venv: &PythonEnvironment,
+    settings: &ResolverSettings,
+) -> Result<BTreeMap<ModuleName, Vec<String>>> {
+    let target = InstallTarget::Workspace { workspace, lock };
+    let marker_env = resolution_markers(None, None, venv.interpreter());
+    let tags = resolution_tags(None, None, venv.interpreter())?;
+    let extras = ExtrasSpecification::from_all_extras().with_defaults(DefaultExtras::default());
+    let groups = DependencyGroups::from_all_groups().with_defaults(DefaultGroups::default());
+
+    let resolution = target.to_resolution(
+        &marker_env,
+        &tags,
+        &extras,
+        &groups,
+        &settings.build_options,
+        &InstallOptions::default(),
+    )?;
+    if resolution.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let workspace_root = PortablePathBuf::from(workspace.install_path().as_path());
+    let mut package_ids = BTreeMap::<PackageName, String>::new();
+    for dist in resolution.distributions().filter(|dist| !is_virtual(dist)) {
+        package_ids.insert(
+            dist.name().clone(),
+            Metadata::package_node_id(&workspace_root, dist)?,
+        );
+    }
 
     let mut owners = BTreeMap::<ModuleName, BTreeSet<String>>::new();
     for dist in SitePackages::from_environment(venv)?.iter() {

--- a/crates/uv/src/commands/workspace/module_owners.rs
+++ b/crates/uv/src/commands/workspace/module_owners.rs
@@ -48,6 +48,9 @@ pub(crate) async fn collect_module_owners(
     let target = InstallTarget::Workspace { workspace, lock };
     let extras = ExtrasSpecification::from_all_extras().with_defaults(DefaultExtras::default());
     let groups = DependencyGroups::from_all_groups().with_defaults(DefaultGroups::default());
+    let Some(package_ids) = selected_package_ids(target, venv, &extras, &groups, settings)? else {
+        return Ok(BTreeMap::new());
+    };
 
     let reinstall = Reinstall::None;
     let installer_settings = InstallerSettingsRef {
@@ -92,7 +95,7 @@ pub(crate) async fn collect_module_owners(
     )
     .await?;
 
-    find_module_owners(target, venv, &extras, &groups, settings)
+    find_module_owners_in_environment(venv, &package_ids)
 }
 
 /// Map the modules in an existing environment to package IDs from the lockfile.
@@ -103,6 +106,21 @@ pub(crate) fn find_module_owners(
     groups: &DependencyGroupsWithDefaults,
     settings: &ResolverSettings,
 ) -> Result<BTreeMap<ModuleName, Vec<String>>> {
+    let Some(package_ids) = selected_package_ids(target, venv, extras, groups, settings)? else {
+        return Ok(BTreeMap::new());
+    };
+
+    find_module_owners_in_environment(venv, &package_ids)
+}
+
+/// Select the package IDs that can own modules in the target resolution.
+fn selected_package_ids(
+    target: InstallTarget<'_>,
+    venv: &PythonEnvironment,
+    extras: &ExtrasSpecificationWithDefaults,
+    groups: &DependencyGroupsWithDefaults,
+    settings: &ResolverSettings,
+) -> Result<Option<BTreeMap<PackageName, String>>> {
     let marker_env = resolution_markers(None, None, venv.interpreter());
     let tags = resolution_tags(None, None, venv.interpreter())?;
 
@@ -115,7 +133,7 @@ pub(crate) fn find_module_owners(
         &InstallOptions::default(),
     )?;
     if resolution.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(None);
     }
 
     let workspace_root = PortablePathBuf::from(target.install_path());
@@ -126,7 +144,14 @@ pub(crate) fn find_module_owners(
             Metadata::package_node_id(&workspace_root, dist)?,
         );
     }
+    Ok(Some(package_ids))
+}
 
+/// Map modules in an existing environment to their selected package IDs.
+fn find_module_owners_in_environment(
+    venv: &PythonEnvironment,
+    package_ids: &BTreeMap<PackageName, String>,
+) -> Result<BTreeMap<ModuleName, Vec<String>>> {
     let mut owners = BTreeMap::<ModuleName, BTreeSet<String>>::new();
     for dist in SitePackages::from_environment(venv)?.iter() {
         let Some(package_id) = package_ids.get(dist.name()) else {

--- a/crates/uv/src/commands/workspace/module_owners.rs
+++ b/crates/uv/src/commands/workspace/module_owners.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use uv_cache::Cache;
 use uv_client::BaseClientBuilder;
 use uv_configuration::{
-    Concurrency, DependencyGroups, DryRun, ExtrasSpecification, InstallOptions, Reinstall,
+    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, DryRun, ExtrasSpecification,
+    ExtrasSpecificationWithDefaults, InstallOptions, Reinstall,
 };
 use uv_distribution_types::{Dist, Name, ResolvedDist};
 use uv_fs::PortablePathBuf;
@@ -91,27 +92,25 @@ pub(crate) async fn collect_module_owners(
     )
     .await?;
 
-    find_module_owners(workspace, lock, venv, settings)
+    find_module_owners(target, venv, &extras, &groups, settings)
 }
 
 /// Map the modules in an existing environment to package IDs from the lockfile.
 pub(crate) fn find_module_owners(
-    workspace: &Workspace,
-    lock: &Lock,
+    target: InstallTarget<'_>,
     venv: &PythonEnvironment,
+    extras: &ExtrasSpecificationWithDefaults,
+    groups: &DependencyGroupsWithDefaults,
     settings: &ResolverSettings,
 ) -> Result<BTreeMap<ModuleName, Vec<String>>> {
-    let target = InstallTarget::Workspace { workspace, lock };
     let marker_env = resolution_markers(None, None, venv.interpreter());
     let tags = resolution_tags(None, None, venv.interpreter())?;
-    let extras = ExtrasSpecification::from_all_extras().with_defaults(DefaultExtras::default());
-    let groups = DependencyGroups::from_all_groups().with_defaults(DefaultGroups::default());
 
     let resolution = target.to_resolution(
         &marker_env,
         &tags,
-        &extras,
-        &groups,
+        extras,
+        groups,
         &settings.build_options,
         &InstallOptions::default(),
     )?;
@@ -119,7 +118,7 @@ pub(crate) fn find_module_owners(
         return Ok(BTreeMap::new());
     }
 
-    let workspace_root = PortablePathBuf::from(workspace.install_path().as_path());
+    let workspace_root = PortablePathBuf::from(target.install_path());
     let mut package_ids = BTreeMap::<PackageName, String>::new();
     for dist in resolution.distributions().filter(|dist| !is_virtual(dist)) {
         package_ids.insert(

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -38,6 +38,49 @@ fn check_project() -> Result<()> {
 }
 
 #[test]
+fn check_passes_workspace_metadata_to_ty() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    context.temp_dir.child("main.py").write_str(indoc! {r"
+        x: int = 1
+    "})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--ty-version")
+            .arg("0.0.17")
+            .arg("--verbose")
+            .env(EnvVars::RUST_LOG, "uv::commands::project::check::ty=debug"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    DEBUG `--exclude-newer` is ignored for pinned version `0.0.17`
+    DEBUG Using `ty==0.0.17`
+    DEBUG Passing workspace metadata to `ty check` via stdin
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn check_rejects_tool_arguments() {
     let context = uv_test::test_context_with_versions!(&[]);
 
@@ -347,6 +390,9 @@ fn check_with_declared_dependency() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = ["iniconfig"]
+
+        [project.optional-dependencies]
+        test = ["typing-extensions"]
     "#})?;
 
     let main_py = context.temp_dir.child("main.py");
@@ -371,6 +417,12 @@ fn check_with_declared_dependency() -> Result<()> {
             "from importlib.metadata import distribution; assert distribution('iniconfig').read_text('INSTALLER') == 'uv'",
         )
         .success();
+    assert!(
+        !context
+            .site_packages()
+            .join("typing_extensions.py")
+            .exists()
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/project/check.rs
+++ b/crates/uv/tests/project/check.rs
@@ -81,6 +81,47 @@ fn check_passes_workspace_metadata_to_ty() -> Result<()> {
 }
 
 #[test]
+fn check_no_sync_ignores_invalid_lockfile() -> Result<()> {
+    let context = uv_test::test_context!("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+    context.temp_dir.child("uv.lock").write_str("invalid")?;
+    context.temp_dir.child("main.py").write_str(indoc! {r"
+        x: int = 1
+    "})?;
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .check()
+            .arg("--no-sync")
+            .arg("--ty-version")
+            .arg("0.0.17")
+            .env(EnvVars::RUST_LOG, "error"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    warning: `uv check` is experimental and may change without warning. Pass `--preview-features check-command` to disable this warning.
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn check_rejects_tool_arguments() {
     let context = uv_test::test_context_with_versions!(&[]);
 


### PR DESCRIPTION
This is my proposed solution to the `uv -> ty -> uv` gordian know that `uv check` uniquely presents. By doing this we get properly handling of `--isolated`, `--index`, and so on "for free" by virtue of ty not needing to call back into us. Also it's just more efficient than ty doing a callback.

This *does not* preclude ty knowing how to call into uv when it's invoked standalone, but in that case ty can be fully in charge of the config/interface so we don't need to worry about preserving it (i.e. we can just tell users to use persistent config or env-vars and they don't have a reason to complain about consistency).